### PR TITLE
fix(secondary): keep app dock static instead of re-sliding on game/media changes

### DIFF
--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -1019,6 +1019,13 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
         ? (1.0 - value.nowPlayingDimLevel.clamp(0, 100) / 100.0)
         : 1.0;
     return Positioned.fill(
+      // Stable key so this subtree's element (and its slide-in
+      // TweenAnimationBuilder state) is preserved across rebuilds of the parent
+      // Stack. Without it, the unkeyed conditional siblings above (game layer,
+      // mute button) inserting/removing on game-select and video-toggle shift
+      // element positions, tearing down and recreating the dock — which restarts
+      // the reveal tween and makes the static dock re-slide up every time.
+      key: const ValueKey('dock-overlay'),
       child: IgnorePointer(
         // Non-interactive while hidden or dimmed — when dimmed, touches fall
         // through to the panel's wake Listener below (first touch only wakes).


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

The app dock on the Now Playing / secondary display was meant to be static once revealed, but it re-played its slide-up-from-below animation every time a game was selected or a screenshot/video was shown.

**Cause:** the dock overlay is an unkeyed conditional child of the top-level `Stack`, sitting next to sibling children that insert/remove on game-select (`isGameSelected`) and screenshot/video toggles (`_showVideo`). That sibling churn shifts element positions, so Flutter's multi-child reconciliation tears down and recreates the dock subtree — including its reveal `TweenAnimationBuilder`, whose fresh state replays the `1.0 → 0.0` slide-up each time.

**Fix:** give the dock's `Positioned.fill` a stable `ValueKey('dock-overlay')`. Flutter's `updateChildren` then reuses the keyed element across sibling changes, so the completed reveal tween is preserved and the dock stays put.

Fixes # (no issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Verified on the AYN Thor: selecting games and toggling screenshots/videos no longer causes the dock to re-slide.
