### PR TITLE
fix(launcher): resolve default emulator live instead of freezing it per-game

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
@@ -265,6 +265,16 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
                     }
                 }
 
+                "isCoreInstalled" -> {
+                    val packageName = call.argument<String>("packageName")
+                    val coreFilename = call.argument<String>("coreFilename")
+                    if (packageName != null && coreFilename != null) {
+                        isCoreInstalled(packageName, coreFilename, result)
+                    } else {
+                        result.error("INVALID_ARGUMENTS", "packageName and coreFilename are required", null)
+                    }
+                }
+
                 "getInstalledApps" -> {
                     val includeSystemApps = call.argument<Boolean>("includeSystemApps") ?: false
                     getInstalledApps(includeSystemApps, result)
@@ -638,6 +648,61 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
             result.success(false)
         } catch (e: Exception) {
             result.success(false)
+        }
+    }
+
+    /**
+     * Determines whether a specific RetroArch libretro core (.so) is actually present,
+     * as opposed to merely having the RetroArch app installed. RetroArch stores its
+     * cores in its own private data dir ({dataDir}/cores/), which this app's sandbox
+     * usually cannot read — so a plain File.exists() from here returns false even when
+     * the core IS installed. We therefore return a TRI-STATE:
+     *   true  = core file positively confirmed present
+     *   false = core file positively confirmed absent (cores dir was readable, or root)
+     *   null  = could not determine (dir unreadable and no root) → caller must fail OPEN
+     * This lets the Ready badge stay accurate where we can tell, without hiding genuinely
+     * installed cores on non-rooted devices. See issue #192.
+     */
+    private fun isCoreInstalled(retroArchPackage: String, coreFilename: String, result: MethodChannel.Result) {
+        try {
+            val coresDir = try {
+                val appInfo = packageManager.getApplicationInfo(retroArchPackage, 0)
+                "${appInfo.dataDir}/cores/"
+            } catch (e: Exception) {
+                "/data/user/0/$retroArchPackage/cores/"
+            }
+            // The DB stores core_filename as the bare base (e.g. "ppsspp"); the actual
+            // Android core is "<base>_libretro_android.so". Probe both the reconstructed
+            // name and the raw value in case a full filename was ever stored.
+            val base = coreFilename
+                .removeSuffix("_libretro_android.so")
+                .removeSuffix("_libretro.so")
+            val candidates = linkedSetOf(
+                "${base}_libretro_android.so",
+                coreFilename,
+            )
+
+            // 1. Direct filesystem check. Trustworthy only if we can actually read the
+            //    cores directory (usually we can't — it's RetroArch's private 0700 dir).
+            if (candidates.any { java.io.File(coresDir, it).exists() }) {
+                result.success(true)
+                return
+            }
+            val dir = java.io.File(coresDir)
+            if (dir.exists() && dir.canRead()) {
+                // Directory readable and none of the candidates were in it → absent.
+                result.success(false)
+                return
+            }
+
+            // 2. Directory unreadable from our sandbox (RetroArch's private 0700 dir).
+            //    We deliberately do NOT escalate to `su` here — requesting root would
+            //    pop a Superuser prompt on rooted devices at game-launch time. Report
+            //    unknown (null) → the caller fails open (treats the core as installed),
+            //    which matches non-rooted/production behavior.
+            result.success(null)
+        } catch (e: Exception) {
+            result.success(null)
         }
     }
 

--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -457,13 +457,17 @@ class SqliteDatabaseService {
     if (isSwitch) await SwitchTitleExtractor.loadKeys();
 
     await db.transaction((txn) async {
+      // app_emulator_unique_id/os_id are left NULL = "inherit the system
+      // default", resolved live at launch. Do NOT freeze the default here:
+      // stamping it made per-game settings stale/"whack-a-mole" and bypassed
+      // the installed-aware default resolution at launch.
       const sql = '''
         INSERT INTO user_roms
         (app_system_id, app_emulator_unique_id, app_emulator_os_id, filename, rom_path, title_id, title_name, created_at)
         VALUES (
           ?,
-          (SELECT e.unique_identifier FROM app_emulators e WHERE e.system_id = ? AND e.os_id = 1 AND e.is_default = 1 LIMIT 1),
-          (SELECT e.os_id FROM app_emulators e WHERE e.system_id = ? AND e.os_id = 1 AND e.is_default = 1 LIMIT 1),
+          NULL,
+          NULL,
           ?, ?, ?, ?, datetime('now')
         )
         ON CONFLICT(rom_path) DO UPDATE SET
@@ -551,8 +555,6 @@ class SqliteDatabaseService {
         }
 
         batch.rawInsert(sql, [
-          systemId,
-          systemId,
           systemId,
           entry.filename,
           entry.path,

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -309,6 +309,9 @@ class SqliteMigrations {
       case 101:
         await _migrateToVersion101(db);
         break;
+      case 102:
+        await _migrateToVersion102(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -4874,6 +4877,53 @@ class SqliteMigrations {
       _log.i('Migration v101 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v101: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v102: Reclaim inherited emulator stamps on [user_roms].
+  ///
+  /// The live ROM-scan path froze the *system default* emulator into
+  /// `user_roms.app_emulator_unique_id` at insert time, making an inherited
+  /// default indistinguishable from a deliberate per-game override. The per-game
+  /// column now means "explicit override, or NULL = inherit the system default"
+  /// (resolved live at launch). This backfill NULLs the rows that merely carry
+  /// the auto-stamped default so they re-inherit, leaving genuine per-game
+  /// overrides (a *different* emulator) untouched.
+  ///
+  /// We reclaim ONLY rows whose emulator equals the system's app-provided
+  /// default core (`app_emulators.is_default = 1`). That is the exact — and
+  /// only — value the batch scan-insert ever auto-stamped (it selected the
+  /// `is_default` core at `os_id = 1`). We deliberately do NOT reclaim rows
+  /// matching the user's `is_user_default` standalone: nothing auto-stamps a
+  /// standalone into user_roms, so such a row can only be a deliberate pin —
+  /// nulling it would destroy a genuine choice.
+  ///
+  /// Residual (irreducible) edge: a user who deliberately pinned a game to the
+  /// emulator that *is* the system default core is indistinguishable from an
+  /// inherited stamp and will be reclaimed to "inherit". This is benign and
+  /// recoverable (it re-inherits the same emulator, and can be re-pinned in the
+  /// per-game emulator tab in two taps).
+  static Future<void> _migrateToVersion102(Database db) async {
+    _log.i('Migration v102: Reclaiming inherited emulator stamps on user_roms');
+    try {
+      db.execute('''
+        UPDATE user_roms
+        SET app_emulator_unique_id = NULL, app_emulator_os_id = NULL
+        WHERE app_emulator_unique_id IS NOT NULL
+          AND EXISTS (
+            SELECT 1 FROM app_emulators e
+            WHERE e.system_id = user_roms.app_system_id
+              AND e.unique_identifier = user_roms.app_emulator_unique_id
+              AND e.os_id = user_roms.app_emulator_os_id
+              AND e.is_default = 1
+          )
+      ''');
+
+      _log.i('Migration v102 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v102: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 101;
+  static const int _databaseVersion = 102;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -3626,13 +3626,16 @@ class SqliteService {
   }
 
   /// Retrieves the effective default emulator for a system, respecting user overrides.
-  static Future<CoreEmulatorModel?> getDefaultEmulatorForSystem(
+  /// Returns the emulator the *user* explicitly set as default for [systemId]
+  /// (`is_user_default = 1`), or null if the user hasn't chosen one. Callers use
+  /// this to honor an explicit user choice before applying any auto-selection
+  /// heuristics.
+  static Future<CoreEmulatorModel?> getUserDefaultEmulatorForSystem(
     String systemId,
   ) async {
     final db = await instance.database;
     final currentOs = getCurrentOs();
 
-    // 1. Check for user-selected standalone default.
     final userStandalone = await db.rawQuery(
       '''
       SELECT e.*, os.name as os_name, uc.emulator_path, uc.is_user_default
@@ -3647,6 +3650,20 @@ class SqliteService {
 
     if (userStandalone.isNotEmpty) {
       return CoreEmulatorModel.fromMap(userStandalone.first);
+    }
+    return null;
+  }
+
+  static Future<CoreEmulatorModel?> getDefaultEmulatorForSystem(
+    String systemId,
+  ) async {
+    final db = await instance.database;
+    final currentOs = getCurrentOs();
+
+    // 1. Check for user-selected standalone default.
+    final userDefault = await getUserDefaultEmulatorForSystem(systemId);
+    if (userDefault != null) {
+      return userDefault;
     }
 
     // 2. Fallback to system-provided default (usually a core).
@@ -4033,12 +4050,32 @@ class SqliteService {
   }) async {
     final db = await instance.database;
     final system = await getSystemByFolderName(systemFolderName);
-    final defaultEmu = await getDefaultEmulatorForSystem(system.id!);
+
+    // Per-game emulator is an OVERRIDE, not an inherited default: leave it NULL
+    // (= "inherit the system default", resolved live at launch) unless the
+    // caller passes an explicit choice. Freezing the default here is what made
+    // per-game settings "whack-a-mole" (stale/uninstalled emulators). We only
+    // store a concrete id when we can also resolve its os_id, so the composite
+    // FK (app_emulator_os_id, app_emulator_unique_id) stays valid.
+    String? emulatorUniqueId;
+    int? emulatorOsId;
+    if (emulatorName != null && emulatorName.isNotEmpty) {
+      final osRow = await db.rawQuery(
+        'SELECT os_id FROM app_emulators '
+        'WHERE system_id = ? AND unique_identifier = ? '
+        'AND os_id = (SELECT id FROM app_os WHERE name = ?) LIMIT 1',
+        [system.id, emulatorName, getCurrentOs()],
+      );
+      if (osRow.isNotEmpty) {
+        emulatorUniqueId = emulatorName;
+        emulatorOsId = osRow.first['os_id'] as int?;
+      }
+    }
 
     await db.insert('user_roms', {
       'app_system_id': system.id,
-      'app_emulator_unique_id': defaultEmu?.uniqueId,
-      'app_emulator_os_id': defaultEmu?.osId,
+      'app_emulator_unique_id': emulatorUniqueId,
+      'app_emulator_os_id': emulatorOsId,
       'filename': filename,
       'rom_path': romPath,
       'ra_hash': raHash,

--- a/lib/repositories/emulator_repository.dart
+++ b/lib/repositories/emulator_repository.dart
@@ -80,6 +80,10 @@ class EmulatorRepository {
     String systemId,
   ) => SqliteService.getDefaultEmulatorForSystem(systemId);
 
+  static Future<CoreEmulatorModel?> getUserDefaultEmulatorForSystem(
+    String systemId,
+  ) => SqliteService.getUserDefaultEmulatorForSystem(systemId);
+
   static Future<List<String>> getAndroidRetroArchPackages() =>
       SqliteService.getAndroidRetroArchPackages();
 

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -10,6 +10,7 @@ import '../../models/system_model.dart';
 import '../../models/emulator_model.dart';
 import '../../models/core_emulator_model.dart';
 import '../../repositories/emulator_repository.dart';
+import '../../utils/emulator_loader.dart';
 import '../config_service.dart';
 import '../android_service.dart';
 import '../launcher_service.dart';
@@ -109,8 +110,7 @@ class GameLaunchService {
         String? preferredPlayerId = game.emulatorName;
 
         if (preferredPlayerId == null) {
-          final defaultEmu =
-              await EmulatorRepository.getDefaultEmulatorForSystem(system.id!);
+          final defaultEmu = await _resolveDefaultInstalledEmulator(system);
           if (defaultEmu != null) {
             preferredPlayerId = defaultEmu.uniqueId;
           }
@@ -648,6 +648,77 @@ class GameLaunchService {
         e.toString(),
       );
     }
+  }
+
+  /// Resolves which emulator to auto-select when a game has no per-game
+  /// override.
+  ///
+  /// [EmulatorRepository.getDefaultEmulatorForSystem] returns the *configured*
+  /// default, which for many systems is a RetroArch core flagged `is_default`.
+  /// That core is frequently not actually installed (the RetroArch app is
+  /// present but the specific libretro core isn't), so auto-selecting it yields
+  /// a generic "Launch error" on a normal launch (issue #192). We therefore
+  /// prefer an installed standalone emulator over a RetroArch-core auto-default
+  /// so normal launches work out of the box — matching the manual workaround
+  /// users otherwise perform on every game.
+  ///
+  /// Precedence:
+  ///   1. An explicit user default (`is_user_default`) is always honored,
+  ///      installed or not — it's a deliberate choice.
+  ///   2. Otherwise prefer any positively-installed standalone for the system.
+  ///   3. Otherwise the configured default if it looks installed, else any
+  ///      installed emulator, else the configured default unchanged (so behavior
+  ///      is identical to before when nothing is installed).
+  ///
+  /// Known, irreducible limitation: a RetroArch core's real install state
+  /// cannot be verified on a stock device. Its `.so` lives in RetroArch's
+  /// private `0700` data dir, unreadable from our sandbox, and neostation must
+  /// never assume/require root — so `isCoreInstalled` fails OPEN (unknown →
+  /// treated as installed). Consequently, on a system that has ONLY an
+  /// uninstalled RetroArch core and no installed standalone, step 3 can still
+  /// return that core and the launch will fail. Step 2 (prefer an installed
+  /// standalone) minimizes this but cannot eliminate it without root or an
+  /// install-state API RetroArch does not expose.
+  static Future<CoreEmulatorModel?> _resolveDefaultInstalledEmulator(
+    SystemModel system,
+  ) async {
+    // 1. Explicit user choice wins outright.
+    final userDefault =
+        await EmulatorRepository.getUserDefaultEmulatorForSystem(system.id!);
+    if (userDefault != null) return userDefault;
+
+    final configured =
+        await EmulatorRepository.getDefaultEmulatorForSystem(system.id!);
+
+    List<CoreEmulatorModel> all;
+    try {
+      all = await loadEmulatorsForSystem(system);
+    } catch (_) {
+      // Enumeration failed → preserve prior behavior.
+      return configured;
+    }
+
+    bool isInstalledUid(String? uid) {
+      if (uid == null) return false;
+      for (final e in all) {
+        if (e.uniqueId == uid && e.isInstalled) return true;
+      }
+      return false;
+    }
+
+    // 2. Prefer a genuinely-installed standalone. This is what fixes the
+    //    non-rooted case: even when a RetroArch core is (falsely) reported
+    //    installed, a real standalone is the reliable choice.
+    for (final e in all) {
+      if (e.isInstalled && e.isStandalone) return e;
+    }
+
+    // 3. Fall back through installed configured default → any installed → raw.
+    if (isInstalledUid(configured?.uniqueId)) return configured;
+    for (final e in all) {
+      if (e.isInstalled) return e;
+    }
+    return configured;
   }
 
   /// Resolves the identifier for the core assigned to the given system.

--- a/lib/services/launcher_service.dart
+++ b/lib/services/launcher_service.dart
@@ -118,6 +118,24 @@ class LauncherService {
         (p) => p['name'] == preferredPlayerId,
         orElse: () => null,
       );
+
+      if (player == null) {
+        // A specific emulator was requested but it no longer exists in the
+        // current systems config — typically a per-game override left stale by
+        // a systems update that renamed the emulator's unique_id. Do NOT fall
+        // through to players.first: the JSON is RetroArch-first for some
+        // systems (e.g. 3DS), so that silently launches a *different*,
+        // possibly-uninstalled emulator (RetroArch) and surfaces a misleading
+        // ACTIVITY_NOT_FOUND. Return empty so the caller falls back to the
+        // user-selected standalone default instead.
+        LoggerService.instance.log(
+          'Requested emulator "$preferredPlayerId" not found in '
+          '${system.folderName} config; falling back to system default '
+          '(stale per-game override?)',
+          level: LogLevel.warning,
+        );
+        return {};
+      }
     }
 
     player ??= players.first;

--- a/lib/utils/emulator_loader.dart
+++ b/lib/utils/emulator_loader.dart
@@ -27,11 +27,32 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
         if (e.androidPackageName != null && e.androidPackageName!.isNotEmpty) {
           try {
             const ch = MethodChannel('com.neogamelab.neostation/game');
-            final installed = await ch.invokeMethod<bool>(
-              'isPackageInstalled',
-              {'packageName': e.androidPackageName},
-            );
-            updated.add(e.copyWith(isInstalled: installed ?? false));
+            var installed =
+                await ch.invokeMethod<bool>('isPackageInstalled', {
+                  'packageName': e.androidPackageName,
+                }) ??
+                false;
+
+            // A RetroArch entry reports its *app* as installed even when the
+            // specific libretro core (.so) isn't present, which made uninstalled
+            // cores show "Ready" and get auto-selected → "Launch error" (#192).
+            // Verify the core file. Tri-state: null means we couldn't determine
+            // (RetroArch's cores dir is private and no root) → fail OPEN and leave
+            // the package-based result untouched.
+            if (installed &&
+                e.isRetroArch &&
+                e.coreFilename != null &&
+                e.coreFilename!.isNotEmpty) {
+              final coreInstalled = await ch.invokeMethod<bool>(
+                'isCoreInstalled',
+                {
+                  'packageName': e.androidPackageName,
+                  'coreFilename': e.coreFilename,
+                },
+              );
+              if (coreInstalled != null) installed = coreInstalled;
+            }
+            updated.add(e.copyWith(isInstalled: installed));
           } catch (_) {
             updated.add(e);
           }
@@ -41,11 +62,18 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
       }
       emulators = updated;
     } else {
-      // Desktop: RetroArch cores are considered installed when the global
-      // RetroArch executable has been detected/configured by the user.
+      // Desktop: a RetroArch core is only usable when its libretro core file
+      // actually exists — having the RetroArch executable configured is not
+      // enough (#192). Probe the cores dir next to the executable. If we can't
+      // locate a readable cores dir (layout varies by platform/install), fail
+      // OPEN and keep the executable-based assumption rather than hide a
+      // genuinely-installed core.
       final retroArchPath =
           await EmulatorRepository.getRetroArchExecutablePath();
       if (retroArchPath != null && retroArchPath.isNotEmpty) {
+        final coresDir = '${File(retroArchPath).parent.path}'
+            '${Platform.pathSeparator}cores';
+        final coresDirReadable = await Directory(coresDir).exists();
         final updated = <CoreEmulatorModel>[];
         for (final e in emulators) {
           final uid = e.uniqueId;
@@ -54,7 +82,13 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
               uid.contains('.ra32.') ||
               uid.contains('.ra64.');
           if (isRaCore && !e.isInstalled) {
-            updated.add(e.copyWith(isInstalled: true));
+            var installed = true; // fail-open default
+            if (coresDirReadable &&
+                e.coreFilename != null &&
+                e.coreFilename!.isNotEmpty) {
+              installed = await _desktopCoreExists(coresDir, e.coreFilename!);
+            }
+            updated.add(e.copyWith(isInstalled: installed));
           } else {
             updated.add(e);
           }
@@ -67,4 +101,33 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
     log.e('Emulator enumeration failed: $e');
     return [];
   }
+}
+
+/// Returns whether a libretro core exists in [coresDir] on a desktop host.
+///
+/// The DB [coreFilename] may carry the Android-style name (e.g.
+/// `ppsspp_libretro_android.so`), whereas desktop cores are named
+/// `<base>_libretro.{dll,so,dylib}`. We therefore strip the known libretro
+/// suffixes down to the base and probe each desktop extension, so a correct
+/// core install isn't missed due to a platform naming mismatch.
+Future<bool> _desktopCoreExists(String coresDir, String coreFilename) async {
+  const suffixes = [
+    '_libretro_android.so',
+    '_libretro.so',
+    '_libretro.dll',
+    '_libretro.dylib',
+  ];
+  var base = coreFilename;
+  for (final s in suffixes) {
+    if (base.endsWith(s)) {
+      base = base.substring(0, base.length - s.length);
+      break;
+    }
+  }
+  for (final ext in const ['_libretro.dll', '_libretro.so', '_libretro.dylib']) {
+    if (await File('$coresDir${Platform.pathSeparator}$base$ext').exists()) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/test/emulator_default_migration_test.dart
+++ b/test/emulator_default_migration_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+
+/// Tests for migration v102, which reclaims *inherited* emulator stamps on
+/// `user_roms` back to NULL ("inherit the system default") while preserving
+/// genuine per-game overrides.
+///
+/// Background: the ROM-scan path used to freeze the system default emulator
+/// into `user_roms.app_emulator_unique_id`, making an inherited default
+/// indistinguishable from a deliberate choice. v102 nulls only the rows whose
+/// emulator equals the system's `is_default` core — the exact value the scan
+/// auto-stamped — and leaves everything else alone.
+void main() {
+  late Database db;
+
+  setUp(() {
+    db = sqlite3.openInMemory();
+    db.execute('''
+      CREATE TABLE app_emulators (
+        unique_identifier TEXT NOT NULL,
+        os_id INTEGER NOT NULL,
+        system_id TEXT NOT NULL,
+        name TEXT,
+        is_standalone INTEGER NOT NULL DEFAULT 0,
+        is_default INTEGER NOT NULL DEFAULT 0
+      )
+    ''');
+    db.execute('''
+      CREATE TABLE user_emulator_config (
+        emulator_unique_id TEXT PRIMARY KEY,
+        emulator_path TEXT,
+        is_user_default INTEGER
+      )
+    ''');
+    db.execute('''
+      CREATE TABLE user_roms (
+        app_system_id TEXT NOT NULL,
+        app_emulator_unique_id TEXT,
+        app_emulator_os_id INTEGER,
+        filename TEXT NOT NULL,
+        rom_path TEXT NOT NULL
+      )
+    ''');
+
+    // neogeo has a default core (fbneo) and a standalone alternative that the
+    // user has picked as their personal default.
+    db.execute('''
+      INSERT INTO app_emulators
+        (unique_identifier, os_id, system_id, name, is_standalone, is_default)
+      VALUES
+        ('neogeo.ra.fbneo', 1, 'neogeo', 'FBNeo', 0, 1),
+        ('neogeo.standalone.gemrb', 1, 'neogeo', 'Standalone', 1, 0)
+    ''');
+    db.execute('''
+      INSERT INTO user_emulator_config (emulator_unique_id, emulator_path, is_user_default)
+      VALUES ('neogeo.standalone.gemrb', '/some/path', 1)
+    ''');
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  Map<String, Object?> rowFor(String filename) {
+    final r = db.select(
+      'SELECT app_emulator_unique_id, app_emulator_os_id FROM user_roms WHERE filename = ?',
+      [filename],
+    );
+    return r.first;
+  }
+
+  Future<void> runV102() => SqliteMigrations.migrateToVersion(db, 102);
+
+  test('reclaims a row stamped with the system is_default core to NULL', () async {
+    db.execute(
+      "INSERT INTO user_roms VALUES ('neogeo', 'neogeo.ra.fbneo', 1, 'garou.zip', '/roms/garou.zip')",
+    );
+
+    await runV102();
+
+    final row = rowFor('garou.zip');
+    expect(row['app_emulator_unique_id'], isNull);
+    expect(row['app_emulator_os_id'], isNull);
+  });
+
+  test('preserves a genuine per-game override (a different emulator)', () async {
+    // User pinned this game to the standalone, which is NOT the is_default core.
+    db.execute(
+      "INSERT INTO user_roms VALUES ('neogeo', 'neogeo.standalone.gemrb', 1, 'kof98.zip', '/roms/kof98.zip')",
+    );
+
+    await runV102();
+
+    final row = rowFor('kof98.zip');
+    expect(row['app_emulator_unique_id'], 'neogeo.standalone.gemrb');
+    expect(row['app_emulator_os_id'], 1);
+  });
+
+  test(
+    'preserves a pin to the user is_user_default standalone (never auto-stamped)',
+    () async {
+      // A row equal to the user's is_user_default standalone can only be a
+      // deliberate pin — the scan never auto-stamps a standalone — so v102 must
+      // NOT reclaim it, even though it is "a default" from another angle.
+      db.execute(
+        "INSERT INTO user_roms VALUES ('neogeo', 'neogeo.standalone.gemrb', 1, 'mslug.zip', '/roms/mslug.zip')",
+      );
+
+      await runV102();
+
+      final row = rowFor('mslug.zip');
+      expect(row['app_emulator_unique_id'], 'neogeo.standalone.gemrb');
+      expect(row['app_emulator_os_id'], 1);
+    },
+  );
+
+  test('leaves an already-inherited (NULL) row untouched', () async {
+    db.execute(
+      "INSERT INTO user_roms VALUES ('neogeo', NULL, NULL, 'sengoku.zip', '/roms/sengoku.zip')",
+    );
+
+    await runV102();
+
+    final row = rowFor('sengoku.zip');
+    expect(row['app_emulator_unique_id'], isNull);
+    expect(row['app_emulator_os_id'], isNull);
+  });
+
+  test('does not reclaim a stamp belonging to a different system', () async {
+    // Same unique_id string but the default core is defined for 'neogeo', not
+    // 'snes' — the EXISTS join is scoped by system, so this must survive.
+    db.execute(
+      "INSERT INTO user_roms VALUES ('snes', 'neogeo.ra.fbneo', 1, 'mario.smc', '/roms/mario.smc')",
+    );
+
+    await runV102();
+
+    final row = rowFor('mario.smc');
+    expect(row['app_emulator_unique_id'], 'neogeo.ra.fbneo');
+  });
+}

--- a/test/rom_scan_emulator_default_test.dart
+++ b/test/rom_scan_emulator_default_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_database_service.dart';
+import 'package:neostation/models/system_model.dart';
+
+import 'database_test_helper.dart';
+
+/// Regression guard: scanning ROMs must leave the per-game emulator columns
+/// NULL ("inherit the system default"), NOT freeze the system default into
+/// every row. Freezing the default is what made per-game emulator settings
+/// stale/"whack-a-mole".
+void main() {
+  final dbHelper = DatabaseTestHelper();
+  late dynamic db;
+
+  setUp(() async {
+    db = await dbHelper.setUp();
+    await db.execute(
+      "INSERT INTO app_systems (id, real_name, folder_name) VALUES ('snes', 'Super Nintendo', 'snes')",
+    );
+    await db.execute(
+      "INSERT INTO app_system_extensions (system_id, extension) VALUES ('snes', 'smc')",
+    );
+    // A system default core EXISTS — the scan must still not stamp it.
+    await db.execute(
+      "INSERT INTO app_emulators (system_id, os_id, name, unique_identifier, is_standalone, is_default, is_ra_compatible) "
+      "VALUES ('snes', 1, 'Snes9x', 'snes.ra.snes9x', 0, 1, 1)",
+    );
+  });
+
+  tearDown(() async {
+    await dbHelper.tearDown();
+  });
+
+  test('scanned rows inherit (NULL emulator) instead of the stamped default', () async {
+    final root = await Directory.systemTemp.createTemp('neostation_emu_scan_');
+    addTearDown(() async {
+      if (await root.exists()) await root.delete(recursive: true);
+    });
+
+    final snesDir = Directory('${root.path}/snes')..createSync(recursive: true);
+    File('${snesDir.path}/mario.smc').writeAsStringSync('ok');
+
+    final system = SystemModel(
+      id: 'snes',
+      realName: 'Super Nintendo',
+      folderName: 'snes',
+      iconImage: '',
+      color: '#000000',
+      recursiveScan: true,
+    );
+
+    await SqliteDatabaseService.scanSystemRoms(system, [root.path]);
+
+    final rows = await db.rawQuery(
+      "SELECT app_emulator_unique_id, app_emulator_os_id FROM user_roms WHERE app_system_id = 'snes'",
+    );
+
+    expect(rows, hasLength(1));
+    expect(rows.first['app_emulator_unique_id'], isNull);
+    expect(rows.first['app_emulator_os_id'], isNull);
+  });
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code).

# Description

Fixes the root cause behind recurring per-game emulator "whack-a-mole": the per-game emulator column could not distinguish a **deliberate override** from an **inherited system default**, because the ROM-scan path froze the current system default into every `user_roms` row at scan time. That frozen value was often a RetroArch core that isn't actually installed → generic "Launch error", and it went stale whenever the system default changed.

`user_roms.app_emulator_unique_id` now means exactly one thing — **an explicit per-game override, or `NULL` = inherit the system default** (resolved live at launch). This is the semantics the per-game settings UI and the launch resolver already assumed; the scan paths were violating it.

### Changes
- **Stop freezing the default at scan** — `sqlite_database_service` batch-insert and `sqlite_service.saveRom` store `NULL` (= inherit) instead of stamping the system default.
- **v102 migration** reclaims legacy stamped rows, NULLing **only** those matching the system's `is_default` core (the exact value the scan auto-stamped). It deliberately does **not** touch rows matching the user's `is_user_default` standalone — nothing auto-stamps a standalone, so such a row can only be a deliberate pin.
- **Never assume root** — removed the `checkCoreViaRoot()` `su` probe (added alongside the installed-core detection) that popped a Magisk Superuser prompt at game launch on rooted devices. The unreadable-cores-dir case now fails open (unknown → assume installed), identical to stock/production behavior.
- Documented the one **irreducible limitation** on `_resolveDefaultInstalledEmulator`: a RetroArch core's install state can't be verified on a stock device (private `0700` dir, no root), so a system with only an uninstalled core and no standalone can still fail to launch. The installed-standalone preference minimizes but cannot eliminate this.

This PR also carries one earlier, on-theme launcher fix already on the investigation branch: not silently substituting `players.first` for an unknown emulator id (`fe68f80`), which degrades a stale/unknown emulator id to the standalone default instead of launching an often-uninstalled `players.first`.

Fixes # (default emulator launch errors)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Notes for reviewers

- **Migration is a one-way data correction** (v102). On an existing DB it re-inherits every ROM that merely carried the auto-stamped default; genuine overrides (a *different* emulator) survive.
- New tests: `test/emulator_default_migration_test.dart` (v102 reclaims the default-core stamp, preserves a different-emulator override, preserves a standalone pin, leaves NULL rows alone, respects system boundaries) and `test/rom_scan_emulator_default_test.dart` (scans leave the emulator columns NULL even when an `is_default` core exists).
- Verified on an AYN Thor: v102 ran, all inherited stamps reclaimed to NULL with no false matches; no Superuser prompt on relaunch.
