### PR TITLE
fix: prevent user-data relocation from deleting foreign files (data-loss)

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -796,6 +796,14 @@ mixin AppLocale {
   static const String userDataLocationSubtitle = 'user_data_location_subtitle';
   static const String userDataLocationDefault = 'user_data_location_default';
   static const String selectUserDataFolder = 'select_user_data_folder';
+  static const String folderNotEmptyTitle = 'folder_not_empty_title';
+  static const String folderNotEmptyBody = 'folder_not_empty_body';
+  static const String folderNotEmptyUseAnyway = 'folder_not_empty_use_anyway';
+  static const String moveUserDataTitle = 'move_user_data_title';
+  static const String moveUserDataBody = 'move_user_data_body';
+  static const String moveUserDataDestNotEmpty =
+      'move_user_data_dest_not_empty';
+  static const String moveUserDataConfirm = 'move_user_data_confirm';
   static const String migratingUserData = 'migrating_user_data';
   static const String migratingUserDataComplete =
       'migrating_user_data_complete';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -794,6 +794,16 @@ const Map<String, dynamic> appLocaleDe = {
       'Wähle, wo Medien, Themes und App-Daten gespeichert werden',
   AppLocale.userDataLocationDefault: 'Standardspeicherort',
   AppLocale.selectUserDataFolder: 'Datenordner auswählen',
+  AppLocale.folderNotEmptyTitle: 'Ordner nicht leer',
+  AppLocale.folderNotEmptyBody:
+      'Dieser Ordner enthält bereits {count} Element(e). NeoStation speichert seine eigenen Daten hier, zusammen mit den vorhandenen Inhalten.',
+  AppLocale.folderNotEmptyUseAnyway: 'Trotzdem verwenden',
+  AppLocale.moveUserDataTitle: 'Benutzerdaten verschieben?',
+  AppLocale.moveUserDataBody:
+      'NeoStation verschiebt seine eigenen Daten – Datenbank, gescrapte Medien und Einstellungen – vom aktuellen Ordner in den neuen. Dateien, die nicht von NeoStation erstellt wurden, bleiben unberührt.',
+  AppLocale.moveUserDataDestNotEmpty:
+      'Der neue Ordner enthält bereits {count} Element(e). Die Daten von NeoStation werden daneben abgelegt.',
+  AppLocale.moveUserDataConfirm: 'Daten verschieben',
   AppLocale.migratingUserData: 'Daten werden verschoben',
   AppLocale.migratingUserDataComplete: 'Migration abgeschlossen',
   AppLocale.migratingUserDataError: 'Migration fehlgeschlagen',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -768,6 +768,16 @@ const Map<String, dynamic> appLocaleEn = {
       'Choose where scraped media, themes, and app data are stored',
   AppLocale.userDataLocationDefault: 'Default location',
   AppLocale.selectUserDataFolder: 'Select User Data Folder',
+  AppLocale.folderNotEmptyTitle: 'Folder Not Empty',
+  AppLocale.folderNotEmptyBody:
+      'This folder already contains {count} item(s). NeoStation will store its own data here, alongside the existing contents.',
+  AppLocale.folderNotEmptyUseAnyway: 'Use Anyway',
+  AppLocale.moveUserDataTitle: 'Move User Data?',
+  AppLocale.moveUserDataBody:
+      'NeoStation will move its own data — database, scraped media, and settings — from the current folder to the new one. Files not created by NeoStation are left untouched.',
+  AppLocale.moveUserDataDestNotEmpty:
+      'The new folder already contains {count} item(s). NeoStation data will be added alongside them.',
+  AppLocale.moveUserDataConfirm: 'Move Data',
   AppLocale.migratingUserData: 'Moving User Data',
   AppLocale.migratingUserDataComplete: 'Migration complete',
   AppLocale.migratingUserDataError: 'Migration failed',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -793,6 +793,16 @@ const Map<String, dynamic> appLocaleEs = {
       'Elige dónde se almacenan los medios, temas y datos de la aplicación',
   AppLocale.userDataLocationDefault: 'Ubicación predeterminada',
   AppLocale.selectUserDataFolder: 'Seleccionar Carpeta de Datos',
+  AppLocale.folderNotEmptyTitle: 'La carpeta no está vacía',
+  AppLocale.folderNotEmptyBody:
+      'Esta carpeta ya contiene {count} elemento(s). NeoStation almacenará sus propios datos aquí, junto con el contenido existente.',
+  AppLocale.folderNotEmptyUseAnyway: 'Usar de todos modos',
+  AppLocale.moveUserDataTitle: '¿Mover datos de usuario?',
+  AppLocale.moveUserDataBody:
+      'NeoStation moverá sus propios datos (base de datos, medios extraídos y ajustes) de la carpeta actual a la nueva. Los archivos no creados por NeoStation permanecen intactos.',
+  AppLocale.moveUserDataDestNotEmpty:
+      'La nueva carpeta ya contiene {count} elemento(s). Los datos de NeoStation se añadirán junto a ellos.',
+  AppLocale.moveUserDataConfirm: 'Mover datos',
   AppLocale.migratingUserData: 'Moviendo Datos',
   AppLocale.migratingUserDataComplete: 'Migración completada',
   AppLocale.migratingUserDataError: 'Error en la migración',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -796,6 +796,16 @@ const Map<String, dynamic> appLocaleFr = {
       'Choisissez où sont stockés les médias, thèmes et données de l\'application',
   AppLocale.userDataLocationDefault: 'Emplacement par défaut',
   AppLocale.selectUserDataFolder: 'Sélectionner le dossier de données',
+  AppLocale.folderNotEmptyTitle: 'Dossier non vide',
+  AppLocale.folderNotEmptyBody:
+      'Ce dossier contient déjà {count} élément(s). NeoStation y stockera ses propres données, aux côtés du contenu existant.',
+  AppLocale.folderNotEmptyUseAnyway: 'Utiliser quand même',
+  AppLocale.moveUserDataTitle: 'Déplacer les données ?',
+  AppLocale.moveUserDataBody:
+      'NeoStation déplacera ses propres données (base de données, médias récupérés et paramètres) du dossier actuel vers le nouveau. Les fichiers non créés par NeoStation restent intacts.',
+  AppLocale.moveUserDataDestNotEmpty:
+      'Le nouveau dossier contient déjà {count} élément(s). Les données de NeoStation seront ajoutées à côté.',
+  AppLocale.moveUserDataConfirm: 'Déplacer',
   AppLocale.migratingUserData: 'Déplacement des données',
   AppLocale.migratingUserDataComplete: 'Migration terminée',
   AppLocale.migratingUserDataError: 'Échec de la migration',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -770,6 +770,16 @@ const Map<String, dynamic> appLocaleId = {
       'Pilih di mana media, tema, dan data aplikasi disimpan',
   AppLocale.userDataLocationDefault: 'Lokasi default',
   AppLocale.selectUserDataFolder: 'Pilih Folder Data',
+  AppLocale.folderNotEmptyTitle: 'Folder Tidak Kosong',
+  AppLocale.folderNotEmptyBody:
+      'Folder ini sudah berisi {count} item. NeoStation akan menyimpan datanya sendiri di sini, bersama konten yang sudah ada.',
+  AppLocale.folderNotEmptyUseAnyway: 'Tetap Gunakan',
+  AppLocale.moveUserDataTitle: 'Pindahkan Data Pengguna?',
+  AppLocale.moveUserDataBody:
+      'NeoStation akan memindahkan datanya sendiri — basis data, media hasil scrape, dan pengaturan — dari folder saat ini ke folder baru. Berkas yang tidak dibuat oleh NeoStation tidak akan diubah.',
+  AppLocale.moveUserDataDestNotEmpty:
+      'Folder baru sudah berisi {count} item. Data NeoStation akan ditambahkan di sampingnya.',
+  AppLocale.moveUserDataConfirm: 'Pindahkan Data',
   AppLocale.migratingUserData: 'Memindahkan Data',
   AppLocale.migratingUserDataComplete: 'Migrasi selesai',
   AppLocale.migratingUserDataError: 'Migrasi gagal',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -788,6 +788,16 @@ const Map<String, dynamic> appLocaleIt = {
       'Scegli dove vengono archiviati i media, i temi e i dati dell\'app',
   AppLocale.userDataLocationDefault: 'Posizione predefinita',
   AppLocale.selectUserDataFolder: 'Seleziona cartella dati',
+  AppLocale.folderNotEmptyTitle: 'Cartella non vuota',
+  AppLocale.folderNotEmptyBody:
+      'Questa cartella contiene già {count} elemento/i. NeoStation memorizzerà qui i propri dati, insieme ai contenuti esistenti.',
+  AppLocale.folderNotEmptyUseAnyway: 'Usa comunque',
+  AppLocale.moveUserDataTitle: 'Spostare i dati utente?',
+  AppLocale.moveUserDataBody:
+      'NeoStation sposterà i propri dati (database, media recuperati e impostazioni) dalla cartella attuale a quella nuova. I file non creati da NeoStation restano invariati.',
+  AppLocale.moveUserDataDestNotEmpty:
+      'La nuova cartella contiene già {count} elemento/i. I dati di NeoStation verranno aggiunti accanto ad essi.',
+  AppLocale.moveUserDataConfirm: 'Sposta dati',
   AppLocale.migratingUserData: 'Spostamento dati',
   AppLocale.migratingUserDataComplete: 'Migrazione completata',
   AppLocale.migratingUserDataError: 'Migrazione fallita',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -700,6 +700,16 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.userDataLocationSubtitle: 'メディア、テーマ、アプリデータの保存場所を選択します',
   AppLocale.userDataLocationDefault: 'デフォルトの場所',
   AppLocale.selectUserDataFolder: 'データフォルダを選択',
+  AppLocale.folderNotEmptyTitle: 'フォルダが空ではありません',
+  AppLocale.folderNotEmptyBody:
+      'このフォルダには既に {count} 個の項目があります。NeoStation は既存の内容とともに、ここに独自のデータを保存します。',
+  AppLocale.folderNotEmptyUseAnyway: 'このまま使用',
+  AppLocale.moveUserDataTitle: 'ユーザーデータを移動しますか？',
+  AppLocale.moveUserDataBody:
+      'NeoStation は自身のデータ（データベース、取得したメディア、設定）を現在のフォルダから新しいフォルダへ移動します。NeoStation が作成していないファイルはそのまま残ります。',
+  AppLocale.moveUserDataDestNotEmpty:
+      '新しいフォルダには既に {count} 個の項目があります。NeoStation のデータはそれらと一緒に追加されます。',
+  AppLocale.moveUserDataConfirm: 'データを移動',
   AppLocale.migratingUserData: 'データを移動中',
   AppLocale.migratingUserDataComplete: '移行完了',
   AppLocale.migratingUserDataError: '移行に失敗しました',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -777,6 +777,16 @@ const Map<String, dynamic> appLocalePt = {
       'Escolha onde mídias, temas e dados do aplicativo são armazenados',
   AppLocale.userDataLocationDefault: 'Localização padrão',
   AppLocale.selectUserDataFolder: 'Selecionar Pasta de Dados',
+  AppLocale.folderNotEmptyTitle: 'Pasta não vazia',
+  AppLocale.folderNotEmptyBody:
+      'Esta pasta já contém {count} item(ns). O NeoStation irá armazenar os seus próprios dados aqui, junto com o conteúdo existente.',
+  AppLocale.folderNotEmptyUseAnyway: 'Usar mesmo assim',
+  AppLocale.moveUserDataTitle: 'Mover dados do usuário?',
+  AppLocale.moveUserDataBody:
+      'O NeoStation moverá seus próprios dados — banco de dados, mídia obtida e configurações — da pasta atual para a nova. Arquivos não criados pelo NeoStation permanecem intactos.',
+  AppLocale.moveUserDataDestNotEmpty:
+      'A nova pasta já contém {count} item(ns). Os dados do NeoStation serão adicionados junto a eles.',
+  AppLocale.moveUserDataConfirm: 'Mover dados',
   AppLocale.migratingUserData: 'Movendo Dados',
   AppLocale.migratingUserDataComplete: 'Migração concluída',
   AppLocale.migratingUserDataError: 'Falha na migração',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -766,6 +766,16 @@ const Map<String, dynamic> appLocaleRu = {
       'Выберите, где хранятся медиафайлы, темы и данные приложения',
   AppLocale.userDataLocationDefault: 'Стандартное расположение',
   AppLocale.selectUserDataFolder: 'Выбрать папку данных',
+  AppLocale.folderNotEmptyTitle: 'Папка не пуста',
+  AppLocale.folderNotEmptyBody:
+      'Эта папка уже содержит {count} элемент(ов). NeoStation будет хранить свои данные здесь, рядом с существующим содержимым.',
+  AppLocale.folderNotEmptyUseAnyway: 'Всё равно использовать',
+  AppLocale.moveUserDataTitle: 'Переместить данные пользователя?',
+  AppLocale.moveUserDataBody:
+      'NeoStation переместит свои данные (базу данных, загруженные медиа и настройки) из текущей папки в новую. Файлы, созданные не NeoStation, останутся нетронутыми.',
+  AppLocale.moveUserDataDestNotEmpty:
+      'Новая папка уже содержит {count} элемент(ов). Данные NeoStation будут добавлены рядом с ними.',
+  AppLocale.moveUserDataConfirm: 'Переместить',
   AppLocale.migratingUserData: 'Перемещение данных',
   AppLocale.migratingUserDataComplete: 'Миграция завершена',
   AppLocale.migratingUserDataError: 'Ошибка миграции',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -691,6 +691,16 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.userDataLocationSubtitle: '选择媒体、主题和应用数据的存储位置',
   AppLocale.userDataLocationDefault: '默认位置',
   AppLocale.selectUserDataFolder: '选择数据文件夹',
+  AppLocale.folderNotEmptyTitle: '文件夹非空',
+  AppLocale.folderNotEmptyBody:
+      '此文件夹已包含 {count} 个项目。NeoStation 会将自己的数据存储在此处，与现有内容放在一起。',
+  AppLocale.folderNotEmptyUseAnyway: '仍然使用',
+  AppLocale.moveUserDataTitle: '移动用户数据？',
+  AppLocale.moveUserDataBody:
+      'NeoStation 会将自己的数据（数据库、抓取的媒体和设置）从当前文件夹移动到新文件夹。非 NeoStation 创建的文件不会被改动。',
+  AppLocale.moveUserDataDestNotEmpty:
+      '新文件夹已包含 {count} 个项目。NeoStation 的数据将添加在它们旁边。',
+  AppLocale.moveUserDataConfirm: '移动数据',
   AppLocale.migratingUserData: '正在迁移数据',
   AppLocale.migratingUserDataComplete: '迁移完成',
   AppLocale.migratingUserDataError: '迁移失败',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -691,6 +691,16 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.userDataLocationSubtitle: '選擇媒體、主題和應用程式資料的存儲位置',
   AppLocale.userDataLocationDefault: '預設位置',
   AppLocale.selectUserDataFolder: '選擇資料資料夾',
+  AppLocale.folderNotEmptyTitle: '資料夾非空',
+  AppLocale.folderNotEmptyBody:
+      '此資料夾已包含 {count} 個項目。NeoStation 會將自己的資料儲存在此處，與現有內容放在一起。',
+  AppLocale.folderNotEmptyUseAnyway: '仍然使用',
+  AppLocale.moveUserDataTitle: '移動使用者資料？',
+  AppLocale.moveUserDataBody:
+      'NeoStation 會將自己的資料（資料庫、抓取的媒體和設定）從目前的資料夾移動到新的資料夾。非 NeoStation 建立的檔案不會被更動。',
+  AppLocale.moveUserDataDestNotEmpty:
+      '新資料夾已包含 {count} 個項目。NeoStation 的資料將新增在它們旁邊。',
+  AppLocale.moveUserDataConfirm: '移動資料',
   AppLocale.migratingUserData: '正在遷移資料',
   AppLocale.migratingUserDataComplete: '遷移完成',
   AppLocale.migratingUserDataError: '遷移失敗',

--- a/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
@@ -14,6 +14,7 @@ import 'package:neostation/services/permission_service.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/services/user_data_location_service.dart';
 import 'package:neostation/widgets/custom_notification.dart';
+import 'package:neostation/widgets/move_user_data_dialog.dart';
 import 'package:neostation/widgets/permission_check_wrapper.dart';
 import 'package:neostation/widgets/restart_required_dialog.dart';
 import 'package:neostation/widgets/tv_directory_picker.dart';
@@ -271,6 +272,21 @@ class DirectoriesSettingsContentState
 
       final current = _currentUserDataPath;
       if (current == null || selected == current) return;
+
+      // Relocating actually MOVES data (copy + delete of NeoStation's own
+      // files), so confirm the source → destination move explicitly, noting
+      // when the destination already contains files.
+      final entryCount = await UserDataLocationService.countDirectoryEntries(
+        selected,
+      );
+      if (!mounted) return;
+      final proceed = await MoveUserDataDialog.show(
+        context,
+        fromPath: current,
+        toPath: selected,
+        destItemCount: entryCount,
+      );
+      if (!proceed || !mounted) return;
 
       await _migrateUserData(sourcePath: current, destPath: selected);
     } catch (e) {

--- a/lib/services/user_data_location_service.dart
+++ b/lib/services/user_data_location_service.dart
@@ -24,6 +24,27 @@ class UserDataLocationService {
     await prefs.remove(customPathKey);
   }
 
+  /// Counts top-level entries in [dirPath].
+  ///
+  /// Returns 0 if the directory is empty, does not exist, or cannot be listed.
+  /// This is fail-open on purpose: it only decides whether to *warn* the user
+  /// that a chosen folder is non-empty, never to block, so an unreadable
+  /// directory must not surface a spurious warning.
+  static Future<int> countDirectoryEntries(String dirPath) async {
+    try {
+      final dir = Directory(dirPath);
+      if (!await dir.exists()) return 0;
+      var count = 0;
+      await for (final _ in dir.list()) {
+        count++;
+      }
+      return count;
+    } catch (e) {
+      _log.w('countDirectoryEntries failed for $dirPath: $e');
+      return 0;
+    }
+  }
+
   /// Converts an Android SAF tree URI (content://com.android.externalstorage...)
   /// to a real filesystem path.
   ///
@@ -133,10 +154,36 @@ class UserDataLocationService {
     return direct;
   }
 
-  /// Copies all content from [sourceUserDataPath] to [destPath], then deletes source.
+  /// Top-level entry names under the user-data directory that NeoStation
+  /// creates and owns. Only these are ever migrated or deleted.
+  ///
+  /// Any other file/folder sharing the directory — e.g. a user's pre-existing
+  /// ES-DE `downloaded_media/`, `gamelists/`, `es_systems.xml` — is foreign
+  /// data and must never be touched. This is the guard that prevents wiping a
+  /// user's emulation library when the user-data location was pointed at their
+  /// existing front-end folder.
+  static bool _isOwnedEntry(String name) {
+    return name == 'media' ||
+        name == 'systems' ||
+        name == 'temp' ||
+        name == 'config.json' ||
+        name.startsWith('data.sqlite') || // data.sqlite + -wal/-shm/-journal
+        name.startsWith('app.log'); // app.log + rotated variants
+  }
+
+  /// Migrates NeoStation's own user data from [sourceUserDataPath] to
+  /// [destPath], then removes the migrated copies from the source.
+  ///
+  /// Only NeoStation-owned entries (see [_isOwnedEntry]) are copied or deleted.
+  /// Foreign files that happen to share the folder are never read or removed.
+  ///
+  /// A source file is deleted ONLY after its destination copy is verified
+  /// (exists, matching length). If ANY owned file fails to copy, the whole
+  /// operation aborts and nothing is deleted — the source stays fully intact
+  /// and the error is thrown to the caller.
   ///
   /// On platforms where media lives outside user-data (Linux/macOS),
-  /// [sourceMediaPath] is also copied into [destPath]/media/.
+  /// [sourceMediaPath] is also migrated into [destPath]/media/.
   ///
   /// Progress is reported in two phases via [onProgress]:
   ///   - Copy phase: 0.0 → 0.5
@@ -152,24 +199,56 @@ class UserDataLocationService {
       throw Exception('Source path does not exist: $sourceUserDataPath');
     }
 
+    // Guard against source and destination being the same folder (or one
+    // nested in the other). The caller only compares raw strings, so a
+    // normalization difference — trailing slash, a SAF-resolved path vs the
+    // stored path — slips through. Without this, each owned file would be
+    // copied onto itself (truncating it) and then deleted. canonicalize()
+    // normalizes '.', '..' and separators (it does not resolve symlinks).
+    final canonSource = path.canonicalize(sourceUserDataPath);
+    final canonDest = path.canonicalize(destPath);
+    if (canonSource == canonDest) {
+      _log.i('Migration skipped: source and destination are the same folder');
+      onProgress?.call(1.0, '');
+      return;
+    }
+    if (path.isWithin(canonSource, canonDest) ||
+        path.isWithin(canonDest, canonSource)) {
+      throw Exception(
+        'Cannot migrate between overlapping folders: '
+        '$sourceUserDataPath <-> $destPath',
+      );
+    }
+
     final destDir = Directory(destPath);
     if (!await destDir.exists()) {
       await destDir.create(recursive: true);
     }
 
-    // ---- Collect copy jobs ----
+    // ---- Collect copy jobs from OWNED entries only ----
     final List<(String, String)> copyJobs = []; // (src, dest)
-    await _collectCopyJobs(
-      sourceDir: sourceUserDataPath,
-      destDir: destPath,
-      jobs: copyJobs,
-    );
+    // Owned directories whose now-empty tree we prune after deleting files.
+    final List<String> ownedSourceDirs = [];
+
+    await for (final entity in sourceDir.list()) {
+      final name = path.basename(entity.path);
+      if (!_isOwnedEntry(name)) continue; // leave foreign data untouched
+      if (entity is File) {
+        copyJobs.add((entity.path, path.join(destPath, name)));
+      } else if (entity is Directory) {
+        await _collectCopyJobs(
+          sourceDir: entity.path,
+          destDir: path.join(destPath, name),
+          jobs: copyJobs,
+        );
+        ownedSourceDirs.add(entity.path);
+      }
+    }
 
     // If media lives outside user-data dir (Linux/macOS), also migrate it.
     final mediaIsInsideUserData = sourceMediaPath.startsWith(
       sourceUserDataPath,
     );
-    List<String> extraSourceDirs = [];
     if (!mediaIsInsideUserData && await Directory(sourceMediaPath).exists()) {
       final destMediaPath = path.join(destPath, 'media');
       await _collectCopyJobs(
@@ -177,59 +256,76 @@ class UserDataLocationService {
         destDir: destMediaPath,
         jobs: copyJobs,
       );
-      extraSourceDirs.add(sourceMediaPath);
+      ownedSourceDirs.add(sourceMediaPath);
     }
 
     final total = copyJobs.isEmpty ? 1 : copyJobs.length;
 
-    // ---- Copy phase (0.0 → 0.5) ----
+    // ---- Copy phase (0.0 → 0.5) with per-file verification ----
     int copied = 0;
+    final List<String> failedCopies = [];
     for (final (src, dest) in copyJobs) {
-      final destFile = File(dest);
-      await destFile.parent.create(recursive: true);
-      await File(src).copy(dest);
+      try {
+        final destFile = File(dest);
+        await destFile.parent.create(recursive: true);
+        await File(src).copy(dest);
+        // Verify the copy landed intact before it becomes eligible for delete.
+        final srcLen = await File(src).length();
+        if (!await destFile.exists() || await destFile.length() != srcLen) {
+          failedCopies.add(src);
+        }
+      } catch (e) {
+        failedCopies.add(src);
+        _log.e('Migration copy failed for $src: $e');
+      }
       copied++;
       onProgress?.call(0.5 * copied / total, path.basename(src));
+    }
+
+    // SAFETY GATE: if any owned file failed to copy, delete NOTHING. The source
+    // stays fully intact; the caller surfaces the error and keeps the old path.
+    if (failedCopies.isNotEmpty) {
+      throw Exception(
+        'Migration aborted: ${failedCopies.length} of ${copyJobs.length} '
+        'file(s) failed to copy. Source data left intact.',
+      );
     }
 
     _log.i('Migration: $copied files copied to $destPath');
 
     // ---- Delete phase (0.5 → 1.0) ----
-    final allSourceFiles = <FileSystemEntity>[];
-    await for (final e in sourceDir.list(recursive: true)) {
-      allSourceFiles.add(e);
-    }
-    for (final extra in extraSourceDirs) {
-      await for (final e in Directory(extra).list(recursive: true)) {
-        allSourceFiles.add(e);
-      }
-    }
-
-    // Delete files first, then empty subdirs (deepest first).
-    // Root source directories are kept — only their contents are removed.
-    final files = allSourceFiles.whereType<File>().toList();
-    final dirs = allSourceFiles.whereType<Directory>().toList()
-      ..sort((a, b) => b.path.length.compareTo(a.path.length)); // deepest first
-
+    // Delete ONLY the source files we successfully copied (all verified above).
+    // Foreign files were never added to copyJobs, so they are never deleted.
     int deleted = 0;
-    final deleteTotal = files.length + dirs.length;
-
-    for (final f in files) {
+    final deleteTotal = copyJobs.isEmpty ? 1 : copyJobs.length;
+    for (final (src, _) in copyJobs) {
       try {
-        await f.delete();
-      } catch (_) {}
+        await File(src).delete();
+      } catch (e) {
+        _log.w('Migration: could not delete migrated source file $src: $e');
+      }
       deleted++;
-      onProgress?.call(
-        0.5 + 0.5 * deleted / deleteTotal,
-        path.basename(f.path),
-      );
+      onProgress?.call(0.5 + 0.5 * deleted / deleteTotal, path.basename(src));
     }
-    for (final d in dirs) {
-      try {
-        await d.delete();
-      } catch (_) {} // skip if unexpectedly non-empty
-      deleted++;
-      onProgress?.call(0.5 + 0.5 * deleted / deleteTotal, '');
+
+    // Prune now-empty owned subdirectories (deepest first). A dir left
+    // non-empty here still held foreign data, so it is deliberately kept.
+    for (final root in ownedSourceDirs) {
+      final dir = Directory(root);
+      if (!await dir.exists()) continue;
+      final subDirs = <Directory>[];
+      await for (final e in dir.list(recursive: true)) {
+        if (e is Directory) subDirs.add(e);
+      }
+      subDirs.add(dir);
+      subDirs.sort((a, b) => b.path.length.compareTo(a.path.length));
+      for (final d in subDirs) {
+        try {
+          if (await d.exists() && await d.list().isEmpty) {
+            await d.delete();
+          }
+        } catch (_) {}
+      }
     }
 
     onProgress?.call(1.0, '');

--- a/lib/widgets/folder_not_empty_dialog.dart
+++ b/lib/widgets/folder_not_empty_dialog.dart
@@ -1,0 +1,213 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/services/game_service.dart';
+import 'core_footer.dart';
+
+/// Confirmation shown when the user picks a NON-empty folder as the user-data
+/// location. Warns that NeoStation will store its data alongside the existing
+/// contents (a foreign front-end's library, etc.) so the choice is deliberate.
+///
+/// Returns `true` if the user chooses to use the folder anyway, `false`
+/// (or `null` when dismissed) otherwise.
+class FolderNotEmptyDialog extends StatefulWidget {
+  final String path;
+  final int itemCount;
+
+  const FolderNotEmptyDialog({
+    super.key,
+    required this.path,
+    required this.itemCount,
+  });
+
+  /// Shows the dialog and resolves to whether the user confirmed.
+  static Future<bool> show(
+    BuildContext context, {
+    required String path,
+    required int itemCount,
+  }) async {
+    final result = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => FolderNotEmptyDialog(path: path, itemCount: itemCount),
+    );
+    return result ?? false;
+  }
+
+  @override
+  State<FolderNotEmptyDialog> createState() => _FolderNotEmptyDialogState();
+}
+
+class _FolderNotEmptyDialogState extends State<FolderNotEmptyDialog> {
+  late final GamepadNavigation _gamepadNav;
+
+  @override
+  void initState() {
+    super.initState();
+    _gamepadNav = GamepadNavigation(onSelectItem: _confirm, onBack: _cancel);
+    _gamepadNav.initialize();
+    _gamepadNav.activate();
+    GamepadNavigationManager.pushLayer(
+      'folder_not_empty_dialog',
+      onActivate: () => _gamepadNav.activate(),
+      onDeactivate: () => _gamepadNav.deactivate(),
+    );
+  }
+
+  @override
+  void dispose() {
+    GamepadNavigationManager.popLayer('folder_not_empty_dialog');
+    _gamepadNav.dispose();
+    super.dispose();
+  }
+
+  void _confirm() => Navigator.of(context).pop(true);
+
+  void _cancel() => Navigator.of(context).pop(false);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return BackdropFilter(
+      filter: ImageFilter.blur(sigmaX: 5.r, sigmaY: 5.r),
+      child: Dialog(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        child: Container(
+          width: 420.r,
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surface.withValues(alpha: 0.9),
+            borderRadius: BorderRadius.circular(16.r),
+            border: Border.all(
+              color: theme.colorScheme.tertiary.withValues(alpha: 0.4),
+              width: 1.r,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.5),
+                blurRadius: 30.r,
+                spreadRadius: 5.r,
+              ),
+            ],
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(16.r),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: EdgeInsets.symmetric(
+                    vertical: 12.r,
+                    horizontal: 16.r,
+                  ),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.tertiary.withValues(alpha: 0.12),
+                  ),
+                  child: Row(
+                    children: [
+                      Container(
+                        padding: EdgeInsets.all(8.r),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.tertiary.withValues(
+                            alpha: 0.1,
+                          ),
+                          borderRadius: BorderRadius.circular(8.r),
+                        ),
+                        child: Icon(
+                          Symbols.warning_rounded,
+                          color: theme.colorScheme.tertiary,
+                          size: 16.r,
+                        ),
+                      ),
+                      SizedBox(width: 8.r),
+                      Expanded(
+                        child: Text(
+                          AppLocale.folderNotEmptyTitle.getString(context),
+                          style: theme.textTheme.titleLarge?.copyWith(
+                            color: theme.colorScheme.tertiary,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 12.r,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.all(16.r),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        AppLocale.folderNotEmptyBody
+                            .getString(context)
+                            .replaceFirst('{count}', '${widget.itemCount}'),
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurface.withValues(
+                            alpha: 0.8,
+                          ),
+                        ),
+                      ),
+                      SizedBox(height: 10.r),
+                      Container(
+                        padding: EdgeInsets.all(10.r),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.surfaceContainerHighest
+                              .withValues(alpha: 0.4),
+                          borderRadius: BorderRadius.circular(8.r),
+                        ),
+                        child: Text(
+                          widget.path,
+                          style: TextStyle(
+                            fontSize: 11.r,
+                            color: theme.colorScheme.onSurface,
+                            fontFamily: 'monospace',
+                          ),
+                          maxLines: 3,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      SizedBox(height: 16.r),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: GamepadControl(
+                              iconPath:
+                                  'assets/images/gamepad/Xbox_B_button.png',
+                              label: AppLocale.cancel.getString(context),
+                              onTap: _cancel,
+                              backgroundColor: theme.colorScheme.tertiary,
+                              textColor: theme.colorScheme.onSurface,
+                            ),
+                          ),
+                          SizedBox(width: 8.r),
+                          Expanded(
+                            flex: 2,
+                            child: GamepadControl(
+                              iconPath:
+                                  'assets/images/gamepad/Xbox_A_button.png',
+                              label: AppLocale.folderNotEmptyUseAnyway
+                                  .getString(context),
+                              onTap: _confirm,
+                              backgroundColor: theme.colorScheme.primary,
+                              textColor: theme.colorScheme.onPrimary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/move_user_data_dialog.dart
+++ b/lib/widgets/move_user_data_dialog.dart
@@ -1,0 +1,244 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/services/game_service.dart';
+import 'core_footer.dart';
+
+/// Heavier confirmation shown before relocating the user-data folder from
+/// Settings. Unlike the wizard's [FolderNotEmptyDialog], this actually MOVES
+/// data, so it spells out the source → destination move and (when relevant)
+/// notes that the destination already has files.
+///
+/// Returns `true` if the user confirms the move.
+class MoveUserDataDialog extends StatefulWidget {
+  final String fromPath;
+  final String toPath;
+  final int destItemCount;
+
+  const MoveUserDataDialog({
+    super.key,
+    required this.fromPath,
+    required this.toPath,
+    required this.destItemCount,
+  });
+
+  static Future<bool> show(
+    BuildContext context, {
+    required String fromPath,
+    required String toPath,
+    required int destItemCount,
+  }) async {
+    final result = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => MoveUserDataDialog(
+        fromPath: fromPath,
+        toPath: toPath,
+        destItemCount: destItemCount,
+      ),
+    );
+    return result ?? false;
+  }
+
+  @override
+  State<MoveUserDataDialog> createState() => _MoveUserDataDialogState();
+}
+
+class _MoveUserDataDialogState extends State<MoveUserDataDialog> {
+  late final GamepadNavigation _gamepadNav;
+
+  @override
+  void initState() {
+    super.initState();
+    _gamepadNav = GamepadNavigation(onSelectItem: _confirm, onBack: _cancel);
+    _gamepadNav.initialize();
+    _gamepadNav.activate();
+    GamepadNavigationManager.pushLayer(
+      'move_user_data_dialog',
+      onActivate: () => _gamepadNav.activate(),
+      onDeactivate: () => _gamepadNav.deactivate(),
+    );
+  }
+
+  @override
+  void dispose() {
+    GamepadNavigationManager.popLayer('move_user_data_dialog');
+    _gamepadNav.dispose();
+    super.dispose();
+  }
+
+  void _confirm() => Navigator.of(context).pop(true);
+  void _cancel() => Navigator.of(context).pop(false);
+
+  Widget _pathBox(ThemeData theme, String path) {
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.all(10.r),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(8.r),
+      ),
+      child: Text(
+        path,
+        style: TextStyle(
+          fontSize: 11.r,
+          color: theme.colorScheme.onSurface,
+          fontFamily: 'monospace',
+        ),
+        maxLines: 3,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return BackdropFilter(
+      filter: ImageFilter.blur(sigmaX: 5.r, sigmaY: 5.r),
+      child: Dialog(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        child: Container(
+          width: 440.r,
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surface.withValues(alpha: 0.92),
+            borderRadius: BorderRadius.circular(16.r),
+            border: Border.all(
+              color: theme.colorScheme.tertiary.withValues(alpha: 0.4),
+              width: 1.r,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.5),
+                blurRadius: 30.r,
+                spreadRadius: 5.r,
+              ),
+            ],
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(16.r),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: EdgeInsets.symmetric(
+                    vertical: 12.r,
+                    horizontal: 16.r,
+                  ),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.tertiary.withValues(alpha: 0.12),
+                  ),
+                  child: Row(
+                    children: [
+                      Container(
+                        padding: EdgeInsets.all(8.r),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.tertiary.withValues(
+                            alpha: 0.1,
+                          ),
+                          borderRadius: BorderRadius.circular(8.r),
+                        ),
+                        child: Icon(
+                          Symbols.drive_file_move_rounded,
+                          color: theme.colorScheme.tertiary,
+                          size: 16.r,
+                        ),
+                      ),
+                      SizedBox(width: 8.r),
+                      Expanded(
+                        child: Text(
+                          AppLocale.moveUserDataTitle.getString(context),
+                          style: theme.textTheme.titleLarge?.copyWith(
+                            color: theme.colorScheme.tertiary,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 12.r,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.all(16.r),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        AppLocale.moveUserDataBody.getString(context),
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurface.withValues(
+                            alpha: 0.8,
+                          ),
+                        ),
+                      ),
+                      SizedBox(height: 12.r),
+                      _pathBox(theme, widget.fromPath),
+                      Padding(
+                        padding: EdgeInsets.symmetric(vertical: 4.r),
+                        child: Icon(
+                          Symbols.arrow_downward_rounded,
+                          size: 16.r,
+                          color: theme.colorScheme.primary,
+                        ),
+                      ),
+                      _pathBox(theme, widget.toPath),
+                      if (widget.destItemCount > 0) ...[
+                        SizedBox(height: 10.r),
+                        Text(
+                          AppLocale.moveUserDataDestNotEmpty
+                              .getString(context)
+                              .replaceFirst(
+                                '{count}',
+                                '${widget.destItemCount}',
+                              ),
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.tertiary,
+                          ),
+                        ),
+                      ],
+                      SizedBox(height: 16.r),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: GamepadControl(
+                              iconPath:
+                                  'assets/images/gamepad/Xbox_B_button.png',
+                              label: AppLocale.cancel.getString(context),
+                              onTap: _cancel,
+                              backgroundColor: theme.colorScheme.tertiary,
+                              textColor: theme.colorScheme.onSurface,
+                            ),
+                          ),
+                          SizedBox(width: 8.r),
+                          Expanded(
+                            flex: 2,
+                            child: GamepadControl(
+                              iconPath:
+                                  'assets/images/gamepad/Xbox_A_button.png',
+                              label: AppLocale.moveUserDataConfirm.getString(
+                                context,
+                              ),
+                              onTap: _confirm,
+                              backgroundColor: theme.colorScheme.primary,
+                              textColor: theme.colorScheme.onPrimary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -15,6 +15,7 @@ import '../utils/gamepad_nav.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import '../widgets/tv_directory_picker.dart';
+import '../widgets/folder_not_empty_dialog.dart';
 import '../models/secondary_display_state.dart';
 
 /// Initial configuration wizard for the first time the app is opened
@@ -636,6 +637,21 @@ class _SetupWizardState extends State<SetupWizard> {
       }
 
       if (selected == _selectedUserDataPath) return;
+
+      // Warn if the chosen folder already contains files, so the user doesn't
+      // unknowingly store NeoStation's data inside an existing library.
+      final entryCount = await UserDataLocationService.countDirectoryEntries(
+        selected,
+      );
+      if (!mounted) return;
+      if (entryCount > 0) {
+        final proceed = await FolderNotEmptyDialog.show(
+          context,
+          path: selected,
+          itemCount: entryCount,
+        );
+        if (!proceed || !mounted) return;
+      }
 
       await UserDataLocationService.setCustomPath(selected);
 

--- a/test/user_data_migration_test.dart
+++ b/test/user_data_migration_test.dart
@@ -1,0 +1,222 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/user_data_location_service.dart';
+import 'package:path/path.dart' as p;
+
+/// Regression tests for the reported data-loss bug: pointing NeoStation's
+/// user-data location at a pre-existing third-party folder (e.g. an ES-DE
+/// directory full of `downloaded_media/` and `gamelists/`) and then migrating
+/// must NOT destroy the foreign data. `migrateData` may only ever touch
+/// NeoStation-owned entries.
+void main() {
+  group('UserDataLocationService.migrateData', () {
+    late Directory tmp;
+    late Directory esde; // source == NeoStation user-data pointed at ES-DE
+    late Directory dest;
+
+    late File scrapedArt; // foreign (ES-DE)
+    late File gamelist; // foreign (ES-DE)
+    late File esSystems; // foreign (ES-DE)
+    late File db; // owned (NeoStation)
+    late File neoArt; // owned (NeoStation, under media/)
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('neostation_migrate_test_');
+      esde = Directory(p.join(tmp.path, 'ES-DE'))..createSync(recursive: true);
+      dest = Directory(p.join(tmp.path, 'new-location'))
+        ..createSync(recursive: true);
+
+      // --- Foreign, precious data NeoStation did not create ---
+      scrapedArt = File(
+        p.join(esde.path, 'downloaded_media', 'snes', 'Chrono Trigger.png'),
+      )..createSync(recursive: true);
+      scrapedArt.writeAsStringSync('PRECIOUS ARTWORK BYTES');
+
+      gamelist = File(p.join(esde.path, 'gamelists', 'snes', 'gamelist.xml'))
+        ..createSync(recursive: true);
+      gamelist.writeAsStringSync('<gameList>hours of scraping</gameList>');
+
+      esSystems = File(p.join(esde.path, 'es_systems.xml'))
+        ..createSync(recursive: true);
+      esSystems.writeAsStringSync('<systemList/>');
+
+      // --- NeoStation's own data cohabiting the same folder ---
+      db = File(p.join(esde.path, 'data.sqlite'))..createSync(recursive: true);
+      db.writeAsStringSync('db-bytes');
+
+      neoArt = File(p.join(esde.path, 'media', 'snes', 'boxart', 'ct.png'))
+        ..createSync(recursive: true);
+      neoArt.writeAsStringSync('neostation-scraped');
+    });
+
+    tearDown(() async {
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    test('preserves foreign ES-DE data in the source folder', () async {
+      await UserDataLocationService.migrateData(
+        sourceUserDataPath: esde.path,
+        sourceMediaPath: p.join(esde.path, 'media'),
+        destPath: dest.path,
+      );
+
+      // Foreign data must be untouched in the original folder.
+      expect(scrapedArt.existsSync(), isTrue, reason: 'scraped art preserved');
+      expect(gamelist.existsSync(), isTrue, reason: 'gamelist preserved');
+      expect(
+        esSystems.existsSync(),
+        isTrue,
+        reason: 'es_systems.xml preserved',
+      );
+      expect(
+        scrapedArt.readAsStringSync(),
+        'PRECIOUS ARTWORK BYTES',
+        reason: 'foreign content is byte-for-byte intact',
+      );
+
+      // Foreign data must NOT be copied into the destination.
+      expect(
+        File(
+          p.join(dest.path, 'downloaded_media', 'snes', 'Chrono Trigger.png'),
+        ).existsSync(),
+        isFalse,
+        reason: 'foreign data is not migrated into dest',
+      );
+    });
+
+    test('migrates NeoStation-owned data and removes it from source', () async {
+      await UserDataLocationService.migrateData(
+        sourceUserDataPath: esde.path,
+        sourceMediaPath: p.join(esde.path, 'media'),
+        destPath: dest.path,
+      );
+
+      // Owned files are now at the destination...
+      expect(File(p.join(dest.path, 'data.sqlite')).existsSync(), isTrue);
+      expect(
+        File(
+          p.join(dest.path, 'media', 'snes', 'boxart', 'ct.png'),
+        ).existsSync(),
+        isTrue,
+      );
+      // ...and removed from the source.
+      expect(db.existsSync(), isFalse, reason: 'owned db moved out of source');
+      expect(neoArt.existsSync(), isFalse, reason: 'owned art moved out');
+    });
+
+    test(
+      'aborts without deleting anything if a copy fails (safety gate)',
+      () async {
+        // Force a copy failure: put a DIRECTORY where the owned dest file goes,
+        // so File.copy() throws for data.sqlite.
+        Directory(p.join(dest.path, 'data.sqlite')).createSync(recursive: true);
+
+        await expectLater(
+          UserDataLocationService.migrateData(
+            sourceUserDataPath: esde.path,
+            sourceMediaPath: p.join(esde.path, 'media'),
+            destPath: dest.path,
+          ),
+          throwsA(isA<Exception>()),
+        );
+
+        // Nothing in the source was deleted — owned or foreign.
+        expect(
+          db.existsSync(),
+          isTrue,
+          reason: 'owned db not deleted on abort',
+        );
+        expect(neoArt.existsSync(), isTrue, reason: 'owned art not deleted');
+        expect(scrapedArt.existsSync(), isTrue, reason: 'foreign art intact');
+        expect(
+          gamelist.existsSync(),
+          isTrue,
+          reason: 'foreign gamelist intact',
+        );
+      },
+    );
+
+    test(
+      'exact reported repro: user-data pointed at ES-DE/downloaded_media',
+      () async {
+        // The reporting user set User Data Location to their scraped-media
+        // folder itself (…/ES-DE/downloaded_media), which holds per-system art
+        // subdirs directly under it. Migrating away from it must NOT wipe them.
+        final downloadedMedia = Directory(
+          p.join(tmp.path, 'ES-DE', 'downloaded_media'),
+        )..createSync(recursive: true);
+
+        // Foreign ES-DE art: <downloaded_media>/<system>/<type>/<file>.
+        final snesCover = File(
+          p.join(downloadedMedia.path, 'snes', 'covers', 'Chrono Trigger.jpg'),
+        )..createSync(recursive: true);
+        snesCover.writeAsStringSync('hours of scraping');
+        final nesShot = File(
+          p.join(downloadedMedia.path, 'nes', 'screenshots', 'Metroid.png'),
+        )..createSync(recursive: true);
+        nesShot.writeAsStringSync('more scraping');
+
+        // NeoStation's own data written inside that same folder.
+        File(
+          p.join(downloadedMedia.path, 'data.sqlite'),
+        ).writeAsStringSync('db');
+        final neoBox = File(
+          p.join(downloadedMedia.path, 'media', 'snes', 'boxart', 'ct.png'),
+        )..createSync(recursive: true);
+        neoBox.writeAsStringSync('neostation art');
+
+        final newDest = Directory(p.join(tmp.path, 'relocated'))
+          ..createSync(recursive: true);
+
+        await UserDataLocationService.migrateData(
+          sourceUserDataPath: downloadedMedia.path,
+          sourceMediaPath: p.join(downloadedMedia.path, 'media'),
+          destPath: newDest.path,
+        );
+
+        // ES-DE per-system art survives in place.
+        expect(snesCover.existsSync(), isTrue, reason: 'snes cover preserved');
+        expect(
+          nesShot.existsSync(),
+          isTrue,
+          reason: 'nes screenshot preserved',
+        );
+        // NeoStation's own data was migrated out.
+        expect(File(p.join(newDest.path, 'data.sqlite')).existsSync(), isTrue);
+        expect(neoBox.existsSync(), isFalse, reason: 'owned art moved out');
+      },
+    );
+
+    test('no-ops when source and dest are the same folder', () async {
+      // Same physical folder, different path strings (trailing slash) — the
+      // caller's string-equality guard would miss this.
+      await UserDataLocationService.migrateData(
+        sourceUserDataPath: esde.path,
+        sourceMediaPath: p.join(esde.path, 'media'),
+        destPath: '${esde.path}${Platform.pathSeparator}',
+      );
+
+      // Nothing was copied onto itself or deleted — owned AND foreign intact.
+      expect(db.existsSync(), isTrue, reason: 'owned db intact');
+      expect(db.readAsStringSync(), 'db-bytes', reason: 'db not truncated');
+      expect(neoArt.existsSync(), isTrue, reason: 'owned art intact');
+      expect(scrapedArt.existsSync(), isTrue, reason: 'foreign art intact');
+    });
+
+    test('throws on overlapping source/dest without deleting', () async {
+      // dest nested inside source — copying a tree into itself is refused.
+      final nested = p.join(esde.path, 'relocated');
+      await expectLater(
+        UserDataLocationService.migrateData(
+          sourceUserDataPath: esde.path,
+          sourceMediaPath: p.join(esde.path, 'media'),
+          destPath: nested,
+        ),
+        throwsA(isA<Exception>()),
+      );
+      expect(db.existsSync(), isTrue, reason: 'nothing deleted on overlap');
+      expect(scrapedArt.existsSync(), isTrue, reason: 'foreign art intact');
+    });
+  });
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

Fixes a data-loss bug: pointing NeoStation's **User Data Location** at a folder shared with another front-end — e.g. an ES-DE directory, or its `downloaded_media/` subfolder — and then relocating could **destroy that data**.

Root cause: `UserDataLocationService.migrateData` copied the *entire* source folder to the destination and then **recursively deleted the whole source tree** with no ownership check, silently swallowing per-file errors (`catch (_) {}`). ROMs survived only because ES-DE keeps them in a separate folder. Confirmed real-world trigger: a user set User Data Location to `…/ES-DE/downloaded_media` via **Settings → Directories**, then a later change wiped their scraped media and gamelists.

## Changes

**`migrateData` hardening**
- **Owned-entries allowlist:** only NeoStation's own artifacts are copied/deleted — `data.sqlite*`, `config.json`, `app.log`, `media/`, `systems/`, `temp/`. Foreign files are never touched.
- **Verify-before-delete:** a source file is deleted only after its destination copy is confirmed (exists + matching length).
- **Abort-without-deleting safety gate:** if any owned file fails to copy, it throws and deletes nothing; the error is surfaced instead of swallowed.
- **Same-folder / overlap guard:** no-ops when source and destination resolve to the same folder, and refuses overlapping paths — previously a normalization difference (trailing slash, SAF-vs-real path) would copy each owned file onto itself (truncating it) and delete it.

**UI guards**
- **Setup wizard:** warns when the chosen folder already contains files (it only records the path, so a light nudge).
- **Settings relocation:** a heavier **"Move User Data?"** confirmation spelling out the *source → destination* move and flagging a non-empty destination, since this path actually moves and deletes data.
- Strings added for all 11 locales.

## Testing
- New `test/user_data_migration_test.dart` (6 tests): foreign-data preservation, owned-data migration, abort-on-copy-failure gate, the exact reported repro (`user-data = ES-DE/downloaded_media`), same-folder no-op, and overlapping-path refusal.
- `flutter analyze` clean; full `flutter test` passing.
- Built and installed on-device (AYN Thor, dev channel); verified both the wizard warning and the Settings "Move User Data?" confirmation, and confirmed via logcat that the non-empty count resolves correctly.

## Note
The reporter recalled this as "first launch," but the destructive path is **Settings → change User Data Location** (the wizard only records the path). The fix makes the deletion impossible regardless of trigger, since `migrateData` can no longer touch anything NeoStation didn't create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
