### PR TITLE
Fixed RetroAchievements picking up unwanted to hacks

### DIFF
--- a/lib/repositories/retro_achievements_repository.dart
+++ b/lib/repositories/retro_achievements_repository.dart
@@ -90,15 +90,38 @@ class RetroAchievementsRepository {
   // ── ROM RA-data update ─────────────────────────────────────────────────────
 
   /// Finds a matching entry in app_ra_game_list by [consoleName] LIKE and
-  /// [titleLikePattern] LIKE. Returns {hash, gameId} or null.
+  /// [titleLikePattern] LIKE. Normal games are preferred over subsets and
+  /// hacks, unless [preferHackMatches] is true. Returns {hash, gameId} or null.
   static Future<({String hash, int? gameId})?> findRAHashByConsoleName(
     String consoleName,
-    String titleLikePattern,
-  ) async {
+    String titleLikePattern, {
+    bool preferHackMatches = false,
+  }) async {
     final db = await SqliteService.getDatabase();
     final results = await db.rawQuery(
-      'SELECT hash, game_id FROM app_ra_game_list WHERE console_name LIKE ? AND title LIKE ? LIMIT 1',
-      ['%$consoleName%', titleLikePattern],
+      '''
+      SELECT hash, game_id
+      FROM app_ra_game_list
+      WHERE console_name LIKE ? AND title LIKE ?
+      ORDER BY
+        CASE
+          WHEN ? = 1 AND title LIKE '~Hack~%' THEN 0
+          WHEN ? = 1 THEN 1
+          WHEN ? = 0 AND title LIKE '~Hack~%' THEN 1
+          ELSE 0
+        END,
+        CASE WHEN title LIKE '%[Subset%' THEN 1 ELSE 0 END,
+        LENGTH(title) ASC,
+        title ASC
+      LIMIT 1
+      ''',
+      [
+        '%$consoleName%',
+        titleLikePattern,
+        preferHackMatches ? 1 : 0,
+        preferHackMatches ? 1 : 0,
+        preferHackMatches ? 1 : 0,
+      ],
     );
     if (results.isEmpty) return null;
     return (
@@ -175,6 +198,7 @@ class RetroAchievementsRepository {
     // LIKE match with normalized search pattern
     final searchPattern =
         '%${filenameWithoutExt.replaceAll(' - ', ' ').replaceAll(':', '').replaceAll(' ', '%').trim()}%';
+    final preferHackMatches = filenameWithoutExt.toLowerCase().contains('hack');
 
     final likeResults = await db.rawQuery(
       '''
@@ -184,14 +208,23 @@ class RetroAchievementsRepository {
         AND g.title LIKE ? 
       ORDER BY
         CASE
-          WHEN g.title LIKE '~Hack~%' THEN 1
-          WHEN g.title LIKE '%Subset%' THEN 1
+          WHEN ? = 1 AND g.title LIKE '~Hack~%' THEN 0
+          WHEN ? = 1 THEN 1
+          WHEN ? = 0 AND g.title LIKE '~Hack~%' THEN 1
           ELSE 0
         END,
+        CASE WHEN g.title LIKE '%[Subset%' THEN 1 ELSE 0 END,
+        LENGTH(g.title) ASC,
         g.title ASC
       LIMIT 1
       ''',
-      [systemFolderName, searchPattern],
+      [
+        systemFolderName,
+        searchPattern,
+        preferHackMatches ? 1 : 0,
+        preferHackMatches ? 1 : 0,
+        preferHackMatches ? 1 : 0,
+      ],
     );
     if (likeResults.isNotEmpty) {
       return int.tryParse(likeResults.first['game_id']?.toString() ?? '0') ?? 0;

--- a/lib/utils/optimized_md5_utils.dart
+++ b/lib/utils/optimized_md5_utils.dart
@@ -558,6 +558,7 @@ class OptimizedMd5Utils {
       final raEntry = await RetroAchievementsRepository.findRAHashByConsoleName(
         consoleName,
         likePattern,
+        preferHackMatches: cleanedFilename.toLowerCase().contains('hack'),
       );
 
       if (raEntry != null) {

--- a/test/retro_achievements_repository_test.dart
+++ b/test/retro_achievements_repository_test.dart
@@ -89,6 +89,46 @@ void main() {
       expect(result.gameId, 99);
     });
 
+    test('findRAHashByConsoleName prefers a base game over variants', () async {
+      await db.execute(
+        "INSERT INTO app_ra_game_list (hash, game_id, console_name, title) VALUES ('hack', 101, 'PlayStation', '~Hack~ Castlevania: Symphony of the Night - Reborn')",
+      );
+      await db.execute(
+        "INSERT INTO app_ra_game_list (hash, game_id, console_name, title) VALUES ('subset', 102, 'PlayStation', 'Crash Bandicoot 3: Warped [Subset - Developer Times]')",
+      );
+      await db.execute(
+        "INSERT INTO app_ra_game_list (hash, game_id, console_name, title) VALUES ('base', 103, 'PlayStation', 'Crash Bandicoot 3: Warped')",
+      );
+
+      final result = await RetroAchievementsRepository.findRAHashByConsoleName(
+        'PlayStation',
+        '%Crash%Bandicoot%3:%Warped%',
+      );
+
+      expect(result, isNotNull);
+      expect(result!.hash, 'base');
+      expect(result.gameId, 103);
+    });
+
+    test('findRAHashByConsoleName prefers hacks for hack filenames', () async {
+      await db.execute(
+        "INSERT INTO app_ra_game_list (hash, game_id, console_name, title) VALUES ('base', 104, 'Nintendo Entertainment System', 'Super Mario Bros')",
+      );
+      await db.execute(
+        "INSERT INTO app_ra_game_list (hash, game_id, console_name, title) VALUES ('hack', 105, 'Nintendo Entertainment System', '~Hack~ Super Mario Bros Remix')",
+      );
+
+      final result = await RetroAchievementsRepository.findRAHashByConsoleName(
+        'Nintendo',
+        '%Super%Mario%Bros%',
+        preferHackMatches: true,
+      );
+
+      expect(result, isNotNull);
+      expect(result!.hash, 'hack');
+      expect(result.gameId, 105);
+    });
+
     test('updateRomRAData updates hash and id_ra', () async {
       await db.execute(
         "INSERT INTO user_roms (filename, rom_path, app_system_id) VALUES ('a.nes', '/roms/nes/a.nes', 'nes')",
@@ -141,6 +181,25 @@ void main() {
         'Zelda',
       );
       expect(gameId, 3001);
+    });
+
+    test('findGameIdByFilename prefers the base game over variants', () async {
+      await db.execute(
+        "INSERT INTO app_ra_game_list (hash, game_id, console_id, title) VALUES ('hack', 4001, '7', '~Hack~ Legend of Zelda Remix')",
+      );
+      await db.execute(
+        "INSERT INTO app_ra_game_list (hash, game_id, console_id, title) VALUES ('subset', 4002, '7', 'Legend of Zelda [Subset - Challenge]')",
+      );
+      await db.execute(
+        "INSERT INTO app_ra_game_list (hash, game_id, console_id, title) VALUES ('base', 4003, '7', 'Legend of Zelda')",
+      );
+
+      final gameId = await RetroAchievementsRepository.findGameIdByFilename(
+        'nes',
+        'Legend Zelda',
+      );
+
+      expect(gameId, 4003);
     });
 
     test('findGameIdByFilename returns null when no match', () async {


### PR DESCRIPTION
# Description

As raised on #8, Fixed logic to prefer base games over hacks/subsets.

Fixes # (issue)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [X] I have run `flutter analyze` and there are no errors.
- [X] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [ ] My changes do not introduce secrets, credentials, or sensitive data.
- [ ] I have verified that any new assets have compatible licenses.
- [X] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [X] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

<img width="4032" height="3024" alt="IMG_3276" src="https://github.com/user-attachments/assets/1c1c4c0f-da45-4a2e-908f-d395e79f1a37" />
