### PR TITLE
fix(scraper): refresh artwork after scraping

### DIFF
--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1508,7 +1508,11 @@ class _SystemGamesListState extends State<SystemGamesList> {
             (g) => g.romname == updatedGame.romname,
           );
           if (index != -1) {
-            _games[index] = updatedGame;
+            // Grid and carousel views use the games-list identity to know
+            // when their cached artwork cards must be rebuilt. Publish a new
+            // list instead of mutating this one in place so a completed
+            // scrape is visible as soon as the settings dialog is closed.
+            _games = List<GameModel>.of(_games)..[index] = updatedGame;
           }
         });
 

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -42,6 +42,7 @@ import '../../models/secondary_display_state.dart';
 import '../../widgets/game_view_mode_dropdown.dart';
 import '../../widgets/game_action_buttons.dart';
 import '../../constants/system_folder_names.dart';
+import '../../utils/game_list_update.dart';
 import '../../themes/corner_radii.dart';
 
 part 'my_games_list/gamepad_nav.dart';
@@ -1504,16 +1505,10 @@ class _SystemGamesListState extends State<SystemGamesList> {
           _selectedGame = updatedGame;
           _artworkVersion++;
 
-          final index = _games.indexWhere(
-            (g) => g.romname == updatedGame.romname,
-          );
-          if (index != -1) {
-            // Grid and carousel views use the games-list identity to know
-            // when their cached artwork cards must be rebuilt. Publish a new
-            // list instead of mutating this one in place so a completed
-            // scrape is visible as soon as the settings dialog is closed.
-            _games = List<GameModel>.of(_games)..[index] = updatedGame;
-          }
+          // Grid and carousel views use the games-list identity to know when
+          // their cached artwork cards must be rebuilt. Publish a new list
+          // instead of mutating this one in place.
+          _games = replaceGameInList(_games, updatedGame);
         });
 
         _loadLocalizedDescription();

--- a/lib/utils/game_list_update.dart
+++ b/lib/utils/game_list_update.dart
@@ -1,0 +1,16 @@
+import '../models/game_model.dart';
+
+/// Returns a new games list with [updatedGame] replacing the matching ROM.
+///
+/// A new list identity is intentional: game-view widgets use it to distinguish
+/// changed card content from ordinary selection changes. If no game matches,
+/// the original list is returned unchanged.
+List<GameModel> replaceGameInList(
+  List<GameModel> games,
+  GameModel updatedGame,
+) {
+  final index = games.indexWhere((game) => game.romname == updatedGame.romname);
+  if (index == -1) return games;
+
+  return List<GameModel>.of(games)..[index] = updatedGame;
+}

--- a/test/game_list_update_test.dart
+++ b/test/game_list_update_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/utils/game_list_update.dart';
+
+GameModel game(String romname, String name) => GameModel(
+  romname: romname,
+  realname: name,
+  name: name,
+  year: '',
+  developer: '',
+  publisher: '',
+  genre: '',
+  players: '',
+  rating: 0,
+);
+
+void main() {
+  test('replacing a scraped game publishes a new list identity', () {
+    final original = [game('mario.nes', 'Mario'), game('zelda.nes', 'Zelda')];
+    final updated = game('mario.nes', 'Super Mario Bros.');
+
+    final result = replaceGameInList(original, updated);
+
+    expect(identical(result, original), isFalse);
+    expect(result, hasLength(2));
+    expect(result[0], same(updated));
+    expect(result[1], same(original[1]));
+    expect(original[0].name, 'Mario');
+  });
+
+  test('an update for an unknown ROM leaves the list unchanged', () {
+    final original = [game('mario.nes', 'Mario')];
+
+    final result = replaceGameInList(original, game('zelda.nes', 'Zelda'));
+
+    expect(result, same(original));
+  });
+}


### PR DESCRIPTION
# Description

As per #203. Fixed both bulk and individual force scraping.

Fixes # (issue)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [X] I have run `flutter analyze` and there are no errors.
- [X] I have added tests demonstrating that my fix or feature works.
- [X] I have updated the corresponding documentation.
- [X] My changes do not introduce secrets, credentials, or sensitive data.
- [X] I have verified that any new assets have compatible licenses.
- [X] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [X] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Add screenshots or GIFs showing the visual change.
