### PR TITLE
fix: stop battery drain while locked by releasing audio engine + websocket on screen-off

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
@@ -150,8 +150,14 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
         val receiver = object : android.content.BroadcastReceiver() {
             override fun onReceive(context: android.content.Context?, intent: android.content.Intent?) {
                 when (intent?.action) {
-                    android.content.Intent.ACTION_SCREEN_OFF -> pushDeviceScreenOn(false)
-                    android.content.Intent.ACTION_SCREEN_ON -> pushDeviceScreenOn(true)
+                    android.content.Intent.ACTION_SCREEN_OFF -> {
+                        pushDeviceScreenOn(false)
+                        notifyFlutterScreenState(false)
+                    }
+                    android.content.Intent.ACTION_SCREEN_ON -> {
+                        pushDeviceScreenOn(true)
+                        notifyFlutterScreenState(true)
+                    }
                 }
             }
         }
@@ -175,6 +181,25 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
             SharedStateManager.updateState(type, current)
         } catch (e: Exception) {
             android.util.Log.e("MainActivity", "pushDeviceScreenOn: ${e.message}")
+        }
+    }
+
+    // As a HOME launcher, this Activity is NOT paused when the device screen
+    // turns off, so Flutter never sees AppLifecycleState.paused on lock. Bridge
+    // the raw screen on/off state to Dart so it can release the shared audio
+    // engine while locked (its output device otherwise keeps the SoC awake and
+    // drains the battery). Independent of pushDeviceScreenOn(), which no-ops on
+    // single-screen devices.
+    private fun notifyFlutterScreenState(on: Boolean) {
+        runOnUiThread {
+            try {
+                methodChannel?.invokeMethod(
+                    if (on) "onDeviceScreenOn" else "onDeviceScreenOff",
+                    null
+                )
+            } catch (e: Exception) {
+                android.util.Log.e("MainActivity", "notifyFlutterScreenState: ${e.message}")
+            }
         }
     }
 

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -18,6 +18,7 @@ import '../constants/system_folder_names.dart';
 import 'config_service.dart';
 import 'game_session_persistence.dart';
 import 'android_service.dart';
+import 'music_player_service.dart';
 import 'launcher_service.dart';
 
 /// Represents the result of a game launch attempt.
@@ -213,6 +214,17 @@ class GameService {
 
         if (_onGameReturnedCallback != null) {
           _onGameReturnedCallback!(elapsedSeconds);
+        }
+      } else if (call.method == 'onDeviceScreenOff') {
+        // As a HOME launcher we are not paused on lock, so this is the only
+        // reliable signal to release the audio engine while the screen is off.
+        MusicPlayerService().appPaused();
+      } else if (call.method == 'onDeviceScreenOn') {
+        // Skip restore while a game owns the foreground — the game-return
+        // (lifecycle resumed) path re-opens the engine. Restoring here would
+        // reopen it (and restart music) behind the running emulator.
+        if (!_isGameLaunched) {
+          MusicPlayerService().appResumed();
         }
       }
     });

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -186,6 +186,11 @@ class GameService {
   /// Callback triggered when a game session terminates on Android.
   static Function(int)? _onGameReturnedCallback;
 
+  /// Callback for raw device screen on/off, registered by a context-aware
+  /// widget so context-only services (e.g. NotificationService) can be
+  /// suspended while locked. `true` = screen on, `false` = screen off.
+  static void Function(bool screenOn)? onScreenStateChanged;
+
   /// Callback triggered when the game process exits on desktop platforms.
   static Function()? _onProcessExitCallback;
 
@@ -217,14 +222,17 @@ class GameService {
         }
       } else if (call.method == 'onDeviceScreenOff') {
         // As a HOME launcher we are not paused on lock, so this is the only
-        // reliable signal to release the audio engine while the screen is off.
+        // reliable signal to release background resources while locked.
         MusicPlayerService().appPaused();
+        onScreenStateChanged?.call(false);
       } else if (call.method == 'onDeviceScreenOn') {
         // Skip restore while a game owns the foreground — the game-return
-        // (lifecycle resumed) path re-opens the engine. Restoring here would
-        // reopen it (and restart music) behind the running emulator.
+        // (lifecycle resumed) path re-opens everything. Restoring here would
+        // reopen the audio engine (and restart music/websocket) behind the
+        // running emulator.
         if (!_isGameLaunched) {
           MusicPlayerService().appResumed();
+          onScreenStateChanged?.call(true);
         }
       }
     });

--- a/lib/services/music_player_service.dart
+++ b/lib/services/music_player_service.dart
@@ -7,6 +7,7 @@ import 'package:audio_metadata_reader/audio_metadata_reader.dart';
 import 'package:logger/logger.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:neostation/services/saf_directory_service.dart';
+import 'package:neostation/services/sfx_service.dart';
 import '../repositories/game_repository.dart';
 import '../models/game_model.dart';
 
@@ -126,6 +127,14 @@ class MusicPlayerService extends ChangeNotifier {
   GameModel? get activeTrack => _activeTrack;
 
   bool _isAppActive = true;
+
+  // Battery: when the app is backgrounded/locked we fully release the shared
+  // SoLoud engine so its audio output device stops running and the CPU can
+  // deep-sleep. These fields remember what to restore on resume.
+  bool _engineTornDownByPause = false;
+  bool _wasPlayingBeforePause = false;
+  int _resumeIndexAfterPause = -1;
+
   final _positionController = StreamController<Duration>.broadcast();
   final _durationController = StreamController<Duration>.broadcast();
   final _playerStateController = StreamController<bool>.broadcast();
@@ -171,12 +180,68 @@ class MusicPlayerService extends ChangeNotifier {
     _positionTimer = null;
     _durationTimer = null;
     _playerStateTimer = null;
+
+    // Release the shared audio engine while backgrounded. An initialized
+    // SoLoud engine keeps its output device (and mixing callback) running
+    // continuously, which prevents the SoC from deep-sleeping and drains the
+    // battery while the device is locked. Key off the engine's real state:
+    // SFX may hold it open even when this service was never initialized.
+    if (!SoLoud.instance.isInitialized) return;
+    _teardownEngine();
   }
 
-  void appResumed() {
-    if (!_isAppActive) {
-      _isAppActive = true;
+  /// Tears down the shared SoLoud engine and records what to restore later.
+  void _teardownEngine() {
+    _wasPlayingBeforePause = _isPlaying || _wasPlayingBeforeGame;
+    _resumeIndexAfterPause = _activeIndex;
+    try {
+      SoLoud.instance.deinit();
+    } catch (e) {
+      _logger.w("Error releasing SoLoud engine on pause: $e");
+    }
+    // The engine is gone; all handles/sources are now invalid.
+    _currentHandle = null;
+    _currentSource = null;
+    _audioData = null;
+    _isPlaying = false;
+    _isInitialized = false;
+    _initCompleter = null;
+    _engineTornDownByPause = true;
+    // SFX shares the engine — drop its cached sources so it reloads on resume.
+    SfxService().handleEngineTornDown();
+  }
+
+  Future<void> appResumed() async {
+    if (_isAppActive) return;
+    _isAppActive = true;
+
+    if (!_engineTornDownByPause) {
+      // Nothing was released (e.g. engine was never open); just restart timers.
       if (_isInitialized) _startStreamTimers();
+      return;
+    }
+    _engineTornDownByPause = false;
+
+    final restoreMusic = _wasPlayingBeforePause && _playlist.isNotEmpty;
+    final restoreIndex = _resumeIndexAfterPause;
+    _wasPlayingBeforePause = false;
+    _wasPlayingBeforeGame = false;
+
+    // Reopen the engine for SFX (the eager consumer). This re-inits the shared
+    // native engine, so a subsequent music init() will find it already up.
+    try {
+      await SfxService().reinitializeAfterEngineRestart();
+    } catch (e) {
+      _logger.w("Error reloading SFX after resume: $e");
+    }
+
+    // Resume music from the top of the track it was playing when we paused.
+    if (restoreMusic) {
+      try {
+        await start(index: restoreIndex, updateUI: true);
+      } catch (e) {
+        _logger.w("Error resuming music after resume: $e");
+      }
     }
   }
 

--- a/lib/services/sfx_service.dart
+++ b/lib/services/sfx_service.dart
@@ -135,6 +135,27 @@ class SfxService {
     }
   }
 
+  /// Resets SFX state after the shared [SoLoud] engine has been torn down
+  /// elsewhere (e.g. [MusicPlayerService] releasing it while the app is
+  /// backgrounded for battery reasons).
+  ///
+  /// The engine tear-down already disposed every source, so we just drop our
+  /// stale handles and mark uninitialized; assets reload on the next
+  /// [init]/playback call.
+  void handleEngineTornDown() {
+    _sources.clear();
+    _isInitialized = false;
+    _isInitializing = false;
+    _initCompleter = null;
+    _log.i('[SfxService] Engine released; SFX will reload on resume.');
+  }
+
+  /// Reopens the engine (if needed) and reloads SFX assets after a tear-down.
+  Future<void> reinitializeAfterEngineRestart() async {
+    if (_isInitialized) return;
+    await init();
+  }
+
   /// Unloads all cached audio sources.
   ///
   /// Note: This does NOT shut down the shared [SoLoud] engine.

--- a/lib/widgets/app_lifecycle_handler.dart
+++ b/lib/widgets/app_lifecycle_handler.dart
@@ -55,6 +55,26 @@ class _AppLifecycleHandlerState extends State<AppLifecycleHandler>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+
+    // A HOME launcher is not paused on screen-off, so lifecycle `paused` never
+    // fires on lock. Bridge the native screen on/off signal to the websocket:
+    // suspend it while locked, reconnect on wake (music/audio is handled in
+    // GameService's channel handler). Screen-on only fires here when NeoStation
+    // is foreground (gated on !isGameLaunched at the call site).
+    GameService.onScreenStateChanged = (screenOn) {
+      if (!mounted) return;
+      final notificationService = Provider.of<NotificationService>(
+        context,
+        listen: false,
+      );
+      if (screenOn) {
+        notificationService.connect().catchError((error) {
+          _log.e('Failed to reconnect notifications on screen-on: $error');
+        });
+      } else {
+        notificationService.suspend();
+      }
+    };
     // Initialize with current plan after a delay to ensure auth is loaded
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       // Wait a bit more to ensure auth service is fully loaded
@@ -69,6 +89,7 @@ class _AppLifecycleHandlerState extends State<AppLifecycleHandler>
 
   @override
   void dispose() {
+    GameService.onScreenStateChanged = null;
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

Fixes heavy battery drain while the device is locked/asleep (reported as ~10-12%/hr on Retroid Classic, ~6-7%/hr on RG Rotate). In Android's battery-usage screen NeoStation showed **59% of total battery for 2 minutes of screen time** — the drain was almost entirely with the screen off.

## Root cause

Two issues sharing one root cause:

1. **The shared SoLoud audio engine holds an output device open for the app's entire lifetime.** `SfxService` initializes SoLoud eagerly at startup (for nav sounds), which opens an AAudio output stream that keeps running (`state:started`) even with nothing playing. An always-started audio output stream prevents the SoC from entering deep sleep.

2. **As a HOME launcher, the activity is not paused on screen-off**, so `AppLifecycleState.paused` never fires on lock. The existing `MusicPlayerService.appPaused()` (which only cancelled UI timers anyway) and `NotificationService.suspend()` are both wired to that lifecycle event — so on lock, *neither* ran. The audio device stayed open and the sync websocket + its reconnect/health-check timers kept running.

## Fix

- **`MusicPlayerService`**: `appPaused()` now fully `deinit()`s the shared SoLoud engine (keyed off the engine's real state, since SFX may hold it open when the music service was never initialized) and records restore state; `appResumed()` reopens the engine, reloads SFX, and resumes music if it was playing.
- **`SfxService`**: adds `handleEngineTornDown()` / `reinitializeAfterEngineRestart()` to drop stale sources and reload after the shared engine is released.
- **`NotificationService`** is suspended on lock and reconnected on wake.
- **`MainActivity`**: bridges the existing `ACTION_SCREEN_OFF/ON` receiver to Dart (`onDeviceScreenOff/On`) — the only reliable lock signal for a HOME launcher. Screen-on restore is gated on `!isGameLaunched` so nothing wakes up behind a running emulator.

## Testing (on-device, AYN Thor, same-device before/after)

Idle on the home screen, locked, unplugged:

| | Pre-fix (`main`) | Post-fix |
|---|---|---|
| **CPU uptime on battery** | **100.0%** (never slept) | **0.9%** (slept 99.1%) |
| Screen-off discharge | ~43 mAh/hr | ~4.6 mAh/hr |
| Battery %/hr | ~0.55 | ~0.10 |

Verified via `dumpsys audio` that the AAudio output device is released on screen-off and re-created on wake, and via `dumpsys batterystats` that the SoC now deep-sleeps ~99% of the locked window instead of never sleeping. ~9-10× reduction in idle-locked power draw; on the smaller-battery Retroid/RG this should turn the reported drain negligible.

`flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)