### PR TITLE
fix(startup): don't gate ROM scan behind network update checks

### DIFF
--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -85,7 +85,10 @@ class SqliteConfigProvider extends ChangeNotifier {
       .toList();
   List<SystemModel> get availableSystems => _availableSystems;
   Map<String, EmulatorModel> get availableEmulators => _availableEmulators;
-  bool get isLoading => _isLoading;
+  // Treat a deferred startup scan as a loading state so the home screen shows a
+  // spinner — not a blank screen — between initialization completing and the
+  // scan actually starting (see fix/cold-boot-empty-home).
+  bool get isLoading => _isLoading || _pendingStartupScan;
   bool get isScanning => _isScanning;
   String? get error => _error;
   bool get isScanningRoms => _isScanningRoms;

--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -150,30 +150,38 @@ class AppScreenState extends State<AppScreen> {
   Future<void> _performUpdateSequence(
     SqliteConfigProvider configProvider,
   ) async {
-    bool systemsUpdated = false;
+    // Fire the deferred startup scan IMMEDIATELY — it must never be gated behind
+    // the network update checks below. On a freshly rebooted device the network
+    // is often not up yet, so awaiting those checks (each guarded by ~10s
+    // timeouts) left the Systems tab completely blank until they timed out. The
+    // scan flips isScanning/isLoading, so the user sees a spinner then content.
+    final startupScanPending = configProvider.consumeStartupScan();
+    Future<void>? initialScan;
+    if (startupScanPending && configProvider.hasRomFolder && mounted) {
+      initialScan = configProvider.scanSystems();
+    }
 
+    unawaited(_fixRetroarchAndroidDefault());
+
+    // App update check (network) — runs alongside the scan, no longer blocking it.
     if (configProvider.config.autoUpdateApp) {
       final appUpdateResult = await _checkAndShowAppUpdate();
       if (appUpdateResult == true) {
-        // User chose Update Now — consume scan flag but don't scan now.
-        // User will restart after updating.
-        configProvider.consumeStartupScan();
+        // User chose Update Now and will restart; nothing more to do here.
         return;
       }
     }
 
+    // Systems/emulator config update check (network).
     if (configProvider.config.autoUpdateSystems) {
-      systemsUpdated = await _checkAndShowSystemsUpdate(configProvider);
+      final systemsUpdated = await _checkAndShowSystemsUpdate(configProvider);
+      if (systemsUpdated && mounted) {
+        // New definitions were applied — re-scan to reflect them. Wait for the
+        // initial scan to settle first, since scanSystems ignores concurrent calls.
+        await initialScan;
+        if (mounted) configProvider.scanSystems();
+      }
     }
-
-    final startupScanPending = configProvider.consumeStartupScan();
-    if ((systemsUpdated || startupScanPending) &&
-        configProvider.hasRomFolder &&
-        mounted) {
-      configProvider.scanSystems();
-    }
-
-    unawaited(_fixRetroarchAndroidDefault());
   }
 
   /// Detects which RetroArch variant the user has installed on Android and sets


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

Fixes the home screen showing **completely empty after a device reboot** until the user enters Settings and exits back out.

## Root cause

On cold boot the deferred startup scan fired **only after** two awaited network calls (app + systems update checks, ~10s timeouts each). The reporting user runs NeoStation as their **default launcher** on an RGrotate (`CATEGORY_HOME`), so a reboot auto-launches it before WiFi is up — those checks sit on their full timeouts with no network, and for that window the Systems tab is `scanCompleted == false` while `isLoading == false`, which renders nothing. Entering/exiting Settings just buys enough time for the awaits to resolve and the scan to finish — hence the workaround, and why it's reboot-specific.

## Fix

- Fire the deferred startup scan **immediately**, with the update checks running alongside it instead of blocking it.
- If a systems update is accepted, re-scan once the initial scan settles (`scanSystems` ignores concurrent calls).
- Treat a pending startup scan as loading (`isLoading || _pendingStartupScan`) so a spinner shows instead of a blank screen.

This also helps users who just want to get into the launcher: a pending **systems update dialog no longer holds the scan hostage** — the home fills in first, then the dialog appears over a usable launcher rather than a blank screen.

## Tradeoffs

- If a systems update is accepted, the scan runs twice (boot scan, then re-scan with new definitions). Correctness preserved; just extra work.
- Dart is single-threaded, so the scan running concurrently with the dialogs/reload is race-free.

## Testing

`flutter analyze` clean, `flutter test` 113 passing. Verified on-device (AYN Thor, dev): home populates immediately on cold boot, no Settings detour. Simulated a systems-update-on-startup and confirmed the home populates first.

## Files

- `lib/screens/app_screen.dart` — `_performUpdateSequence()` restructured.
- `lib/providers/sqlite_config_provider.dart` — `isLoading` getter widened.
