### PR TITLE
fix(ra): unify RA dashboard chip accents & fix gold legibility on light themes

### DIFF
--- a/lib/screens/retro_achievements_screen/ra_dashboard.dart
+++ b/lib/screens/retro_achievements_screen/ra_dashboard.dart
@@ -150,9 +150,12 @@ class _RADashboardHubState extends State<RADashboardHub> {
     final user = raProvider.user!;
     final showCompletions = user.isCasual;
     final trackedGames = raProvider.completionProgress?.total ?? 0;
+    // Bright gold/silver read fine on dark surfaces but wash out on light
+    // palettes, so pick a darker goldenrod/grey when the theme is light.
+    final isLightTheme = theme.brightness == Brightness.light;
     final highlightColor = showCompletions
-        ? const Color(0xFFC0C0C0)
-        : const Color(0xFFFFD700);
+        ? (isLightTheme ? const Color(0xFF757575) : const Color(0xFFC0C0C0))
+        : (isLightTheme ? const Color(0xFFB8860B) : const Color(0xFFFFD700));
     final highlightCount = showCompletions
         ? (raProvider.userAwards?.completionAwardsCount ?? 0)
         : (raProvider.userAwards?.masteryAwardsCount ?? 0);
@@ -224,13 +227,13 @@ class _RADashboardHubState extends State<RADashboardHub> {
                       icon: Symbols.stars_rounded,
                       label:
                           '${user.totalPoints} ${AppLocale.raPointsAbbrev.getString(context)}',
-                      color: theme.colorScheme.tertiary,
+                      color: theme.colorScheme.primary,
                     ),
                     _buildPill(
                       context,
                       icon: Symbols.sports_esports_rounded,
                       label: '$trackedGames games played',
-                      color: theme.colorScheme.secondary,
+                      color: theme.colorScheme.primary,
                     ),
                     _buildPill(
                       context,
@@ -281,8 +284,9 @@ class _RADashboardHubState extends State<RADashboardHub> {
     final gotw = raProvider.gotw;
     final owned = raProvider.ownedWeekGame;
     final earned = raProvider.gotwEarned;
+    final isLightTheme = theme.brightness == Brightness.light;
     final accent = earned
-        ? const Color(0xFFFFD700)
+        ? (isLightTheme ? const Color(0xFFB8860B) : const Color(0xFFFFD700))
         : owned != null
         ? theme.colorScheme.secondary
         : theme.colorScheme.primary;
@@ -447,14 +451,14 @@ class _RADashboardHubState extends State<RADashboardHub> {
                     icon: Symbols.groups_rounded,
                     label:
                         '${gotw.totalPlayers} ${AppLocale.players.getString(context)}',
-                    color: theme.colorScheme.tertiary,
+                    color: accent,
                   ),
                   _buildPill(
                     context,
                     icon: Symbols.trophy_rounded,
                     label:
                         '${gotw.unlocksCount} ${AppLocale.unlocks.getString(context)}',
-                    color: theme.colorScheme.tertiary,
+                    color: accent,
                   ),
                 ],
               ),
@@ -536,6 +540,9 @@ class _RADashboardHubState extends State<RADashboardHub> {
     RetroAchievementsProvider raProvider,
   ) {
     final showCompletions = raProvider.user?.isCasual ?? false;
+    // Darken the gold/silver accent on light themes for legibility (see the
+    // profile chip highlightColor above).
+    final isLightTheme = Theme.of(context).brightness == Brightness.light;
     final items =
         (showCompletions
                 ? raProvider.recentCompletions
@@ -566,8 +573,8 @@ class _RADashboardHubState extends State<RADashboardHub> {
             ? AppLocale.raCompletionLabel.getString(context)
             : AppLocale.raMasteryLabel.getString(context),
         accentLabelColor: showCompletions
-            ? const Color(0xFFC0C0C0)
-            : const Color(0xFFFFD700),
+            ? (isLightTheme ? const Color(0xFF757575) : const Color(0xFFC0C0C0))
+            : (isLightTheme ? const Color(0xFFB8860B) : const Color(0xFFFFD700)),
       ),
     );
   }


### PR DESCRIPTION
> 🤖 This PR was created with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

The RetroAchievements dashboard chips mixed `ColorScheme` roles (primary/secondary/tertiary) with hardcoded gold/silver literals, producing a noisy "fruit salad" of accents. The bright gold (`#FFD700`) and silver (`#C0C0C0`) also washed out and were hard to read against light palettes (originally reported for the profile "Masteries" chip).

This change:

- **Profile chips** — "pts" and "games played" now share `colorScheme.primary` with the "Hardcore User" chip, so the metadata row is one cohesive accent. The Masteries/Completions chip keeps its gold/silver identity as the one deliberately highlighted stat.
- **Achievement-of-the-Week card** — the two hardcoded `tertiary` stat pills ("Players", "Unlocks") now use the card's own `accent`, matching the "pts" pill.
- **Legibility** — all gold/silver highlights are now brightness-aware: darker goldenrod (`#B8860B`) / grey (`#757575`) on light themes, unchanged bright gold/silver on dark themes. This covers the profile chip, the AOTW earned-state accent, and the Recent Masteries award rows.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [ ] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Verified on-device (AYN Thor):
- **Light theme** — Masteries chip now renders in a legible darker goldenrod instead of the washed-out pale yellow.
- **Dark theme** — profile metadata chips share a single purple accent (gold Masteries stands out); AOTW stat pills are uniform.