### PR TITLE
fix: show console art on secondary display under the OLED palette

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -450,6 +450,11 @@ class _MyAppState extends State<MyApp> {
         ChangeNotifierProvider(create: (context) => PaletteProvider()),
         ChangeNotifierProvider(create: (context) => ScrapingProvider()),
         ChangeNotifierProvider(
+          // Eager (not lazy): auto-login must run at startup so RA is connected
+          // regardless of which screen is shown first. Otherwise launching a
+          // game straight from the systems/recent screen (which never reads the
+          // provider) would find RA disconnected and skip the secondary panel.
+          lazy: false,
           create: (context) => RetroAchievementsProvider()..initialize(),
         ),
         ChangeNotifierProvider(create: (context) => SystemBackgroundProvider()),

--- a/lib/models/secondary_achievement_item.dart
+++ b/lib/models/secondary_achievement_item.dart
@@ -1,0 +1,66 @@
+/// A minimal, serializable representation of a single RetroAchievements
+/// achievement, tailored for transport across the secondary-display bridge.
+///
+/// The secondary display runs in a separate Flutter engine and receives all
+/// data as JSON via the `sub_screen` shared state. Shipping the full
+/// [Achievement] model would be wasteful, so this carries only the fields the
+/// secondary achievement panel needs to render (title, points, badge, and
+/// unlock state).
+class SecondaryAchievementItem {
+  /// Unique RetroAchievements identifier for the achievement.
+  final int id;
+
+  /// Display title of the achievement.
+  final String title;
+
+  /// Point value awarded for earning the achievement.
+  final int points;
+
+  /// Identifier for the achievement's badge icon on the RA media CDN.
+  final String badgeName;
+
+  /// Original display order, used to sort locked achievements consistently.
+  final int displayOrder;
+
+  /// Whether the current user has earned this achievement (casual or hardcore).
+  final bool earned;
+
+  /// Whether the achievement was earned in hardcore mode.
+  final bool earnedHardcore;
+
+  const SecondaryAchievementItem({
+    required this.id,
+    required this.title,
+    required this.points,
+    required this.badgeName,
+    required this.displayOrder,
+    required this.earned,
+    required this.earnedHardcore,
+  });
+
+  /// Creates an item from a JSON-compatible map.
+  factory SecondaryAchievementItem.fromJson(Map<String, dynamic> json) {
+    return SecondaryAchievementItem(
+      id: (json['id'] as num?)?.toInt() ?? 0,
+      title: json['title'] as String? ?? '',
+      points: (json['points'] as num?)?.toInt() ?? 0,
+      badgeName: json['badgeName'] as String? ?? '',
+      displayOrder: (json['displayOrder'] as num?)?.toInt() ?? 0,
+      earned: json['earned'] as bool? ?? false,
+      earnedHardcore: json['earnedHardcore'] as bool? ?? false,
+    );
+  }
+
+  /// Converts the item into a JSON-compatible map.
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'points': points,
+      'badgeName': badgeName,
+      'displayOrder': displayOrder,
+      'earned': earned,
+      'earnedHardcore': earnedHardcore,
+    };
+  }
+}

--- a/lib/models/secondary_achievement_item.dart
+++ b/lib/models/secondary_achievement_item.dart
@@ -13,6 +13,9 @@ class SecondaryAchievementItem {
   /// Display title of the achievement.
   final String title;
 
+  /// Short description of what is required to earn the achievement.
+  final String description;
+
   /// Point value awarded for earning the achievement.
   final int points;
 
@@ -31,6 +34,7 @@ class SecondaryAchievementItem {
   const SecondaryAchievementItem({
     required this.id,
     required this.title,
+    required this.description,
     required this.points,
     required this.badgeName,
     required this.displayOrder,
@@ -43,6 +47,7 @@ class SecondaryAchievementItem {
     return SecondaryAchievementItem(
       id: (json['id'] as num?)?.toInt() ?? 0,
       title: json['title'] as String? ?? '',
+      description: json['description'] as String? ?? '',
       points: (json['points'] as num?)?.toInt() ?? 0,
       badgeName: json['badgeName'] as String? ?? '',
       displayOrder: (json['displayOrder'] as num?)?.toInt() ?? 0,
@@ -56,6 +61,7 @@ class SecondaryAchievementItem {
     return {
       'id': id,
       'title': title,
+      'description': description,
       'points': points,
       'badgeName': badgeName,
       'displayOrder': displayOrder,

--- a/lib/models/secondary_display_state.dart
+++ b/lib/models/secondary_display_state.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:sub_screen/shared_state_manager.dart';
 import 'package:neostation/services/logger_service.dart';
+import 'secondary_achievement_item.dart';
 
 /// Data structure representing the current state of the secondary/bottom display.
 ///
@@ -97,6 +98,34 @@ class SecondaryDisplayStateData {
   /// Whether to optimize the secondary display for OLED panels (e.g., using pure blacks).
   final bool isOled;
 
+  /// Whether the RetroAchievements panel should be rendered (in-game view).
+  final bool showAchievementPanel;
+
+  /// Condensed achievement list for the current game, or null when unavailable.
+  final List<SecondaryAchievementItem>? achievements;
+
+  /// Number of achievements the user has earned for the current game.
+  final int raEarned;
+
+  /// Total number of achievements available for the current game.
+  final int raTotal;
+
+  /// Points the user has earned for the current game.
+  final int raPoints;
+
+  /// Total points available for the current game.
+  final int raPointsTotal;
+
+  /// User completion percentage string for the current game (e.g. '50.00%').
+  final String? raCompletionPct;
+
+  /// Standardized RetroAchievements title for the current game.
+  final String? raGameTitle;
+
+  /// Ids of achievements earned during the most recent play session, used to
+  /// highlight/celebrate fresh unlocks when the user returns from the emulator.
+  final List<int>? newlyEarnedIds;
+
   SecondaryDisplayStateData({
     required this.systemName,
     this.gameFanart,
@@ -127,6 +156,15 @@ class SecondaryDisplayStateData {
     this.shaderColor2,
     this.useFluidShader = false,
     this.isOled = false,
+    this.showAchievementPanel = false,
+    this.achievements,
+    this.raEarned = 0,
+    this.raTotal = 0,
+    this.raPoints = 0,
+    this.raPointsTotal = 0,
+    this.raCompletionPct,
+    this.raGameTitle,
+    this.newlyEarnedIds,
   });
 
   /// Returns a new instance with the specified properties updated.
@@ -170,6 +208,19 @@ class SecondaryDisplayStateData {
     int? shaderColor2,
     bool? useFluidShader,
     bool? isOled,
+    bool? showAchievementPanel,
+    List<SecondaryAchievementItem>? achievements,
+    bool clearAchievements = false,
+    int? raEarned,
+    int? raTotal,
+    int? raPoints,
+    int? raPointsTotal,
+    String? raCompletionPct,
+    bool clearRaCompletionPct = false,
+    String? raGameTitle,
+    bool clearRaGameTitle = false,
+    List<int>? newlyEarnedIds,
+    bool clearNewlyEarnedIds = false,
   }) {
     return SecondaryDisplayStateData(
       systemName: systemName ?? this.systemName,
@@ -211,6 +262,21 @@ class SecondaryDisplayStateData {
       shaderColor2: shaderColor2 ?? this.shaderColor2,
       useFluidShader: useFluidShader ?? this.useFluidShader,
       isOled: isOled ?? this.isOled,
+      showAchievementPanel: showAchievementPanel ?? this.showAchievementPanel,
+      achievements: clearAchievements
+          ? null
+          : (achievements ?? this.achievements),
+      raEarned: raEarned ?? this.raEarned,
+      raTotal: raTotal ?? this.raTotal,
+      raPoints: raPoints ?? this.raPoints,
+      raPointsTotal: raPointsTotal ?? this.raPointsTotal,
+      raCompletionPct: clearRaCompletionPct
+          ? null
+          : (raCompletionPct ?? this.raCompletionPct),
+      raGameTitle: clearRaGameTitle ? null : (raGameTitle ?? this.raGameTitle),
+      newlyEarnedIds: clearNewlyEarnedIds
+          ? null
+          : (newlyEarnedIds ?? this.newlyEarnedIds),
     );
   }
 
@@ -248,6 +314,27 @@ class SecondaryDisplayStateData {
       shaderColor2: json['shaderColor2'] as int?,
       useFluidShader: json['useFluidShader'] as bool? ?? false,
       isOled: json['isOled'] as bool? ?? false,
+      showAchievementPanel: json['showAchievementPanel'] as bool? ?? false,
+      achievements: json['achievements'] != null
+          ? (json['achievements'] as List<dynamic>)
+                .map(
+                  (e) => SecondaryAchievementItem.fromJson(
+                    e as Map<String, dynamic>,
+                  ),
+                )
+                .toList()
+          : null,
+      raEarned: json['raEarned'] as int? ?? 0,
+      raTotal: json['raTotal'] as int? ?? 0,
+      raPoints: json['raPoints'] as int? ?? 0,
+      raPointsTotal: json['raPointsTotal'] as int? ?? 0,
+      raCompletionPct: json['raCompletionPct'] as String?,
+      raGameTitle: json['raGameTitle'] as String?,
+      newlyEarnedIds: json['newlyEarnedIds'] != null
+          ? (json['newlyEarnedIds'] as List<dynamic>)
+                .map((e) => (e as num).toInt())
+                .toList()
+          : null,
     );
   }
 
@@ -285,6 +372,15 @@ class SecondaryDisplayStateData {
       'shaderColor2': shaderColor2,
       'useFluidShader': useFluidShader,
       'isOled': isOled,
+      'showAchievementPanel': showAchievementPanel,
+      'achievements': achievements?.map((e) => e.toJson()).toList(),
+      'raEarned': raEarned,
+      'raTotal': raTotal,
+      'raPoints': raPoints,
+      'raPointsTotal': raPointsTotal,
+      'raCompletionPct': raCompletionPct,
+      'raGameTitle': raGameTitle,
+      'newlyEarnedIds': newlyEarnedIds,
     };
   }
 }
@@ -347,6 +443,19 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
     int? shaderColor2,
     bool? useFluidShader,
     bool? isOled,
+    bool? showAchievementPanel,
+    List<SecondaryAchievementItem>? achievements,
+    bool clearAchievements = false,
+    int? raEarned,
+    int? raTotal,
+    int? raPoints,
+    int? raPointsTotal,
+    String? raCompletionPct,
+    bool clearRaCompletionPct = false,
+    String? raGameTitle,
+    bool clearRaGameTitle = false,
+    List<int>? newlyEarnedIds,
+    bool clearNewlyEarnedIds = false,
   }) async {
     if (!Platform.isAndroid) return;
 
@@ -395,6 +504,19 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
           shaderColor2: shaderColor2,
           useFluidShader: useFluidShader,
           isOled: isOled,
+          showAchievementPanel: showAchievementPanel,
+          achievements: achievements,
+          clearAchievements: clearAchievements,
+          raEarned: raEarned,
+          raTotal: raTotal,
+          raPoints: raPoints,
+          raPointsTotal: raPointsTotal,
+          raCompletionPct: raCompletionPct,
+          clearRaCompletionPct: clearRaCompletionPct,
+          raGameTitle: raGameTitle,
+          clearRaGameTitle: clearRaGameTitle,
+          newlyEarnedIds: newlyEarnedIds,
+          clearNewlyEarnedIds: clearNewlyEarnedIds,
         ),
       );
     } catch (e) {

--- a/lib/models/secondary_display_state.dart
+++ b/lib/models/secondary_display_state.dart
@@ -126,6 +126,26 @@ class SecondaryDisplayStateData {
   /// highlight/celebrate fresh unlocks when the user returns from the emulator.
   final List<int>? newlyEarnedIds;
 
+  /// Whether an in-game session is active, gating the paged "Now Playing" /
+  /// achievements container on the secondary display. Independent of
+  /// [showAchievementPanel]: it is true for every launched game, even ones
+  /// without a RetroAchievements set.
+  final bool nowPlayingActive;
+
+  /// Display title of the launched game (real [GameModel.name]; the RA title
+  /// may differ or be null for non-RA games).
+  final String? gameTitle;
+
+  /// Absolute local path to the launched game's boxart, or null when missing.
+  final String? gameBoxart;
+
+  /// Total accumulated play time for the launched game, in seconds.
+  final int? playTimeSeconds;
+
+  /// When the launched game was last played, as milliseconds since epoch
+  /// ([DateTime] does not survive the JSON bridge), or null if never played.
+  final int? lastPlayedMillis;
+
   SecondaryDisplayStateData({
     required this.systemName,
     this.gameFanart,
@@ -165,6 +185,11 @@ class SecondaryDisplayStateData {
     this.raCompletionPct,
     this.raGameTitle,
     this.newlyEarnedIds,
+    this.nowPlayingActive = false,
+    this.gameTitle,
+    this.gameBoxart,
+    this.playTimeSeconds,
+    this.lastPlayedMillis,
   });
 
   /// Returns a new instance with the specified properties updated.
@@ -221,6 +246,15 @@ class SecondaryDisplayStateData {
     bool clearRaGameTitle = false,
     List<int>? newlyEarnedIds,
     bool clearNewlyEarnedIds = false,
+    bool? nowPlayingActive,
+    String? gameTitle,
+    bool clearGameTitle = false,
+    String? gameBoxart,
+    bool clearGameBoxart = false,
+    int? playTimeSeconds,
+    bool clearPlayTimeSeconds = false,
+    int? lastPlayedMillis,
+    bool clearLastPlayed = false,
   }) {
     return SecondaryDisplayStateData(
       systemName: systemName ?? this.systemName,
@@ -277,6 +311,15 @@ class SecondaryDisplayStateData {
       newlyEarnedIds: clearNewlyEarnedIds
           ? null
           : (newlyEarnedIds ?? this.newlyEarnedIds),
+      nowPlayingActive: nowPlayingActive ?? this.nowPlayingActive,
+      gameTitle: clearGameTitle ? null : (gameTitle ?? this.gameTitle),
+      gameBoxart: clearGameBoxart ? null : (gameBoxart ?? this.gameBoxart),
+      playTimeSeconds: clearPlayTimeSeconds
+          ? null
+          : (playTimeSeconds ?? this.playTimeSeconds),
+      lastPlayedMillis: clearLastPlayed
+          ? null
+          : (lastPlayedMillis ?? this.lastPlayedMillis),
     );
   }
 
@@ -335,6 +378,11 @@ class SecondaryDisplayStateData {
                 .map((e) => (e as num).toInt())
                 .toList()
           : null,
+      nowPlayingActive: json['nowPlayingActive'] as bool? ?? false,
+      gameTitle: json['gameTitle'] as String?,
+      gameBoxart: json['gameBoxart'] as String?,
+      playTimeSeconds: (json['playTimeSeconds'] as num?)?.toInt(),
+      lastPlayedMillis: (json['lastPlayedMillis'] as num?)?.toInt(),
     );
   }
 
@@ -381,6 +429,11 @@ class SecondaryDisplayStateData {
       'raCompletionPct': raCompletionPct,
       'raGameTitle': raGameTitle,
       'newlyEarnedIds': newlyEarnedIds,
+      'nowPlayingActive': nowPlayingActive,
+      'gameTitle': gameTitle,
+      'gameBoxart': gameBoxart,
+      'playTimeSeconds': playTimeSeconds,
+      'lastPlayedMillis': lastPlayedMillis,
     };
   }
 }
@@ -456,6 +509,15 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
     bool clearRaGameTitle = false,
     List<int>? newlyEarnedIds,
     bool clearNewlyEarnedIds = false,
+    bool? nowPlayingActive,
+    String? gameTitle,
+    bool clearGameTitle = false,
+    String? gameBoxart,
+    bool clearGameBoxart = false,
+    int? playTimeSeconds,
+    bool clearPlayTimeSeconds = false,
+    int? lastPlayedMillis,
+    bool clearLastPlayed = false,
   }) async {
     if (!Platform.isAndroid) return;
 
@@ -517,6 +579,15 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
           clearRaGameTitle: clearRaGameTitle,
           newlyEarnedIds: newlyEarnedIds,
           clearNewlyEarnedIds: clearNewlyEarnedIds,
+          nowPlayingActive: nowPlayingActive,
+          gameTitle: gameTitle,
+          clearGameTitle: clearGameTitle,
+          gameBoxart: gameBoxart,
+          clearGameBoxart: clearGameBoxart,
+          playTimeSeconds: playTimeSeconds,
+          clearPlayTimeSeconds: clearPlayTimeSeconds,
+          lastPlayedMillis: lastPlayedMillis,
+          clearLastPlayed: clearLastPlayed,
         ),
       );
     } catch (e) {

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -20,6 +20,7 @@ import '../../services/music_player_service.dart';
 import '../../repositories/system_repository.dart';
 import '../../repositories/game_repository.dart';
 import '../../services/screenscraper_service.dart';
+import '../../services/retro_achievements_resolver.dart';
 import '../../utils/gamepad_nav.dart';
 import '../../utils/centered_scroll_controller.dart';
 import '../../providers/file_provider.dart';
@@ -161,6 +162,30 @@ class _SystemGamesListState extends State<SystemGamesList> {
   // Secondary display hardware management (OEM support).
   SecondaryDisplayState? _secondaryDisplayState;
 
+  /// Snapshot of achievement ids earned before the current launch, used to
+  /// detect freshly-earned achievements when the user returns (Tier 1).
+  Set<int> _preGameEarnedIds = <int>{};
+
+  /// RA game id whose achievement panel was pushed for the current launch, or
+  /// null when the launched game has no RetroAchievements data.
+  int? _achievementGameId;
+
+  /// While true, the secondary display keeps the achievement panel shown
+  /// instead of reverting to game art — used both in-game and during the
+  /// post-session celebration window so list/selection updates don't hide it.
+  bool _achievementCelebrationActive = false;
+
+  /// ROM path of the game being celebrated, so navigating to a different game
+  /// ends the celebration immediately.
+  String? _celebrationRomPath;
+
+  /// Reverts the secondary display from the celebration panel back to art.
+  Timer? _celebrationRevertTimer;
+
+  /// In-game live poll: periodically re-fetches RA progress while a game runs
+  /// so freshly-earned achievements surface on the secondary display live.
+  Timer? _livePollTimer;
+
   bool _canPop = false;
 
   // View keys for scroll synchronization.
@@ -266,6 +291,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
     MusicPlayerService().removeListener(_onMusicPlayerStateChanged);
 
     _secondaryDisplayState?.dispose();
+    _celebrationRevertTimer?.cancel();
+    _livePollTimer?.cancel();
 
     _cleanupResources();
     _backButtonFocusNode.dispose();
@@ -757,8 +784,16 @@ class _SystemGamesListState extends State<SystemGamesList> {
   }
 
   /// Synchronizes selection metadata and assets with secondary hardware displays.
-  void _updateSecondaryDisplay(GameModel game) async {
+  Future<void> _updateSecondaryDisplay(GameModel game) async {
     if (_secondaryDisplayState == null || _isNavigatingBack) return;
+
+    // Navigating to a different game ends any in-progress achievement
+    // celebration so the new game's art is shown instead of a stale panel.
+    if (_achievementCelebrationActive && game.romPath != _celebrationRomPath) {
+      _achievementCelebrationActive = false;
+      _celebrationRevertTimer?.cancel();
+      _achievementGameId = null;
+    }
 
     final systemFolderName =
         (widget.system.folderName == 'all' ||
@@ -812,7 +847,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
         currentState.gameVideo !=
             (isMusicSystem ? null : (videoExists ? videoPath : null)) ||
         currentState.isVideoMuted != isVideoMuted ||
-        currentState.isGameLaunching != _isGameLaunching;
+        currentState.isGameLaunching != _isGameLaunching ||
+        currentState.showAchievementPanel != _achievementCelebrationActive;
 
     if (shouldUpdate && !_isNavigatingBack) {
       final bool hasFanart = !isMusicSystem && File(fanartPath).existsSync();
@@ -844,6 +880,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
             ? MusicPlayerService().activeTrack?.romPath
             : game.romPath,
         isScraperLoggedIn: isScraperLoggedIn,
+        // Browsing hides the in-game achievement panel; the launch push and the
+        // post-session celebration window keep it shown via this flag.
+        showAchievementPanel: _achievementCelebrationActive,
       );
     }
 
@@ -1138,14 +1177,202 @@ class _SystemGamesListState extends State<SystemGamesList> {
   }
 
   /// Restores UI state and input focus after an external emulator process terminates.
+  /// Resolves the effective system folder name for a game, accounting for the
+  /// aggregate "all"/favorites views where each game carries its own system.
+  String _resolveSystemFolderName(GameModel game) {
+    return (widget.system.folderName == 'all' ||
+                widget.system.folderName == SystemFolderNames.favorites) &&
+            game.systemFolderName != null
+        ? game.systemFolderName!
+        : widget.system.primaryFolderName;
+  }
+
+  /// Tier 0: resolves and pushes the launched game's achievement panel to the
+  /// secondary display, snapshotting earned ids for the return-diff. No-op when
+  /// RA is disconnected or the game has no achievement set.
+  Future<void> _pushAchievementsForLaunch(GameModel game) async {
+    if (!Platform.isAndroid || _secondaryDisplayState == null || !mounted) {
+      return;
+    }
+    _achievementGameId = null;
+    _preGameEarnedIds = <int>{};
+
+    final provider = _retroAchievementsProvider;
+    if (!provider.isConnected) return;
+
+    final snapshot = await RetroAchievementsResolver.fetchSnapshot(
+      game: game,
+      systemFolderName: _resolveSystemFolderName(game),
+      provider: provider,
+    );
+    if (snapshot == null) return;
+
+    _achievementGameId = snapshot.gameId;
+    _preGameEarnedIds = snapshot.earnedIds;
+
+    // ignore: unawaited_futures
+    _secondaryDisplayState?.updateState(
+      showAchievementPanel: true,
+      achievements: snapshot.achievements,
+      raEarned: snapshot.earned,
+      raTotal: snapshot.total,
+      raPoints: snapshot.points,
+      raPointsTotal: snapshot.pointsTotal,
+      raCompletionPct: snapshot.completionPct,
+      raGameTitle: snapshot.gameTitle,
+      clearNewlyEarnedIds: true,
+    );
+
+    _startLivePoll();
+  }
+
+  /// Poll interval for live in-game RA progress. RA only reflects an unlock
+  /// after the emulator submits it server-side, so finer granularity buys
+  /// little; this keeps the panel current without hammering the API.
+  static const Duration _livePollInterval = Duration(seconds: 30);
+
+  /// Starts the in-game live poll: re-fetches RA progress on each interval so
+  /// achievements earned during play surface on the secondary display.
+  void _startLivePoll() {
+    if (!Platform.isAndroid) return;
+    _livePollTimer?.cancel();
+    _livePollTimer = Timer.periodic(
+      _livePollInterval,
+      (_) => _onLivePollTick(),
+    );
+  }
+
+  void _stopLivePoll() {
+    _livePollTimer?.cancel();
+    _livePollTimer = null;
+  }
+
+  Future<void> _onLivePollTick() async {
+    if (_secondaryDisplayState == null || _achievementGameId == null) {
+      _stopLivePoll();
+      return;
+    }
+
+    final game = _selectedGame;
+    if (game == null || !mounted) return;
+    final provider = _retroAchievementsProvider;
+    if (!provider.isConnected) return;
+
+    final snapshot = await RetroAchievementsResolver.fetchSnapshot(
+      game: game,
+      systemFolderName: _resolveSystemFolderName(game),
+      provider: provider,
+      forceRefresh: true,
+    );
+    // Keep _preGameEarnedIds anchored to launch so the diff covers the whole
+    // session (both for the live highlight and the return celebration).
+    if (snapshot == null || _achievementGameId == null) return;
+    final newly = snapshot.earnedIds.difference(_preGameEarnedIds).toList();
+
+    // ignore: unawaited_futures
+    _secondaryDisplayState?.updateState(
+      showAchievementPanel: true,
+      achievements: snapshot.achievements,
+      raEarned: snapshot.earned,
+      raTotal: snapshot.total,
+      raPoints: snapshot.points,
+      raPointsTotal: snapshot.pointsTotal,
+      raCompletionPct: snapshot.completionPct,
+      raGameTitle: snapshot.gameTitle,
+      newlyEarnedIds: newly.isEmpty ? null : newly,
+      clearNewlyEarnedIds: newly.isEmpty,
+    );
+  }
+
+  /// Tier 1: after returning from the emulator, re-fetches progress, diffs it
+  /// against the pre-launch snapshot, and re-shows the panel with this
+  /// session's freshly-earned achievements highlighted.
+  Future<void> _refreshAchievementsAfterSession(GameModel game) async {
+    if (!Platform.isAndroid ||
+        _secondaryDisplayState == null ||
+        _achievementGameId == null ||
+        !mounted) {
+      return;
+    }
+
+    final provider = _retroAchievementsProvider;
+    if (!provider.isConnected) {
+      _endCelebration();
+      return;
+    }
+
+    final snapshot = await RetroAchievementsResolver.fetchSnapshot(
+      game: game,
+      systemFolderName: _resolveSystemFolderName(game),
+      provider: provider,
+      forceRefresh: true,
+    );
+    if (snapshot == null || !_achievementCelebrationActive) {
+      _endCelebration();
+      return;
+    }
+
+    final newly = snapshot.earnedIds.difference(_preGameEarnedIds).toList();
+    _preGameEarnedIds = snapshot.earnedIds;
+
+    // ignore: unawaited_futures
+    _secondaryDisplayState?.updateState(
+      showAchievementPanel: true,
+      achievements: snapshot.achievements,
+      raEarned: snapshot.earned,
+      raTotal: snapshot.total,
+      raPoints: snapshot.points,
+      raPointsTotal: snapshot.pointsTotal,
+      raCompletionPct: snapshot.completionPct,
+      raGameTitle: snapshot.gameTitle,
+      newlyEarnedIds: newly.isEmpty ? null : newly,
+      clearNewlyEarnedIds: newly.isEmpty,
+    );
+
+    // Hold the panel through the celebration window, then revert to game art.
+    _celebrationRevertTimer?.cancel();
+    _celebrationRevertTimer = Timer(
+      const Duration(seconds: 8),
+      _endCelebration,
+    );
+  }
+
+  /// Ends the post-session celebration and reverts the secondary display from
+  /// the achievement panel back to normal game art.
+  void _endCelebration() {
+    _celebrationRevertTimer?.cancel();
+    _celebrationRevertTimer = null;
+    if (!_achievementCelebrationActive) return;
+    _achievementCelebrationActive = false;
+    _achievementGameId = null;
+    _celebrationRomPath = null;
+    if (mounted && _selectedGame != null) {
+      // ignore: unawaited_futures
+      _updateSecondaryDisplay(_selectedGame!);
+    }
+  }
+
   void _reactivateGamepadNavigation() async {
     if (!mounted) return;
+
+    _stopLivePoll();
 
     if (mounted) {
       setState(() {
         _isGameLaunching = false;
       });
-      if (_selectedGame != null) _updateSecondaryDisplay(_selectedGame!);
+      if (_selectedGame != null) {
+        // Keep the panel up through the post-session celebration (set before
+        // the art update so it isn't hidden by the games-list reload below).
+        if (_achievementGameId != null) {
+          _achievementCelebrationActive = true;
+          _celebrationRomPath = _selectedGame!.romPath;
+        }
+        _updateSecondaryDisplay(_selectedGame!);
+        // Re-show the panel with this session's freshly-earned achievements.
+        // ignore: unawaited_futures
+        _refreshAchievementsAfterSession(_selectedGame!);
+      }
     }
 
     GamepadNavigationManager.reactivate();
@@ -1388,7 +1615,17 @@ class _SystemGamesListState extends State<SystemGamesList> {
 
     // Resource termination and UI synchronization prior to process handoff.
     _stopVideoAndCleanup();
-    _updateSecondaryDisplay(_selectedGame!);
+    // Await the art push first so it can't land after the achievement push and
+    // re-hide the panel; the panel push is then the definitive last write.
+    await _updateSecondaryDisplay(_selectedGame!);
+    if (!mounted) return;
+
+    // Push the in-game RetroAchievements panel. Fired without awaiting so it
+    // never blocks the emulator handoff; it lands during launchGameWithDialog's
+    // ~2s foreground window, giving the secondary engine time to paint the
+    // panel and load badge art before the activity is backgrounded.
+    // ignore: unawaited_futures
+    _pushAchievementsForLaunch(_selectedGame!);
 
     // CRITICAL: Deactivate local input to avoid conflicts with external processes.
     _gamepadNav.deactivate();

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -787,6 +787,12 @@ class _SystemGamesListState extends State<SystemGamesList> {
       _fileProvider,
     );
 
+    final wheelPath = game.getImagePath(
+      systemFolderName,
+      'wheels',
+      _fileProvider,
+    );
+
     final videoPath = _getVideoPath(game);
     final videoExists = await _fileProvider.fileExists(videoPath);
 
@@ -819,6 +825,10 @@ class _SystemGamesListState extends State<SystemGamesList> {
                       : null)) ||
         currentState.gameVideo !=
             (isMusicSystem ? null : (videoExists ? videoPath : null)) ||
+        currentState.gameWheel !=
+            (isMusicSystem
+                ? null
+                : (File(wheelPath).existsSync() ? wheelPath : null)) ||
         currentState.isVideoMuted != isVideoMuted ||
         currentState.isGameLaunching != _isGameLaunching;
 
@@ -826,6 +836,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
       final bool hasFanart = !isMusicSystem && File(fanartPath).existsSync();
       final bool hasScreenshot =
           !isMusicSystem && File(screenshotPath).existsSync();
+      final bool hasWheel = !isMusicSystem && File(wheelPath).existsSync();
 
       // ignore: unawaited_futures
       _secondaryDisplayState?.updateState(
@@ -834,8 +845,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
         gameScreenshot: hasScreenshot ? screenshotPath : null,
         clearFanart: !hasFanart,
         clearScreenshot: !hasScreenshot,
-        gameWheel: null,
-        clearWheel: true,
+        gameWheel: hasWheel ? wheelPath : null,
+        clearWheel: !hasWheel,
         gameVideo: null, // Reset video state during active scrolling.
         clearVideo: true,
         gameImageBytes: null,

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1164,11 +1164,17 @@ class _SystemGamesListState extends State<SystemGamesList> {
   /// [SecondaryAchievementsController]; no-op when there is no active secondary
   /// display, RA is disconnected, or the game has no achievement set.
   Future<void> _pushAchievementsForLaunch(GameModel game) {
+    final systemFolderName = _resolveSystemFolderName(game);
     return _achievementsController.pushForLaunch(
       state: _secondaryDisplayState,
       provider: _retroAchievementsProvider,
       game: game,
-      systemFolderName: _resolveSystemFolderName(game),
+      systemFolderName: systemFolderName,
+      boxartPath: SecondaryAchievementsController.resolveBoxart(
+        game,
+        systemFolderName,
+        _fileProvider,
+      ),
     );
   }
 

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -20,7 +20,7 @@ import '../../services/music_player_service.dart';
 import '../../repositories/system_repository.dart';
 import '../../repositories/game_repository.dart';
 import '../../services/screenscraper_service.dart';
-import '../../services/retro_achievements_resolver.dart';
+import '../../services/secondary_achievements_controller.dart';
 import '../../utils/gamepad_nav.dart';
 import '../../utils/centered_scroll_controller.dart';
 import '../../providers/file_provider.dart';
@@ -162,17 +162,11 @@ class _SystemGamesListState extends State<SystemGamesList> {
   // Secondary display hardware management (OEM support).
   SecondaryDisplayState? _secondaryDisplayState;
 
-  /// Snapshot of achievement ids earned before the current launch, used to
-  /// detect freshly-earned achievements when the user returns (Tier 1).
-  Set<int> _preGameEarnedIds = <int>{};
-
-  /// RA game id whose achievement panel was pushed for the current launch, or
-  /// null when the launched game has no RetroAchievements data.
-  int? _achievementGameId;
-
-  /// In-game live poll: periodically re-fetches RA progress while a game runs
-  /// so freshly-earned achievements surface on the secondary display live.
-  Timer? _livePollTimer;
+  /// Drives the live RetroAchievements panel on the secondary display for the
+  /// duration of a launched game (push at launch, poll during play, stop on
+  /// return). Shared with the systems carousel/grid "Recent Games" launches.
+  final SecondaryAchievementsController _achievementsController =
+      SecondaryAchievementsController();
 
   bool _canPop = false;
 
@@ -279,7 +273,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
     MusicPlayerService().removeListener(_onMusicPlayerStateChanged);
 
     _secondaryDisplayState?.dispose();
-    _livePollTimer?.cancel();
+    _achievementsController.dispose();
 
     _cleanupResources();
     _backButtonFocusNode.dispose();
@@ -1165,120 +1159,25 @@ class _SystemGamesListState extends State<SystemGamesList> {
         : widget.system.primaryFolderName;
   }
 
-  /// Whether a secondary display is actually present and active. False on
-  /// single-screen devices and when the user has disabled the bottom screen,
-  /// in which case the achievement panel work is skipped entirely.
-  bool get _secondaryDisplayActive =>
-      _secondaryDisplayState?.value?.isSecondaryActive ?? false;
-
-  /// Tier 0: resolves and pushes the launched game's achievement panel to the
-  /// secondary display, snapshotting earned ids for the return-diff. No-op when
-  /// there is no active secondary display, RA is disconnected, or the game has
-  /// no achievement set.
-  Future<void> _pushAchievementsForLaunch(GameModel game) async {
-    if (!Platform.isAndroid ||
-        _secondaryDisplayState == null ||
-        !_secondaryDisplayActive ||
-        !mounted) {
-      return;
-    }
-    _achievementGameId = null;
-    _preGameEarnedIds = <int>{};
-
-    final provider = _retroAchievementsProvider;
-    if (!provider.isConnected) return;
-
-    final snapshot = await RetroAchievementsResolver.fetchSnapshot(
+  /// Resolves and pushes the launched game's achievement panel to the secondary
+  /// display, then keeps it live for the session. Delegates to the shared
+  /// [SecondaryAchievementsController]; no-op when there is no active secondary
+  /// display, RA is disconnected, or the game has no achievement set.
+  Future<void> _pushAchievementsForLaunch(GameModel game) {
+    return _achievementsController.pushForLaunch(
+      state: _secondaryDisplayState,
+      provider: _retroAchievementsProvider,
       game: game,
       systemFolderName: _resolveSystemFolderName(game),
-      provider: provider,
-    );
-    if (snapshot == null) return;
-
-    _achievementGameId = snapshot.gameId;
-    _preGameEarnedIds = snapshot.earnedIds;
-
-    // ignore: unawaited_futures
-    _secondaryDisplayState?.updateState(
-      showAchievementPanel: true,
-      achievements: snapshot.achievements,
-      raEarned: snapshot.earned,
-      raTotal: snapshot.total,
-      raPoints: snapshot.points,
-      raPointsTotal: snapshot.pointsTotal,
-      raCompletionPct: snapshot.completionPct,
-      raGameTitle: snapshot.gameTitle,
-      clearNewlyEarnedIds: true,
-    );
-
-    _startLivePoll();
-  }
-
-  /// Poll interval for live in-game RA progress. RA only reflects an unlock
-  /// after the emulator submits it server-side, so finer granularity buys
-  /// little; this keeps the panel current without hammering the API.
-  static const Duration _livePollInterval = Duration(seconds: 30);
-
-  /// Starts the in-game live poll: re-fetches RA progress on each interval so
-  /// achievements earned during play surface on the secondary display.
-  void _startLivePoll() {
-    if (!Platform.isAndroid) return;
-    _livePollTimer?.cancel();
-    _livePollTimer = Timer.periodic(
-      _livePollInterval,
-      (_) => _onLivePollTick(),
-    );
-  }
-
-  void _stopLivePoll() {
-    _livePollTimer?.cancel();
-    _livePollTimer = null;
-  }
-
-  Future<void> _onLivePollTick() async {
-    if (_secondaryDisplayState == null ||
-        _achievementGameId == null ||
-        !_secondaryDisplayActive) {
-      _stopLivePoll();
-      return;
-    }
-
-    final game = _selectedGame;
-    if (game == null || !mounted) return;
-    final provider = _retroAchievementsProvider;
-    if (!provider.isConnected) return;
-
-    final snapshot = await RetroAchievementsResolver.fetchSnapshot(
-      game: game,
-      systemFolderName: _resolveSystemFolderName(game),
-      provider: provider,
-      forceRefresh: true,
-    );
-    // Keep _preGameEarnedIds anchored to launch so the diff covers the whole
-    // session (both for the live highlight and the return celebration).
-    if (snapshot == null || _achievementGameId == null) return;
-    final newly = snapshot.earnedIds.difference(_preGameEarnedIds).toList();
-
-    // ignore: unawaited_futures
-    _secondaryDisplayState?.updateState(
-      showAchievementPanel: true,
-      achievements: snapshot.achievements,
-      raEarned: snapshot.earned,
-      raTotal: snapshot.total,
-      raPoints: snapshot.points,
-      raPointsTotal: snapshot.pointsTotal,
-      raCompletionPct: snapshot.completionPct,
-      raGameTitle: snapshot.gameTitle,
-      newlyEarnedIds: newly.isEmpty ? null : newly,
-      clearNewlyEarnedIds: newly.isEmpty,
     );
   }
 
   void _reactivateGamepadNavigation() async {
     if (!mounted) return;
 
-    _stopLivePoll();
-    _achievementGameId = null;
+    // Host re-pushes full game art below (hidePanel: false), which carries the
+    // panel-off flag, so the panel fades back to the art on return.
+    _achievementsController.stop();
 
     if (mounted) {
       setState(() {

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1402,9 +1402,12 @@ class _SystemGamesListState extends State<SystemGamesList> {
       _log.e('Error refreshing game data after gameplay: $e');
     }
 
-    if (_refreshAchievementsCallback != null) {
-      _refreshAchievementsCallback!();
-    }
+    // Defer to after the games-list reload settles and the details card has
+    // re-registered its callback, otherwise this fires against the old/unmounted
+    // card and no-ops — which is why a manual refresh was previously needed.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _refreshAchievementsCallback?.call();
+    });
 
     // Trigger sync after returning from game so local save gets uploaded.
     if (_selectedGame != null && mounted) {

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -170,18 +170,6 @@ class _SystemGamesListState extends State<SystemGamesList> {
   /// null when the launched game has no RetroAchievements data.
   int? _achievementGameId;
 
-  /// While true, the secondary display keeps the achievement panel shown
-  /// instead of reverting to game art — used both in-game and during the
-  /// post-session celebration window so list/selection updates don't hide it.
-  bool _achievementCelebrationActive = false;
-
-  /// ROM path of the game being celebrated, so navigating to a different game
-  /// ends the celebration immediately.
-  String? _celebrationRomPath;
-
-  /// Reverts the secondary display from the celebration panel back to art.
-  Timer? _celebrationRevertTimer;
-
   /// In-game live poll: periodically re-fetches RA progress while a game runs
   /// so freshly-earned achievements surface on the secondary display live.
   Timer? _livePollTimer;
@@ -291,7 +279,6 @@ class _SystemGamesListState extends State<SystemGamesList> {
     MusicPlayerService().removeListener(_onMusicPlayerStateChanged);
 
     _secondaryDisplayState?.dispose();
-    _celebrationRevertTimer?.cancel();
     _livePollTimer?.cancel();
 
     _cleanupResources();
@@ -787,14 +774,6 @@ class _SystemGamesListState extends State<SystemGamesList> {
   Future<void> _updateSecondaryDisplay(GameModel game) async {
     if (_secondaryDisplayState == null || _isNavigatingBack) return;
 
-    // Navigating to a different game ends any in-progress achievement
-    // celebration so the new game's art is shown instead of a stale panel.
-    if (_achievementCelebrationActive && game.romPath != _celebrationRomPath) {
-      _achievementCelebrationActive = false;
-      _celebrationRevertTimer?.cancel();
-      _achievementGameId = null;
-    }
-
     final systemFolderName =
         (widget.system.folderName == 'all' ||
                 widget.system.folderName == SystemFolderNames.favorites) &&
@@ -847,8 +826,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
         currentState.gameVideo !=
             (isMusicSystem ? null : (videoExists ? videoPath : null)) ||
         currentState.isVideoMuted != isVideoMuted ||
-        currentState.isGameLaunching != _isGameLaunching ||
-        currentState.showAchievementPanel != _achievementCelebrationActive;
+        currentState.isGameLaunching != _isGameLaunching;
 
     if (shouldUpdate && !_isNavigatingBack) {
       final bool hasFanart = !isMusicSystem && File(fanartPath).existsSync();
@@ -880,9 +858,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
             ? MusicPlayerService().activeTrack?.romPath
             : game.romPath,
         isScraperLoggedIn: isScraperLoggedIn,
-        // Browsing hides the in-game achievement panel; the launch push and the
-        // post-session celebration window keep it shown via this flag.
-        showAchievementPanel: _achievementCelebrationActive,
+        // Panel is shown only by the launch push / live poll; browsing and
+        // returning from a game hide it (it fades out on the secondary screen).
+        showAchievementPanel: false,
       );
     }
 
@@ -1187,11 +1165,21 @@ class _SystemGamesListState extends State<SystemGamesList> {
         : widget.system.primaryFolderName;
   }
 
+  /// Whether a secondary display is actually present and active. False on
+  /// single-screen devices and when the user has disabled the bottom screen,
+  /// in which case the achievement panel work is skipped entirely.
+  bool get _secondaryDisplayActive =>
+      _secondaryDisplayState?.value?.isSecondaryActive ?? false;
+
   /// Tier 0: resolves and pushes the launched game's achievement panel to the
   /// secondary display, snapshotting earned ids for the return-diff. No-op when
-  /// RA is disconnected or the game has no achievement set.
+  /// there is no active secondary display, RA is disconnected, or the game has
+  /// no achievement set.
   Future<void> _pushAchievementsForLaunch(GameModel game) async {
-    if (!Platform.isAndroid || _secondaryDisplayState == null || !mounted) {
+    if (!Platform.isAndroid ||
+        _secondaryDisplayState == null ||
+        !_secondaryDisplayActive ||
+        !mounted) {
       return;
     }
     _achievementGameId = null;
@@ -1248,7 +1236,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
   }
 
   Future<void> _onLivePollTick() async {
-    if (_secondaryDisplayState == null || _achievementGameId == null) {
+    if (_secondaryDisplayState == null ||
+        _achievementGameId == null ||
+        !_secondaryDisplayActive) {
       _stopLivePoll();
       return;
     }
@@ -1284,95 +1274,19 @@ class _SystemGamesListState extends State<SystemGamesList> {
     );
   }
 
-  /// Tier 1: after returning from the emulator, re-fetches progress, diffs it
-  /// against the pre-launch snapshot, and re-shows the panel with this
-  /// session's freshly-earned achievements highlighted.
-  Future<void> _refreshAchievementsAfterSession(GameModel game) async {
-    if (!Platform.isAndroid ||
-        _secondaryDisplayState == null ||
-        _achievementGameId == null ||
-        !mounted) {
-      return;
-    }
-
-    final provider = _retroAchievementsProvider;
-    if (!provider.isConnected) {
-      _endCelebration();
-      return;
-    }
-
-    final snapshot = await RetroAchievementsResolver.fetchSnapshot(
-      game: game,
-      systemFolderName: _resolveSystemFolderName(game),
-      provider: provider,
-      forceRefresh: true,
-    );
-    if (snapshot == null || !_achievementCelebrationActive) {
-      _endCelebration();
-      return;
-    }
-
-    final newly = snapshot.earnedIds.difference(_preGameEarnedIds).toList();
-    _preGameEarnedIds = snapshot.earnedIds;
-
-    // ignore: unawaited_futures
-    _secondaryDisplayState?.updateState(
-      showAchievementPanel: true,
-      achievements: snapshot.achievements,
-      raEarned: snapshot.earned,
-      raTotal: snapshot.total,
-      raPoints: snapshot.points,
-      raPointsTotal: snapshot.pointsTotal,
-      raCompletionPct: snapshot.completionPct,
-      raGameTitle: snapshot.gameTitle,
-      newlyEarnedIds: newly.isEmpty ? null : newly,
-      clearNewlyEarnedIds: newly.isEmpty,
-    );
-
-    // Hold the panel through the celebration window, then revert to game art.
-    _celebrationRevertTimer?.cancel();
-    _celebrationRevertTimer = Timer(
-      const Duration(seconds: 8),
-      _endCelebration,
-    );
-  }
-
-  /// Ends the post-session celebration and reverts the secondary display from
-  /// the achievement panel back to normal game art.
-  void _endCelebration() {
-    _celebrationRevertTimer?.cancel();
-    _celebrationRevertTimer = null;
-    if (!_achievementCelebrationActive) return;
-    _achievementCelebrationActive = false;
-    _achievementGameId = null;
-    _celebrationRomPath = null;
-    if (mounted && _selectedGame != null) {
-      // ignore: unawaited_futures
-      _updateSecondaryDisplay(_selectedGame!);
-    }
-  }
-
   void _reactivateGamepadNavigation() async {
     if (!mounted) return;
 
     _stopLivePoll();
+    _achievementGameId = null;
 
     if (mounted) {
       setState(() {
         _isGameLaunching = false;
       });
-      if (_selectedGame != null) {
-        // Keep the panel up through the post-session celebration (set before
-        // the art update so it isn't hidden by the games-list reload below).
-        if (_achievementGameId != null) {
-          _achievementCelebrationActive = true;
-          _celebrationRomPath = _selectedGame!.romPath;
-        }
-        _updateSecondaryDisplay(_selectedGame!);
-        // Re-show the panel with this session's freshly-earned achievements.
-        // ignore: unawaited_futures
-        _refreshAchievementsAfterSession(_selectedGame!);
-      }
+      // Returning from the game: hide the panel so it fades back to game art.
+      // Any unlocks were already surfaced live during play.
+      if (_selectedGame != null) _updateSecondaryDisplay(_selectedGame!);
     }
 
     GamepadNavigationManager.reactivate();

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:video_player/video_player.dart';
+import '../../models/secondary_achievement_item.dart';
 import '../../models/secondary_display_state.dart';
 import '../../widgets/shaders/shader_gif_widget.dart';
 import '../../utils/image_utils.dart' as image_utils;
@@ -23,6 +24,11 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   Timer? _videoTimer;
   bool _showVideo = false;
   String? _currentVideoPath;
+
+  /// Auto-clearing timer for the "newly earned this session" celebration.
+  Timer? _celebrationTimer;
+  bool _celebrate = false;
+  String? _celebrationKey;
 
   @override
   void initState() {
@@ -43,6 +49,8 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     final state = _secondaryDisplayState?.value;
     if (state == null) return;
 
+    _maybeStartCelebration(state);
+
     if (state.isGameLaunching) {
       _stopVideo();
       return;
@@ -62,6 +70,29 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
         _videoController!.setVolume(state.isVideoMuted ? 0.0 : 1.0);
       }
     }
+  }
+
+  /// Triggers (or refreshes) the celebration banner when a new set of
+  /// session-earned achievements arrives, auto-clearing it after a few seconds.
+  void _maybeStartCelebration(SecondaryDisplayStateData state) {
+    final ids = state.newlyEarnedIds;
+    final key = (ids == null || ids.isEmpty)
+        ? null
+        : (List<int>.from(ids)..sort()).join(',');
+
+    if (key == _celebrationKey) return;
+    _celebrationKey = key;
+    _celebrationTimer?.cancel();
+
+    if (key == null) {
+      if (_celebrate && mounted) setState(() => _celebrate = false);
+      return;
+    }
+
+    if (mounted) setState(() => _celebrate = true);
+    _celebrationTimer = Timer(const Duration(seconds: 8), () {
+      if (mounted) setState(() => _celebrate = false);
+    });
   }
 
   void _startVideoTimer(String path) {
@@ -126,6 +157,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   void dispose() {
     _secondaryDisplayState?.removeListener(_onStateChanged);
     _secondaryDisplayState?.dispose();
+    _celebrationTimer?.cancel();
     _stopVideo();
     super.dispose();
   }
@@ -246,6 +278,11 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                 ),
                             ],
                           ),
+
+                        // Achievement panel (in-game): covers the game art.
+                        if (value.showAchievementPanel &&
+                            value.achievements != null)
+                          _buildAchievementPanel(value),
 
                         // Center Content
                         if (!value.isGameSelected)
@@ -530,6 +567,215 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
           fontFamily: 'Anta',
         ),
       ),
+    );
+  }
+
+  /// Renders the in-game RetroAchievements panel: a progress header plus an
+  /// unlocked-first grid of achievement badges. View-only (no gamepad input
+  /// reaches the secondary engine), so there is no selection/scroll affordance.
+  Widget _buildAchievementPanel(SecondaryDisplayStateData value) {
+    final achievements =
+        List<SecondaryAchievementItem>.from(value.achievements!)..sort((a, b) {
+          if (a.earned != b.earned) return a.earned ? -1 : 1;
+          return a.displayOrder.compareTo(b.displayOrder);
+        });
+
+    final newlyEarned = value.newlyEarnedIds?.toSet() ?? const <int>{};
+    final progress = value.raTotal > 0 ? value.raEarned / value.raTotal : 0.0;
+    final title = (value.raGameTitle != null && value.raGameTitle!.isNotEmpty)
+        ? value.raGameTitle!
+        : value.systemName;
+
+    return Positioned.fill(
+      child: Container(
+        // Opaque background so the underlying game screenshot doesn't bleed
+        // through; matches the secondary display's themed background color.
+        color: value.backgroundColor != null
+            ? Color(value.backgroundColor!)
+            : Colors.black,
+        padding: EdgeInsets.symmetric(horizontal: 24.r, vertical: 20.r),
+        child: Stack(
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Header: title + earned/total + points.
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Symbols.trophy_rounded,
+                      color: const Color(0xFFFFC107),
+                      size: 26.r,
+                    ),
+                    SizedBox(width: 10.r),
+                    Expanded(
+                      child: Text(
+                        title.toUpperCase(),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 18.r,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 1.5.r,
+                          fontFamily: 'Anta',
+                        ),
+                      ),
+                    ),
+                    SizedBox(width: 12.r),
+                    Text(
+                      '${value.raEarned}/${value.raTotal}',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 18.r,
+                        fontWeight: FontWeight.bold,
+                        fontFamily: 'Anta',
+                      ),
+                    ),
+                    SizedBox(width: 12.r),
+                    Text(
+                      '${value.raPoints}/${value.raPointsTotal}p',
+                      style: TextStyle(
+                        color: const Color(0xFFFFC107),
+                        fontSize: 16.r,
+                        fontWeight: FontWeight.bold,
+                        fontFamily: 'Anta',
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 12.r),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4.r),
+                  child: LinearProgressIndicator(
+                    value: progress.clamp(0.0, 1.0),
+                    minHeight: 6.r,
+                    backgroundColor: Colors.white10,
+                    valueColor: const AlwaysStoppedAnimation<Color>(
+                      Color(0xFFFFC107),
+                    ),
+                  ),
+                ),
+                SizedBox(height: 16.r),
+                // Badge grid. Unlocked-first; overflow is clipped (view-only).
+                Expanded(
+                  child: ClipRect(
+                    child: Wrap(
+                      spacing: 8.r,
+                      runSpacing: 8.r,
+                      children: [
+                        for (final a in achievements)
+                          _buildAchievementBadge(
+                            a,
+                            isNew: newlyEarned.contains(a.id),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+
+            // Celebration banner for freshly-earned achievements.
+            if (_celebrate && newlyEarned.isNotEmpty)
+              Align(
+                alignment: Alignment.topCenter,
+                child: Container(
+                  margin: EdgeInsets.only(top: 2.r),
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 20.r,
+                    vertical: 10.r,
+                  ),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFFFC107),
+                    borderRadius: BorderRadius.circular(20.r),
+                    boxShadow: [
+                      BoxShadow(
+                        color: const Color(0xFFFFC107).withValues(alpha: 0.5),
+                        blurRadius: 24.r,
+                      ),
+                    ],
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Symbols.celebration_rounded,
+                        color: Colors.black,
+                        size: 22.r,
+                      ),
+                      SizedBox(width: 8.r),
+                      Text(
+                        '+${newlyEarned.length} this session',
+                        style: TextStyle(
+                          color: Colors.black,
+                          fontSize: 16.r,
+                          fontWeight: FontWeight.bold,
+                          fontFamily: 'Anta',
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// A single achievement badge: full-color when earned, dimmed locked icon
+  /// otherwise, with a gold glow when earned during the current session.
+  Widget _buildAchievementBadge(
+    SecondaryAchievementItem a, {
+    required bool isNew,
+  }) {
+    final double size = 46.r;
+    final url = a.earned
+        ? 'https://media.retroachievements.org/Badge/${a.badgeName}.png'
+        : 'https://media.retroachievements.org/Badge/${a.badgeName}_lock.png';
+
+    Widget badge = ClipRRect(
+      borderRadius: BorderRadius.circular(8.r),
+      child: Image.network(
+        url,
+        width: size,
+        height: size,
+        fit: BoxFit.cover,
+        gaplessPlayback: true,
+        errorBuilder: (context, error, stackTrace) => Container(
+          width: size,
+          height: size,
+          color: Colors.white10,
+          child: Icon(
+            Symbols.trophy_rounded,
+            color: Colors.white24,
+            size: 24.r,
+          ),
+        ),
+      ),
+    );
+
+    if (!a.earned) {
+      badge = Opacity(opacity: 0.45, child: badge);
+    }
+
+    return Container(
+      decoration: isNew
+          ? BoxDecoration(
+              borderRadius: BorderRadius.circular(10.r),
+              border: Border.all(color: const Color(0xFFFFC107), width: 2.r),
+              boxShadow: [
+                BoxShadow(
+                  color: const Color(0xFFFFC107).withValues(alpha: 0.6),
+                  blurRadius: 12.r,
+                ),
+              ],
+            )
+          : null,
+      padding: EdgeInsets.all(isNew ? 2.r : 0),
+      child: badge,
     );
   }
 

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -262,7 +262,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                     ),
                                 child: Stack(
                                   key: ValueKey(
-                                    'game_content_${value.systemName}_${value.gameId}_${value.gameScreenshot ?? 'none'}_${value.gameImageBytes != null ? value.gameImageBytes.hashCode : 'none'}',
+                                    'game_content_${value.systemName}_${value.gameId}_${value.gameScreenshot ?? 'none'}_${value.gameFanart ?? 'none'}_${value.gameWheel ?? 'none'}_${value.gameImageBytes != null ? value.gameImageBytes.hashCode : 'none'}',
                                   ),
                                   fit: StackFit.expand,
                                   children: [
@@ -280,7 +280,9 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                             value.gameScreenshot!,
                                             fit: BoxFit
                                                 .contain, // "se debe ver completo"
-                                          ),
+                                          )
+                                        else if (value.gameFanart != null)
+                                          _buildFanartWithLogo(value),
                                       ] else ...[
                                         if (value.gameImageBytes != null)
                                           _buildBackgroundBytes(
@@ -293,7 +295,9 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                             value.gameScreenshot!,
                                             fit: BoxFit
                                                 .contain, // "se debe ver completo"
-                                          ),
+                                          )
+                                        else if (value.gameFanart != null)
+                                          _buildFanartWithLogo(value),
                                       ],
                                     ],
                                   ],
@@ -427,6 +431,31 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
 
   Widget _buildDefaultBackground() {
     return const SizedBox.shrink();
+  }
+
+  /// Mirrors the main screen's game art as a fallback when no screenshot or
+  /// video is available: fanart filling the screen (cover) with the game's
+  /// wheel/logo centered on top.
+  Widget _buildFanartWithLogo(SecondaryDisplayStateData value) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        _buildBackground(value.gameFanart!, fit: BoxFit.cover),
+        if (value.gameWheel != null)
+          Center(
+            child: Padding(
+              padding: EdgeInsets.all(48.r),
+              child: Image.file(
+                File(value.gameWheel!),
+                fit: BoxFit.contain,
+                width: 600.r,
+                errorBuilder: (context, error, stackTrace) =>
+                    const SizedBox.shrink(),
+              ),
+            ),
+          ),
+      ],
+    );
   }
 
   Widget _buildUnifiedAppBackground(SecondaryDisplayStateData value) {

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -476,14 +476,11 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   }
 
   Widget _buildSystemBackground(SecondaryDisplayStateData value) {
-    if (value.isOled) {
-      return Container(
-        color: value.backgroundColor != null
-            ? Color(value.backgroundColor!)
-            : Colors.black,
-      );
-    }
-
+    // Note: OLED is intentionally NOT short-circuited here. For a highlighted
+    // system the console artwork IS the background, so blacking it out would
+    // leave only the console name on screen. The black/background-color
+    // fallback below (via _buildShaderFallback) still applies when no system
+    // image is available, preserving the OLED look in the empty case.
     final bgPath = value.systemBackground;
     final hasBg = bgPath != null && bgPath.isNotEmpty;
 

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -30,6 +30,10 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   bool _celebrate = false;
   String? _celebrationKey;
 
+  /// Whether the achievement panel renders the list view (vs the badge grid).
+  /// Toggled by touch on the secondary screen; local to this engine.
+  bool _achievementListView = false;
+
   @override
   void initState() {
     super.initState();
@@ -643,6 +647,35 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                         fontFamily: 'Anta',
                       ),
                     ),
+                    SizedBox(width: 14.r),
+                    // Touch toggle: grid <-> list. Shows the icon of the view
+                    // you'll switch to. The bottom screen is touch-only since
+                    // the gamepad is driving the game on the main screen.
+                    GestureDetector(
+                      onTap: () {
+                        SfxService().playNavSound();
+                        setState(
+                          () => _achievementListView = !_achievementListView,
+                        );
+                      },
+                      child: Container(
+                        padding: EdgeInsets.all(8.r),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(10.r),
+                          border: Border.all(
+                            color: Colors.white.withValues(alpha: 0.2),
+                          ),
+                        ),
+                        child: Icon(
+                          _achievementListView
+                              ? Symbols.grid_view_rounded
+                              : Symbols.view_list_rounded,
+                          color: Colors.white,
+                          size: 22.r,
+                        ),
+                      ),
+                    ),
                   ],
                 ),
                 SizedBox(height: 12.r),
@@ -658,21 +691,24 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                   ),
                 ),
                 SizedBox(height: 16.r),
-                // Badge grid. Unlocked-first; overflow is clipped (view-only).
+                // Content: badge grid or list, both touch-scrollable. Unlocked
+                // achievements are sorted first.
                 Expanded(
-                  child: ClipRect(
-                    child: Wrap(
-                      spacing: 8.r,
-                      runSpacing: 8.r,
-                      children: [
-                        for (final a in achievements)
-                          _buildAchievementBadge(
-                            a,
-                            isNew: newlyEarned.contains(a.id),
+                  child: _achievementListView
+                      ? _buildAchievementListView(achievements, newlyEarned)
+                      : SingleChildScrollView(
+                          child: Wrap(
+                            spacing: 8.r,
+                            runSpacing: 8.r,
+                            children: [
+                              for (final a in achievements)
+                                _buildAchievementBadge(
+                                  a,
+                                  isNew: newlyEarned.contains(a.id),
+                                ),
+                            ],
                           ),
-                      ],
-                    ),
-                  ),
+                        ),
                 ),
               ],
             ),
@@ -722,6 +758,91 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
           ],
         ),
       ),
+    );
+  }
+
+  /// Touch-scrollable list of achievements: badge + title + description, with
+  /// points and an earned/locked indicator. Shows detail the grid can't.
+  Widget _buildAchievementListView(
+    List<SecondaryAchievementItem> achievements,
+    Set<int> newlyEarned,
+  ) {
+    return ListView.separated(
+      padding: EdgeInsets.only(bottom: 8.r),
+      itemCount: achievements.length,
+      separatorBuilder: (_, _) => SizedBox(height: 8.r),
+      itemBuilder: (context, i) {
+        final a = achievements[i];
+        final isNew = newlyEarned.contains(a.id);
+        return Container(
+          padding: EdgeInsets.all(8.r),
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: a.earned ? 0.08 : 0.03),
+            borderRadius: BorderRadius.circular(10.r),
+            border: isNew
+                ? Border.all(color: const Color(0xFFFFC107), width: 1.5.r)
+                : null,
+          ),
+          child: Row(
+            children: [
+              _buildAchievementBadge(a, isNew: false),
+              SizedBox(width: 12.r),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      a.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 15.r,
+                        fontWeight: FontWeight.w600,
+                        fontFamily: 'Anta',
+                      ),
+                    ),
+                    if (a.description.isNotEmpty) ...[
+                      SizedBox(height: 2.r),
+                      Text(
+                        a.description,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(color: Colors.white60, fontSize: 12.r),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              SizedBox(width: 10.r),
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    '${a.points}p',
+                    style: TextStyle(
+                      color: const Color(0xFFFFC107),
+                      fontSize: 13.r,
+                      fontWeight: FontWeight.bold,
+                      fontFamily: 'Anta',
+                    ),
+                  ),
+                  SizedBox(height: 4.r),
+                  Icon(
+                    a.earned
+                        ? Symbols.check_circle_rounded
+                        : Symbols.lock_rounded,
+                    color: a.earned ? const Color(0xFF66BB6A) : Colors.white24,
+                    size: 18.r,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -636,6 +636,16 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
 
     return Stack(
       children: [
+        // Opaque backdrop: while the two pages cross-fade they are both
+        // briefly translucent, so without this the game-art layer underneath
+        // the container would bleed through during the transition.
+        Positioned.fill(
+          child: ColoredBox(
+            color: value.backgroundColor != null
+                ? Color(value.backgroundColor!)
+                : Colors.black,
+          ),
+        ),
         Positioned.fill(
           child: AnimatedSwitcher(
             duration: const Duration(milliseconds: 300),

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -34,6 +34,13 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   /// Toggled by touch on the secondary screen; local to this engine.
   bool _achievementListView = false;
 
+  /// Which page of the in-game container is showing: 0 = Now Playing,
+  /// 1 = RetroAchievements. Local to this engine, flipped by the edge chevrons;
+  /// resets to 0 on each new launch.
+  int _inGamePanelPage = 0;
+  bool _wasNowPlayingActive = false;
+  String? _panelGameId;
+
   @override
   void initState() {
     super.initState();
@@ -53,6 +60,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     final state = _secondaryDisplayState?.value;
     if (state == null) return;
 
+    _maybeResetInGamePage(state);
     _maybeStartCelebration(state);
 
     if (state.isGameLaunching) {
@@ -93,10 +101,33 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
       return;
     }
 
-    if (mounted) setState(() => _celebrate = true);
+    // Surface the unlock: Now Playing is the default page, so jump to the
+    // achievements page (when present) where the celebration is visible.
+    final raAvailable =
+        state.showAchievementPanel && state.achievements != null;
+    if (mounted) {
+      setState(() {
+        _celebrate = true;
+        if (raAvailable) _inGamePanelPage = 1;
+      });
+    }
     _celebrationTimer = Timer(const Duration(seconds: 8), () {
       if (mounted) setState(() => _celebrate = false);
     });
+  }
+
+  /// Resets the in-game container to the Now Playing page (0) on each new
+  /// launch — detected by the session activating, or the game id changing while
+  /// it stays active.
+  void _maybeResetInGamePage(SecondaryDisplayStateData state) {
+    final freshLaunch =
+        state.nowPlayingActive &&
+        (!_wasNowPlayingActive || state.gameId != _panelGameId);
+    _wasNowPlayingActive = state.nowPlayingActive;
+    _panelGameId = state.gameId;
+    if (freshLaunch && _inGamePanelPage != 0 && mounted) {
+      setState(() => _inGamePanelPage = 0);
+    }
   }
 
   void _startVideoTimer(String path) {
@@ -283,35 +314,33 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                             ],
                           ),
 
-                        // Achievement panel (in-game): covers the game art,
-                        // fading in on launch and out on return.
+                        // In-game paged container: Now Playing (page 0) and,
+                        // when the game has a RetroAchievements set, the
+                        // achievements panel (page 1). Touch-paged via edge
+                        // chevrons; covers the game art, fading in on launch
+                        // and out on return.
                         Positioned.fill(
                           child: IgnorePointer(
-                            ignoring:
-                                !(value.showAchievementPanel &&
-                                    value.achievements != null),
+                            ignoring: !value.nowPlayingActive,
                             child: AnimatedSwitcher(
                               duration: const Duration(milliseconds: 400),
-                              child:
-                                  (value.showAchievementPanel &&
-                                      value.achievements != null)
+                              child: value.nowPlayingActive
                                   ? KeyedSubtree(
-                                      key: const ValueKey('ra-panel'),
-                                      child: _buildAchievementPanel(value),
+                                      key: const ValueKey('in-game-panel'),
+                                      child: _buildInGamePanel(value),
                                     )
                                   : const SizedBox.shrink(
-                                      key: ValueKey('ra-panel-empty'),
+                                      key: ValueKey('in-game-panel-empty'),
                                     ),
                             ),
                           ),
                         ),
 
                         // Center Content (system/recent-game logo). Suppressed
-                        // while the achievement panel is up so the logo doesn't
+                        // while the in-game container is up so the logo doesn't
                         // draw on top of it (recent-game launches push state
                         // with isGameSelected: false + the wheel as systemLogo).
-                        if (!value.isGameSelected &&
-                            !value.showAchievementPanel)
+                        if (!value.isGameSelected && !value.nowPlayingActive)
                           _buildCenterContent(
                             value,
                             isTab: value.useFluidShader,
@@ -594,6 +623,234 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
         ),
       ),
     );
+  }
+
+  /// The in-game container body: shows the Now Playing page or the
+  /// achievements page, with edge chevrons to flip between them when the game
+  /// has a RetroAchievements set. The page index is clamped so the RA page is
+  /// only shown when it actually exists.
+  Widget _buildInGamePanel(SecondaryDisplayStateData value) {
+    final raAvailable =
+        value.showAchievementPanel && value.achievements != null;
+    final page = (_inGamePanelPage == 1 && raAvailable) ? 1 : 0;
+
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 300),
+            transitionBuilder: (child, animation) =>
+                FadeTransition(opacity: animation, child: child),
+            child: KeyedSubtree(
+              key: ValueKey('in-game-page-$page'),
+              child: page == 1
+                  ? _buildAchievementPanel(value)
+                  : _buildNowPlayingPanel(value),
+            ),
+          ),
+        ),
+        // Edge chevrons: only meaningful when there are two pages. The chevron
+        // points toward the page it reveals (right on Now Playing, left on RA).
+        if (raAvailable && page == 0) _buildPageChevron(left: false),
+        if (raAvailable && page == 1) _buildPageChevron(left: true),
+      ],
+    );
+  }
+
+  /// A translucent circular chevron pinned to the left/right edge that flips
+  /// the in-game page. Styled like the mute toggle.
+  Widget _buildPageChevron({required bool left}) {
+    return Positioned(
+      left: left ? 12.r : null,
+      right: left ? null : 12.r,
+      top: 0,
+      bottom: 0,
+      child: Center(
+        child: GestureDetector(
+          onTap: () {
+            SfxService().playNavSound();
+            setState(() => _inGamePanelPage = left ? 0 : 1);
+          },
+          child: Container(
+            padding: EdgeInsets.all(8.r),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.55),
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: Colors.white.withValues(alpha: 0.15),
+                width: 1.r,
+              ),
+            ),
+            child: Icon(
+              left
+                  ? Symbols.chevron_left_rounded
+                  : Symbols.chevron_right_rounded,
+              color: Colors.white,
+              size: 30.r,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Renders the "Now Playing" page: boxart, title, system, total play time
+  /// and last-played. Shown for every launched game (page 0). View-only.
+  Widget _buildNowPlayingPanel(SecondaryDisplayStateData value) {
+    final title = (value.gameTitle != null && value.gameTitle!.isNotEmpty)
+        ? value.gameTitle!
+        : value.systemName;
+
+    return Container(
+      width: double.infinity,
+      height: double.infinity,
+      color: value.backgroundColor != null
+          ? Color(value.backgroundColor!)
+          : Colors.black,
+      padding: EdgeInsets.symmetric(horizontal: 44.r, vertical: 32.r),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          _buildNowPlayingBoxart(value.gameBoxart),
+          SizedBox(width: 32.r),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  'NOW PLAYING',
+                  style: TextStyle(
+                    color: const Color(0xFFFFC107),
+                    fontSize: 14.r,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 3.r,
+                  ),
+                ),
+                SizedBox(height: 12.r),
+                Text(
+                  title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 30.r,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                SizedBox(height: 8.r),
+                Text(
+                  value.systemName.toUpperCase(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: Colors.white70,
+                    fontSize: 16.r,
+                    letterSpacing: 1.5.r,
+                  ),
+                ),
+                SizedBox(height: 26.r),
+                _buildNowPlayingStat(
+                  icon: Symbols.schedule_rounded,
+                  label: 'PLAY TIME',
+                  text: _formatPlayTime(value.playTimeSeconds),
+                ),
+                SizedBox(height: 12.r),
+                _buildNowPlayingStat(
+                  icon: Symbols.history_rounded,
+                  label: 'LAST PLAYED',
+                  text: _formatLastPlayed(value.lastPlayedMillis),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNowPlayingBoxart(String? path) {
+    Widget placeholder() => Container(
+      width: 184.r,
+      height: 264.r,
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12.r),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+      ),
+      child: Icon(
+        Symbols.videogame_asset_rounded,
+        color: Colors.white24,
+        size: 64.r,
+      ),
+    );
+
+    if (path == null) return placeholder();
+    final file = File(path);
+    if (!file.existsSync()) return placeholder();
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12.r),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: 360.r, maxWidth: 200.r),
+        child: Image.file(
+          file,
+          fit: BoxFit.contain,
+          errorBuilder: (context, error, stackTrace) => placeholder(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNowPlayingStat({
+    required IconData icon,
+    required String label,
+    required String text,
+  }) {
+    return Row(
+      children: [
+        Icon(icon, color: Colors.white54, size: 20.r),
+        SizedBox(width: 10.r),
+        Text(
+          '$label  ',
+          style: TextStyle(
+            color: Colors.white54,
+            fontSize: 14.r,
+            letterSpacing: 1.r,
+          ),
+        ),
+        Text(
+          text,
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 16.r,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _formatPlayTime(int? seconds) {
+    if (seconds == null || seconds <= 0) return '—';
+    final h = seconds ~/ 3600;
+    final m = (seconds % 3600) ~/ 60;
+    if (h > 0) return '${h}h ${m}m';
+    if (m > 0) return '${m}m';
+    return '<1m';
+  }
+
+  String _formatLastPlayed(int? millis) {
+    if (millis == null) return 'Never';
+    final then = DateTime.fromMillisecondsSinceEpoch(millis);
+    final diff = DateTime.now().difference(then);
+    if (diff.inDays >= 1) {
+      final d = diff.inDays;
+      return d == 1 ? 'Yesterday' : '$d days ago';
+    }
+    if (diff.inHours >= 1) return '${diff.inHours}h ago';
+    if (diff.inMinutes >= 1) return '${diff.inMinutes}m ago';
+    return 'Just now';
   }
 
   /// Renders the in-game RetroAchievements panel: a progress header plus an

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -283,10 +283,28 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                             ],
                           ),
 
-                        // Achievement panel (in-game): covers the game art.
-                        if (value.showAchievementPanel &&
-                            value.achievements != null)
-                          _buildAchievementPanel(value),
+                        // Achievement panel (in-game): covers the game art,
+                        // fading in on launch and out on return.
+                        Positioned.fill(
+                          child: IgnorePointer(
+                            ignoring:
+                                !(value.showAchievementPanel &&
+                                    value.achievements != null),
+                            child: AnimatedSwitcher(
+                              duration: const Duration(milliseconds: 400),
+                              child:
+                                  (value.showAchievementPanel &&
+                                      value.achievements != null)
+                                  ? KeyedSubtree(
+                                      key: const ValueKey('ra-panel'),
+                                      child: _buildAchievementPanel(value),
+                                    )
+                                  : const SizedBox.shrink(
+                                      key: ValueKey('ra-panel-empty'),
+                                    ),
+                            ),
+                          ),
+                        ),
 
                         // Center Content
                         if (!value.isGameSelected)
@@ -590,173 +608,170 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
         ? value.raGameTitle!
         : value.systemName;
 
-    return Positioned.fill(
-      child: Container(
-        // Opaque background so the underlying game screenshot doesn't bleed
-        // through; matches the secondary display's themed background color.
-        color: value.backgroundColor != null
-            ? Color(value.backgroundColor!)
-            : Colors.black,
-        padding: EdgeInsets.symmetric(horizontal: 24.r, vertical: 20.r),
-        child: Stack(
-          children: [
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Header: title + earned/total + points.
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Icon(
-                      Symbols.trophy_rounded,
-                      color: const Color(0xFFFFC107),
-                      size: 26.r,
-                    ),
-                    SizedBox(width: 10.r),
-                    Expanded(
-                      child: Text(
-                        title.toUpperCase(),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 18.r,
-                          fontWeight: FontWeight.w600,
-                          letterSpacing: 1.5.r,
-                          fontFamily: 'Anta',
-                        ),
-                      ),
-                    ),
-                    SizedBox(width: 12.r),
-                    Text(
-                      '${value.raEarned}/${value.raTotal}',
+    return Container(
+      width: double.infinity,
+      height: double.infinity,
+      // Opaque background so the underlying game screenshot doesn't bleed
+      // through; matches the secondary display's themed background color.
+      color: value.backgroundColor != null
+          ? Color(value.backgroundColor!)
+          : Colors.black,
+      padding: EdgeInsets.symmetric(horizontal: 24.r, vertical: 20.r),
+      child: Stack(
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Header: title + earned/total + points.
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Icon(
+                    Symbols.trophy_rounded,
+                    color: const Color(0xFFFFC107),
+                    size: 26.r,
+                  ),
+                  SizedBox(width: 10.r),
+                  Expanded(
+                    child: Text(
+                      title.toUpperCase(),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                       style: TextStyle(
                         color: Colors.white,
                         fontSize: 18.r,
-                        fontWeight: FontWeight.bold,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: 1.5.r,
                         fontFamily: 'Anta',
                       ),
                     ),
-                    SizedBox(width: 12.r),
+                  ),
+                  SizedBox(width: 12.r),
+                  Text(
+                    '${value.raEarned}/${value.raTotal}',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 18.r,
+                      fontWeight: FontWeight.bold,
+                      fontFamily: 'Anta',
+                    ),
+                  ),
+                  SizedBox(width: 12.r),
+                  Text(
+                    '${value.raPoints}/${value.raPointsTotal}p',
+                    style: TextStyle(
+                      color: const Color(0xFFFFC107),
+                      fontSize: 16.r,
+                      fontWeight: FontWeight.bold,
+                      fontFamily: 'Anta',
+                    ),
+                  ),
+                  SizedBox(width: 14.r),
+                  // Touch toggle: grid <-> list. Shows the icon of the view
+                  // you'll switch to. The bottom screen is touch-only since
+                  // the gamepad is driving the game on the main screen.
+                  GestureDetector(
+                    onTap: () {
+                      SfxService().playNavSound();
+                      setState(
+                        () => _achievementListView = !_achievementListView,
+                      );
+                    },
+                    child: Container(
+                      padding: EdgeInsets.all(8.r),
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.1),
+                        borderRadius: BorderRadius.circular(10.r),
+                        border: Border.all(
+                          color: Colors.white.withValues(alpha: 0.2),
+                        ),
+                      ),
+                      child: Icon(
+                        _achievementListView
+                            ? Symbols.grid_view_rounded
+                            : Symbols.view_list_rounded,
+                        color: Colors.white,
+                        size: 22.r,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: 12.r),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4.r),
+                child: LinearProgressIndicator(
+                  value: progress.clamp(0.0, 1.0),
+                  minHeight: 6.r,
+                  backgroundColor: Colors.white10,
+                  valueColor: const AlwaysStoppedAnimation<Color>(
+                    Color(0xFFFFC107),
+                  ),
+                ),
+              ),
+              SizedBox(height: 16.r),
+              // Content: badge grid or list, both touch-scrollable. Unlocked
+              // achievements are sorted first.
+              Expanded(
+                child: _achievementListView
+                    ? _buildAchievementListView(achievements, newlyEarned)
+                    : SingleChildScrollView(
+                        child: Wrap(
+                          spacing: 8.r,
+                          runSpacing: 8.r,
+                          children: [
+                            for (final a in achievements)
+                              _buildAchievementBadge(
+                                a,
+                                isNew: newlyEarned.contains(a.id),
+                              ),
+                          ],
+                        ),
+                      ),
+              ),
+            ],
+          ),
+
+          // Celebration banner for freshly-earned achievements.
+          if (_celebrate && newlyEarned.isNotEmpty)
+            Align(
+              alignment: Alignment.topCenter,
+              child: Container(
+                margin: EdgeInsets.only(top: 2.r),
+                padding: EdgeInsets.symmetric(horizontal: 20.r, vertical: 10.r),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFFFC107),
+                  borderRadius: BorderRadius.circular(20.r),
+                  boxShadow: [
+                    BoxShadow(
+                      color: const Color(0xFFFFC107).withValues(alpha: 0.5),
+                      blurRadius: 24.r,
+                    ),
+                  ],
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Symbols.celebration_rounded,
+                      color: Colors.black,
+                      size: 22.r,
+                    ),
+                    SizedBox(width: 8.r),
                     Text(
-                      '${value.raPoints}/${value.raPointsTotal}p',
+                      '+${newlyEarned.length} this session',
                       style: TextStyle(
-                        color: const Color(0xFFFFC107),
+                        color: Colors.black,
                         fontSize: 16.r,
                         fontWeight: FontWeight.bold,
                         fontFamily: 'Anta',
                       ),
                     ),
-                    SizedBox(width: 14.r),
-                    // Touch toggle: grid <-> list. Shows the icon of the view
-                    // you'll switch to. The bottom screen is touch-only since
-                    // the gamepad is driving the game on the main screen.
-                    GestureDetector(
-                      onTap: () {
-                        SfxService().playNavSound();
-                        setState(
-                          () => _achievementListView = !_achievementListView,
-                        );
-                      },
-                      child: Container(
-                        padding: EdgeInsets.all(8.r),
-                        decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.1),
-                          borderRadius: BorderRadius.circular(10.r),
-                          border: Border.all(
-                            color: Colors.white.withValues(alpha: 0.2),
-                          ),
-                        ),
-                        child: Icon(
-                          _achievementListView
-                              ? Symbols.grid_view_rounded
-                              : Symbols.view_list_rounded,
-                          color: Colors.white,
-                          size: 22.r,
-                        ),
-                      ),
-                    ),
                   ],
                 ),
-                SizedBox(height: 12.r),
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(4.r),
-                  child: LinearProgressIndicator(
-                    value: progress.clamp(0.0, 1.0),
-                    minHeight: 6.r,
-                    backgroundColor: Colors.white10,
-                    valueColor: const AlwaysStoppedAnimation<Color>(
-                      Color(0xFFFFC107),
-                    ),
-                  ),
-                ),
-                SizedBox(height: 16.r),
-                // Content: badge grid or list, both touch-scrollable. Unlocked
-                // achievements are sorted first.
-                Expanded(
-                  child: _achievementListView
-                      ? _buildAchievementListView(achievements, newlyEarned)
-                      : SingleChildScrollView(
-                          child: Wrap(
-                            spacing: 8.r,
-                            runSpacing: 8.r,
-                            children: [
-                              for (final a in achievements)
-                                _buildAchievementBadge(
-                                  a,
-                                  isNew: newlyEarned.contains(a.id),
-                                ),
-                            ],
-                          ),
-                        ),
-                ),
-              ],
-            ),
-
-            // Celebration banner for freshly-earned achievements.
-            if (_celebrate && newlyEarned.isNotEmpty)
-              Align(
-                alignment: Alignment.topCenter,
-                child: Container(
-                  margin: EdgeInsets.only(top: 2.r),
-                  padding: EdgeInsets.symmetric(
-                    horizontal: 20.r,
-                    vertical: 10.r,
-                  ),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFFFC107),
-                    borderRadius: BorderRadius.circular(20.r),
-                    boxShadow: [
-                      BoxShadow(
-                        color: const Color(0xFFFFC107).withValues(alpha: 0.5),
-                        blurRadius: 24.r,
-                      ),
-                    ],
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        Symbols.celebration_rounded,
-                        color: Colors.black,
-                        size: 22.r,
-                      ),
-                      SizedBox(width: 8.r),
-                      Text(
-                        '+${newlyEarned.length} this session',
-                        style: TextStyle(
-                          color: Colors.black,
-                          fontSize: 16.r,
-                          fontWeight: FontWeight.bold,
-                          fontFamily: 'Anta',
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
               ),
-          ],
-        ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -306,8 +306,12 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                           ),
                         ),
 
-                        // Center Content
-                        if (!value.isGameSelected)
+                        // Center Content (system/recent-game logo). Suppressed
+                        // while the achievement panel is up so the logo doesn't
+                        // draw on top of it (recent-game launches push state
+                        // with isGameSelected: false + the wheel as systemLogo).
+                        if (!value.isGameSelected &&
+                            !value.showAchievementPanel)
                           _buildCenterContent(
                             value,
                             isTab: value.useFluidShader,

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -371,12 +371,18 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
         // Fired without awaiting so it never blocks the emulator handoff; it
         // lands during launchGameWithDialog's foreground window, overlaying the
         // recent game's art until the game exits.
+        final boxartPath = SecondaryAchievementsController.resolveBoxart(
+          systemInfo.gameModel!,
+          gameSystemModel.primaryFolderName,
+          fileProvider,
+        );
         // ignore: unawaited_futures
         _achievementsController.pushForLaunch(
           state: _secondaryDisplayState,
           provider: context.read<RetroAchievementsProvider>(),
           game: systemInfo.gameModel!,
           systemFolderName: gameSystemModel.primaryFolderName,
+          boxartPath: boxartPath,
         );
 
         await launchGameWithDialog(

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -22,6 +22,8 @@ import '../../game_screen/android_apps/android_apps_grid.dart';
 import 'package:neostation/sync/sync_manager.dart';
 import 'package:neostation/providers/neo_assets_provider.dart';
 import 'package:neostation/providers/palette_provider.dart';
+import 'package:neostation/providers/retro_achievements_provider.dart';
+import 'package:neostation/services/secondary_achievements_controller.dart';
 import '../../game_screen/my_games_list.dart';
 import '../../../widgets/shaders/shader_gif_widget.dart';
 import '../../../widgets/shaders/music_card_shader_background.dart';
@@ -75,6 +77,11 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
   bool _pullReady = false;
 
   SecondaryDisplayState? _secondaryDisplayState;
+
+  /// Drives the live RetroAchievements panel on the secondary display for games
+  /// launched directly from the "Recent Games" cards.
+  final SecondaryAchievementsController _achievementsController =
+      SecondaryAchievementsController();
 
   /// In-memory cache for resolved ID3v2 album art.
   Uint8List? _resolvedMusicCoverBytes;
@@ -158,6 +165,7 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
     _secondaryDisplayState?.removeListener(_onSecondaryStateChanged);
     _cleanupGamepad();
     _scrollController.dispose();
+    _achievementsController.dispose();
     _secondaryDisplayState?.dispose();
     super.dispose();
   }
@@ -359,6 +367,18 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
 
         final syncProvider = context.read<SyncManager>().active!;
 
+        // Push the in-game RetroAchievements panel to the secondary display.
+        // Fired without awaiting so it never blocks the emulator handoff; it
+        // lands during launchGameWithDialog's foreground window, overlaying the
+        // recent game's art until the game exits.
+        // ignore: unawaited_futures
+        _achievementsController.pushForLaunch(
+          state: _secondaryDisplayState,
+          provider: context.read<RetroAchievementsProvider>(),
+          game: systemInfo.gameModel!,
+          systemFolderName: gameSystemModel.primaryFolderName,
+        );
+
         await launchGameWithDialog(
           context: context,
           game: systemInfo.gameModel!,
@@ -366,6 +386,8 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
           fileProvider: fileProvider,
           syncProvider: syncProvider,
           onGameClosed: () {
+            // Stop the poll and hide the panel so it fades back to the art.
+            _achievementsController.stop(hidePanel: true);
             if (mounted) setState(() => _isGameLaunching = false);
             _gamepadNav.activate();
             Provider.of<SqliteDatabaseProvider>(
@@ -374,6 +396,7 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
             ).refresh();
           },
           onLaunchFailed: (ctx, r) async {
+            _achievementsController.stop(hidePanel: true);
             if (mounted) setState(() => _isGameLaunching = false);
             _gamepadNav.activate();
           },

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -33,6 +33,8 @@ import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/models/secondary_display_state.dart';
 import 'package:neostation/providers/neo_assets_provider.dart';
 import 'package:neostation/providers/system_background_provider.dart';
+import 'package:neostation/providers/retro_achievements_provider.dart';
+import 'package:neostation/services/secondary_achievements_controller.dart';
 import 'system_list_builder.dart';
 
 /// Primary widget for the 'My Systems' view, supporting both Grid and Carousel layouts.
@@ -512,6 +514,21 @@ class MySystems extends StatelessWidget {
           context.read<SystemBackgroundProvider>().clear();
         }
 
+        // Drive the in-game RetroAchievements panel on the secondary display.
+        // This launch path lives on the stateless [MySystems] widget, so the
+        // controller is scoped to this session: the periodic poll keeps itself
+        // alive via the event loop, and the onGameClosed/onLaunchFailed
+        // callbacks stop it. The app-lifetime shared state lives on the config
+        // provider (the grid/footer have no per-widget instance of their own).
+        final achievementsController = SecondaryAchievementsController();
+        // ignore: unawaited_futures
+        achievementsController.pushForLaunch(
+          state: configProvider.secondaryDisplayState,
+          provider: context.read<RetroAchievementsProvider>(),
+          game: systemInfo.gameModel!,
+          systemFolderName: gameSystemModel.primaryFolderName,
+        );
+
         await launchGameWithDialog(
           context: context,
           game: systemInfo.gameModel!,
@@ -519,6 +536,8 @@ class MySystems extends StatelessWidget {
           fileProvider: fileProvider,
           syncProvider: syncProvider,
           onGameClosed: () {
+            // Stop the poll and hide the panel so it fades back to the art.
+            achievementsController.stop(hidePanel: true);
             MySystems.gridLaunchNotifier.value = false;
             GamepadNavigationManager.reactivate();
             Provider.of<SqliteDatabaseProvider>(
@@ -527,6 +546,7 @@ class MySystems extends StatelessWidget {
             ).refresh();
           },
           onLaunchFailed: (ctx, r) async {
+            achievementsController.stop(hidePanel: true);
             MySystems.gridLaunchNotifier.value = false;
             GamepadNavigationManager.reactivate();
           },

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -527,6 +527,11 @@ class MySystems extends StatelessWidget {
           provider: context.read<RetroAchievementsProvider>(),
           game: systemInfo.gameModel!,
           systemFolderName: gameSystemModel.primaryFolderName,
+          boxartPath: SecondaryAchievementsController.resolveBoxart(
+            systemInfo.gameModel!,
+            gameSystemModel.primaryFolderName,
+            fileProvider,
+          ),
         );
 
         await launchGameWithDialog(

--- a/lib/services/retro_achievements_resolver.dart
+++ b/lib/services/retro_achievements_resolver.dart
@@ -192,6 +192,7 @@ class RetroAchievementsResolver {
         return SecondaryAchievementItem(
           id: a.id,
           title: a.title,
+          description: a.description,
           points: a.points,
           badgeName: a.badgeName,
           displayOrder: a.displayOrder,

--- a/lib/services/retro_achievements_resolver.dart
+++ b/lib/services/retro_achievements_resolver.dart
@@ -1,0 +1,231 @@
+import 'dart:io';
+
+import '../models/game_model.dart';
+import '../models/retro_achievements_summary.dart';
+import '../models/secondary_achievement_item.dart';
+import '../providers/retro_achievements_provider.dart';
+import '../repositories/retro_achievements_repository.dart';
+import 'logger_service.dart';
+import 'retroachievements_hash_service.dart';
+
+/// A condensed snapshot of a game's RetroAchievements progress, ready to be
+/// pushed to the secondary display.
+class SecondaryAchievementsSnapshot {
+  /// RetroAchievements internal game id.
+  final int gameId;
+
+  /// Standardized game title from RA.
+  final String gameTitle;
+
+  /// Achievements for the game (unsorted; the panel sorts unlocked-first).
+  final List<SecondaryAchievementItem> achievements;
+
+  /// Number of achievements the user has earned.
+  final int earned;
+
+  /// Total number of achievements available for the game.
+  final int total;
+
+  /// Points the user has earned.
+  final int points;
+
+  /// Total points available for the game.
+  final int pointsTotal;
+
+  /// User completion percentage string (e.g. '50.00%').
+  final String completionPct;
+
+  const SecondaryAchievementsSnapshot({
+    required this.gameId,
+    required this.gameTitle,
+    required this.achievements,
+    required this.earned,
+    required this.total,
+    required this.points,
+    required this.pointsTotal,
+    required this.completionPct,
+  });
+
+  /// The set of achievement ids the user has earned, for session-diffing.
+  Set<int> get earnedIds =>
+      achievements.where((a) => a.earned).map((a) => a.id).toSet();
+}
+
+/// Resolves a local [GameModel] to its RetroAchievements game id and fetches a
+/// condensed progress snapshot for the secondary display.
+///
+/// The resolution strategy mirrors the one used by the game-details
+/// achievements view (`game_details_card_list.dart`): exact MD5-hash match
+/// against the local RA database, then a sanitized-filename lookup, then a
+/// heuristic match against the user's recently-played history. The underlying
+/// hashing and database lookups are reused from [RetroAchievementsHashService]
+/// and [RetroAchievementsRepository].
+class RetroAchievementsResolver {
+  static final _log = LoggerService.instance;
+
+  /// Maximum ROM size for which a fallback MD5 hash is generated, mirroring the
+  /// limit applied in the game-details achievements flow.
+  static const int _maxHashFileSize = 512 * 1024 * 1024;
+
+  /// Resolves the MD5 hash used for RA matching, generating one if absent.
+  static Future<String?> resolveMd5Hash(
+    GameModel game, {
+    required bool hasSpecificGenerator,
+  }) async {
+    var md5Hash = game.raHash;
+    if (md5Hash != null && md5Hash.isNotEmpty) return md5Hash;
+
+    if (hasSpecificGenerator) {
+      // Core systems (e.g. PSX, GBA): always generate for precise matching.
+      return RetroAchievementsHashService.generateHashForGame(game);
+    }
+
+    // Fallback systems: only hash reasonably sized files to keep launch snappy.
+    final romPath = game.romPath;
+    if (romPath == null) return null;
+    final file = File(romPath);
+    if (!await file.exists()) return null;
+    if (await file.length() >= _maxHashFileSize) return null;
+    return RetroAchievementsHashService.generateHashForGame(game);
+  }
+
+  /// Resolves the RA game id for [game] using hash, filename, then history.
+  static Future<int?> resolveGameId({
+    required GameModel game,
+    required String systemFolderName,
+    required RetroAchievementsUserSummary? summary,
+    required bool hasSpecificGenerator,
+    String? md5Hash,
+  }) async {
+    // Strategy 1: exact hash match against the local RA database.
+    if (md5Hash != null && md5Hash.isNotEmpty) {
+      try {
+        final gameId = await RetroAchievementsRepository.findGameIdByHash(
+          md5Hash,
+        );
+        if (gameId != null && gameId != 0) return gameId;
+      } catch (e) {
+        _log.e('RA resolver: hash lookup failed: $e');
+      }
+    }
+
+    // Hash-specific systems must match by hash only to avoid false positives.
+    if (hasSpecificGenerator) return null;
+
+    // Strategy 2: sanitized filename match.
+    try {
+      var filename = game.romname.contains('.')
+          ? game.romname.substring(0, game.romname.lastIndexOf('.'))
+          : game.romname;
+      filename = filename
+          .replaceAll(RegExp(r'\([^)]*\)'), '')
+          .replaceAll(RegExp(r'\[[^\]]*\]'), '')
+          .trim();
+
+      final gameId = await RetroAchievementsRepository.findGameIdByFilename(
+        systemFolderName,
+        filename,
+      );
+      if (gameId != null && gameId != 0) return gameId;
+    } catch (e) {
+      _log.e('RA resolver: filename lookup failed: $e');
+    }
+
+    // Strategy 3: heuristic match against recently-played history.
+    try {
+      final normalizedLocal = _normalize(game.name);
+      for (final recent in summary?.recentlyPlayed ?? const []) {
+        if (_normalize(recent.title) == normalizedLocal) {
+          return recent.gameId;
+        }
+      }
+    } catch (e) {
+      _log.e('RA resolver: history lookup failed: $e');
+    }
+
+    return null;
+  }
+
+  /// Resolves and fetches a condensed achievements snapshot for [game].
+  ///
+  /// Returns null when RA is disconnected, the game cannot be matched, or no
+  /// achievement data is available. Reuses the provider's in-memory cache.
+  static Future<SecondaryAchievementsSnapshot?> fetchSnapshot({
+    required GameModel game,
+    required String systemFolderName,
+    required RetroAchievementsProvider provider,
+    bool forceRefresh = false,
+  }) async {
+    if (!provider.isConnected) return null;
+
+    try {
+      final hasSpecificGenerator =
+          RetroAchievementsHashService.hasSpecificHashGenerator(
+            game.systemFolderName,
+          );
+      final md5Hash = await resolveMd5Hash(
+        game,
+        hasSpecificGenerator: hasSpecificGenerator,
+      );
+      final gameId = await resolveGameId(
+        game: game,
+        systemFolderName: systemFolderName,
+        summary: provider.userSummary,
+        hasSpecificGenerator: hasSpecificGenerator,
+        md5Hash: md5Hash,
+      );
+      if (gameId == null) return null;
+
+      final info = await provider.getGameInfoAndUserProgress(
+        gameId,
+        forceRefresh: forceRefresh,
+        md5Hash: md5Hash,
+      );
+      if (info == null || info.achievements.isEmpty) return null;
+
+      final items = info.achievements.values.map((a) {
+        final earnedHardcore =
+            a.dateEarnedHardcore != null && a.dateEarnedHardcore!.isNotEmpty;
+        final earned =
+            earnedHardcore ||
+            (a.dateEarned != null && a.dateEarned!.isNotEmpty);
+        return SecondaryAchievementItem(
+          id: a.id,
+          title: a.title,
+          points: a.points,
+          badgeName: a.badgeName,
+          displayOrder: a.displayOrder,
+          earned: earned,
+          earnedHardcore: earnedHardcore,
+        );
+      }).toList();
+
+      final pointsTotal = items.fold<int>(0, (sum, a) => sum + a.points);
+      final pointsEarned = items
+          .where((a) => a.earned)
+          .fold<int>(0, (sum, a) => sum + a.points);
+
+      return SecondaryAchievementsSnapshot(
+        gameId: gameId,
+        gameTitle: info.title,
+        achievements: items,
+        earned: info.numAwardedToUser,
+        total: info.numAchievements,
+        points: pointsEarned,
+        pointsTotal: pointsTotal,
+        completionPct: info.userCompletion,
+      );
+    } catch (e) {
+      _log.e('RA resolver: failed to fetch snapshot for ${game.name}: $e');
+      return null;
+    }
+  }
+
+  static String _normalize(String value) {
+    return value
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^\w\s]'), '')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+  }
+}

--- a/lib/services/secondary_achievements_controller.dart
+++ b/lib/services/secondary_achievements_controller.dart
@@ -177,16 +177,19 @@ class SecondaryAchievementsController {
     _pollTimer = null;
   }
 
-  /// Stops the live poll when the game exits. When [hidePanel] is true the
-  /// panel is hidden here (it fades back to whatever art is underneath); leave
-  /// it false when the host re-pushes full display state itself.
+  /// Stops the live poll when the game exits. The in-game container is always
+  /// retired here (the session is over), so [nowPlayingActive] is cleared
+  /// unconditionally. When [hidePanel] is true the RA panel is also hidden here
+  /// (it fades back to whatever art is underneath); leave it false when the host
+  /// re-pushes full display state itself.
   void stop({bool hidePanel = false}) {
     _stopPoll();
     _gameId = null;
-    if (hidePanel) {
-      // ignore: unawaited_futures
-      _state?.updateState(showAchievementPanel: false, nowPlayingActive: false);
-    }
+    // ignore: unawaited_futures
+    _state?.updateState(
+      nowPlayingActive: false,
+      showAchievementPanel: hidePanel ? false : null,
+    );
   }
 
   void dispose() => stop();

--- a/lib/services/secondary_achievements_controller.dart
+++ b/lib/services/secondary_achievements_controller.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import '../models/game_model.dart';
 import '../models/secondary_display_state.dart';
+import '../providers/file_provider.dart';
 import '../providers/retro_achievements_provider.dart';
 import 'retro_achievements_resolver.dart';
 
@@ -27,6 +28,18 @@ class SecondaryAchievementsController {
   /// little; this keeps the panel current without hammering the API.
   static const Duration pollInterval = Duration(seconds: 30);
 
+  /// Resolves a launched game's boxart for the "Now Playing" page, returning
+  /// null when no file exists ([GameModel.getImagePath] otherwise falls back to
+  /// a non-existent path). Static so every launch site shares one resolution.
+  static String? resolveBoxart(
+    GameModel game,
+    String systemFolderName,
+    FileProvider fileProvider,
+  ) {
+    final path = game.getImagePath(systemFolderName, 'box2d', fileProvider);
+    return (path.isNotEmpty && File(path).existsSync()) ? path : null;
+  }
+
   SecondaryDisplayState? _state;
   RetroAchievementsProvider? _provider;
   GameModel? _game;
@@ -46,6 +59,7 @@ class SecondaryAchievementsController {
     required RetroAchievementsProvider provider,
     required GameModel game,
     required String systemFolderName,
+    String? boxartPath,
   }) async {
     if (!Platform.isAndroid || state == null) return;
 
@@ -57,6 +71,22 @@ class SecondaryAchievementsController {
     _preGameEarnedIds = <int>{};
 
     if (!_active) return;
+
+    // Show the "Now Playing" page immediately for every launched game — this
+    // is independent of RetroAchievements, needs no network, and is the first
+    // page the secondary display shows. The RA fetch below may then add the
+    // achievements page on top.
+    // ignore: unawaited_futures
+    state.updateState(
+      nowPlayingActive: true,
+      gameTitle: game.name,
+      gameBoxart: boxartPath,
+      clearGameBoxart: boxartPath == null,
+      playTimeSeconds: game.playTime,
+      clearPlayTimeSeconds: game.playTime == null,
+      lastPlayedMillis: game.lastPlayed?.millisecondsSinceEpoch,
+      clearLastPlayed: game.lastPlayed == null,
+    );
 
     // Startup auto-login is async; on a quick launch straight from the systems/
     // recent screen it may still be in flight. Give it a short grace period
@@ -155,7 +185,7 @@ class SecondaryAchievementsController {
     _gameId = null;
     if (hidePanel) {
       // ignore: unawaited_futures
-      _state?.updateState(showAchievementPanel: false);
+      _state?.updateState(showAchievementPanel: false, nowPlayingActive: false);
     }
   }
 

--- a/lib/services/secondary_achievements_controller.dart
+++ b/lib/services/secondary_achievements_controller.dart
@@ -1,0 +1,163 @@
+import 'dart:async';
+import 'dart:io';
+
+import '../models/game_model.dart';
+import '../models/secondary_display_state.dart';
+import '../providers/retro_achievements_provider.dart';
+import 'retro_achievements_resolver.dart';
+
+/// Drives the live RetroAchievements panel on the secondary display for a
+/// single game session, independent of which screen launched the game.
+///
+/// The same flow is needed from several launch sites (the per-system games
+/// list and the "Recent Games" cards on the systems carousel/grid), so the
+/// orchestration lives here rather than being duplicated per screen:
+///   * [pushForLaunch] resolves the game's RA progress, pushes the panel to the
+///     secondary display, and snapshots the earned ids for the session diff.
+///   * a 30s timer re-fetches progress while the emulator is foregrounded, so
+///     unlocks earned mid-game surface on the bottom screen (verified to keep
+///     repainting while NeoStation is backgrounded).
+///   * [stop] ends the poll when the game exits.
+///
+/// Everything is a no-op off Android, when there is no active secondary
+/// display, when RA is disconnected, or when the game has no achievement set.
+class SecondaryAchievementsController {
+  /// Poll interval for live in-game RA progress. RA only reflects an unlock
+  /// after the emulator submits it server-side, so finer granularity buys
+  /// little; this keeps the panel current without hammering the API.
+  static const Duration pollInterval = Duration(seconds: 30);
+
+  SecondaryDisplayState? _state;
+  RetroAchievementsProvider? _provider;
+  GameModel? _game;
+  String? _systemFolderName;
+
+  int? _gameId;
+  Set<int> _preGameEarnedIds = <int>{};
+  Timer? _pollTimer;
+
+  bool get _active => _state?.value?.isSecondaryActive ?? false;
+
+  /// Resolves and pushes the launched game's achievement panel to the secondary
+  /// display, snapshotting earned ids for the session diff, then starts the
+  /// live poll. Safe to fire-and-forget; it never throws into the launch path.
+  Future<void> pushForLaunch({
+    required SecondaryDisplayState? state,
+    required RetroAchievementsProvider provider,
+    required GameModel game,
+    required String systemFolderName,
+  }) async {
+    if (!Platform.isAndroid || state == null) return;
+
+    _state = state;
+    _provider = provider;
+    _game = game;
+    _systemFolderName = systemFolderName;
+    _gameId = null;
+    _preGameEarnedIds = <int>{};
+
+    if (!_active) return;
+
+    // Startup auto-login is async; on a quick launch straight from the systems/
+    // recent screen it may still be in flight. Give it a short grace period
+    // rather than bailing immediately. The push is fired unawaited and the
+    // secondary display keeps repainting while backgrounded, so a late push
+    // still lands.
+    for (var i = 0; i < 10 && !provider.isConnected; i++) {
+      await Future.delayed(const Duration(milliseconds: 500));
+    }
+    if (!provider.isConnected) return;
+
+    final snapshot = await RetroAchievementsResolver.fetchSnapshot(
+      game: game,
+      systemFolderName: systemFolderName,
+      provider: provider,
+    );
+    if (snapshot == null) return;
+
+    _gameId = snapshot.gameId;
+    _preGameEarnedIds = snapshot.earnedIds;
+
+    // ignore: unawaited_futures
+    state.updateState(
+      showAchievementPanel: true,
+      achievements: snapshot.achievements,
+      raEarned: snapshot.earned,
+      raTotal: snapshot.total,
+      raPoints: snapshot.points,
+      raPointsTotal: snapshot.pointsTotal,
+      raCompletionPct: snapshot.completionPct,
+      raGameTitle: snapshot.gameTitle,
+      clearNewlyEarnedIds: true,
+    );
+
+    _startPoll();
+  }
+
+  void _startPoll() {
+    if (!Platform.isAndroid) return;
+    _pollTimer?.cancel();
+    _pollTimer = Timer.periodic(pollInterval, (_) => _onTick());
+  }
+
+  Future<void> _onTick() async {
+    final state = _state;
+    final provider = _provider;
+    final game = _game;
+    final folder = _systemFolderName;
+    if (state == null ||
+        provider == null ||
+        game == null ||
+        folder == null ||
+        _gameId == null ||
+        !_active) {
+      _stopPoll();
+      return;
+    }
+    if (!provider.isConnected) return;
+
+    final snapshot = await RetroAchievementsResolver.fetchSnapshot(
+      game: game,
+      systemFolderName: folder,
+      provider: provider,
+      forceRefresh: true,
+    );
+    // Keep _preGameEarnedIds anchored to launch so the diff covers the whole
+    // session (both for the live highlight and the return celebration).
+    if (snapshot == null || _gameId == null) return;
+    final newly = snapshot.earnedIds.difference(_preGameEarnedIds).toList();
+
+    // ignore: unawaited_futures
+    state.updateState(
+      showAchievementPanel: true,
+      achievements: snapshot.achievements,
+      raEarned: snapshot.earned,
+      raTotal: snapshot.total,
+      raPoints: snapshot.points,
+      raPointsTotal: snapshot.pointsTotal,
+      raCompletionPct: snapshot.completionPct,
+      raGameTitle: snapshot.gameTitle,
+      newlyEarnedIds: newly.isEmpty ? null : newly,
+      clearNewlyEarnedIds: newly.isEmpty,
+    );
+  }
+
+  void _stopPoll() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  /// Stops the live poll when the game exits. When [hidePanel] is true the
+  /// panel is hidden here (it fades back to whatever art is underneath); leave
+  /// it false when the host re-pushes full display state itself.
+  void stop({bool hidePanel = false}) {
+    _stopPoll();
+    _gameId = null;
+    if (hidePanel) {
+      // ignore: unawaited_futures
+      _state?.updateState(showAchievementPanel: false);
+    }
+  }
+
+  void dispose() => stop();
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

On the secondary (bottom) display, highlighting a console mirrors its
artwork for every palette except OLED, where the screen went fully black
with only the console name showing. This fixes the OLED palette to render
console art like the others.

Closes #62

## Root cause

The OLED palette is meant to suppress *decorative ambient backgrounds* in
favor of pure black — not to hide content artwork. That's how it behaves
everywhere else: the `if (!isOled)` guards on the main screen drop only an
ambient fluid-gradient layer while still rendering game/console art, and the
secondary screen's game layer (screenshots/fanart) already renders under OLED.

The secondary screen has two background builders sharing the identical
`if (value.isOled) return Container(color: ...)` snippet:

- `_buildUnifiedAppBackground` — **correct**: this is the app/menu background
  (a decorative layer); content layers draw on top of it.
- `_buildSystemBackground` — **wrong**: here the "background" *is* the
  highlighted console's content artwork. The copy-pasted OLED gate returned a
  solid container immediately, so the artwork was never built — only the
  console name (a separate center layer) remained.

So this was an over-application of the OLED "pure black" rule to a function
where the background carries content.

## Fix

Remove the OLED short-circuit in `_buildSystemBackground` so the system art
renders under OLED too, realigning the secondary screen with how OLED already
behaves on the main screen and for games. The black fallback
(`_buildShaderFallback`) still applies when a system has no image, preserving
the OLED look in the empty case. `_buildUnifiedAppBackground` is left intact.

## Testing

- `flutter analyze lib/screens/secondary_screen/secondary_screen.dart` — clean.
- Built and installed on an AYN Thor; confirmed the OLED palette now shows
  console artwork on the secondary display.
