### PR TITLE
perf(dock): faster secondary app dock/drawer + fix accidental dismiss & stuck-hidden dock

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
@@ -35,6 +35,9 @@ import androidx.core.content.FileProvider
 
 class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
     private val CHANNEL = "com.neogamelab.neostation/game"
+    // Max size the dock/picker renders an app icon at; icons are rasterized to
+    // this (in px) before encoding so we don't ship/decode full-res drawables.
+    private val ICON_TARGET_DP = 56f
     private val LAUNCHER_CHANNEL = "com.neogamelab.neostation/launcher"
     var keyListener: ((KeyEvent) -> Boolean)? = null
     var motionListener: ((MotionEvent) -> Boolean)? = null
@@ -863,23 +866,18 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
                     val isGame = false
 
                     val label = resolveInfo.loadLabel(pm).toString()
-                    
-                    var firstInstallTime: Long = 0
-                    var versionName = ""
-                    try {
-                        val pInfo = pm.getPackageInfo(packageName, 0)
-                        firstInstallTime = pInfo.firstInstallTime
-                        versionName = pInfo.versionName ?: ""
-                    } catch (e: Exception) { }
 
+                    // Only name+package are consumed by the dock/picker on the
+                    // Dart side, so we deliberately skip the extra per-app
+                    // pm.getPackageInfo() round-trip that used to fetch
+                    // firstInstallTime/versionName here — on a device with many
+                    // installed apps that second PackageManager hit per app was
+                    // the bulk of the "app drawer takes seconds to wake up" lag.
                     apps.add(mapOf(
                         "name" to label,
                         "package" to packageName,
                         "isSystemApp" to isSystemApp,
-                        "isGame" to isGame,
-                        "firstInstallTime" to firstInstallTime,
-                        "version" to versionName,
-                        "description" to "Android Application ($versionName)"
+                        "isGame" to isGame
                     ))
                 }
                 
@@ -1001,19 +999,21 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
         Thread {
             try {
                 val iconDrawable = packageManager.getApplicationIcon(packageName)
-                val bitmap = if (iconDrawable is BitmapDrawable) {
-                    iconDrawable.bitmap
-                } else {
-                    val bitmap = android.graphics.Bitmap.createBitmap(
-                        iconDrawable.intrinsicWidth,
-                        iconDrawable.intrinsicHeight,
-                        android.graphics.Bitmap.Config.ARGB_8888
-                    )
-                    val canvas = android.graphics.Canvas(bitmap)
-                    iconDrawable.setBounds(0, 0, canvas.width, canvas.height)
-                    iconDrawable.draw(canvas)
-                    bitmap
-                }
+                // The dock/picker never renders an icon larger than ~56dp, so
+                // rasterize straight into a small target bitmap instead of
+                // encoding the source drawable at its native resolution
+                // (adaptive icons are often 192-432px). This shrinks both the
+                // PNG encode here and the Image.memory decode on the Dart side,
+                // which was making the dock feel sluggish while icons loaded.
+                val targetPx = (ICON_TARGET_DP * resources.displayMetrics.density).toInt()
+                val bitmap = android.graphics.Bitmap.createBitmap(
+                    targetPx,
+                    targetPx,
+                    android.graphics.Bitmap.Config.ARGB_8888
+                )
+                val canvas = android.graphics.Canvas(bitmap)
+                iconDrawable.setBounds(0, 0, targetPx, targetPx)
+                iconDrawable.draw(canvas)
 
                 val stream = ByteArrayOutputStream()
                 bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, stream)

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -1434,9 +1434,14 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   /// the backdrop cancels; tapping an app assigns it.
   Widget _buildAppPickerOverlay() {
     return Positioned.fill(
+      // Opaque hit barrier (no onTap) so taps land on the grid/✕ only and never
+      // fall through to the dock beneath. Deliberately NOT tap-to-dismiss: this
+      // picker is fullscreen and fully opaque, so there's no "outside" to
+      // reveal, and the ~20px frame around the grid used to sit right under the
+      // bottom/edge icons — a near-miss reaching for an icon dismissed the whole
+      // drawer. Closing is explicit via the ✕ button.
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: _closeAppPicker,
         child: ColoredBox(
           // Fully opaque so the Now Playing screen behind is not visible while
           // choosing an app for a dock slot.
@@ -1459,11 +1464,19 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                       ),
                       const Spacer(),
                       GestureDetector(
+                        // Opaque + generous padding so the whole ~50px corner
+                        // region closes the picker, not just the 26px glyph.
+                        // (Now that the backdrop no longer dismisses, a near-miss
+                        // on the bare icon would otherwise do nothing.)
+                        behavior: HitTestBehavior.opaque,
                         onTap: _closeAppPicker,
-                        child: Icon(
-                          Symbols.close_rounded,
-                          color: Colors.white,
-                          size: 26.r,
+                        child: Padding(
+                          padding: EdgeInsets.all(12.r),
+                          child: Icon(
+                            Symbols.close_rounded,
+                            color: Colors.white,
+                            size: 26.r,
+                          ),
                         ),
                       ),
                     ],

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -108,6 +108,12 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   List<Map<String, dynamic>>? _pickerApps;
   bool _loadingPickerApps = false;
 
+  /// Guards the one-shot background warm of the installed-app list + dock icons.
+  /// Deliberately deferred until *after* the dock has revealed (`appReady`), so
+  /// the heavy `getInstalledApps` scan can never contend with the cross-engine
+  /// dock-reveal timing race during cold boot.
+  bool _dockPrefetchStarted = false;
+
   @override
   void initState() {
     super.initState();
@@ -138,9 +144,44 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     state.updateState(isSecondaryActive: true);
   }
 
+  /// Pre-populates the picker's installed-app list and warms the in-process
+  /// icon cache so both the dock and the app picker render instantly on first
+  /// open instead of decoding icons on demand.
+  ///
+  /// Docked apps are warmed first (they're visible the moment the dock reveals),
+  /// then every installed app the picker can show. Icons are fetched one at a
+  /// time — each `getAppIcon` spins up native work, so a sequential trickle
+  /// avoids a CPU spike on low-power hardware. `getAppIcon` caches per package,
+  /// so this only ever pays the cost once.
+  Future<void> _prefetchDockData() async {
+    await _ensurePickerApps();
+    if (!mounted) return;
+
+    // Dock apps first, then the rest of the picker list, de-duplicated so a
+    // docked app isn't fetched twice.
+    final warmed = <String>{};
+    final order = <String>[
+      ..._dockApps,
+      ...?_pickerApps?.map((app) => (app['package'] ?? '').toString()),
+    ];
+    for (final package in order) {
+      if (package.isEmpty || !warmed.add(package)) continue;
+      if (!mounted) return; // stop if the screen went away mid-warm
+      await SecondaryAppsService.getAppIcon(package);
+    }
+  }
+
   void _onStateChanged() {
     final state = _secondaryDisplayState?.value;
     if (state == null) return;
+
+    // Warm the app list + dock icons exactly once, only after the dock has
+    // revealed. Gating on `appReady` keeps this heavy work off the cold-boot
+    // reveal path so it can't perturb the cross-engine dock-reveal race.
+    if (state.appReady && !_dockPrefetchStarted) {
+      _dockPrefetchStarted = true;
+      unawaited(_prefetchDockData());
+    }
 
     // A re-scrape rewrites the art at the same path, so this engine's image
     // cache still holds the old bitmap. When the producer bumps mediaRevision,
@@ -565,6 +606,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   /// Lazily loads the installed-app list backing the picker/launcher, once.
   Future<void> _ensurePickerApps() async {
     if (_pickerApps != null || _loadingPickerApps) return;
+    if (!mounted) return;
     setState(() => _loadingPickerApps = true);
     final apps = await SecondaryAppsService.getInstalledApps();
     if (!mounted) return;

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -39,6 +39,14 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   /// can't un-reveal the dock. See [_buildDockOverlay].
   bool _dockRevealed = false;
 
+  /// Failsafe that reveals the dock even if the `appReady` flag never arrives.
+  /// `appReady` is written by both engines and the secondary's own pushes can
+  /// clobber the main engine's `true` back to `false` before this engine ever
+  /// observes it (a slow fresh-install cold boot loses this race reliably),
+  /// leaving the dock parked off-screen forever. This timer guarantees the dock
+  /// still slides in shortly after the screen appears. See [_buildDockOverlay].
+  Timer? _dockRevealFallback;
+
   /// A BuildContext captured from *under* this screen's MaterialApp (and its
   /// Localizations). The _buildXxx helpers below run as methods on this State,
   /// so a bare `context` resolves to `this.context` — which sits ABOVE the
@@ -125,6 +133,15 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
       // updateState fall back to the WELCOME default and clobber the real
       // retained display state, which then shows until the next push.
       _signalSecondaryActiveWhenSynced();
+      // Failsafe reveal: if `appReady` never lands (the cross-engine clobber
+      // described on [_dockRevealFallback]), slide the dock in anyway so it's
+      // never permanently stuck off-screen. The `appReady` path in
+      // [_buildDockOverlay] still wins the moment it arrives.
+      _dockRevealFallback = Timer(const Duration(seconds: 4), () {
+        if (mounted && !_dockRevealed) {
+          setState(() => _dockRevealed = true);
+        }
+      });
     }
   }
 
@@ -537,6 +554,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     _celebrationTimer?.cancel();
     _playTimeTicker?.cancel();
     _dimTimer?.cancel();
+    _dockRevealFallback?.cancel();
     _stopVideo();
     super.dispose();
   }
@@ -1045,7 +1063,10 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     // mute/screenshot toggles) copyWith from a local snapshot that may still
     // carry appReady=false, so the incoming flag oscillates. Latch it locally on
     // first true and ignore later falses, so the dock slides up once and stays.
-    if (value.appReady) _dockRevealed = true;
+    if (value.appReady && !_dockRevealed) {
+      _dockRevealed = true;
+      _dockRevealFallback?.cancel();
+    }
     final raAvailable =
         value.showAchievementPanel && value.achievements != null;
     // Off the Now Playing page (achievements/comments) → hide the dock.

--- a/lib/screens/secondary_screen/widgets/app_dock.dart
+++ b/lib/screens/secondary_screen/widgets/app_dock.dart
@@ -236,7 +236,14 @@ Widget buildDockIcon(String package) {
     builder: (context, snapshot) {
       final bytes = snapshot.data;
       if (bytes != null) {
-        return Image.memory(bytes, fit: BoxFit.contain, gaplessPlayback: true);
+        return Image.memory(
+          bytes,
+          fit: BoxFit.contain,
+          gaplessPlayback: true,
+          // Native side already rasterizes to ~56dp; cap the decode so the
+          // engine keeps a small texture in memory rather than a full-res one.
+          cacheWidth: 112,
+        );
       }
       return Icon(
         Symbols.android_rounded,


### PR DESCRIPTION
> 🤖 This PR was authored with [Claude Code](https://claude.com/claude-code).

# Description

Addresses user feedback that the bottom-screen **app dock / app drawer** felt laggy to open and slow to paint on an (underclocked Thor Max), plus two dock reliability bugs found while investigating.

**Performance (`da681a1`)**
- **Drop a redundant PackageManager call.** `getInstalledApps` fetched `firstInstallTime`/`versionName` per app via a second `pm.getPackageInfo()` that the Dart side never reads (only `name`+`package` are used) — halves PackageManager I/O across the whole app list, which was the bulk of the "app drawer takes a few seconds to wake up" stall.
- **Stop encoding icons at full resolution.** `getAppIcon` PNG-encoded each launcher icon at the drawable's native size (adaptive icons are often 192–432px) and re-decoded full-res on every build, for a slot rendered at ~56dp. Icons are now rasterized into a 56dp target bitmap before encode, with `cacheWidth` on the Dart `Image.memory`.
- **Warm the caches off the critical path.** The installed-app list + all picker icons are now warmed in the background **after** the dock reveals (gated on `appReady`), fetched one at a time to avoid a CPU spike. First drawer open is instant instead of enumerating + decoding on demand.

**Fix: app drawer dismissing when reaching for edge icons (`3b94574`)**
The picker overlay is fullscreen and fully opaque, but its `Positioned.fill` barrier called `_closeAppPicker` on tap. The grid is inset by `SafeArea` + 20px padding, so that frame around the icons was a close-on-tap strip — a near-miss reaching for a bottom/edge icon dismissed the whole drawer. Since the picker is opaque there's no "outside" to reveal, so tap-to-dismiss is removed; closing stays explicit via the ✕, whose hit target is enlarged to ~50px so corner near-misses still register.

**Fix: dock could get permanently stuck off-screen (`9aff89e`)**
The dock only slides in when this engine observes `appReady == true`, but that flag is shared across both display engines and `updateState` writes a whole-object `copyWith` from each engine's own copy. On a slow (fresh-install) cold boot the secondary engine can push an update while its local `appReady` is still stale-`false`, clobbering the main engine's `true`; `markAppReady` is one-shot and never re-asserts, so the dock never sees `true` and stays parked off-screen (a restart just re-rolls the timing). Adds a 4s failsafe timer that reveals the dock if `appReady` never lands — the fast path still wins immediately when it arrives.

Fixes # (no issue filed)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Verified on-device (AYN Thor Max, secondary display). No screenshots — `FLAG_SECURE` blocks screencap on the secondary display. Behavior confirmed via on-device interaction and instrumented tracing of the picker open/close path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
