### PR TITLE
fix: exclude virtual 'all'/'favorites' groups from "systems found" count

### DIFF
--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -72,6 +72,17 @@ class SqliteConfigProvider extends ChangeNotifier {
   // Getters
   ConfigModel get config => _config;
   List<SystemModel> get detectedSystems => _detectedSystems;
+
+  /// Detected systems excluding virtual aggregate groups (e.g. 'all',
+  /// 'favorites'), which are not real systems and would inflate any
+  /// "X systems found" count shown to the user.
+  List<SystemModel> get detectedRealSystems => _detectedSystems
+      .where(
+        (s) =>
+            s.folderName != SystemFolderNames.all &&
+            s.folderName != SystemFolderNames.favorites,
+      )
+      .toList();
   List<SystemModel> get availableSystems => _availableSystems;
   Map<String, EmulatorModel> get availableEmulators => _availableEmulators;
   bool get isLoading => _isLoading;

--- a/lib/screens/systems_screen/my_systems_section/initial_setup_widget.dart
+++ b/lib/screens/systems_screen/my_systems_section/initial_setup_widget.dart
@@ -311,7 +311,7 @@ class InitialSetupWidget extends StatelessWidget {
                 .getString(context)
                 .replaceFirst(
                   '{count}',
-                  configProvider.detectedSystems.length.toString(),
+                  configProvider.detectedRealSystems.length.toString(),
                 ),
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               color: Theme.of(

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -881,7 +881,7 @@ class _SetupWizardState extends State<SetupWizard> {
                       SizedBox(width: 12.r),
                       Expanded(
                         child: Text(
-                          '${AppLocale.foundSystemsWithGames.getString(context).replaceFirst('{count}', provider.detectedSystems.length.toString())}\n${AppLocale.tapFinishToStart.getString(context)}',
+                          '${AppLocale.foundSystemsWithGames.getString(context).replaceFirst('{count}', provider.detectedRealSystems.length.toString())}\n${AppLocale.tapFinishToStart.getString(context)}',
                           style: TextStyle(
                             fontSize: textSize,
                             color: Colors.green[700],

--- a/lib/widgets/system_scan_progress_widget.dart
+++ b/lib/widgets/system_scan_progress_widget.dart
@@ -114,7 +114,7 @@ class SystemScanProgressWidget extends StatelessWidget {
                       .getString(context)
                       .replaceFirst(
                         '{count}',
-                        configProvider.detectedSystems.length.toString(),
+                        configProvider.detectedRealSystems.length.toString(),
                       ),
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Theme.of(context).colorScheme.onSurface,


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

The "systems found" counts shown to the user were inflated because they counted the virtual aggregate groups (`all`, and `favorites` when present) as real systems. After a ROM scan, the scan's second/third passes append `all` (and `favorites` if there are favorited games) to `detectedSystems`, persist them, and reload them on every launch — so any `detectedSystems.length` count was off by one or two.

This adds a `detectedRealSystems` getter on `SqliteConfigProvider` that filters out the `all`/`favorites` aggregate groups, and points all three user-facing count displays at it.

## Why a name-based filter (not `isVirtual`/`type`)

The system JSON marks many systems `"type": "virtual"` — including **mame, scummvm, rpgmaker, android, music, steam, epic, gog, amazon** — most of which are real library categories with their own games. Filtering on that flag would wrongly drop mame/scummvm/rpgmaker. Only `all` and `favorites` are genuine cross-cutting aggregates, so those two names are the correct discriminator. (`SystemModel.isVirtual` is also moot: it reads `is_virtual` keys that don't exist in the JSON, so it's always false.)

## Changes

- **`lib/providers/sqlite_config_provider.dart`** — new `detectedRealSystems` getter excluding `all`/`favorites`.
- **`lib/widgets/setup_wizard.dart`** — "Found {count} systems with games!"
- **`lib/screens/systems_screen/my_systems_section/initial_setup_widget.dart`** — "Found {count} systems in your ROM folder."
- **`lib/widgets/system_scan_progress_widget.dart`** — "{count} systems detected" (shown during/after scan).

All three sites read the same backing list, so all three were inflated — only the setup wizard was reported, but the systems-screen header and scan-progress text had the same bug.

The scan *progress denominator* (`_totalSystemsToScan`) is intentionally left unchanged — it tracks what is actually scanned, not a "found" count.

## Notes / scope

- `all` is only appended when ≥1 real emulator system has games, so virtual-only libraries never showed the inflation.
- `favorites` is excluded too (off-by-two when favorited games exist), not just `all`.

## Testing

- `flutter analyze` clean on all changed files.
- On-device validation recommended (SAF path scanning differs from desktop); the wizard count was confirmed wrong before the fix.
