### PR TITLE
fix(secondary): stop Now Playing screen being clobbered on launch

### DIFF
--- a/lib/models/secondary_display_state.dart
+++ b/lib/models/secondary_display_state.dart
@@ -555,6 +555,23 @@ class SecondaryDisplayStateData {
 /// Extends [SharedState] to leverage cross-process or cross-display communication
 /// provided by the `sub_screen` package.
 class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
+  SecondaryDisplayState._();
+
+  /// Per-isolate shared instance. All producers within an engine MUST use this
+  /// so every partial update copyWith's from one authoritative local state.
+  ///
+  /// The `sub_screen` [SharedState] base ships a full-state snapshot on every
+  /// setState and syncs sibling instances only asynchronously. With multiple
+  /// instances, a producer whose local copy hasn't synced yet ships a stale
+  /// snapshot that clobbers fields another instance just set (this caused the
+  /// intermittent "no Now Playing screen" on PSX/GameCube). A single instance
+  /// removes the cross-instance race. Each Flutter engine (main vs. secondary
+  /// display) is a separate isolate and gets its own instance — correct, since
+  /// they sync across the process boundary via the platform channel.
+  ///
+  /// Never dispose this — it lives for the isolate's lifetime.
+  static final SecondaryDisplayState instance = SecondaryDisplayState._();
+
   @override
   SecondaryDisplayStateData fromJson(Map<String, dynamic> json) {
     return SecondaryDisplayStateData.fromJson(json);

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -187,7 +187,12 @@ class SqliteConfigProvider extends ChangeNotifier {
       _initialized = true;
 
       if (Platform.isAndroid) {
-        _secondaryDisplayState = SecondaryDisplayState();
+        _secondaryDisplayState = SecondaryDisplayState.instance;
+        // Idempotent: reinitialize() can re-run initialize() (first-launch
+        // custom data dir). Since the state is now a shared singleton that is
+        // never disposed, remove any prior registration before re-adding so a
+        // second init can't accumulate a duplicate listener.
+        _secondaryDisplayState!.removeListener(_onSecondaryStateChanged);
         _secondaryDisplayState!.addListener(_onSecondaryStateChanged);
 
         _secondaryDisplayChannel.setMethodCallHandler(

--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -286,11 +286,14 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
     // When NeoStation's own UI regains focus and no game is actually running,
-    // clear any stale Now Playing state left over from quitting mid-game. The
-    // isGameLaunched guard avoids interfering with the emulator launch handoff.
+    // clear any stale Now Playing state left over from quitting mid-game. Use
+    // isGameLaunchInProgress (not isGameLaunched) so a transient resume during
+    // the launch dialog/handoff window — before _registerGameLaunch flips
+    // isGameLaunched ~2s in — can't clobber the Now Playing state we just
+    // pushed. This was the PSX/GameCube "no Now Playing" race.
     if (state == AppLifecycleState.resumed &&
         Platform.isAndroid &&
-        !GameService.isGameLaunched) {
+        !GameService.isGameLaunchInProgress) {
       Provider.of<SqliteConfigProvider>(
         context,
         listen: false,

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -245,13 +245,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
     MusicPlayerService().addListener(_onMusicPlayerStateChanged);
 
     if (Platform.isAndroid) {
-      _secondaryDisplayState = SecondaryDisplayState();
-      _secondaryDisplayState!.addListener(() {
-        if (mounted) {
-          setState(() {});
-          _updateMusicDucking();
-        }
-      });
+      _secondaryDisplayState = SecondaryDisplayState.instance;
+      _secondaryDisplayState!.addListener(_onSecondaryDisplayChanged);
     }
   }
 
@@ -265,6 +260,13 @@ class _SystemGamesListState extends State<SystemGamesList> {
     _letterIndicatorTextShadow = primary;
   }
 
+  void _onSecondaryDisplayChanged() {
+    if (mounted) {
+      setState(() {});
+      _updateMusicDucking();
+    }
+  }
+
   @override
   void dispose() {
     // Detach listeners before disposal.
@@ -272,7 +274,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
     _databaseProvider.removeListener(_onDatabaseUpdated);
     MusicPlayerService().removeListener(_onMusicPlayerStateChanged);
 
-    _secondaryDisplayState?.dispose();
+    // Shared singleton — detach our listener, never dispose the instance.
+    _secondaryDisplayState?.removeListener(_onSecondaryDisplayChanged);
     _achievementsController.dispose();
 
     _cleanupResources();
@@ -1499,9 +1502,13 @@ class _SystemGamesListState extends State<SystemGamesList> {
 
     // Resource termination and UI synchronization prior to process handoff.
     _stopVideoAndCleanup();
-    // Await the art push first so it can't land after the achievement push and
-    // re-hide the panel; the panel push is then the definitive last write.
-    await _updateSecondaryDisplay(_selectedGame!);
+    // NOTE: do NOT push a separate _updateSecondaryDisplay here. The game's
+    // media is already in the shared state from browsing, and a separate launch
+    // snapshot (carrying nowPlayingActive=false + isGameLaunching=true) can be
+    // delivered to the secondary engine AFTER the Now Playing push below and
+    // clobber it — the cross-engine transport gives no ordering guarantee. The
+    // launch push (_pushAchievementsForLaunch) now carries isGameLaunching
+    // itself, so it is the single authoritative launch write.
     if (!mounted) return;
 
     // Push the in-game RetroAchievements panel. Fired without awaiting so it

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -70,7 +70,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   void initState() {
     super.initState();
     if (Platform.isAndroid) {
-      _secondaryDisplayState = SecondaryDisplayState();
+      _secondaryDisplayState = SecondaryDisplayState.instance;
       _secondaryDisplayState!.addListener(_onStateChanged);
       // Signal that the secondary screen is active — but only after the initial
       // state sync. Pushing it while the synced value is still null makes
@@ -325,8 +325,8 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
 
   @override
   void dispose() {
+    // Shared singleton — detach our listener, never dispose the instance.
     _secondaryDisplayState?.removeListener(_onStateChanged);
-    _secondaryDisplayState?.dispose();
     _celebrationTimer?.cancel();
     _playTimeTicker?.cancel();
     _dimTimer?.cancel();

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -112,7 +112,7 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
     _initializeGamepad();
 
     if (Platform.isAndroid) {
-      _secondaryDisplayState = SecondaryDisplayState();
+      _secondaryDisplayState = SecondaryDisplayState.instance;
       _secondaryDisplayState!.addListener(_onSecondaryStateChanged);
     }
 
@@ -167,11 +167,11 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
   @override
   void dispose() {
     _musicPlayerService.removeListener(_handleMusicStateChanged);
+    // Shared singleton — detach our listener, never dispose the instance.
     _secondaryDisplayState?.removeListener(_onSecondaryStateChanged);
     _cleanupGamepad();
     _scrollController.dispose();
     _achievementsController.dispose();
-    _secondaryDisplayState?.dispose();
     super.dispose();
   }
 

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -837,7 +837,7 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
     _initializeGamepad();
 
     if (Platform.isAndroid) {
-      _secondaryDisplayState = SecondaryDisplayState();
+      _secondaryDisplayState = SecondaryDisplayState.instance;
       _secondaryDisplayState!.addListener(_onSecondaryStateChanged);
     }
 
@@ -1116,10 +1116,10 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
   void dispose() {
     _cardSizeLabelTimer?.cancel();
     _cardSizeLabel.dispose();
+    // Shared singleton — detach our listener, never dispose the instance.
     _secondaryDisplayState?.removeListener(_onSecondaryStateChanged);
     _cleanupGamepad();
     _scrollController.dispose();
-    _secondaryDisplayState?.dispose();
     super.dispose();
   }
 

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -170,6 +170,26 @@ class GameService {
   static bool _isGameLaunched = false;
   static bool get isGameLaunched => _isGameLaunched;
 
+  /// True from the moment a launch is initiated (Now Playing pushed) until the
+  /// launch resolves — i.e. [_registerGameLaunch] flips [_isGameLaunched], or
+  /// the launch fails. Covers the ~2s dialog+handoff window during which
+  /// [_isGameLaunched] is still false, so a transient resume in that window
+  /// can't clear the Now Playing state we just pushed.
+  static bool _launchPending = false;
+
+  /// Whether a game is running OR a launch is in progress. Callers reacting to
+  /// an app resume should use this (not [isGameLaunched]) before clearing
+  /// secondary-display in-game state, to avoid a launch-window race.
+  static bool get isGameLaunchInProgress => _isGameLaunched || _launchPending;
+
+  /// Opens the launch-pending window. Call when a launch is initiated, before
+  /// the emulator handoff. Cleared by [_registerGameLaunch] on success or
+  /// [clearLaunchPending] on failure.
+  static void beginLaunchPending() => _launchPending = true;
+
+  /// Closes the launch-pending window (e.g. on launch failure).
+  static void clearLaunchPending() => _launchPending = false;
+
   /// Timestamp when the current game session was initiated.
   static DateTime? _gameLaunchTime;
 
@@ -696,6 +716,7 @@ class GameService {
     String? emulatorExeName,
   ]) {
     _isGameLaunched = true;
+    _launchPending = false;
     _gameLaunchTime = DateTime.now();
     _lastPlaytimeSave = _gameLaunchTime;
     _launchedEmulatorExe = emulatorExeName;

--- a/lib/services/secondary_achievements_controller.dart
+++ b/lib/services/secondary_achievements_controller.dart
@@ -78,6 +78,15 @@ class SecondaryAchievementsController {
     // achievements page on top.
     // ignore: unawaited_futures
     state.updateState(
+      // isGameLaunching is set here — in the SAME atomic snapshot as
+      // nowPlayingActive — rather than via a separate _updateSecondaryDisplay
+      // push. The cross-engine transport delivers full snapshots without
+      // ordering guarantees, so a separate launch snapshot carrying
+      // nowPlayingActive=false could land after this one and clobber it (the
+      // intermittent "no Now Playing on PSX/GameCube" race). One snapshot = no
+      // race. It also stops the secondary preview video (the receiver keys the
+      // video teardown off isGameLaunching).
+      isGameLaunching: true,
       nowPlayingActive: true,
       gameTitle: game.name,
       gameBoxart: boxartPath,

--- a/lib/utils/game_launch_utils.dart
+++ b/lib/utils/game_launch_utils.dart
@@ -32,8 +32,16 @@ Future<void> launchGameWithDialog({
   Future<void> Function(BuildContext context, GameLaunchResult result)?
   onLaunchFailed,
 }) async {
+  // Open the launch-pending window immediately so a transient app resume during
+  // the dialog/handoff can't clear the Now Playing state (see
+  // GameService.isGameLaunchInProgress). Closed by _registerGameLaunch on
+  // success, or below on failure.
+  GameService.beginLaunchPending();
   await GameLaunchManager().beginSession();
-  if (!context.mounted) return;
+  if (!context.mounted) {
+    GameService.clearLaunchPending();
+    return;
+  }
 
   // Display the launch overlay.
   showDialog(
@@ -50,17 +58,23 @@ Future<void> launchGameWithDialog({
 
   // Artificial delay for UX consistency and asset loading.
   await Future.delayed(const Duration(seconds: 2));
-  if (!context.mounted) return;
+  if (!context.mounted) {
+    GameService.clearLaunchPending();
+    return;
+  }
 
   final result = await GameService.launchGame(context, system, game);
 
   if (result.success) {
-    // Notify manager to begin background process monitoring.
+    // Notify manager to begin background process monitoring. On success
+    // _registerGameLaunch has already closed the launch-pending window
+    // (isGameLaunched now covers it).
     GameLaunchManager().onGameStarted(
       emulatorExe: GameService.launchedEmulatorExe,
     );
   } else {
     // Clean up session and close dialog on failure.
+    GameService.clearLaunchPending();
     GameLaunchManager().onDialogDisposed();
     if (context.mounted) Navigator.of(context).pop();
     if (onLaunchFailed != null && context.mounted) {

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -45,7 +45,7 @@ class _SetupWizardState extends State<SetupWizard> {
     _initializeSteps();
     _initGamepad();
     if (Platform.isAndroid) {
-      _secondaryDisplayState = SecondaryDisplayState();
+      _secondaryDisplayState = SecondaryDisplayState.instance;
     }
   }
 
@@ -78,7 +78,7 @@ class _SetupWizardState extends State<SetupWizard> {
   @override
   void dispose() {
     _gamepadNav?.dispose();
-    _secondaryDisplayState?.dispose();
+    // Shared singleton — never dispose the instance.
     super.dispose();
   }
 

--- a/test/game_service_test.dart
+++ b/test/game_service_test.dart
@@ -133,4 +133,31 @@ void main() {
       expect(names, isNot(contains('fav-android.apk')));
     });
   });
+
+  // isGameLaunchInProgress widens the launch window used to suppress the
+  // resume-triggered secondary-display reset. It must be true from the moment a
+  // launch is initiated (beginLaunchPending) — before _registerGameLaunch flips
+  // isGameLaunched ~2s later — otherwise a transient resume clears Now Playing.
+  group('GameService launch-pending window', () {
+    tearDown(GameService.clearLaunchPending);
+
+    test('is not in progress before a launch begins', () {
+      GameService.clearLaunchPending();
+      expect(GameService.isGameLaunchInProgress, isFalse);
+    });
+
+    test('beginLaunchPending opens the window before the game is registered',
+        () {
+      expect(GameService.isGameLaunched, isFalse);
+      GameService.beginLaunchPending();
+      // Guard is true even though the game process is not yet registered.
+      expect(GameService.isGameLaunchInProgress, isTrue);
+    });
+
+    test('clearLaunchPending closes the window (failed/aborted launch)', () {
+      GameService.beginLaunchPending();
+      GameService.clearLaunchPending();
+      expect(GameService.isGameLaunchInProgress, isFalse);
+    });
+  });
 }

--- a/test/secondary_display_state_test.dart
+++ b/test/secondary_display_state_test.dart
@@ -147,4 +147,58 @@ void main() {
       expect(restored.dockSlotCount, 5);
     });
   });
+
+  // The "no Now Playing on launch" bug was a partial state update silently
+  // dropping nowPlayingActive. Every secondary-display write goes through
+  // copyWith, so these pin the merge contract the fix depends on: a field not
+  // named in a copyWith call must survive unchanged.
+  group('SecondaryDisplayStateData.copyWith merge contract', () {
+    final active = SecondaryDisplayStateData(
+      systemName: 'ps1',
+      gameTitle: 'Silent Hill',
+      nowPlayingActive: true,
+      isGameLaunching: true,
+    );
+
+    test('a partial update that omits nowPlayingActive preserves it', () {
+      // This is exactly the clobber that broke Now Playing: a browse-style
+      // update (media/system fields) that never mentions nowPlayingActive must
+      // NOT turn it off.
+      final next = active.copyWith(
+        systemName: 'ps1',
+        gameFanart: '/data/fanart.png',
+        gameScreenshot: '/data/shot.png',
+      );
+
+      expect(next.nowPlayingActive, isTrue);
+      expect(next.gameTitle, 'Silent Hill');
+      expect(next.gameFanart, '/data/fanart.png');
+    });
+
+    test('an explicit nowPlayingActive: false clears it (game exit)', () {
+      // The legitimate way Now Playing turns off — on game return.
+      final next = active.copyWith(nowPlayingActive: false);
+
+      expect(next.nowPlayingActive, isFalse);
+      // Other fields still untouched.
+      expect(next.gameTitle, 'Silent Hill');
+      expect(next.isGameLaunching, isTrue);
+    });
+
+    test('the atomic launch write sets isGameLaunching + nowPlayingActive '
+        'together without dropping either', () {
+      // Models pushForLaunch's single authoritative write: both flags on in one
+      // copyWith, and neither is lost.
+      final idle = SecondaryDisplayStateData(systemName: 'ps1');
+      final launched = idle.copyWith(
+        isGameLaunching: true,
+        nowPlayingActive: true,
+        gameTitle: 'Silent Hill',
+      );
+
+      expect(launched.isGameLaunching, isTrue);
+      expect(launched.nowPlayingActive, isTrue);
+      expect(launched.gameTitle, 'Silent Hill');
+    });
+  });
 }


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

The "Now Playing" screen on the secondary display intermittently failed to appear when launching a game — **reliably for large disc-based systems (PSX / GameCube / Dreamcast), rarely for NES / retro**. The cause was a race in the cross-engine secondary-display state layer, not anything emulator- or video-related (the branch's original "video freeze" framing was a red herring).

**Root cause:** the secondary display is fed by `SharedState` (from `sub_screen`), which replicates **full-state snapshots** to the secondary Flutter engine **with no ordering guarantee**. On launch the app fired two snapshots — a browse-state push (`nowPlayingActive=false`) then the Now Playing push (`nowPlayingActive=true`); when the stale one arrived last it wiped Now Playing. Large systems lose more often because their launch does more async work (preview-video teardown, larger media), widening the window. Two contributors compounded it: five separate `SecondaryDisplayState` instances each shipping full snapshots, and a resume-triggered reset firing during the launch handoff.

**Fixes:**
1. **Atomic launch snapshot (primary).** Fold `isGameLaunching` into `pushForLaunch`'s single Now Playing write and drop the redundant `_updateSecondaryDisplay` at launch — one authoritative launch write, no competing stale snapshot.
2. **Single shared `SecondaryDisplayState` instance.** Collapse five producer instances into one per-isolate singleton; detach listeners instead of disposing, with idempotent registration so the first-launch `reinitialize()` path can't accumulate a duplicate listener.
3. **Launch-pending guard (defense-in-depth).** `GameService.isGameLaunchInProgress` keeps the resume-triggered `resetSecondaryInGameState` from clearing Now Playing during the ~2s launch handoff, before `isGameLaunched` flips.

Fixes # N/A (no tracked issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring (secondary-display state collapsed to a shared singleton)

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation. _(N/A — no docs cover this internal behavior)_
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. _(N/A — no new assets)_
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (launches driven via the AYN Thor's controller during testing; no navigation code changed).

### Testing notes (on-device, AYN Thor)

- **5/5 PSX launches** now show Now Playing, plus NES — previously ~1/3 for PSX.
- Stress-tested browse-time video scrolling: no regression.
- Exercised the first-launch **setup-wizard `reinitialize()`** path directly: same singleton reused, no crash, no duplicate listener.
- Unit tests added over the `copyWith` merge contract and the launch-pending window (the cross-engine ordering race itself is device-verified, not unit-testable).

**Out of scope (parked):** the original `_videoToken` browse-video guard (not what fixed this — separate branch `fix/secondary-video-init-guard`), and a pre-existing "emulator not configured" stale-selection issue surfaced during testing.

## Screenshots (if applicable)

Not captured — this is secondary-display (bottom screen) behavior; verified via on-device `logcat` state traces showing `nowPlayingActive` set and retained across each launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
