### PR TITLE
perf(game-views): fix grid/carousel navigation jank from #188

### DIFF
--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -387,10 +387,16 @@ class _GamesCarouselState extends State<GamesCarousel> {
       return;
     }
 
-    if (mounted) {
-      setState(() => _isLoadingAchievements = true);
-    }
+    // Clear the previous game's info immediately (not just after the async load
+    // returns) so fast scrolling never shows the prior game's achievement
+    // counts/icon while this load is pending.
     _achievementsTargetRomname = game.romname;
+    if (mounted) {
+      setState(() {
+        _currentGameInfo = null;
+        _isLoadingAchievements = true;
+      });
+    }
 
     try {
       final provider = context.read<RetroAchievementsProvider>();

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -74,6 +74,12 @@ class _GamesCarouselState extends State<GamesCarousel> {
   static final Map<String, bool> _fileExistsCache = {};
   int _lastBgIndex = -1;
 
+  /// Memoized `File.existsSync()` — synchronous disk stats on the UI thread
+  /// while cards build are a known jank source. Entries are evicted by
+  /// [GamesCarousel.evictArtworkCaches] when a scrape replaces artwork.
+  static bool _fileExists(String path) =>
+      _fileExistsCache.putIfAbsent(path, () => File(path).existsSync());
+
   GameInfoAndUserProgress? _currentGameInfo;
   bool _isLoadingAchievements = false;
   String? _achievementsTargetRomname;
@@ -497,7 +503,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
       imageType,
       widget.fileProvider,
     );
-    if (File(path).existsSync()) return path;
+    if (_fileExists(path)) return path;
     return '';
   }
 
@@ -505,13 +511,13 @@ class _GamesCarouselState extends State<GamesCarousel> {
     final theme = Theme.of(context);
     final folder = _folderForGame(game);
     final screenshotPath = game.getScreenshotPath(folder, widget.fileProvider);
-    final hasScreenshot = File(screenshotPath).existsSync();
+    final hasScreenshot = _fileExists(screenshotPath);
     final fanartPath = game.getImagePath(
       folder,
       'fanarts',
       widget.fileProvider,
     );
-    final hasFanart = File(fanartPath).existsSync();
+    final hasFanart = _fileExists(fanartPath);
     final bgPath = hasFanart
         ? fanartPath
         : (hasScreenshot ? screenshotPath : '');

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -257,6 +257,15 @@ class _GamesGridState extends State<GamesGrid> {
     return game.getScreenshotPath(_folderForGame(game), widget.fileProvider);
   }
 
+  String _wheelsPath(int index) {
+    final game = widget.games[index];
+    return game.getImagePath(
+      _folderForGame(game),
+      'wheels',
+      widget.fileProvider,
+    );
+  }
+
   bool get _isFanart =>
       context.read<SqliteConfigProvider>().config.gameCarouselCardStyle ==
       'fanart';
@@ -1035,8 +1044,10 @@ class _GamesGridState extends State<GamesGrid> {
   Widget _buildFanartGridCard(int index, GameModel game, ThemeData theme) {
     final fanartPath = _fanartPath(index);
     final screenshotPath = _screenshotPath(index);
+    final wheelsPath = _wheelsPath(index);
     final hasFanart = _fileExists(fanartPath);
     final hasScreenshot = !hasFanart && _fileExists(screenshotPath);
+    final hasWheel = _fileExists(wheelsPath);
     final bgPath = hasFanart
         ? fanartPath
         : (hasScreenshot ? screenshotPath : '');
@@ -1100,6 +1111,48 @@ class _GamesGridState extends State<GamesGrid> {
                                 )
                               else
                                 _buildFallbackCard(game, theme),
+                              // Darkening gradient so the overlaid logo stays
+                              // legible against bright fanart.
+                              if (bgPath.isNotEmpty && hasWheel)
+                                const Positioned.fill(
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      gradient: LinearGradient(
+                                        begin: Alignment.topCenter,
+                                        end: Alignment.bottomCenter,
+                                        colors: [
+                                          Colors.transparent,
+                                          Colors.black54,
+                                          Colors.black87,
+                                        ],
+                                        stops: [0.5, 0.75, 1.0],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              // Wheel/logo overlaid at the bottom (restores the
+                              // pre-#188 fanart look).
+                              if (hasWheel)
+                                Positioned(
+                                  left: 10.r,
+                                  right: 10.r,
+                                  bottom: 5.r,
+                                  child: Padding(
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: 6.r,
+                                      vertical: 4.r,
+                                    ),
+                                    child: Image.file(
+                                      File(wheelsPath),
+                                      key: ValueKey('wheel_${game.romname}'),
+                                      fit: BoxFit.contain,
+                                      cacheWidth: 384,
+                                      gaplessPlayback: true,
+                                      errorBuilder: (ctx, e, s) =>
+                                          const SizedBox.shrink(),
+                                    ),
+                                  ),
+                                ),
                               if (game.isFavorite == true)
                                 Positioned(
                                   top: 4.r,

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -74,11 +74,48 @@ class _GamesGridState extends State<GamesGrid> {
   late GamepadNavigation _gamepadNav;
   int _selectedIndex = 0;
   int _crossAxisCount = 5;
+
+  // Bumped whenever card *content* (as opposed to selection) changes, so the
+  // SelectionGrid rebuilds its cached card widgets. A pure selection move
+  // deliberately leaves this untouched — the cards are then reused and only
+  // the highlight repositions.
+  int _gridRevision = 0;
   bool _isNavigatingFast = false;
 
   GameInfoAndUserProgress? _currentGameInfo;
   bool _isLoadingAchievements = false;
   String? _achievementsTargetRomname;
+
+  // RetroAchievements info is loaded per selected game, but firing it (plus its
+  // setState churn) on every gamepad move floods the UI thread during fast
+  // navigation. Debounce so it loads once the selection settles.
+  Timer? _achievementsDebounce;
+  static const Duration _achievementsSettleDelay = Duration(milliseconds: 280);
+
+  /// Debounced entry point for the navigation hot path — coalesces rapid moves
+  /// into a single load once the user stops on a game.
+  void _scheduleAchievementsLoad() {
+    // Reflect the new selection in the footer's RA indicator immediately, so
+    // fast navigation never shows the *previous* game's achievement counts/icon
+    // while the (debounced) load is pending. Fields are mutated directly — every
+    // caller already has a rebuild in flight (setState on the move, or a
+    // didUpdateWidget). The actual load below fills in the real data on settle.
+    final selectedRomname = widget.games.isEmpty
+        ? null
+        : widget
+              .games[_selectedIndex.clamp(0, widget.games.length - 1)]
+              .romname;
+    if (selectedRomname != _achievementsTargetRomname) {
+      _achievementsTargetRomname = selectedRomname;
+      _currentGameInfo = null;
+      _isLoadingAchievements = true;
+    }
+    _achievementsDebounce?.cancel();
+    _achievementsDebounce = Timer(_achievementsSettleDelay, () {
+      if (mounted) _loadAchievementsForSelectedGame();
+    });
+  }
+
   DateTime? _lastNavTime;
   static const Duration _fastNavThreshold = Duration(milliseconds: 150);
 
@@ -449,6 +486,19 @@ class _GamesGridState extends State<GamesGrid> {
   void didUpdateWidget(GamesGrid oldWidget) {
     super.didUpdateWidget(oldWidget);
     _updateCrossAxisCount();
+    // Card *content* changed (not just selection) — bump the revision so the
+    // SelectionGrid rebuilds cached card widgets instead of reusing stale ones.
+    //   - games: gets a fresh list instance on favorite toggle / reorder /
+    //     update, and length changes on delete (which also re-keys geometry),
+    //     so an identity check catches those.
+    //   - scrape sets/maps are `final` and mutated in place (stable identity),
+    //     so bump while a scrape is active — or was on the previous frame — to
+    //     keep progress bars animating and to clear them when the scrape ends.
+    if (!identical(widget.games, oldWidget.games) ||
+        widget.scrapingGameRomnames.isNotEmpty ||
+        oldWidget.scrapingGameRomnames.isNotEmpty) {
+      _gridRevision++;
+    }
     // Artwork replaced by a finished scrape must be re-checked on disk.
     final finishedScrapes = oldWidget.scrapingGameRomnames.difference(
       widget.scrapingGameRomnames,
@@ -464,7 +514,7 @@ class _GamesGridState extends State<GamesGrid> {
         0,
         (widget.games.length - 1).clamp(0, 999999),
       );
-      _loadAchievementsForSelectedGame();
+      _scheduleAchievementsLoad();
     }
   }
 
@@ -504,6 +554,7 @@ class _GamesGridState extends State<GamesGrid> {
   @override
   void dispose() {
     _cardSizeLabelTimer?.cancel();
+    _achievementsDebounce?.cancel();
     _cardSizeLabel.dispose();
     GamepadNavigationManager.popLayer('games_grid');
     _gamepadNav.dispose();
@@ -565,7 +616,7 @@ class _GamesGridState extends State<GamesGrid> {
   void _onSelectionChanged() {
     if (_selectedIndex < widget.games.length) {
       widget.onGameSelected(widget.games[_selectedIndex]);
-      _loadAchievementsForSelectedGame();
+      _scheduleAchievementsLoad();
     }
   }
 
@@ -732,6 +783,7 @@ class _GamesGridState extends State<GamesGrid> {
                             bottom: padB,
                           ),
                           selectedIndex: _selectedIndex,
+                          revision: _gridRevision,
                           isNavigatingFast: _isNavigatingFast,
                           // On a discontinuous layout change (density or card
                           // style) the highlight re-creates and jumps to the
@@ -852,7 +904,7 @@ class _GamesGridState extends State<GamesGrid> {
         setState(() => _selectedIndex = index);
         widget.onGameSelected(game);
         SfxService().playNavSound();
-        _loadAchievementsForSelectedGame();
+        _scheduleAchievementsLoad();
       },
       child: RepaintBoundary(
         child: Padding(
@@ -995,7 +1047,7 @@ class _GamesGridState extends State<GamesGrid> {
         setState(() => _selectedIndex = index);
         widget.onGameSelected(game);
         SfxService().playNavSound();
-        _loadAchievementsForSelectedGame();
+        _scheduleAchievementsLoad();
       },
       child: RepaintBoundary(
         child: Padding(

--- a/lib/widgets/native_carousel.dart
+++ b/lib/widgets/native_carousel.dart
@@ -172,9 +172,23 @@ class NativeCarouselState extends State<NativeCarousel> {
               allowImplicitScrolling: true,
               itemCount: widget.itemCount,
               itemBuilder: (context, index) {
+                // Build the card exactly once and pass it as the
+                // ValueListenableBuilder's `child`. Only the cheap
+                // Opacity/Transform.scale envelope reacts to per-frame page
+                // scroll updates — the card subtree (which does disk reads and
+                // Image.file decoding) is NOT rebuilt on every scroll frame.
+                // RepaintBoundary lets the card's raster be cached and reused
+                // as the scale/opacity animate.
+                final card = RepaintBoundary(
+                  child: AspectRatio(
+                    aspectRatio: pageAspectRatio,
+                    child: widget.itemBuilder(context, index),
+                  ),
+                );
                 return ValueListenableBuilder<double>(
                   valueListenable: _pageNotifier,
-                  builder: (context, page, _) {
+                  child: card,
+                  builder: (context, page, child) {
                     final distance = (index - page).abs() - 0.6;
                     final scale = (1.0 - distance * 0.4).clamp(0.25, 1.0);
                     final opacity = (0.6 - distance * 1).clamp(0.1, 1.0);
@@ -184,10 +198,7 @@ class NativeCarouselState extends State<NativeCarousel> {
                       child: Transform.scale(
                         scale: scale,
                         alignment: Alignment.center,
-                        child: AspectRatio(
-                          aspectRatio: pageAspectRatio,
-                          child: widget.itemBuilder(context, index),
-                        ),
+                        child: child,
                       ),
                     );
                   },

--- a/lib/widgets/selection_grid/selection_grid.dart
+++ b/lib/widgets/selection_grid/selection_grid.dart
@@ -45,6 +45,12 @@ class SelectionGrid extends StatefulWidget {
 
   final SelectionGridItemBuilder itemBuilder;
 
+  /// Monotonic counter the parent bumps whenever card *content* (not
+  /// selection) changes — e.g. scrape progress, favorite toggles, or a games
+  /// list swap. Cached card widgets are rebuilt when this changes; leaving it
+  /// at its default means a selection move alone never rebuilds cards.
+  final int revision;
+
   /// Optional custom visuals for the selection highlight. Defaults to the
   /// standard primary-gradient frame used across the app.
   final WidgetBuilder? highlightBuilder;
@@ -55,6 +61,7 @@ class SelectionGrid extends StatefulWidget {
     required this.padding,
     required this.selectedIndex,
     required this.itemBuilder,
+    this.revision = 0,
     this.isNavigatingFast = false,
     this.highlightKey,
     this.highlightBuilder,
@@ -71,7 +78,37 @@ class SelectionGridState extends State<SelectionGrid> {
   int _firstRow = 0;
   int _lastRow = -1;
 
-  static const int _rowBuffer = 2;
+  static const int _rowBuffer = 4;
+
+  // ---- Card cell cache (per index) ----
+  // Cards are cached individually by item index and the *same widget instance*
+  // is reused across rebuilds. Two payoffs:
+  //   1. A selection move (range unchanged) rebuilds no cards — only the
+  //      highlight repositions, like the pre-#188 scroll-driven overlay.
+  //   2. When the scroll animation shifts the visible window by a row, only
+  //      the newly-entered indices are built; the rest are reused. This is the
+  //      key win — the old list cache rebuilt the *entire* window on every
+  //      shift (~70 cards → measured 20–28ms build frames), whereas building
+  //      one new row is a handful of cards.
+  // Passing identical instances lets Flutter skip diffing those subtrees.
+  final Map<int, Widget> _cellCache = {};
+  SelectionGridGeometry? _cacheGeometry;
+  int _cacheEpoch = -1;
+  int _cacheRevision = -1;
+
+  /// Extra indices kept warm on each side of the visible window so scrolling
+  /// back a little reuses cells instead of rebuilding them.
+  static const int _cacheMargin = 60;
+
+  /// Bumped when an inherited dependency (theme, media query, …) changes, so
+  /// cached card widgets — which capture theme-derived values — are rebuilt.
+  int _depEpoch = 0;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _depEpoch++;
+  }
 
   @override
   void initState() {
@@ -118,20 +155,11 @@ class SelectionGridState extends State<SelectionGrid> {
     final startY = _scrollController.offset;
     final endY = startY + _scrollController.position.viewportDimension;
 
-    int first = 0;
-    for (int r = 0; r < rows.length; r++) {
-      if (rows[r].bottom >= startY) {
-        first = r;
-        break;
-      }
-    }
-    int last = rows.length - 1;
-    for (int r = first; r < rows.length; r++) {
-      if (rows[r].top > endY) {
-        last = r - 1;
-        break;
-      }
-    }
+    // Rows are sorted by vertical position, so binary-search the visible
+    // window instead of scanning every row on each scroll frame (a large
+    // library can have thousands of rows).
+    int first = _firstRowAtOrBelow(rows, startY);
+    int last = _lastRowAbove(rows, endY, first);
 
     first = (first - _rowBuffer).clamp(0, rows.length - 1);
     last = (last + _rowBuffer).clamp(first, rows.length - 1);
@@ -142,6 +170,36 @@ class SelectionGridState extends State<SelectionGrid> {
         _lastRow = last;
       });
     }
+  }
+
+  /// First row whose bottom edge is at or below [y] (i.e. still visible).
+  static int _firstRowAtOrBelow(List<GridRowInfo> rows, double y) {
+    int lo = 0, hi = rows.length - 1, result = rows.length - 1;
+    while (lo <= hi) {
+      final mid = (lo + hi) >> 1;
+      if (rows[mid].bottom >= y) {
+        result = mid;
+        hi = mid - 1;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    return result;
+  }
+
+  /// Last row whose top edge is at or above [y], searching from [from].
+  static int _lastRowAbove(List<GridRowInfo> rows, double y, int from) {
+    int lo = from, hi = rows.length - 1, result = rows.length - 1;
+    while (lo <= hi) {
+      final mid = (lo + hi) >> 1;
+      if (rows[mid].top > y) {
+        result = mid - 1;
+        hi = mid - 1;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    return result.clamp(from, rows.length - 1);
   }
 
   /// Animates the viewport so the selected card sits centered.
@@ -182,26 +240,50 @@ class SelectionGridState extends State<SelectionGrid> {
       if (selectedRow < first) first = selectedRow;
       if (selectedRow > last) last = selectedRow;
 
-      for (int r = first; r <= last; r++) {
-        final row = rows[r];
-        for (int j = 0; j < row.count; j++) {
-          final index = row.startIndex + j;
+      // Drop the whole cache when something that affects *card content* (not
+      // selection or scroll position) changed: a new geometry (rects moved),
+      // a revision bump (scrape/favorite/games swap), or an inherited
+      // dependency (theme). Otherwise cells survive across rebuilds.
+      if (!identical(_cacheGeometry, geometry) ||
+          _cacheEpoch != _depEpoch ||
+          _cacheRevision != widget.revision) {
+        _cellCache.clear();
+        _cacheGeometry = geometry;
+        _cacheEpoch = _depEpoch;
+        _cacheRevision = widget.revision;
+      }
+
+      // Build only indices not already cached; reuse the rest by identity so a
+      // one-row window shift builds one row of cards, not the whole window.
+      final firstIndex = rows[first].startIndex;
+      final lastRow = rows[last];
+      final lastIndex = lastRow.startIndex + lastRow.count - 1;
+
+      for (int index = firstIndex; index <= lastIndex; index++) {
+        final cell = _cellCache[index] ??= () {
           final rect = geometry.cardRects[index];
-          children.add(
-            Positioned(
-              key: ValueKey('selection_grid_cell_$index'),
-              left: rect.left,
-              top: rect.top,
-              width: rect.width,
-              height: rect.height,
-              child: widget.itemBuilder(
-                context,
-                index,
-                Size(rect.width, rect.height),
-              ),
+          return Positioned(
+            key: ValueKey('selection_grid_cell_$index'),
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+            height: rect.height,
+            child: widget.itemBuilder(
+              context,
+              index,
+              Size(rect.width, rect.height),
             ),
           );
-        }
+        }();
+        children.add(cell);
+      }
+
+      // Evict cells well outside the visible window to bound memory during a
+      // long scroll (kept generous so small back-scrolls still hit the cache).
+      if (_cellCache.length > (lastIndex - firstIndex + 1) + 4 * _cacheMargin) {
+        final keepFrom = firstIndex - _cacheMargin;
+        final keepTo = lastIndex + _cacheMargin;
+        _cellCache.removeWhere((i, _) => i < keepFrom || i > keepTo);
       }
     }
 


### PR DESCRIPTION
> 🤖 This PR was authored with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

The #188 game-list redesign regressed **grid** and **carousel** scroll/navigation performance versus the list view — noticeably janky on low-spec hardware (AYN Thor). On-device frame profiling (`FrameTiming`) showed the cost was UI-thread **build**, not raster: janky frames spent **18–28 ms building** and ~2 ms rasterizing.

**Grid (`selection_grid` / `my_games_grid`)**
- `SelectionGrid` rebuilt its *entire* visible card window (~70 cards) on every `setState` — including each row-crossing during the centered-scroll animation, and every selection move. The pre-#188 grid was a `SliverList` of rows whose selector was an independent scroll-driven overlay, so it only ever built the single row entering the viewport.
- Cards are now cached per index and reused by identity: a selection move rebuilds **no** cards (only the highlight repositions), and a scroll shift builds just the newly-entered row. **Measured: build on janky frames fell from 18–28 ms to ~1 ms; jank frames from ~12 to 2.**
- Cache invalidation is driven by a parent `revision` (games-list identity for favorite/reorder/update, geometry re-key on delete, and active-scrape detection so progress bars still animate), plus a dependency epoch for theme changes.
- Debounced per-selection RetroAchievements loading (fires once the selection settles), and reset the footer's RA indicator immediately on selection change so fast scrolling never shows the previous game's data. Also bumped the row buffer and binary-search the visible window.

**Carousel (`native_carousel` / `my_games_carousel`)**
- Each `PageView` page wrapped its whole card in a `ValueListenableBuilder` tied to the page-scroll notifier, rebuilding the entire card subtree (`File.existsSync` + `Image.file`) on every scroll frame for every visible page. Now the card is built once and passed as `child`; only the `Opacity`/`Transform.scale` envelope reacts per frame, wrapped in a `RepaintBoundary`. Card existence checks routed through the existing memoized cache. RA indicator also resets immediately on page change.

**Also:** restored the pre-#188 look of overlaying the game logo (wheel art) on fanart grid cards.

Fixes # (no tracked issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

N/A — performance change; verified via `FrameTiming` profiling on-device (build 18–28 ms → ~1 ms).
