### PR TITLE
fix(settings): add confirmation guards to destructive actions + unify confirm dialogs

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -821,6 +821,14 @@ mixin AppLocale {
   static const String addRomFolder = 'add_rom_folder';
   static const String removeRomFolder = 'remove_rom_folder';
 
+  // Destructive-action confirmation prompts
+  static const String resetPlayTimeConfirm = 'reset_play_time_confirm';
+  static const String resetPlayTimeConfirmBody = 'reset_play_time_confirm_body';
+  static const String removeRomFolderConfirmBody = 'remove_rom_folder_confirm_body';
+  static const String disconnectRaConfirm = 'disconnect_ra_confirm';
+  static const String disconnectRaConfirmBody = 'disconnect_ra_confirm_body';
+  static const String neoSyncLogoutConfirmBody = 'neo_sync_logout_confirm_body';
+
   // RetroAchievements dashboard & achievement comments
   static const String raCompletionsLabel = 'ra_completions_label';
   static const String raMasteriesLabel = 'ra_masteries_label';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -816,6 +816,16 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.romDirectories: 'ROM-Verzeichnisse',
   AppLocale.addRomFolder: 'ROM-Ordner hinzufügen',
   AppLocale.removeRomFolder: 'Entfernen',
+  AppLocale.resetPlayTimeConfirm: 'Spielzeit zurücksetzen',
+  AppLocale.resetPlayTimeConfirmBody:
+      'Dadurch wird die erfasste Spielzeit dieses Spiels dauerhaft auf null zurückgesetzt. Dies kann nicht rückgängig gemacht werden.',
+  AppLocale.removeRomFolderConfirmBody:
+      'Dadurch wird dieser ROM-Ordner aus deinen Bibliotheksquellen entfernt. Deine Dateien auf dem Datenträger werden nicht gelöscht.',
+  AppLocale.disconnectRaConfirm: 'RetroAchievements trennen',
+  AppLocale.disconnectRaConfirmBody:
+      'Dadurch wirst du abgemeldet und deine gespeicherten RetroAchievements-Anmeldedaten werden von diesem Gerät entfernt.',
+  AppLocale.neoSyncLogoutConfirmBody:
+      'Dadurch wirst du auf diesem Gerät von deinem NeoSync-Konto abgemeldet.',
 
   AppLocale.deleteGame: 'Spiel löschen',
   AppLocale.deleteGameConfirm: 'Endgültig löschen',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -790,6 +790,16 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.romDirectories: 'ROM Directories',
   AppLocale.addRomFolder: 'Add ROM Folder',
   AppLocale.removeRomFolder: 'Remove',
+  AppLocale.resetPlayTimeConfirm: 'Reset Play Time',
+  AppLocale.resetPlayTimeConfirmBody:
+      'This will permanently reset the recorded play time for this game to zero. This cannot be undone.',
+  AppLocale.removeRomFolderConfirmBody:
+      'This will remove this ROM folder from your library sources. Your files on disk are not deleted.',
+  AppLocale.disconnectRaConfirm: 'Disconnect RetroAchievements',
+  AppLocale.disconnectRaConfirmBody:
+      'This will sign you out and remove your saved RetroAchievements credentials from this device.',
+  AppLocale.neoSyncLogoutConfirmBody:
+      'This will sign you out of your NeoSync account on this device.',
 
   AppLocale.deleteGame: 'Delete Game',
   AppLocale.deleteGameConfirm: 'Delete Forever',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -815,6 +815,16 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.romDirectories: 'Directorios de ROMs',
   AppLocale.addRomFolder: 'Añadir carpeta de ROMs',
   AppLocale.removeRomFolder: 'Eliminar',
+  AppLocale.resetPlayTimeConfirm: 'Restablecer tiempo de juego',
+  AppLocale.resetPlayTimeConfirmBody:
+      'Esto restablecerá permanentemente a cero el tiempo de juego registrado de este juego. Esta acción no se puede deshacer.',
+  AppLocale.removeRomFolderConfirmBody:
+      'Esto eliminará esta carpeta de ROM de las fuentes de tu biblioteca. Tus archivos en el disco no se eliminarán.',
+  AppLocale.disconnectRaConfirm: 'Desconectar RetroAchievements',
+  AppLocale.disconnectRaConfirmBody:
+      'Esto cerrará tu sesión y eliminará tus credenciales guardadas de RetroAchievements de este dispositivo.',
+  AppLocale.neoSyncLogoutConfirmBody:
+      'Esto cerrará la sesión de tu cuenta de NeoSync en este dispositivo.',
 
   AppLocale.deleteGame: 'Eliminar Juego',
   AppLocale.deleteGameConfirm: 'Eliminar Permanentemente',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -818,6 +818,16 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.romDirectories: 'Répertoires ROM',
   AppLocale.addRomFolder: 'Ajouter un dossier ROM',
   AppLocale.removeRomFolder: 'Supprimer',
+  AppLocale.resetPlayTimeConfirm: 'Réinitialiser le temps de jeu',
+  AppLocale.resetPlayTimeConfirmBody:
+      'Cela réinitialisera définitivement à zéro le temps de jeu enregistré pour ce jeu. Cette action est irréversible.',
+  AppLocale.removeRomFolderConfirmBody:
+      'Cela supprimera ce dossier de ROM des sources de votre bibliothèque. Vos fichiers sur le disque ne sont pas supprimés.',
+  AppLocale.disconnectRaConfirm: 'Déconnecter RetroAchievements',
+  AppLocale.disconnectRaConfirmBody:
+      'Cela vous déconnectera et supprimera vos identifiants RetroAchievements enregistrés de cet appareil.',
+  AppLocale.neoSyncLogoutConfirmBody:
+      'Cela vous déconnectera de votre compte NeoSync sur cet appareil.',
 
   AppLocale.deleteGame: 'Supprimer le jeu',
   AppLocale.deleteGameConfirm: 'Supprimer définitivement',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -792,6 +792,16 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.romDirectories: 'Direktori ROM',
   AppLocale.addRomFolder: 'Tambah Folder ROM',
   AppLocale.removeRomFolder: 'Hapus',
+  AppLocale.resetPlayTimeConfirm: 'Atur Ulang Waktu Bermain',
+  AppLocale.resetPlayTimeConfirmBody:
+      'Ini akan mengatur ulang waktu bermain yang tercatat untuk game ini menjadi nol secara permanen. Tindakan ini tidak dapat dibatalkan.',
+  AppLocale.removeRomFolderConfirmBody:
+      'Ini akan menghapus folder ROM ini dari sumber pustaka Anda. File Anda di disk tidak akan dihapus.',
+  AppLocale.disconnectRaConfirm: 'Putuskan RetroAchievements',
+  AppLocale.disconnectRaConfirmBody:
+      'Ini akan mengeluarkan Anda dan menghapus kredensial RetroAchievements yang tersimpan dari perangkat ini.',
+  AppLocale.neoSyncLogoutConfirmBody:
+      'Ini akan mengeluarkan Anda dari akun NeoSync di perangkat ini.',
 
   AppLocale.deleteGame: 'Hapus Game',
   AppLocale.deleteGameConfirm: 'Hapus Secara Permanen',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -810,6 +810,16 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.romDirectories: 'Directory ROM',
   AppLocale.addRomFolder: 'Aggiungi cartella ROM',
   AppLocale.removeRomFolder: 'Rimuovi',
+  AppLocale.resetPlayTimeConfirm: 'Reimposta tempo di gioco',
+  AppLocale.resetPlayTimeConfirmBody:
+      'Questa operazione azzererà in modo permanente il tempo di gioco registrato per questo gioco. Non può essere annullata.',
+  AppLocale.removeRomFolderConfirmBody:
+      'Questa operazione rimuoverà questa cartella ROM dalle fonti della tua libreria. I file sul disco non vengono eliminati.',
+  AppLocale.disconnectRaConfirm: 'Disconnetti RetroAchievements',
+  AppLocale.disconnectRaConfirmBody:
+      'Questa operazione ti disconnetterà e rimuoverà le credenziali RetroAchievements salvate da questo dispositivo.',
+  AppLocale.neoSyncLogoutConfirmBody:
+      'Questa operazione ti disconnetterà dal tuo account NeoSync su questo dispositivo.',
 
   AppLocale.deleteGame: 'Elimina gioco',
   AppLocale.deleteGameConfirm: 'Elimina per sempre',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -721,6 +721,16 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.romDirectories: 'ROMディレクトリ',
   AppLocale.addRomFolder: 'ROMフォルダを追加',
   AppLocale.removeRomFolder: '削除',
+  AppLocale.resetPlayTimeConfirm: 'プレイ時間をリセット',
+  AppLocale.resetPlayTimeConfirmBody:
+      'このゲームの記録されたプレイ時間を完全にゼロにリセットします。この操作は元に戻せません。',
+  AppLocale.removeRomFolderConfirmBody:
+      'このROMフォルダをライブラリのソースから削除します。ディスク上のファイルは削除されません。',
+  AppLocale.disconnectRaConfirm: 'RetroAchievements の接続を解除',
+  AppLocale.disconnectRaConfirmBody:
+      'ログアウトし、保存されたRetroAchievementsの認証情報をこのデバイスから削除します。',
+  AppLocale.neoSyncLogoutConfirmBody:
+      'このデバイスでNeoSyncアカウントからログアウトします。',
 
   AppLocale.deleteGame: 'ゲームを削除',
   AppLocale.deleteGameConfirm: '完全に削除する',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -799,6 +799,16 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.romDirectories: 'Diretórios de ROM',
   AppLocale.addRomFolder: 'Adicionar pasta de ROM',
   AppLocale.removeRomFolder: 'Remover',
+  AppLocale.resetPlayTimeConfirm: 'Redefinir tempo de jogo',
+  AppLocale.resetPlayTimeConfirmBody:
+      'Isto irá redefinir permanentemente para zero o tempo de jogo registado deste jogo. Esta ação não pode ser desfeita.',
+  AppLocale.removeRomFolderConfirmBody:
+      'Isto irá remover esta pasta de ROMs das fontes da sua biblioteca. Os seus ficheiros no disco não são eliminados.',
+  AppLocale.disconnectRaConfirm: 'Desligar RetroAchievements',
+  AppLocale.disconnectRaConfirmBody:
+      'Isto irá terminar a sua sessão e remover as suas credenciais guardadas do RetroAchievements deste dispositivo.',
+  AppLocale.neoSyncLogoutConfirmBody:
+      'Isto irá terminar a sessão da sua conta NeoSync neste dispositivo.',
 
   AppLocale.deleteGame: 'Excluir Jogo',
   AppLocale.deleteGameConfirm: 'Excluir Permanentemente',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -788,6 +788,16 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.romDirectories: 'Директории ROM',
   AppLocale.addRomFolder: 'Добавить папку ROM',
   AppLocale.removeRomFolder: 'Удалить',
+  AppLocale.resetPlayTimeConfirm: 'Сбросить время игры',
+  AppLocale.resetPlayTimeConfirmBody:
+      'Записанное время игры для этой игры будет безвозвратно сброшено до нуля. Это действие нельзя отменить.',
+  AppLocale.removeRomFolderConfirmBody:
+      'Эта папка ROM будет удалена из источников вашей библиотеки. Ваши файлы на диске не будут удалены.',
+  AppLocale.disconnectRaConfirm: 'Отключить RetroAchievements',
+  AppLocale.disconnectRaConfirmBody:
+      'Вы выйдете из системы, а сохранённые учётные данные RetroAchievements будут удалены с этого устройства.',
+  AppLocale.neoSyncLogoutConfirmBody:
+      'Вы выйдете из своей учётной записи NeoSync на этом устройстве.',
 
   AppLocale.deleteGame: 'Удалить игру',
   AppLocale.deleteGameConfirm: 'Удалить навсегда',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -712,6 +712,16 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.romDirectories: 'ROM 目录',
   AppLocale.addRomFolder: '添加 ROM 文件夹',
   AppLocale.removeRomFolder: '删除',
+  AppLocale.resetPlayTimeConfirm: '重置游戏时间',
+  AppLocale.resetPlayTimeConfirmBody:
+      '这将永久将此游戏记录的游戏时间重置为零。此操作无法撤销。',
+  AppLocale.removeRomFolderConfirmBody:
+      '这将从您的库来源中移除此 ROM 文件夹。磁盘上的文件不会被删除。',
+  AppLocale.disconnectRaConfirm: '断开 RetroAchievements 连接',
+  AppLocale.disconnectRaConfirmBody:
+      '这将使您退出登录，并从此设备中移除已保存的 RetroAchievements 凭据。',
+  AppLocale.neoSyncLogoutConfirmBody:
+      '这将使您在此设备上退出 NeoSync 账户。',
 
   AppLocale.deleteGame: '删除游戏',
   AppLocale.deleteGameConfirm: '永久删除',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -712,6 +712,16 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.romDirectories: 'ROM 目錄',
   AppLocale.addRomFolder: '新增 ROM 資料夾',
   AppLocale.removeRomFolder: '移除',
+  AppLocale.resetPlayTimeConfirm: '重設遊玩時間',
+  AppLocale.resetPlayTimeConfirmBody:
+      '這將永久將此遊戲記錄的遊玩時間重設為零。此操作無法復原。',
+  AppLocale.removeRomFolderConfirmBody:
+      '這將從您的媒體庫來源中移除此 ROM 資料夾。磁碟上的檔案不會被刪除。',
+  AppLocale.disconnectRaConfirm: '中斷 RetroAchievements 連線',
+  AppLocale.disconnectRaConfirmBody:
+      '這將使您登出，並從此裝置中移除已儲存的 RetroAchievements 憑證。',
+  AppLocale.neoSyncLogoutConfirmBody:
+      '這將使您在此裝置上登出 NeoSync 帳戶。',
 
   AppLocale.deleteGame: '刪除遊戲',
   AppLocale.deleteGameConfirm: '永久刪除',

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_settings_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_settings_tab.dart
@@ -10,6 +10,7 @@ import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/widgets/custom_notification.dart';
 import 'package:neostation/services/game_service.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/widgets/confirm_action_dialog.dart';
 import 'package:provider/provider.dart';
 import '../../../../models/system_model.dart';
 import '../../../../providers/file_provider.dart';
@@ -157,7 +158,7 @@ class GameDetailsSettingsTabState extends State<GameDetailsSettingsTab> {
     }
     // Play-time Reset Action.
     else if (idx == _settingsPlayTimeIdx) {
-      if ((_game.playTime ?? 0) > 0) _resetPlayTime();
+      if ((_game.playTime ?? 0) > 0) _confirmResetPlayTime();
     }
     // Delete Game Action.
     else if (idx == _settingsDeleteGameIdx) {
@@ -262,6 +263,21 @@ class GameDetailsSettingsTabState extends State<GameDetailsSettingsTab> {
       _log.e('Play-time reset operation failed: \$e');
     } finally {
       if (mounted) setState(() => _isResettingPlayTime = false);
+    }
+  }
+
+  /// Confirms with the user before clearing the recorded play-time.
+  Future<void> _confirmResetPlayTime() async {
+    SfxService().playNavSound();
+    final confirmed = await ConfirmActionDialog.show(
+      context,
+      title: AppLocale.resetPlayTimeConfirm.getString(context),
+      body: AppLocale.resetPlayTimeConfirmBody.getString(context),
+      confirmLabel: AppLocale.reset.getString(context),
+      icon: Symbols.timer_off_rounded,
+    );
+    if (confirmed && mounted) {
+      _resetPlayTime();
     }
   }
 
@@ -505,7 +521,7 @@ class GameDetailsSettingsTabState extends State<GameDetailsSettingsTab> {
                           );
                           if ((_game.playTime ?? 0) > 0 &&
                               !_isResettingPlayTime) {
-                            _resetPlayTime();
+                            _confirmResetPlayTime();
                           }
                         },
                         trailing: _isResettingPlayTime
@@ -527,7 +543,7 @@ class GameDetailsSettingsTabState extends State<GameDetailsSettingsTab> {
                                         !_isResettingPlayTime;
                                     final theme = Theme.of(context);
                                     return GestureDetector(
-                                      onTap: canReset ? _resetPlayTime : null,
+                                      onTap: canReset ? _confirmResetPlayTime : null,
                                       child: Container(
                                         padding: EdgeInsets.symmetric(
                                           horizontal: 8.r,

--- a/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
+++ b/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
@@ -461,17 +461,10 @@ class NeoSyncContentState extends State<NeoSyncContent>
                     onPressed: _onLogout,
                     icon: Icon(
                       Symbols.logout_rounded,
-                      size: 12.r,
+                      size: 20.r,
                       color: Theme.of(context).colorScheme.error,
                     ),
                     tooltip: AppLocale.logout.getString(context),
-                    style: IconButton.styleFrom(
-                      backgroundColor: Theme.of(
-                        context,
-                      ).colorScheme.error.withValues(alpha: 0.1),
-                      padding: EdgeInsets.all(8.r),
-                      minimumSize: Size(32.r, 32.r),
-                    ),
                   ),
                 ],
               ),

--- a/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
+++ b/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
@@ -203,15 +203,13 @@ class NeoSyncContentState extends State<NeoSyncContent>
     _savesGamepadNav.deactivate();
 
     // Show confirmation dialog
-    final confirmed = await showDialog<bool>(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context) {
-        return _CancelSubscriptionDialog(
-          onKeepSubscription: () => Navigator.of(context).pop(false),
-          onCancelSubscription: () => Navigator.of(context).pop(true),
-        );
-      },
+    final confirmed = await ConfirmActionDialog.show(
+      context,
+      title: AppLocale.cancelSubscription.getString(context),
+      body: AppLocale.cancelSubscriptionConfirm.getString(context),
+      confirmLabel: AppLocale.cancelSubscription.getString(context),
+      cancelLabel: AppLocale.keepSubscription.getString(context),
+      icon: Symbols.cancel_rounded,
     );
 
     // Reactivar navegación por gamepad después de cerrar el modal
@@ -2380,135 +2378,6 @@ class _UpgradeModalDialogState extends State<_UpgradeModalDialog> {
 }
 
 // Cancel Subscription Dialog with Gamepad Navigation
-class _CancelSubscriptionDialog extends StatefulWidget {
-  final VoidCallback onKeepSubscription;
-  final VoidCallback onCancelSubscription;
-
-  const _CancelSubscriptionDialog({
-    required this.onKeepSubscription,
-    required this.onCancelSubscription,
-  });
-
-  @override
-  State<_CancelSubscriptionDialog> createState() =>
-      _CancelSubscriptionDialogState();
-}
-
-class _CancelSubscriptionDialogState extends State<_CancelSubscriptionDialog> {
-  late GamepadNavigation _gamepadNav;
-
-  @override
-  void initState() {
-    super.initState();
-    _gamepadNav = GamepadNavigation(
-      onSelectItem: () {
-        widget.onCancelSubscription();
-      },
-      onBack: () {
-        widget.onKeepSubscription();
-      },
-    );
-    _gamepadNav.initialize();
-    _gamepadNav.activate();
-  }
-
-  @override
-  void dispose() {
-    _gamepadNav.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return AlertDialog(
-      backgroundColor: theme.colorScheme.surface,
-      surfaceTintColor: theme.colorScheme.surface,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.r)),
-      title: Row(
-        children: [
-          Icon(
-            Symbols.cancel_rounded,
-            color: theme.colorScheme.error,
-            size: 24.r,
-          ),
-          SizedBox(width: 12.r),
-          Text(
-            AppLocale.cancelSubscription.getString(context),
-            style: TextStyle(
-              fontSize: 18.r,
-              fontWeight: FontWeight.bold,
-              color: theme.colorScheme.onSurface,
-            ),
-          ),
-        ],
-      ),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            AppLocale.cancelSubscriptionConfirm.getString(context),
-            style: TextStyle(
-              fontSize: 14.r,
-              color: theme.colorScheme.onSurface.withValues(alpha: 0.9),
-              height: 1.4,
-            ),
-          ),
-        ],
-      ),
-      actions: [
-        TextButton.icon(
-          onPressed: widget.onKeepSubscription,
-          icon: Image.asset(
-            'assets/images/gamepad/Xbox_B_button.png',
-            width: 16.r,
-            height: 16.r,
-            color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
-          ),
-          label: Text(
-            AppLocale.keepSubscription.getString(context),
-            style: TextStyle(
-              fontSize: 14.r,
-              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
-            ),
-          ),
-          style: TextButton.styleFrom(
-            padding: EdgeInsets.symmetric(horizontal: 16.r, vertical: 8.r),
-          ),
-        ),
-        TextButton.icon(
-          onPressed: widget.onCancelSubscription,
-          icon: Image.asset(
-            'assets/images/gamepad/Xbox_A_button.png',
-            width: 16.r,
-            height: 16.r,
-            color: theme.colorScheme.error,
-          ),
-          label: Text(
-            AppLocale.cancelSubscription.getString(context),
-            style: TextStyle(
-              fontSize: 14.r,
-              color: theme.colorScheme.error,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          style: TextButton.styleFrom(
-            padding: EdgeInsets.symmetric(horizontal: 16.r, vertical: 8.r),
-          ),
-        ),
-      ],
-      actionsPadding: EdgeInsets.only(
-        left: 16.r,
-        right: 16.r,
-        bottom: 16.r,
-        top: 8.r,
-      ),
-    );
-  }
-}
-
 // Delete Cloud Save Dialog with Gamepad Navigation
 class _DeleteCloudSaveDialog extends StatefulWidget {
   final NeoSyncFile file;

--- a/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
+++ b/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/widgets/confirm_action_dialog.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/widgets/custom_notification.dart' as custom;
 import 'package:neostation/services/neosync/auth_service.dart';
@@ -1085,7 +1086,16 @@ class NeoSyncContentState extends State<NeoSyncContent>
     }
   }
 
-  void _onLogout() {
+  Future<void> _onLogout() async {
+    final confirmed = await ConfirmActionDialog.show(
+      context,
+      title: AppLocale.logoutConfirm.getString(context),
+      body: AppLocale.neoSyncLogoutConfirmBody.getString(context),
+      confirmLabel: AppLocale.logout.getString(context),
+      icon: Symbols.logout_rounded,
+    );
+    if (!confirmed || !mounted) return;
+
     final authService = Provider.of<AuthService>(context, listen: false);
     authService.logout();
     // Reset profile loaded flag for next login

--- a/lib/screens/retro_achievements_screen/ra_dashboard.dart
+++ b/lib/screens/retro_achievements_screen/ra_dashboard.dart
@@ -5,6 +5,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 
 import '../../l10n/app_locale.dart';
+import '../../widgets/confirm_action_dialog.dart';
 import '../../models/retro_achievements_dashboard_models.dart';
 import '../../models/retro_achievements_user_awards.dart';
 import '../../providers/file_provider.dart';
@@ -243,7 +244,15 @@ class _RADashboardHubState extends State<RADashboardHub> {
             ),
           ),
           IconButton(
-            onPressed: () {
+            onPressed: () async {
+              final confirmed = await ConfirmActionDialog.show(
+                context,
+                title: AppLocale.disconnectRaConfirm.getString(context),
+                body: AppLocale.disconnectRaConfirmBody.getString(context),
+                confirmLabel: AppLocale.logout.getString(context),
+                icon: Symbols.logout_rounded,
+              );
+              if (!confirmed || !context.mounted) return;
               raProvider.disconnect(clearSavedUser: true);
               if (!context.mounted) return;
               AppNotification.showNotification(

--- a/lib/screens/scraper_screen/new_scraper_options_screen.dart
+++ b/lib/screens/scraper_screen/new_scraper_options_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/widgets/confirm_action_dialog.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/services/screenscraper_service.dart';
 import 'package:neostation/services/sfx_service.dart';
@@ -364,25 +365,12 @@ class _NewScraperOptionsScreenState extends State<NewScraperOptionsScreen> {
   }
 
   Future<void> _handleLogout() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(AppLocale.logoutConfirm.getString(context)),
-        content: Text(AppLocale.logoutConfirmationDesc.getString(context)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(AppLocale.cancel.getString(context)),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            style: TextButton.styleFrom(
-              foregroundColor: Theme.of(context).colorScheme.error,
-            ),
-            child: Text(AppLocale.logout.getString(context)),
-          ),
-        ],
-      ),
+    final confirmed = await ConfirmActionDialog.show(
+      context,
+      title: AppLocale.logoutConfirm.getString(context),
+      body: AppLocale.logoutConfirmationDesc.getString(context),
+      confirmLabel: AppLocale.logout.getString(context),
+      icon: Symbols.logout_rounded,
     );
 
     if (confirmed == true) {

--- a/lib/screens/scraper_screen/scraper_contents/account_content.dart
+++ b/lib/screens/scraper_screen/scraper_contents/account_content.dart
@@ -3,7 +3,6 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
-import '../../settings_screen/new_settings_options/settings_title.dart';
 
 class AccountContent extends StatelessWidget {
   final bool isContentFocused;
@@ -67,28 +66,8 @@ class AccountContent extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          SettingsTitle(title: AppLocale.screenscraper.getString(context)),
-          SizedBox(height: 12.r),
-
-          // Row for Username (50%) and Max Threads (50%)
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // User Information (50%)
-              Expanded(flex: 1, child: _buildCompactUserHeader(context, theme)),
-              SizedBox(width: 12.r),
-              // Max Threads (50%)
-              Expanded(
-                flex: 1,
-                child: _buildCompactStatTile(
-                  theme,
-                  AppLocale.maxThreads.getString(context),
-                  userInfo!['maxthreads'] ?? '1',
-                  Symbols.lan_rounded,
-                ),
-              ),
-            ],
-          ),
+          // Full-width member header pill (avatar + name + chips + logout)
+          _buildMemberHeader(context, theme),
 
           SizedBox(height: 12.h),
 
@@ -103,175 +82,132 @@ class AccountContent extends StatelessWidget {
             ),
             SizedBox(height: 16.h),
           ],
-
-          // Disconnect Button
-          Padding(
-            padding: EdgeInsets.only(bottom: 24.r),
-            child: Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(8.r),
-                border: Border.all(
-                  color: isContentFocused && selectedContentIndex == 0
-                      ? theme.colorScheme.primary
-                      : Colors.transparent,
-                  width: 2.r,
-                ),
-              ),
-              child: ElevatedButton.icon(
-                onPressed: onLogout,
-                icon: Icon(
-                  Symbols.logout_rounded,
-                  size: 14.r,
-                  color: Colors.white,
-                ),
-                label: Text(
-                  AppLocale.disconnectAccount.getString(context),
-                  style: TextStyle(
-                    fontSize: 10.r,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                  ),
-                ),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: theme.colorScheme.error,
-                  foregroundColor: theme.colorScheme.error,
-                  padding: EdgeInsets.symmetric(
-                    horizontal: 16.r,
-                    vertical: 16.r,
-                  ),
-                  side: BorderSide(color: theme.colorScheme.error),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8.r),
-                  ),
-                ),
-              ),
-            ),
-          ),
         ],
       ),
     );
   }
 
-  Widget _buildCompactUserHeader(BuildContext context, ThemeData theme) {
+  Widget _buildMemberHeader(BuildContext context, ThemeData theme) {
     return Container(
-      padding: EdgeInsets.all(12.r),
-      decoration: BoxDecoration(
-        color: theme.cardColor.withValues(alpha: 0.25),
-        borderRadius: BorderRadius.circular(12.r),
-        border: Border.all(
-          color: theme.colorScheme.primary.withValues(alpha: 0.15),
-          width: 1.r,
-        ),
-      ),
+      padding: EdgeInsets.symmetric(horizontal: 14.r, vertical: 12.r),
+      decoration: _cardDecoration(theme),
       child: Row(
         children: [
           CircleAvatar(
-            radius: 18.r,
+            radius: 24.r,
             backgroundColor: theme.colorScheme.primary.withValues(alpha: 0.2),
             child: Text(
               (userInfo!['username'] ?? 'U').substring(0, 1).toUpperCase(),
               style: TextStyle(
-                fontSize: 14.r,
+                fontSize: 18.r,
                 fontWeight: FontWeight.bold,
                 color: theme.colorScheme.primary,
               ),
             ),
           ),
-          SizedBox(width: 10.r),
+          SizedBox(width: 12.r),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
               children: [
                 Text(
                   userInfo!['username'] ??
                       AppLocale.unknownUser.getString(context),
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 12.r,
-                  ),
+                  maxLines: 1,
                   overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14.r,
+                  ),
                 ),
-                SizedBox(height: 2.r),
-                _buildBadge(
-                  _getContributionLevel(context, userInfo!['contribution']),
-                  _getContributionColor(userInfo!['contribution']),
+                SizedBox(height: 4.r),
+                Wrap(
+                  spacing: 8.r,
+                  runSpacing: 6.r,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    _buildPill(
+                      icon: Symbols.workspace_premium_rounded,
+                      label: _getContributionLevel(
+                        context,
+                        userInfo!['contribution'],
+                      ),
+                      color: _getContributionColor(userInfo!['contribution']),
+                    ),
+                    _buildPill(
+                      icon: Symbols.lan_rounded,
+                      label:
+                          '${AppLocale.maxThreads.getString(context)}: ${userInfo!['maxthreads'] ?? '1'}',
+                      color: theme.colorScheme.secondary,
+                    ),
+                  ],
                 ),
               ],
             ),
           ),
+          SizedBox(width: 8.r),
+          Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8.r),
+              border: Border.all(
+                color: isContentFocused && selectedContentIndex == 0
+                    ? theme.colorScheme.primary
+                    : Colors.transparent,
+                width: 2.r,
+              ),
+            ),
+            child: IconButton(
+              onPressed: onLogout,
+              icon: Icon(
+                Symbols.logout_rounded,
+                size: 20.r,
+                color: theme.colorScheme.error,
+              ),
+              tooltip: AppLocale.disconnectAccount.getString(context),
+            ),
+          ),
         ],
       ),
     );
   }
 
-  Widget _buildCompactStatTile(
-    ThemeData theme,
-    String label,
-    String value,
-    IconData icon,
-  ) {
+  BoxDecoration _cardDecoration(ThemeData theme) {
+    return BoxDecoration(
+      color: theme.cardColor.withValues(alpha: 0.25),
+      borderRadius: BorderRadius.circular(12.r),
+      border: Border.all(
+        color: theme.colorScheme.primary.withValues(alpha: 0.15),
+        width: 1.r,
+      ),
+    );
+  }
+
+  Widget _buildPill({
+    required IconData icon,
+    required String label,
+    required Color color,
+  }) {
     return Container(
-      padding: EdgeInsets.all(12.r),
+      padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
       decoration: BoxDecoration(
-        color: theme.cardColor.withValues(alpha: 0.25),
-        borderRadius: BorderRadius.circular(12.r),
-        border: Border.all(
-          color: theme.colorScheme.primary.withValues(alpha: 0.15),
-          width: 1.r,
-        ),
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(999.r),
+        border: Border.all(color: color.withValues(alpha: 0.22)),
       ),
       child: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
-            padding: EdgeInsets.all(12.r),
-            decoration: BoxDecoration(
-              color: theme.colorScheme.secondary.withValues(alpha: 0.1),
-              shape: BoxShape.circle,
+          Icon(icon, size: 10.r, color: color),
+          SizedBox(width: 4.r),
+          Text(
+            label,
+            style: TextStyle(
+              color: color,
+              fontSize: 8.r,
+              fontWeight: FontWeight.w700,
             ),
-            child: Icon(icon, color: theme.colorScheme.secondary, size: 14.r),
-          ),
-          SizedBox(width: 8.r),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                label,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurface,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 12.r,
-                ),
-              ),
-              Text(
-                value,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 11.sp,
-                ),
-              ),
-            ],
           ),
         ],
-      ),
-    );
-  }
-
-  Widget _buildBadge(String label, Color color) {
-    return Container(
-      padding: EdgeInsets.symmetric(horizontal: 6.w, vertical: 2.h),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(4.r),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          color: color,
-          fontSize: 8.sp,
-          fontWeight: FontWeight.bold,
-        ),
       ),
     );
   }

--- a/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
@@ -6,6 +6,7 @@ import 'package:flutter_localization/flutter_localization.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/widgets/confirm_action_dialog.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/repositories/config_repository.dart';
 import 'package:neostation/services/config_service.dart';
@@ -204,6 +205,15 @@ class DirectoriesSettingsContentState
   }
 
   Future<void> _removeRomFolder(String path) async {
+    final confirmed = await ConfirmActionDialog.show(
+      context,
+      title: AppLocale.removeRomFolder.getString(context),
+      body: AppLocale.removeRomFolderConfirmBody.getString(context),
+      confirmLabel: AppLocale.removeRomFolder.getString(context),
+      icon: Symbols.folder_delete_rounded,
+    );
+    if (!confirmed || !mounted) return;
+
     final configProvider = Provider.of<SqliteConfigProvider>(
       context,
       listen: false,

--- a/lib/screens/settings_screen/new_settings_options/themes_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/themes_settings_content.dart
@@ -6,12 +6,11 @@ import 'package:neostation/l10n/app_locale.dart';
 import 'package:neostation/providers/neo_assets_provider.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/responsive.dart';
-import 'package:neostation/services/game_service.dart'
-    show GamepadNavigationManager;
 import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/utils/adaptive_scroll.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/widgets/confirm_action_dialog.dart';
 import 'package:provider/provider.dart';
 import 'settings_title.dart';
 
@@ -155,13 +154,17 @@ class ThemesSettingsContentState extends State<ThemesSettingsContent> {
   }
 
   Future<bool> _showConfirmDialog(String themeName, bool isNone) async {
-    final result = await showDialog<bool>(
-      context: context,
-      barrierDismissible: false,
-      builder: (ctx) =>
-          _ThemeConfirmDialog(themeName: themeName, isNone: isNone),
+    final body = isNone
+        ? '"$themeName"'
+        : '"$themeName"\n\n${AppLocale.neoThemesApplyBody.getString(context)}';
+    return ConfirmActionDialog.show(
+      context,
+      title: AppLocale.neoThemesApplyTitle.getString(context),
+      body: body,
+      confirmLabel: AppLocale.apply.getString(context),
+      icon: Symbols.image_rounded,
+      accentColor: Theme.of(context).colorScheme.primary,
     );
-    return result ?? false;
   }
 
   @override
@@ -573,154 +576,3 @@ class _NeoThemeCard extends StatelessWidget {
   }
 }
 
-class _ThemeConfirmDialog extends StatefulWidget {
-  final String themeName;
-  final bool isNone;
-
-  const _ThemeConfirmDialog({required this.themeName, required this.isNone});
-
-  @override
-  State<_ThemeConfirmDialog> createState() => _ThemeConfirmDialogState();
-}
-
-class _ThemeConfirmDialogState extends State<_ThemeConfirmDialog> {
-  late final GamepadNavigation _gamepadNav;
-
-  @override
-  void initState() {
-    super.initState();
-    _gamepadNav = GamepadNavigation(
-      onSelectItem: () {
-        if (mounted) Navigator.of(context).pop(true);
-      },
-      onBack: () {
-        if (mounted) Navigator.of(context).pop(false);
-      },
-    );
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      _gamepadNav.initialize();
-      GamepadNavigationManager.pushLayer(
-        'theme_confirm_dialog',
-        onActivate: () => _gamepadNav.activate(),
-        onDeactivate: () => _gamepadNav.deactivate(),
-      );
-    });
-  }
-
-  @override
-  void dispose() {
-    GamepadNavigationManager.popLayer('theme_confirm_dialog');
-    _gamepadNav.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final primary = theme.colorScheme.primary;
-
-    return AlertDialog(
-      backgroundColor: theme.cardColor,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12.r),
-        side: BorderSide(color: primary.withValues(alpha: 0.3)),
-      ),
-      title: Row(
-        children: [
-          Icon(Symbols.image_rounded, color: primary, size: 20.r),
-          SizedBox(width: 8.r),
-          Text(
-            AppLocale.neoThemesApplyTitle.getString(context),
-            style: theme.textTheme.titleMedium?.copyWith(
-              fontSize: 14.r,
-              color: primary,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
-      ),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            '"${widget.themeName}"',
-            style: theme.textTheme.bodyLarge?.copyWith(
-              fontSize: 13.r,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          if (!widget.isNone) ...[
-            SizedBox(height: 8.r),
-            Text(
-              AppLocale.neoThemesApplyBody.getString(context),
-              style: theme.textTheme.bodyMedium?.copyWith(
-                fontSize: 11.r,
-                color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
-              ),
-            ),
-          ],
-        ],
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(false),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(
-                width: 18.r,
-                height: 18.r,
-                child: Image.asset(
-                  'assets/images/gamepad/Xbox_B_button.png',
-                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
-                  colorBlendMode: BlendMode.srcIn,
-                ),
-              ),
-              SizedBox(width: 4.r),
-              Text(
-                AppLocale.cancel.getString(context),
-                style: TextStyle(
-                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
-                  fontSize: 12.r,
-                ),
-              ),
-            ],
-          ),
-        ),
-        ElevatedButton(
-          style: ElevatedButton.styleFrom(
-            backgroundColor: primary,
-            foregroundColor: theme.colorScheme.onPrimary,
-            padding: EdgeInsets.symmetric(horizontal: 16.r, vertical: 8.r),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8.r),
-            ),
-          ),
-          onPressed: () => Navigator.of(context).pop(true),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(
-                width: 18.r,
-                height: 18.r,
-                child: Image.asset(
-                  'assets/images/gamepad/Xbox_A_button.png',
-                  color: theme.colorScheme.onPrimary,
-                  colorBlendMode: BlendMode.srcIn,
-                ),
-              ),
-              SizedBox(width: 4.r),
-              Text(
-                AppLocale.apply.getString(context),
-                style: TextStyle(fontSize: 12.r),
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-}

--- a/lib/widgets/confirm_action_dialog.dart
+++ b/lib/widgets/confirm_action_dialog.dart
@@ -20,6 +20,9 @@ class ConfirmActionDialog extends StatefulWidget {
   final String confirmLabel;
   final IconData icon;
 
+  /// Label for the cancel/back button. Defaults to `AppLocale.cancel`.
+  final String? cancelLabel;
+
   /// Accent colour for the title icon and confirm button. Defaults to the
   /// theme error colour for destructive intent.
   final Color? accentColor;
@@ -30,6 +33,7 @@ class ConfirmActionDialog extends StatefulWidget {
     required this.body,
     required this.confirmLabel,
     required this.icon,
+    this.cancelLabel,
     this.accentColor,
   });
 
@@ -39,6 +43,7 @@ class ConfirmActionDialog extends StatefulWidget {
     required String body,
     required String confirmLabel,
     required IconData icon,
+    String? cancelLabel,
     Color? accentColor,
   }) async {
     final result = await showDialog<bool>(
@@ -49,6 +54,7 @@ class ConfirmActionDialog extends StatefulWidget {
         body: body,
         confirmLabel: confirmLabel,
         icon: icon,
+        cancelLabel: cancelLabel,
         accentColor: accentColor,
       ),
     );
@@ -146,7 +152,7 @@ class _ConfirmActionDialogState extends State<ConfirmActionDialog> {
               ),
               SizedBox(width: 4.r),
               Text(
-                AppLocale.cancel.getString(context),
+                widget.cancelLabel ?? AppLocale.cancel.getString(context),
                 style: TextStyle(
                   color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
                   fontSize: 12.r,

--- a/lib/widgets/confirm_action_dialog.dart
+++ b/lib/widgets/confirm_action_dialog.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/services/game_service.dart';
+
+/// Reusable, gamepad-friendly confirmation dialog for destructive actions.
+///
+/// Mirrors the gamepad wiring of the newest in-app dialog (`_DeleteGameDialog`):
+/// the navigation layer is registered in a post-frame callback (never eagerly in
+/// `initState`) and activation is left to the [GamepadNavigationManager] via the
+/// `onActivate` callback, which avoids an activation race when the dialog pushes
+/// its layer before the first frame is built.
+///
+/// Returns `true` when the user confirms, `false` on cancel/back/dismiss.
+class ConfirmActionDialog extends StatefulWidget {
+  final String title;
+  final String body;
+  final String confirmLabel;
+  final IconData icon;
+
+  /// Accent colour for the title icon and confirm button. Defaults to the
+  /// theme error colour for destructive intent.
+  final Color? accentColor;
+
+  const ConfirmActionDialog({
+    super.key,
+    required this.title,
+    required this.body,
+    required this.confirmLabel,
+    required this.icon,
+    this.accentColor,
+  });
+
+  static Future<bool> show(
+    BuildContext context, {
+    required String title,
+    required String body,
+    required String confirmLabel,
+    required IconData icon,
+    Color? accentColor,
+  }) async {
+    final result = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => ConfirmActionDialog(
+        title: title,
+        body: body,
+        confirmLabel: confirmLabel,
+        icon: icon,
+        accentColor: accentColor,
+      ),
+    );
+    return result ?? false;
+  }
+
+  @override
+  State<ConfirmActionDialog> createState() => _ConfirmActionDialogState();
+}
+
+class _ConfirmActionDialogState extends State<ConfirmActionDialog> {
+  late final GamepadNavigation _gamepadNav;
+
+  @override
+  void initState() {
+    super.initState();
+    _gamepadNav = GamepadNavigation(
+      onSelectItem: () {
+        if (mounted) Navigator.of(context).pop(true);
+      },
+      onBack: () {
+        if (mounted) Navigator.of(context).pop(false);
+      },
+    );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _gamepadNav.initialize();
+      GamepadNavigationManager.pushLayer(
+        'confirm_action_dialog',
+        onActivate: () => _gamepadNav.activate(),
+        onDeactivate: () => _gamepadNav.deactivate(),
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    GamepadNavigationManager.popLayer('confirm_action_dialog');
+    _gamepadNav.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accentColor = widget.accentColor ?? theme.colorScheme.error;
+    final onAccent = accentColor == theme.colorScheme.error
+        ? theme.colorScheme.onError
+        : theme.colorScheme.onPrimary;
+
+    return AlertDialog(
+      backgroundColor: theme.cardColor,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12.r),
+        side: BorderSide(color: accentColor.withValues(alpha: 0.3)),
+      ),
+      title: Row(
+        children: [
+          Icon(widget.icon, color: accentColor, size: 20.r),
+          SizedBox(width: 8.r),
+          Flexible(
+            child: Text(
+              widget.title,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontSize: 14.r,
+                color: accentColor,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+      content: Text(
+        widget.body,
+        style: theme.textTheme.bodyMedium?.copyWith(
+          fontSize: 11.r,
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                width: 18.r,
+                height: 18.r,
+                child: Image.asset(
+                  'assets/images/gamepad/Xbox_B_button.png',
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                  colorBlendMode: BlendMode.srcIn,
+                ),
+              ),
+              SizedBox(width: 4.r),
+              Text(
+                AppLocale.cancel.getString(context),
+                style: TextStyle(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                  fontSize: 12.r,
+                ),
+              ),
+            ],
+          ),
+        ),
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: accentColor,
+            foregroundColor: onAccent,
+            padding: EdgeInsets.symmetric(horizontal: 16.r, vertical: 8.r),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(6.r),
+            ),
+          ),
+          onPressed: () => Navigator.of(context).pop(true),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                width: 18.r,
+                height: 18.r,
+                child: Image.asset(
+                  'assets/images/gamepad/Xbox_A_button.png',
+                  color: onAccent,
+                  colorBlendMode: BlendMode.srcIn,
+                ),
+              ),
+              SizedBox(width: 4.r),
+              Text(
+                widget.confirmLabel,
+                style: TextStyle(
+                  color: onAccent,
+                  fontSize: 12.r,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/confirm_action_dialog_test.dart
+++ b/test/confirm_action_dialog_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/widgets/confirm_action_dialog.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    // FlutterLocalization reads the saved locale from SharedPreferences.
+    SharedPreferences.setMockInitialValues({});
+
+    // Stub the gamepads plugin so GamepadNavigation.initialize() finds no
+    // devices instead of relying on a real platform channel.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('xyz.luan/gamepads'),
+          (call) async => <dynamic>[],
+        );
+
+    await FlutterLocalization.instance.ensureInitialized();
+    FlutterLocalization.instance.init(
+      mapLocales: [MapLocale('en', AppLocale.en)],
+      initLanguageCode: 'en',
+    );
+  });
+
+  /// Pumps a minimal localized + ScreenUtil-initialized host and hands back a
+  /// [BuildContext] under the MaterialApp navigator, ready to open a dialog.
+  Future<BuildContext> pumpHost(WidgetTester tester) async {
+    late BuildContext ctx;
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(size: Size(1920, 1080)),
+        child: ScreenUtilInit(
+          designSize: const Size(1920, 1080),
+          builder: (context, child) => MaterialApp(
+            localizationsDelegates:
+                FlutterLocalization.instance.localizationsDelegates,
+            supportedLocales: FlutterLocalization.instance.supportedLocales,
+            home: Builder(
+              builder: (context) {
+                ctx = context;
+                return const Scaffold(body: SizedBox.shrink());
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return ctx;
+  }
+
+  testWidgets('shows the title, body and confirm label', (tester) async {
+    final ctx = await pumpHost(tester);
+    // ignore: unawaited_futures
+    ConfirmActionDialog.show(
+      ctx,
+      title: 'Reset Play Time',
+      body: 'This cannot be undone.',
+      confirmLabel: 'Reset',
+      cancelLabel: 'Keep',
+      icon: Symbols.timer_off_rounded,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Reset Play Time'), findsOneWidget);
+    expect(find.text('This cannot be undone.'), findsOneWidget);
+    expect(find.text('Reset'), findsOneWidget);
+    expect(find.text('Keep'), findsOneWidget);
+  });
+
+  testWidgets('resolves true when the confirm button is tapped', (
+    tester,
+  ) async {
+    final ctx = await pumpHost(tester);
+    bool? result;
+    // ignore: unawaited_futures
+    ConfirmActionDialog.show(
+      ctx,
+      title: 'Reset Play Time',
+      body: 'This cannot be undone.',
+      confirmLabel: 'Reset',
+      cancelLabel: 'Keep',
+      icon: Symbols.timer_off_rounded,
+    ).then((value) => result = value);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reset'));
+    await tester.pumpAndSettle();
+
+    expect(result, isTrue);
+    expect(find.text('Reset Play Time'), findsNothing);
+  });
+
+  testWidgets('resolves false when the cancel button is tapped', (
+    tester,
+  ) async {
+    final ctx = await pumpHost(tester);
+    bool? result;
+    // ignore: unawaited_futures
+    ConfirmActionDialog.show(
+      ctx,
+      title: 'Reset Play Time',
+      body: 'This cannot be undone.',
+      confirmLabel: 'Reset',
+      cancelLabel: 'Keep',
+      icon: Symbols.timer_off_rounded,
+    ).then((value) => result = value);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Keep'));
+    await tester.pumpAndSettle();
+
+    expect(result, isFalse);
+    expect(find.text('Reset Play Time'), findsNothing);
+  });
+
+  testWidgets('falls back to the localized Cancel label when none is given', (
+    tester,
+  ) async {
+    final ctx = await pumpHost(tester);
+    // ignore: unawaited_futures
+    ConfirmActionDialog.show(
+      ctx,
+      title: 'Remove ROM Folder',
+      body: 'Removes this source.',
+      confirmLabel: 'Remove',
+      icon: Symbols.folder_delete_rounded,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(AppLocale.en['cancel']), findsOneWidget);
+  });
+}


### PR DESCRIPTION
> 🤖 This PR was developed with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

Several destructive/irreversible actions in the frontend fired immediately on tap with only a post-hoc toast and **no confirmation**. This PR adds a shared confirmation guard to all of them, then folds the existing bespoke confirm dialogs onto that same shared component and cleans up the logout/disconnect UI for consistency.

**Confirmation guards (new `ConfirmActionDialog`)**
- Introduces `lib/widgets/confirm_action_dialog.dart` — a reusable, gamepad-navigable confirm dialog (post-frame layer push, manager-driven activation, `mounted`-guarded pops), modeled on the newest `_DeleteGameDialog`.
- Gates the previously-unguarded actions: **Reset Play Time**, **Remove ROM Folder**, **RetroAchievements disconnect** (clears saved credentials), and **NeoSync logout**.
- Converts the **ScreenScraper logout** from a bare inline `AlertDialog` to the shared dialog.

**Consolidation**
- Migrates the two remaining bespoke confirm/cancel dialogs — **Cancel subscription** and **Apply theme** — onto `ConfirmActionDialog` (adds an optional `cancelLabel`, e.g. "Keep Subscription"), deleting `_CancelSubscriptionDialog` and `_ThemeConfirmDialog`.

**UI consistency**
- Makes all three logout/disconnect triggers (ScreenScraper, RA, NeoSync) bare error-colored door `IconButton`s with tooltips.
- Reworks the ScreenScraper account page to match the RA dashboard header: removes the redundant "ScreenScraper Account" heading and uses a full-width member pill (avatar + username + Member/Max Threads chips) with the logout icon on the far right.

Adds localized confirm strings across all 11 locales.

Fixes # (n/a)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

_Reworked ScreenScraper account page (now matches the RA dashboard header); the four newly-guarded actions each now prompt with the shared confirmation dialog before proceeding._

