### PR TITLE
fix: persist game carousel Card Style across restarts

### DIFF
--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -167,6 +167,8 @@ class SqliteConfigService {
         systemGridColumns:
             userConfig?['system_grid_columns']?.toString() ?? 'M',
         gameGridColumns: userConfig?['game_grid_columns']?.toString() ?? 'M',
+        gameCarouselCardStyle:
+            userConfig?['game_carousel_card_style']?.toString() ?? 'fanart',
         dockApps: ConfigModel.normalizeDock(userConfig?['dock_apps']),
         dockEnabled:
             (int.tryParse(userConfig?['dock_enabled']?.toString() ?? '1') ??
@@ -233,6 +235,7 @@ class SqliteConfigService {
         autoUpdateSystems: config.autoUpdateSystems ? 1 : 0,
         systemGridColumns: config.systemGridColumns,
         gameGridColumns: config.gameGridColumns,
+        gameCarouselCardStyle: config.gameCarouselCardStyle,
         dockApps: jsonEncode(config.dockApps),
         dockEnabled: config.dockEnabled ? 1 : 0,
         dockSlotCount: config.dockSlotCount,

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -288,6 +288,9 @@ class SqliteMigrations {
       case 94:
         await _migrateToVersion94(db);
         break;
+      case 95:
+        await _migrateToVersion95(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -4667,6 +4670,26 @@ class SqliteMigrations {
       }
     } catch (e, stackTrace) {
       _log.e('Error in migration v94: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  static Future<void> _migrateToVersion95(Database db) async {
+    _log.i('Migration v95: Adding game_carousel_card_style to user_config');
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_config)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+      if (!columns.contains('game_carousel_card_style')) {
+        db.execute(
+          "ALTER TABLE user_config ADD COLUMN game_carousel_card_style TEXT DEFAULT 'fanart'",
+        );
+        _log.i('Column game_carousel_card_style added via v95');
+      } else {
+        _log.i('Column game_carousel_card_style already exists');
+      }
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v95: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 94;
+  static const int _databaseVersion = 95;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -1615,6 +1615,7 @@ class SqliteService {
         auto_update_systems INTEGER DEFAULT 1,
         system_grid_columns TEXT DEFAULT 'M',
         game_grid_columns TEXT DEFAULT 'M',
+        game_carousel_card_style TEXT DEFAULT 'fanart',
         use_12_hour_clock INTEGER DEFAULT 0,
         dock_apps TEXT,
         dock_enabled INTEGER DEFAULT 1,
@@ -2342,6 +2343,7 @@ class SqliteService {
     int? autoUpdateSystems,
     String? systemGridColumns,
     String? gameGridColumns,
+    String? gameCarouselCardStyle,
     String? dockApps,
     int? dockEnabled,
     int? dockSlotCount,
@@ -2428,6 +2430,9 @@ class SqliteService {
     }
     if (gameGridColumns != null) {
       newConfig['game_grid_columns'] = gameGridColumns;
+    }
+    if (gameCarouselCardStyle != null) {
+      newConfig['game_carousel_card_style'] = gameCarouselCardStyle;
     }
     if (dockApps != null) {
       newConfig['dock_apps'] = dockApps;


### PR DESCRIPTION
> 🤖 This PR was authored with [Claude Code](https://claude.com/claude-code).

# Description

Reported by a user on Discord (v0.9.4, POCO M6 Pro): changing **Card Style** from Fanart to Box does not persist — after closing and reopening the app it resets to Fanart, while Card Size and other settings save correctly.

Card Style (`gameCarouselCardStyle`) was only ever held in memory — the SQLite persistence layer for it was missing entirely (no column, no write, no read), so it silently reset to the `fanart` default on every launch while Card Size (`game_grid_columns`) saved correctly. Most visible on Android, where the process is killed on close.

This mirrors the existing `game_grid_columns` path to add the missing persistence:

- **Schema:** add `game_carousel_card_style TEXT DEFAULT 'fanart'` to `user_config` — via `CREATE TABLE` (fresh installs) and a new versioned migration **v95** (existing installs), guarded by a column-exists check.
- **Write:** add the `gameCarouselCardStyle` parameter to `SqliteService.saveUserConfig` and pass `config.gameCarouselCardStyle` from `SqliteConfigService.saveConfig`.
- **Read:** load `game_carousel_card_style` in `SqliteConfigService.loadConfig` (falls back to `'fanart'`).

Stored as a name string (`'fanart'`/`'box'`), consistent with the model's existing JSON serialization. Model, provider, and UI already handled the value correctly and are unchanged.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

N/A — behavior fix (setting now persists across restarts); no visual change. Verified on-device: set Card Style → Box, killed the app from recents, reopened → stays Box (Card Size persistence re-checked as regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
