### PR TITLE
fix(test): repair box2d_aspect_ratio fixture drift and run tests in CI

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   lint:
-    name: Lint & Analysis
+    name: Lint, Analysis & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -30,6 +30,9 @@ jobs:
 
       - name: Analyze project
         run: flutter analyze
+
+      - name: Run tests
+        run: flutter test
 
   build:
     name: Build ${{ matrix.target }}

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -82,7 +82,8 @@ class DatabaseTestHelper {
         created_at TEXT,
         updated_at TEXT,
         app_emulator_unique_id TEXT,
-        app_emulator_os_id INTEGER
+        app_emulator_os_id INTEGER,
+        box2d_aspect_ratio TEXT
       )
     ''');
 


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

Two favorites tests have been red on `main` since 2026-05-27. The `user_roms` table in `test/database_test_helper.dart` was never updated when `fb727d0` added the `box2d_aspect_ratio` column to the production schema and to the `getFavoriteGames` query, so those tests failed with `no such column: ur.box2d_aspect_ratio`.

This PR fixes the fixture and adds a `flutter test` step to CI so the suite can't silently rot again.

## Changes

- **`test: add box2d_aspect_ratio column to test DB fixture`** — adds the missing `box2d_aspect_ratio TEXT` column to the `user_roms` fixture so it matches the real `CREATE TABLE`. Full suite green again (113 passing).
- **`ci: run flutter test in the lint job`** — adds a `flutter test` step to the Lint & Analysis job. The build job already gates on `needs: lint`, so a test failure now blocks build and deploy.

## Affected tests (now passing)

- `game_repository_test.dart` — `getFavoriteGames excludes android and music`
- `game_service_test.dart` — `loadGamesForSystem (favorites)`

## Test plan

- [x] `flutter test` — 113 passing locally
- [x] `flutter analyze` — clean