### PR TITLE
fix(secondary): apply 25% fanart dim on first launch

### DIFF
--- a/lib/models/secondary_display_state.dart
+++ b/lib/models/secondary_display_state.dart
@@ -254,7 +254,14 @@ class SecondaryDisplayStateData {
     this.lastPlayedMillis,
     this.nowPlayingDimDelay = 5,
     this.nowPlayingDimLevel = 100,
-    this.fanartDimLevel = 0,
+    // Mirror the config default (fanart_dim_level DEFAULT 25). On first launch
+    // the native shared-state store is empty, so the initial WELCOME seed
+    // constructs a *fresh* data object and broadcasts it to the secondary
+    // engine before the real _config value is pushed. If this defaulted to 0,
+    // that first snapshot would render the system art undimmed until the later
+    // seed landed. Keeping it in sync with the config default (like
+    // nowPlayingDimLevel = 100 above) makes the 25% dim apply from frame one.
+    this.fanartDimLevel = 25,
     this.dockApps = const ['', '', '', '', ''],
     this.dockEditTrigger = 0,
     this.dockEnabled = true,
@@ -485,7 +492,7 @@ class SecondaryDisplayStateData {
       lastPlayedMillis: (json['lastPlayedMillis'] as num?)?.toInt(),
       nowPlayingDimDelay: (json['nowPlayingDimDelay'] as num?)?.toInt() ?? 5,
       nowPlayingDimLevel: (json['nowPlayingDimLevel'] as num?)?.toInt() ?? 100,
-      fanartDimLevel: (json['fanartDimLevel'] as num?)?.toInt() ?? 0,
+      fanartDimLevel: (json['fanartDimLevel'] as num?)?.toInt() ?? 25,
       dockApps: json['dockApps'] is List
           ? (json['dockApps'] as List<dynamic>)
                 .map((e) => e?.toString() ?? '')

--- a/test/secondary_display_state_test.dart
+++ b/test/secondary_display_state_test.dart
@@ -129,7 +129,9 @@ void main() {
       expect(restored.deviceScreenOn, isTrue);
       expect(restored.nowPlayingDimDelay, 5);
       expect(restored.nowPlayingDimLevel, 100);
-      expect(restored.fanartDimLevel, 0);
+      // Mirrors the config default (fanart_dim_level DEFAULT 25) so the 25% dim
+      // applies from the first-launch WELCOME seed, not just after a relaunch.
+      expect(restored.fanartDimLevel, 25);
       expect(restored.dockEnabled, isTrue);
       expect(restored.dockSlotCount, 3);
       expect(restored.dockApps, const ['', '', '', '', '']);


### PR DESCRIPTION
> 🤖 This PR was authored with [Claude Code](https://claude.com/claude-code).

# Description

The secondary (bottom) screen dims system/fanart art by 25% by default, but this never applied on a **genuine first launch** — the art rendered undimmed until the app was restarted, after which it worked permanently.

**Root cause:** two defaults for the same value had drifted apart.
- Config/DB default is 25 (`sqlite_service.dart`: `fanart_dim_level INTEGER DEFAULT 25`; `ConfigModel`/`loadConfig` also default to 25), so `_config.fanartDimLevel` is always correct.
- The shared-state model `SecondaryDisplayStateData` defaulted `fanartDimLevel` to **0** in both the constructor and `fromJson`.

On first launch the native `sub_screen` shared-state store is empty, so the provider's early WELCOME seed (`initialize()`, the `value == null` branch) constructs a **fresh** state object carrying the model default (0) and broadcasts that full snapshot to the secondary engine — before the real `_config` value (25) is pushed later in the same init. The secondary renders the first, undimmed snapshot. On every later launch the persisted store already holds 25, so the fresh-construct default is never used — which is why the bug only reproduced on a fresh install.

The sibling field `nowPlayingDimLevel` never had this bug because its model default (100) already matched its config default.

**Fix:** align the model default with the config default (25) in both the constructor and `fromJson`.

Fixes # (no issue filed)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

> Note: verified via `flutter analyze` (clean) and the updated `test/secondary_display_state_test.dart` (8/8 pass). Not yet device-verified on Android — reproducing "first launch" requires clearing the persisted shared-state store first.

## Screenshots (if applicable)

N/A — timing/default fix; visual result is the standard 25% dim now present from the first frame on a fresh install.
