### PR TITLE
refactor(retroachievements): rebrand "Softcore" to "Casual"

### DIFF
--- a/lib/models/retro_achievements_gotw.dart
+++ b/lib/models/retro_achievements_gotw.dart
@@ -18,7 +18,7 @@ class RetroAchievementsGOTW {
   /// List of recent unlocks by users during the event.
   final List<Unlock> unlocks;
 
-  /// Total count of unlocks in casual (softcore) mode.
+  /// Total count of unlocks in casual mode.
   final int unlocksCount;
 
   /// Total count of unlocks in hardcore mode.
@@ -166,8 +166,8 @@ class Unlock {
   /// Hardcore points earned.
   final String raPoints;
 
-  /// Softcore points earned.
-  final String raSoftcorePoints;
+  /// Casual points earned.
+  final String raCasualPoints;
 
   /// Indicates if the unlock was in hardcore mode (1) or casual mode (0).
   final int hardcoreMode;
@@ -178,7 +178,7 @@ class Unlock {
   Unlock({
     required this.user,
     required this.raPoints,
-    required this.raSoftcorePoints,
+    required this.raCasualPoints,
     required this.hardcoreMode,
     required this.dateAwarded,
   });
@@ -188,7 +188,7 @@ class Unlock {
     return Unlock(
       user: (json['User'] ?? '').toString(),
       raPoints: (json['RAPoints'] ?? '0').toString(),
-      raSoftcorePoints: (json['RASoftcorePoints'] ?? '0').toString(),
+      raCasualPoints: (json['RASoftcorePoints'] ?? '0').toString(),
       hardcoreMode: int.tryParse((json['HardcoreMode'] ?? '0').toString()) ?? 0,
       dateAwarded: (json['DateAwarded'] ?? '').toString(),
     );

--- a/lib/models/retro_achievements_summary.dart
+++ b/lib/models/retro_achievements_summary.dart
@@ -70,10 +70,10 @@ class AwardedStats {
   /// Maximum possible score achievable for this game.
   final int possibleScore;
 
-  /// Number of achievements currently earned by the user (casual/softcore).
+  /// Number of achievements currently earned by the user (casual).
   final int numAchieved;
 
-  /// Total score accumulated by the user for this game (casual/softcore).
+  /// Total score accumulated by the user for this game (casual).
   final int scoreAchieved;
 
   /// Number of achievements earned in hardcore mode.
@@ -107,7 +107,7 @@ class AwardedStats {
     );
   }
 
-  /// Returns the user's completion percentage (casual/softcore).
+  /// Returns the user's completion percentage (casual).
   double get completionPercentage {
     return numPossibleAchievements > 0
         ? (numAchieved / numPossibleAchievements) * 100
@@ -215,8 +215,8 @@ class RetroAchievementsUserSummary {
   /// Total points accumulated (Hardcore mode).
   final int totalPoints;
 
-  /// Total points accumulated in casual (Softcore) mode.
-  final int totalSoftcorePoints;
+  /// Total points accumulated in casual mode.
+  final int totalCasualPoints;
 
   /// Total weighted "True" points.
   final int totalTruePoints;
@@ -275,7 +275,7 @@ class RetroAchievementsUserSummary {
     required this.contribCount,
     required this.contribYield,
     required this.totalPoints,
-    required this.totalSoftcorePoints,
+    required this.totalCasualPoints,
     required this.totalTruePoints,
     required this.permissions,
     required this.untracked,
@@ -330,7 +330,7 @@ class RetroAchievementsUserSummary {
       contribCount: RAParsingUtils.toInt(json['ContribCount']),
       contribYield: RAParsingUtils.toInt(json['ContribYield']),
       totalPoints: RAParsingUtils.toInt(json['TotalPoints']),
-      totalSoftcorePoints: RAParsingUtils.toInt(json['TotalSoftcorePoints']),
+      totalCasualPoints: RAParsingUtils.toInt(json['TotalSoftcorePoints']),
       totalTruePoints: RAParsingUtils.toInt(json['TotalTruePoints']),
       permissions: RAParsingUtils.toInt(json['Permissions']),
       untracked: RAParsingUtils.toInt(json['Untracked']),

--- a/lib/models/retro_achievements_user.dart
+++ b/lib/models/retro_achievements_user.dart
@@ -32,8 +32,8 @@ class RetroAchievementsUser {
   /// Total points accumulated (Hardcore mode).
   final int totalPoints;
 
-  /// Total points accumulated in casual (Softcore) mode.
-  final int totalSoftcorePoints;
+  /// Total points accumulated in casual mode.
+  final int totalCasualPoints;
 
   /// Total weighted "True" points based on achievement rarity.
   final int totalTruePoints;
@@ -63,7 +63,7 @@ class RetroAchievementsUser {
     required this.contribCount,
     required this.contribYield,
     required this.totalPoints,
-    required this.totalSoftcorePoints,
+    required this.totalCasualPoints,
     required this.totalTruePoints,
     required this.permissions,
     required this.untracked,
@@ -84,7 +84,7 @@ class RetroAchievementsUser {
       contribCount: RAParsingUtils.toInt(json['ContribCount']),
       contribYield: RAParsingUtils.toInt(json['ContribYield']),
       totalPoints: RAParsingUtils.toInt(json['TotalPoints']),
-      totalSoftcorePoints: RAParsingUtils.toInt(json['TotalSoftcorePoints']),
+      totalCasualPoints: RAParsingUtils.toInt(json['TotalSoftcorePoints']),
       totalTruePoints: RAParsingUtils.toInt(json['TotalTruePoints']),
       permissions: RAParsingUtils.toInt(json['Permissions']),
       untracked: RAParsingUtils.toInt(json['Untracked']),
@@ -94,9 +94,9 @@ class RetroAchievementsUser {
     );
   }
 
-  /// Whether the user primarily or exclusively plays in softcore (casual) mode.
-  bool get isSoftcore => totalSoftcorePoints > totalPoints;
+  /// Whether the user primarily or exclusively plays in casual mode.
+  bool get isCasual => totalCasualPoints > totalPoints;
 
   /// Returns a display string representing the user's primary gameplay mode.
-  String get userType => isSoftcore ? 'Softcore User' : 'Hardcore User';
+  String get userType => isCasual ? 'Casual User' : 'Hardcore User';
 }

--- a/lib/models/retro_achievements_user_awards.dart
+++ b/lib/models/retro_achievements_user_awards.dart
@@ -20,8 +20,8 @@ class RetroAchievementsUserAwards {
   /// Number of games "Beaten" in hardcore mode.
   final int beatenHardcoreAwardsCount;
 
-  /// Number of games "Beaten" in casual (softcore) mode.
-  final int beatenSoftcoreAwardsCount;
+  /// Number of games "Beaten" in casual mode.
+  final int beatenCasualAwardsCount;
 
   /// Number of awards earned during special community events.
   final int eventAwardsCount;
@@ -38,7 +38,7 @@ class RetroAchievementsUserAwards {
     required this.masteryAwardsCount,
     required this.completionAwardsCount,
     required this.beatenHardcoreAwardsCount,
-    required this.beatenSoftcoreAwardsCount,
+    required this.beatenCasualAwardsCount,
     required this.eventAwardsCount,
     required this.siteAwardsCount,
     required this.visibleUserAwards,
@@ -56,7 +56,7 @@ class RetroAchievementsUserAwards {
       beatenHardcoreAwardsCount: RAParsingUtils.toInt(
         json['BeatenHardcoreAwardsCount'],
       ),
-      beatenSoftcoreAwardsCount: RAParsingUtils.toInt(
+      beatenCasualAwardsCount: RAParsingUtils.toInt(
         json['BeatenSoftcoreAwardsCount'],
       ),
       eventAwardsCount: RAParsingUtils.toInt(json['EventAwardsCount']),

--- a/lib/providers/retro_achievements_provider.dart
+++ b/lib/providers/retro_achievements_provider.dart
@@ -157,7 +157,7 @@ class RetroAchievementsProvider extends ChangeNotifier {
   /// Recent mastery awards (hardcore) visible to the user.
   List<UserAward> get recentMasteries => _recentAwardsForMode(hardcore: true);
 
-  /// Recent completion awards (softcore) visible to the user.
+  /// Recent completion awards (casual) visible to the user.
   List<UserAward> get recentCompletions =>
       _recentAwardsForMode(hardcore: false);
 

--- a/lib/screens/retro_achievements_screen/ra_dashboard.dart
+++ b/lib/screens/retro_achievements_screen/ra_dashboard.dart
@@ -147,7 +147,7 @@ class _RADashboardHubState extends State<RADashboardHub> {
   ) {
     final theme = Theme.of(context);
     final user = raProvider.user!;
-    final showCompletions = user.isSoftcore;
+    final showCompletions = user.isCasual;
     final trackedGames = raProvider.completionProgress?.total ?? 0;
     final highlightColor = showCompletions
         ? const Color(0xFFC0C0C0)
@@ -526,7 +526,7 @@ class _RADashboardHubState extends State<RADashboardHub> {
     BuildContext context,
     RetroAchievementsProvider raProvider,
   ) {
-    final showCompletions = raProvider.user?.isSoftcore ?? false;
+    final showCompletions = raProvider.user?.isCasual ?? false;
     final items =
         (showCompletions
                 ? raProvider.recentCompletions


### PR DESCRIPTION
> 🤖 This PR was created with assistance from [Claude Code](https://claude.com/claude-code).

# Description

Aligns NeoStation's RetroAchievements terminology with RA's rebrand of **"Softcore" → "Casual"** ([RetroAchievements/RAWeb#5015](https://github.com/RetroAchievements/RAWeb/pull/5015)).

- Renames Dart identifiers: `isSoftcore`→`isCasual`, `totalSoftcorePoints`→`totalCasualPoints`, `beatenSoftcoreAwardsCount`→`beatenCasualAwardsCount`, `raSoftcorePoints`→`raCasualPoints`, plus doc comments.
- Renames the one user-facing dashboard label: **`'Softcore User'` → `'Casual User'`** (the `'Hardcore User'` branch is unchanged — this rebrand only touches softcore).

**No wire-format change.** RAWeb#5015 renamed RAWeb's *internal V2 API* fields, which NeoStation does not consume. NeoStation reads the **legacy Web API** (PascalCase keys like `TotalSoftcorePoints`, `BeatenSoftcoreAwardsCount`, `RASoftcorePoints`), which that PR does **not** touch — so those `json['...']` keys are deliberately left verbatim. NeoStation also never compares the `highestAwardKind` string against `beaten-softcore`, so nothing on the wire breaks.

Fixes # (n/a)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works. <!-- Existing RA parsing tests (159/159 passing) cover the renamed fields; no wire-format change so no new tests needed. -->
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. <!-- No new assets. -->
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android <!-- Not yet device-tested; only user-facing change is the 'Casual User' label, visible only on a casual-mode account. -->
- [ ] **Gamepad support verified** (if applicable). <!-- N/A: no navigation change. -->

## Screenshots (if applicable)

N/A — the only visible change is the account-type label ("Softcore User" → "Casual User") on the RetroAchievements dashboard, shown for casual-mode accounts.
