### PR TITLE
fix(dock): persist dock slot count across reboot when set as home launcher

### DIFF
--- a/lib/providers/sqlite_config_provider/secondary_display.dart
+++ b/lib/providers/sqlite_config_provider/secondary_display.dart
@@ -165,14 +165,31 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
         // ignore: unawaited_futures
         updateDockApps(state.dockApps);
       } else if (_initialized &&
-          !listEquals(state.dockApps, _config.dockApps)) {
-        // No edit trigger, yet the shared dockApps disagrees with the persisted
-        // layout — this is a stale echo from the secondary, whose snapshot
-        // synced before our boot seed and shipped the old (usually empty)
-        // dockApps back, clobbering it. The main engine owns dockApps outside
-        // of user edits, so re-assert the persisted layout. (Guarded on
-        // _initialized so we don't fight before the config has loaded.)
-        _secondaryDisplayState?.updateState(dockApps: _config.dockApps);
+          (!listEquals(state.dockApps, _config.dockApps) ||
+              state.dockEnabled != _config.dockEnabled ||
+              state.dockSlotCount != _config.dockSlotCount ||
+              state.nowPlayingDimDelay != _config.nowPlayingDimDelay ||
+              state.nowPlayingDimLevel != _config.nowPlayingDimLevel ||
+              state.fanartDimLevel != _config.fanartDimLevel)) {
+        // No edit trigger, yet a main-owned field in the shared snapshot
+        // disagrees with the persisted config — this is a stale echo from the
+        // secondary, whose startup snapshot synced before (or raced) our boot
+        // seed and shipped its defaults back, clobbering the seeded values.
+        // Most visible as the dock slot count snapping back to its default (3)
+        // after a reboot when neostation is the home launcher and the secondary
+        // engine broadcasts its default state first. None of these fields are
+        // ever changed from the secondary engine (dock app edits go through
+        // dockEditTrigger above), so the main engine owns them and we re-assert
+        // the persisted values whenever they drift. (Guarded on _initialized so
+        // we don't fight before the config has loaded.)
+        _secondaryDisplayState?.updateState(
+          dockApps: _config.dockApps,
+          dockEnabled: _config.dockEnabled,
+          dockSlotCount: _config.dockSlotCount,
+          nowPlayingDimDelay: _config.nowPlayingDimDelay,
+          nowPlayingDimLevel: _config.nowPlayingDimLevel,
+          fanartDimLevel: _config.fanartDimLevel,
+        );
       }
     }
   }


### PR DESCRIPTION
> 🤖 This PR was authored with [Claude Code](https://claude.com/claude-code).

# Description

The dock renders on the **secondary** display engine from cross-engine `SharedState`, seeded by the main engine on startup. When NeoStation is set as the home launcher, on reboot the secondary engine comes up first and broadcasts its default startup snapshot (`dockSlotCount = 3`) *after* the boot seed — clobbering the seeded persisted value. So the dock always reset to 3 slots.

`dockApps` already had a re-assert guard against this exact stale echo, but `dockSlotCount`, `dockEnabled`, and the dim levels did not. This extends the guard in `_onSecondaryStateChanged` to re-assert **all** main-owned secondary fields when the shared snapshot drifts from persisted config — without triggering a config edit.

Fixes #212

## Type of Change

- [x] Bug fix (non-breaking change fixes an issue)
- [ ] New feature (non-breaking change adds capability)
- [ ] Breaking change (fix or feature would cause existing functionality not work expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I run `flutter analyze` no errors.
- [ ] I added tests demonstrating fix or feature works.
- [ ] I updated corresponding documentation.
- [x] My changes do not introduce secrets, credentials, sensitive data.
- [x] I verified any new assets compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified**
