### PR TITLE
feat(game-view): Select-button modifier, view picker, legend persistence + footer/gamepad polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,5 @@ ROMs/
 
 #linux media
 /media
+# Local scratch / handoff notes (ignored)
+*.local.md

--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -152,6 +152,10 @@ class SqliteConfigService {
             (int.tryParse(userConfig?['hide_recent_card']?.toString() ?? '0') ??
                 0) ==
             1,
+        legendHidden:
+            (int.tryParse(userConfig?['legend_hidden']?.toString() ?? '0') ??
+                0) ==
+            1,
         activeSyncProvider:
             userConfig?['active_sync_provider']?.toString() ?? 'neosync',
         autoUpdateApp:
@@ -230,6 +234,7 @@ class SqliteConfigService {
         appLanguage: config.appLanguage,
         themeName: config.themeName,
         hideRecentCard: config.hideRecentCard ? 1 : 0,
+        legendHidden: config.legendHidden ? 1 : 0,
         activeSyncProvider: config.activeSyncProvider,
         autoUpdateApp: config.autoUpdateApp ? 1 : 0,
         autoUpdateSystems: config.autoUpdateSystems ? 1 : 0,

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -312,6 +312,9 @@ class SqliteMigrations {
       case 102:
         await _migrateToVersion102(db);
         break;
+      case 103:
+        await _migrateToVersion103(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -4924,6 +4927,29 @@ class SqliteMigrations {
       _log.i('Migration v102 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v102: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v103: Persist the game action-button legend visibility so the
+  /// Select + B toggle survives restarts and upgrades.
+  static Future<void> _migrateToVersion103(Database db) async {
+    _log.i('Migration v103: Adding legend_hidden to user_config');
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_config)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+      if (!columns.contains('legend_hidden')) {
+        db.execute(
+          'ALTER TABLE user_config ADD COLUMN legend_hidden INTEGER DEFAULT 0',
+        );
+        _log.i('Column legend_hidden added via v103');
+      } else {
+        _log.i('Column legend_hidden already exists');
+      }
+      _log.i('Migration v103 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v103: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 102;
+  static const int _databaseVersion = 103;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -1626,6 +1626,7 @@ class SqliteService {
         app_language TEXT DEFAULT 'en',
         active_theme TEXT DEFAULT '',
         hide_recent_card INTEGER DEFAULT 0,
+        legend_hidden INTEGER DEFAULT 0,
         active_sync_provider TEXT DEFAULT 'neosync',
         systems_version TEXT DEFAULT '',
         neostation_app_version TEXT DEFAULT '',
@@ -2358,6 +2359,7 @@ class SqliteService {
     String? appLanguage,
     String? activeTheme,
     int? hideRecentCard,
+    int? legendHidden,
     String? activeSyncProvider,
     String? systemsVersion,
     String? neostationAppVersion,
@@ -2432,6 +2434,9 @@ class SqliteService {
     }
     if (hideRecentCard != null) {
       newConfig['hide_recent_card'] = hideRecentCard;
+    }
+    if (legendHidden != null) {
+      newConfig['legend_hidden'] = legendHidden;
     }
     if (activeSyncProvider != null) {
       newConfig['active_sync_provider'] = activeSyncProvider;

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -683,6 +683,7 @@ mixin AppLocale {
   static const String hintRefresh = 'hint_refresh';
   static const String hintViewMode = 'hint_view_mode';
   static const String hintScrape = 'hint_scrape';
+  static const String hintMoreActions = 'hint_more_actions';
 
   // ---------------------------------------------------------------------------
   // Misc

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -470,6 +470,7 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.hintRefresh: 'Aktualisieren',
   AppLocale.hintViewMode: 'Ansicht',
   AppLocale.hintScrape: 'Scrapen',
+  AppLocale.hintMoreActions: 'Mehr',
 
   AppLocale.error: 'Fehler',
   AppLocale.loading: 'Wird geladen...',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -452,6 +452,7 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.hintRefresh: 'Refresh',
   AppLocale.hintViewMode: 'View Mode',
   AppLocale.hintScrape: 'Scrape',
+  AppLocale.hintMoreActions: 'More',
 
   AppLocale.error: 'Error',
   AppLocale.loading: 'Loading...',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -467,6 +467,7 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.hintRefresh: 'Actualizar',
   AppLocale.hintViewMode: 'Modo Vista',
   AppLocale.hintScrape: 'Escanear',
+  AppLocale.hintMoreActions: 'Más',
 
   AppLocale.error: 'Error',
   AppLocale.loading: 'Cargando...',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -476,6 +476,7 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.hintRefresh: 'Actualiser',
   AppLocale.hintViewMode: 'Vue',
   AppLocale.hintScrape: 'Scraper',
+  AppLocale.hintMoreActions: 'Plus',
 
   AppLocale.error: 'Erreur',
   AppLocale.loading: 'Chargement...',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -452,6 +452,7 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.hintRefresh: 'Segarkan',
   AppLocale.hintViewMode: 'Tampilan',
   AppLocale.hintScrape: 'Ambil',
+  AppLocale.hintMoreActions: 'Lainnya',
 
   AppLocale.error: 'Kesalahan',
   AppLocale.loading: 'Memuat...',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -464,6 +464,7 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.hintRefresh: 'Aggiorna',
   AppLocale.hintViewMode: 'Vista',
   AppLocale.hintScrape: 'Scraping',
+  AppLocale.hintMoreActions: 'Altro',
 
   AppLocale.error: 'Errore',
   AppLocale.loading: 'Caricamento...',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -406,6 +406,7 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.hintRefresh: '更新',
   AppLocale.hintViewMode: '表示切替',
   AppLocale.hintScrape: 'スクレイプ',
+  AppLocale.hintMoreActions: 'その他',
 
   AppLocale.error: 'エラー',
   AppLocale.loading: '読み込み中...',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -413,6 +413,7 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.hintRefresh: '새로고침',
   AppLocale.hintViewMode: '보기 모드',
   AppLocale.hintScrape: '정보 가져오기',
+  AppLocale.hintMoreActions: '더보기',
 
   AppLocale.error: '오류',
   AppLocale.loading: '불러오는 중...',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -461,6 +461,7 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.hintRefresh: 'Atualizar',
   AppLocale.hintViewMode: 'Modo',
   AppLocale.hintScrape: 'Raspar',
+  AppLocale.hintMoreActions: 'Mais',
 
   AppLocale.error: 'Erro',
   AppLocale.loading: 'Carregando...',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -461,6 +461,7 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.hintRefresh: 'Обновить',
   AppLocale.hintViewMode: 'Режим',
   AppLocale.hintScrape: 'Скрейп',
+  AppLocale.hintMoreActions: 'Ещё',
 
   AppLocale.error: 'Ошибка',
   AppLocale.loading: 'Загрузка...',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -403,6 +403,7 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.hintRefresh: '刷新',
   AppLocale.hintViewMode: '视图模式',
   AppLocale.hintScrape: '刮削',
+  AppLocale.hintMoreActions: '更多',
 
   AppLocale.error: '错误',
   AppLocale.loading: '正在加载...',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -403,6 +403,7 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.hintRefresh: '重新整理',
   AppLocale.hintViewMode: '檢視模式',
   AppLocale.hintScrape: '刮削',
+  AppLocale.hintMoreActions: '更多',
 
   AppLocale.error: '錯誤',
   AppLocale.loading: '正在載入...',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:neostation/sync/sync_manager.dart';
 import 'package:neostation/sync/providers/neo_sync_adapter.dart';
 import 'package:neostation/services/notification_service.dart';
 import 'package:neostation/services/game_service.dart';
+import 'package:neostation/services/game_legend_visibility.dart';
 import 'package:neostation/repositories/config_repository.dart';
 import 'package:neostation/services/steam_scraper_service.dart';
 import 'package:neostation/providers/system_background_provider.dart';
@@ -301,6 +302,13 @@ void main() async {
   try {
     // 1. Inicializar ConfigProvider primero (sincroniza sistemas)
     await sqliteConfigProvider.initialize();
+
+    // Seed the game legend visibility from persisted config and wire its
+    // persistence sink so the Select + B toggle survives restarts/upgrades.
+    GameLegendVisibility.bind(
+      initialHidden: sqliteConfigProvider.config.legendHidden,
+      persist: sqliteConfigProvider.updateLegendHidden,
+    );
 
     // 2. Inicializar DatabaseProvider (carga juegos basandose en sistemas sincronizados)
     await sqliteDatabaseProvider.initialize(

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -99,6 +99,10 @@ class ConfigModel {
   /// Whether to hide the "Recently Played" card from the main dashboard.
   final bool hideRecentCard;
 
+  /// Whether the vertical action-button legend is hidden across every game view
+  /// (list, grid, carousel). Toggled by the Select + B chord.
+  final bool legendHidden;
+
   /// Seconds of inactivity before the secondary "Now Playing" panel dims, or `0`
   /// to never dim. Only meaningful when a secondary display is active.
   final int nowPlayingDimDelay;
@@ -168,6 +172,7 @@ class ConfigModel {
     this.systemSortOrder = 'asc',
     this.appLanguage = 'es',
     this.hideRecentCard = false,
+    this.legendHidden = false,
     this.activeSyncProvider = 'neosync',
     this.autoUpdateApp = true,
     this.autoUpdateSystems = true,
@@ -269,6 +274,10 @@ class ConfigModel {
                   .toString() ==
               '1' ||
           (json['hideRecentCard'] ?? false).toString().toLowerCase() == 'true',
+      legendHidden:
+          (json['legendHidden'] ?? json['legend_hidden'] ?? 0).toString() ==
+              '1' ||
+          (json['legendHidden'] ?? false).toString().toLowerCase() == 'true',
       activeSyncProvider:
           (json['activeSyncProvider'] ??
                   json['active_sync_provider'] ??
@@ -358,6 +367,7 @@ class ConfigModel {
       'systemSortOrder': systemSortOrder,
       'appLanguage': appLanguage,
       'hideRecentCard': hideRecentCard,
+      'legendHidden': legendHidden,
       'activeSyncProvider': activeSyncProvider,
       'autoUpdateApp': autoUpdateApp,
       'autoUpdateSystems': autoUpdateSystems,
@@ -397,6 +407,7 @@ class ConfigModel {
     String? systemSortOrder,
     String? appLanguage,
     bool? hideRecentCard,
+    bool? legendHidden,
     String? activeSyncProvider,
     bool? autoUpdateApp,
     bool? autoUpdateSystems,
@@ -433,6 +444,7 @@ class ConfigModel {
       systemSortOrder: systemSortOrder ?? this.systemSortOrder,
       appLanguage: appLanguage ?? this.appLanguage,
       hideRecentCard: hideRecentCard ?? this.hideRecentCard,
+      legendHidden: legendHidden ?? this.legendHidden,
       activeSyncProvider: activeSyncProvider ?? this.activeSyncProvider,
       autoUpdateApp: autoUpdateApp ?? this.autoUpdateApp,
       autoUpdateSystems: autoUpdateSystems ?? this.autoUpdateSystems,

--- a/lib/providers/sqlite_config_provider/mutators.dart
+++ b/lib/providers/sqlite_config_provider/mutators.dart
@@ -84,6 +84,13 @@ extension SqliteConfigMutators on SqliteConfigProvider {
     _notify();
   }
 
+  /// Persists whether the game action-button legend is hidden (Select + B).
+  Future<void> updateLegendHidden(bool value) async {
+    _config = _config.copyWith(legendHidden: value);
+    await SqliteConfigService.saveConfig(_config);
+    _notify();
+  }
+
   Future<void> updateActiveSyncProvider(String providerId) async {
     _config = _config.copyWith(activeSyncProvider: providerId);
     await SqliteConfigService.saveConfig(_config);

--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -99,6 +99,9 @@ class GameDetailsCardList extends StatefulWidget {
   /// Callback to register the Select button action.
   final Function(VoidCallback)? onRegisterSelectButton;
 
+  /// Callback to register the scrape action (Select + A combo).
+  final Function(VoidCallback)? onRegisterScrapeAction;
+
   final bool isSecondaryScreenActive;
   final bool isNavigatingFast;
   final VoidCallback? onBack;
@@ -135,6 +138,7 @@ class GameDetailsCardList extends StatefulWidget {
     this.onRegisterIsPlayingGameBlocked,
     this.onRegisterTabNavigation,
     this.onRegisterSelectButton,
+    this.onRegisterScrapeAction,
     this.isSecondaryScreenActive = false,
     this.isNavigatingFast = false,
     this.onBack,
@@ -319,6 +323,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
     });
     widget.onRegisterTabNavigation?.call(_handleTabNavigation);
     widget.onRegisterSelectButton?.call(_handleSelectAction);
+    widget.onRegisterScrapeAction?.call(_onScrapeGameCompact);
     widget.onRegisterNavigation?.call(
       moveUp: () {
         if (_currentTab == DetailTab.achievements) {
@@ -824,6 +829,14 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
     });
 
     if (!mounted) return;
+
+    // Surface immediate feedback — a scrape takes several seconds and can be
+    // triggered "blind" via the Select + A chord from the games list.
+    AppNotification.showNotification(
+      context,
+      AppLocale.scrapingGameData.getString(context),
+      type: NotificationType.info,
+    );
 
     final secondaryState = context.read<SecondaryDisplayState?>();
     if (secondaryState != null && widget.isSecondaryScreenActive) {

--- a/lib/screens/game_screen/game_details_card/random_game_dialog.dart
+++ b/lib/screens/game_screen/game_details_card/random_game_dialog.dart
@@ -200,6 +200,14 @@ class _RandomGameDialogState extends State<RandomGameDialog>
     return game.getImagePath(systemFolder, imageType, widget.fileProvider);
   }
 
+  /// Resolves the background image, preferring the screenshot and falling back
+  /// to fanart when the game has no screenshot on disk.
+  File _resolveBackgroundFile(GameModel game) {
+    final screenshotFile = File(_getImagePath(game, 'screenshots'));
+    if (screenshotFile.existsSync()) return screenshotFile;
+    return File(_getImagePath(game, 'fanarts'));
+  }
+
   @override
   Widget build(BuildContext context) {
     if (widget.games.isEmpty) return _buildEmptyDialog();
@@ -408,8 +416,7 @@ class _RandomGameDialogState extends State<RandomGameDialog>
 
   /// Core UI layout: Features a gradient-masked screenshot background and meta-info overlay.
   Widget _buildBody(ThemeData theme, GameModel currentGame) {
-    final screenshotPath = _getImagePath(currentGame, 'screenshots');
-    final screenshotFile = File(screenshotPath);
+    final screenshotFile = _resolveBackgroundFile(currentGame);
 
     return Stack(
       fit: StackFit.expand,

--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -356,7 +356,11 @@ class GameDetailsFooter extends StatelessWidget {
             child: child,
           ),
           child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 4.r, vertical: 4.r),
+            // Symmetric 8.r horizontal inset so neither the trophy icon nor the
+            // progress bar hugs the pill border. The progress column is always
+            // Expanded, so it simply absorbs the padding at any pill width (the
+            // shown/hidden width animation never overflows).
+            padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
             child: Row(
               children: [
                 // RetroAchievements game icon.
@@ -482,13 +486,31 @@ class _SteamStyleRating extends StatelessWidget {
         children: [
           Icon(Symbols.star_rounded, color: ratingColor, size: 24.r),
           SizedBox(width: 6.r),
-          Text(
-            ratingValue.toStringAsFixed(1),
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurface,
-              fontSize: 22.r,
-              fontWeight: FontWeight.w900,
-            ),
+          // Reserve width for the widest possible value ("10.0") so the pill
+          // stays a static size regardless of the current score (e.g. "1.0"
+          // no longer renders narrower than "10.0"). Scale/font-independent.
+          Stack(
+            alignment: Alignment.centerLeft,
+            children: [
+              Opacity(
+                opacity: 0,
+                child: Text(
+                  '10.0',
+                  style: TextStyle(
+                    fontSize: 22.r,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              Text(
+                ratingValue.toStringAsFixed(1),
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurface,
+                  fontSize: 22.r,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -143,18 +143,27 @@ class GameDetailsFooter extends StatelessWidget {
                       ],
 
                       // RetroAchievements Progress. When the legend is hidden
-                      // the row gains width on the left, so let the indicator
-                      // stretch to fill the gap to PLAY instead of leaving a
-                      // Spacer void; otherwise keep it at natural width.
-                      if (GameLegendVisibility.hidden.value)
-                        Expanded(
-                          child: _buildCompactAchievementsIndicator(context),
-                        )
-                      else ...[
-                        _buildCompactAchievementsIndicator(context),
-                        const Spacer(),
-                      ],
-                      SizedBox(width: 8.r),
+                      // the row gains width on the left; the indicator eases out
+                      // to fill the gap to PLAY (LayoutBuilder gives it a
+                      // concrete target width so the change animates instead of
+                      // snapping). When shown it rests at its natural width,
+                      // left-aligned, and the rest of the slot stays empty.
+                      Expanded(
+                        child: LayoutBuilder(
+                          builder: (context, constraints) => Align(
+                            alignment: Alignment.centerLeft,
+                            child: _buildCompactAchievementsIndicator(
+                              context,
+                              availableWidth: constraints.maxWidth,
+                            ),
+                          ),
+                        ),
+                      ),
+                      // Match the 12.r gap on the RA pill's left (rating side)
+                      // so it sits evenly between rating and PLAY when expanded.
+                      SizedBox(
+                        width: GameLegendVisibility.hidden.value ? 12.r : 8.r,
+                      ),
 
                       // Primary Launch Control.
                       _buildPlayButtonCompact(context),
@@ -267,17 +276,15 @@ class GameDetailsFooter extends StatelessWidget {
   }
 
   /// Resolves the current RetroAchievements progress into a compact visual badge.
-  // Wraps [child] in an Expanded only when [expand] is true.
-  Widget _wrapExpandedIf(bool expand, Widget child) =>
-      expand ? Expanded(child: child) : child;
-
-  Widget _buildCompactAchievementsIndicator(BuildContext context) {
+  Widget _buildCompactAchievementsIndicator(
+    BuildContext context, {
+    required double availableWidth,
+  }) {
     if (!hasRetroAchievements) return const SizedBox.shrink();
 
-    // With the legend hidden the badge is wrapped in an Expanded by the caller,
-    // so let the pill and its inner text/progress bar grow to fill the gap.
+    // With the legend hidden the badge fills its (Expanded) slot; when shown it
+    // rests at 120.r. The width is animated so toggling eases in/out.
     final bool legendHidden = GameLegendVisibility.hidden.value;
-
     final bool noAchievements =
         !isLoadingAchievements &&
         (currentGameInfo == null || currentGameInfo!.numAchievements == 0);
@@ -314,27 +321,39 @@ class GameDetailsFooter extends StatelessWidget {
         highlightColor: Colors.transparent,
         splashColor: theme.colorScheme.onSurface.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(8.r),
-        child: Container(
-          width: legendHidden ? double.infinity : 120.r,
-          height: 45.r,
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
-            borderRadius:
-                Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-                BorderRadius.circular(14.r),
-            border: Border.all(
-              color: Theme.of(context).colorScheme.outline,
-              width: 1.r,
-            ),
-            boxShadow: [
-              BoxShadow(
-                color: Theme.of(
-                  context,
-                ).colorScheme.shadow.withValues(alpha: 0.1),
-                blurRadius: 4.r,
-                offset: Offset(2.0.r, 2.0.r),
+        // Drive the width from a single 0..1 factor on the same 250ms /
+        // easeOutCubic timing as the sidebar margin, so the pill expands in
+        // lockstep with the legend slide (one motion) rather than shifting
+        // into place first and then easing its width (two steps).
+        child: TweenAnimationBuilder<double>(
+          tween: Tween<double>(end: legendHidden ? 1.0 : 0.0),
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeOutCubic,
+          builder: (context, t, child) => Container(
+            width: 120.r + (availableWidth - 120.r) * t,
+            height: 45.r,
+            decoration: BoxDecoration(
+              color: Theme.of(
+                context,
+              ).colorScheme.surface.withValues(alpha: 0.9),
+              borderRadius:
+                  Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
+                  BorderRadius.circular(14.r),
+              border: Border.all(
+                color: Theme.of(context).colorScheme.outline,
+                width: 1.r,
               ),
-            ],
+              boxShadow: [
+                BoxShadow(
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.shadow.withValues(alpha: 0.1),
+                  blurRadius: 4.r,
+                  offset: Offset(2.0.r, 2.0.r),
+                ),
+              ],
+            ),
+            child: child,
           ),
           child: Padding(
             padding: EdgeInsets.symmetric(horizontal: 4.r, vertical: 4.r),
@@ -372,14 +391,13 @@ class GameDetailsFooter extends StatelessWidget {
                 // Progress bar and achievement count. When the legend is hidden
                 // the pill stretches, so let this column (and its bar) fill the
                 // extra width via Expanded; otherwise keep the fixed 70.r width.
-                _wrapExpandedIf(
-                  legendHidden,
-                  Column(
+                Expanded(
+                  child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       SizedBox(
-                        width: legendHidden ? double.infinity : 70.r,
+                        width: double.infinity,
                         child: Text(
                           progressText.toUpperCase(),
                           style: TextStyle(
@@ -394,7 +412,7 @@ class GameDetailsFooter extends StatelessWidget {
                       ),
                       SizedBox(height: 4.r),
                       SizedBox(
-                        width: legendHidden ? double.infinity : 70.r,
+                        width: double.infinity,
                         child: ClipRRect(
                           borderRadius: BorderRadius.circular(4.r),
                           child: LinearProgressIndicator(

--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -148,7 +148,7 @@ class GameDetailsFooter extends StatelessWidget {
                       // Game rating.
                       if (game.rating > 0) ...[
                         _SteamStyleRating(game: game),
-                        SizedBox(width: 12.r),
+                        SizedBox(width: 8.r),
                       ],
 
                       // RetroAchievements Progress. When the legend is hidden
@@ -164,15 +164,24 @@ class GameDetailsFooter extends StatelessWidget {
                             child: _buildCompactAchievementsIndicator(
                               context,
                               availableWidth: constraints.maxWidth,
+                              hasPlayTime:
+                                  GameUtils.formatPlayTime(game.playTime ?? 0) !=
+                                  '0s',
                             ),
                           ),
                         ),
                       ),
-                      // Match the 12.r gap on the RA pill's left (rating side)
-                      // so it sits evenly between rating and PLAY when expanded.
-                      SizedBox(
-                        width: GameLegendVisibility.hidden.value ? 12.r : 8.r,
-                      ),
+                      // Accumulated play time, shown as its own pill to the
+                      // left of PLAY (only once the game has been played).
+                      if (GameUtils.formatPlayTime(game.playTime ?? 0) !=
+                          '0s') ...[
+                        SizedBox(width: 8.r),
+                        _PlayTimePill(game: game),
+                      ],
+
+                      // Consistent 8.r gap before PLAY, matching the spacing
+                      // between the rating, RA and play-time pills.
+                      SizedBox(width: 8.r),
 
                       // Primary Launch Control.
                       _buildPlayButtonCompact(context),
@@ -191,13 +200,12 @@ class GameDetailsFooter extends StatelessWidget {
   ///
   /// Includes visual feedback for gamepad focus and displays accumulated play-time statistics.
   Widget _buildPlayButtonCompact(BuildContext context) {
-    final playTimeText = GameUtils.formatPlayTime(game.playTime ?? 0);
     return Builder(
       builder: (context) {
         final isFocused = Focus.of(context).hasFocus;
         return AnimatedContainer(
           duration: const Duration(milliseconds: 200),
-          width: 120.r,
+          width: 104.r,
           height: 45.r,
           decoration: BoxDecoration(
             color: isFocused
@@ -244,35 +252,15 @@ class GameDetailsFooter extends StatelessWidget {
                       color: Theme.of(context).colorScheme.onPrimary,
                     ),
                     SizedBox(width: 8.r),
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          AppLocale.playButton.getString(context),
-                          style: TextStyle(
-                            color: Theme.of(context).colorScheme.onPrimary,
-                            fontWeight: FontWeight.w900,
-                            fontSize: 14.r,
-                            letterSpacing: 1.5,
-                            height: 1.0,
-                          ),
-                        ),
-                        if (playTimeText.isNotEmpty && playTimeText != '0s')
-                          Text(
-                            playTimeText.toUpperCase(),
-                            style: TextStyle(
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onPrimary.withValues(alpha: 0.8),
-                              fontSize: 8.r,
-                              fontWeight: FontWeight.bold,
-                              height: 1.2,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                      ],
+                    Text(
+                      AppLocale.playButton.getString(context),
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onPrimary,
+                        fontWeight: FontWeight.w900,
+                        fontSize: 14.r,
+                        letterSpacing: 1.5,
+                        height: 1.0,
+                      ),
                     ),
                   ],
                 ),
@@ -288,12 +276,16 @@ class GameDetailsFooter extends StatelessWidget {
   Widget _buildCompactAchievementsIndicator(
     BuildContext context, {
     required double availableWidth,
+    required bool hasPlayTime,
   }) {
     if (!hasRetroAchievements) return const SizedBox.shrink();
 
-    // With the legend hidden the badge fills its (Expanded) slot; when shown it
+    // The badge fills its (Expanded) slot when the legend is hidden, or when
+    // there is no play-time pill claiming the space to its right (otherwise it
+    // would leave dead space between itself and PLAY). When neither applies it
     // rests at 120.r. The width is animated so toggling eases in/out.
     final bool legendHidden = GameLegendVisibility.hidden.value;
+    final bool expand = legendHidden || !hasPlayTime;
     final bool noAchievements =
         !isLoadingAchievements &&
         (currentGameInfo == null || currentGameInfo!.numAchievements == 0);
@@ -335,7 +327,7 @@ class GameDetailsFooter extends StatelessWidget {
         // lockstep with the legend slide (one motion) rather than shifting
         // into place first and then easing its width (two steps).
         child: TweenAnimationBuilder<double>(
-          tween: Tween<double>(end: legendHidden ? 1.0 : 0.0),
+          tween: Tween<double>(end: expand ? 1.0 : 0.0),
           duration: const Duration(milliseconds: 250),
           curve: Curves.easeOutCubic,
           builder: (context, t, child) => Container(
@@ -474,7 +466,7 @@ class _SteamStyleRating extends StatelessWidget {
 
     return Container(
       height: 45.r,
-      padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 6.r),
+      padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 6.r),
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
         borderRadius:
@@ -497,17 +489,17 @@ class _SteamStyleRating extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Icon(Symbols.star_rounded, color: ratingColor, size: 24.r),
-          SizedBox(width: 6.r),
-          // Reserve width for the widest possible value ("10.0") so the pill
-          // stays a static size regardless of the current score (e.g. "1.0"
-          // no longer renders narrower than "10.0"). Scale/font-independent.
+          SizedBox(width: 4.r),
+          // Reserve width for the widest possible value ("10") so the pill
+          // stays a static size regardless of the current score (e.g. "1"
+          // no longer renders narrower than "10"). Scale/font-independent.
           Stack(
             alignment: Alignment.centerLeft,
             children: [
               Opacity(
                 opacity: 0,
                 child: Text(
-                  '10.0',
+                  '10',
                   style: TextStyle(
                     fontSize: 22.r,
                     fontWeight: FontWeight.w900,
@@ -515,7 +507,7 @@ class _SteamStyleRating extends StatelessWidget {
                 ),
               ),
               Text(
-                ratingValue.toStringAsFixed(1),
+                ratingValue.toStringAsFixed(0),
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.onSurface,
                   fontSize: 22.r,
@@ -523,6 +515,71 @@ class _SteamStyleRating extends StatelessWidget {
                 ),
               ),
             ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Compact pill showing the accumulated play time for a game, styled to match
+/// the rating pill. Sits to the left of the PLAY button.
+class _PlayTimePill extends StatelessWidget {
+  final GameModel game;
+
+  const _PlayTimePill({required this.game});
+
+  /// Formats accumulated seconds as a zero-padded HH:MM:SS clock.
+  String _formatClock(int seconds) {
+    final h = seconds ~/ 3600;
+    final m = (seconds % 3600) ~/ 60;
+    final s = seconds % 60;
+    String pad(int v) => v.toString().padLeft(2, '0');
+    return '${pad(h)}:${pad(m)}:${pad(s)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 45.r,
+      padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
+        borderRadius:
+            Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
+            BorderRadius.circular(14.r),
+        border: Border.all(
+          color: Theme.of(context).colorScheme.outline,
+          width: 1.r,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.5),
+            blurRadius: 3.r,
+            offset: Offset(2.0.r, 2.0.r),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Icon(
+            Symbols.schedule_rounded,
+            color: Theme.of(context).colorScheme.onSurface,
+            size: 14.r,
+          ),
+          SizedBox(height: 1.r),
+          Text(
+            _formatClock(game.playTime ?? 0),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurface,
+              fontSize: 10.r,
+              fontWeight: FontWeight.w800,
+              height: 1.0,
+              fontFeatures: const [FontFeature.tabularFigures()],
+            ),
           ),
         ],
       ),

--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -3,6 +3,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/services/game_legend_visibility.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/themes/app_themes.dart';
 import '../../../../models/system_model.dart';
@@ -141,10 +142,18 @@ class GameDetailsFooter extends StatelessWidget {
                         SizedBox(width: 12.r),
                       ],
 
-                      // RetroAchievements Progress.
-                      _buildCompactAchievementsIndicator(context),
-
-                      const Spacer(),
+                      // RetroAchievements Progress. When the legend is hidden
+                      // the row gains width on the left, so let the indicator
+                      // stretch to fill the gap to PLAY instead of leaving a
+                      // Spacer void; otherwise keep it at natural width.
+                      if (GameLegendVisibility.hidden.value)
+                        Expanded(
+                          child: _buildCompactAchievementsIndicator(context),
+                        )
+                      else ...[
+                        _buildCompactAchievementsIndicator(context),
+                        const Spacer(),
+                      ],
                       SizedBox(width: 8.r),
 
                       // Primary Launch Control.
@@ -258,8 +267,16 @@ class GameDetailsFooter extends StatelessWidget {
   }
 
   /// Resolves the current RetroAchievements progress into a compact visual badge.
+  // Wraps [child] in an Expanded only when [expand] is true.
+  Widget _wrapExpandedIf(bool expand, Widget child) =>
+      expand ? Expanded(child: child) : child;
+
   Widget _buildCompactAchievementsIndicator(BuildContext context) {
     if (!hasRetroAchievements) return const SizedBox.shrink();
+
+    // With the legend hidden the badge is wrapped in an Expanded by the caller,
+    // so let the pill and its inner text/progress bar grow to fill the gap.
+    final bool legendHidden = GameLegendVisibility.hidden.value;
 
     final bool noAchievements =
         !isLoadingAchievements &&
@@ -298,7 +315,7 @@ class GameDetailsFooter extends StatelessWidget {
         splashColor: theme.colorScheme.onSurface.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(8.r),
         child: Container(
-          width: 120.r,
+          width: legendHidden ? double.infinity : 120.r,
           height: 45.r,
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
@@ -352,42 +369,47 @@ class GameDetailsFooter extends StatelessWidget {
                   ),
                 ),
                 SizedBox(width: 4.r),
-                // Progress bar and achievement count.
-                Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    SizedBox(
-                      width: 70.r,
-                      child: Text(
-                        progressText.toUpperCase(),
-                        style: TextStyle(
-                          color: theme.colorScheme.onSurface,
-                          fontSize: 10.r,
-                          fontWeight: FontWeight.bold,
-                          letterSpacing: 0.5,
+                // Progress bar and achievement count. When the legend is hidden
+                // the pill stretches, so let this column (and its bar) fill the
+                // extra width via Expanded; otherwise keep the fixed 70.r width.
+                _wrapExpandedIf(
+                  legendHidden,
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SizedBox(
+                        width: legendHidden ? double.infinity : 70.r,
+                        child: Text(
+                          progressText.toUpperCase(),
+                          style: TextStyle(
+                            color: theme.colorScheme.onSurface,
+                            fontSize: 10.r,
+                            fontWeight: FontWeight.bold,
+                            letterSpacing: 0.5,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
                       ),
-                    ),
-                    SizedBox(height: 4.r),
-                    SizedBox(
-                      width: 70.r,
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(4.r),
-                        child: LinearProgressIndicator(
-                          value: isLoadingAchievements ? null : progress,
-                          minHeight: 5.r,
-                          backgroundColor: theme.colorScheme.onSurface
-                              .withValues(alpha: 0.1),
-                          valueColor: AlwaysStoppedAnimation<Color>(
-                            statusColor,
+                      SizedBox(height: 4.r),
+                      SizedBox(
+                        width: legendHidden ? double.infinity : 70.r,
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(4.r),
+                          child: LinearProgressIndicator(
+                            value: isLoadingAchievements ? null : progress,
+                            minHeight: 5.r,
+                            backgroundColor: theme.colorScheme.onSurface
+                                .withValues(alpha: 0.1),
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              statusColor,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ],
             ),

--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -104,26 +104,35 @@ class GameDetailsFooter extends StatelessWidget {
                                 ],
                               ),
                             ),
-                            if (game.showRomFileNameSubtitle) ...[
-                              Text(
-                                game.romname,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: TextStyle(
-                                  color: Colors.white.withValues(alpha: 0.72),
-                                  fontSize: 12.r,
-                                  fontWeight: FontWeight.w400,
-                                  height: 1.15,
-                                  shadows: [
-                                    Shadow(
-                                      blurRadius: 1.r,
-                                      color: Colors.black,
-                                      offset: const Offset(2, 2),
-                                    ),
-                                  ],
-                                ),
+                            // Always reserve the ROM-filename subtitle's line
+                            // height so the action row below keeps a constant
+                            // baseline. Unscraped games have no subtitle; without
+                            // this reservation the rating/RA pill + PLAY button
+                            // float up one line. The empty string still lays out
+                            // a full line box via the shared strut/style.
+                            Text(
+                              game.showRomFileNameSubtitle ? game.romname : '',
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              strutStyle: StrutStyle(
+                                fontSize: 12.r,
+                                height: 1.15,
+                                forceStrutHeight: true,
                               ),
-                            ],
+                              style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.72),
+                                fontSize: 12.r,
+                                fontWeight: FontWeight.w400,
+                                height: 1.15,
+                                shadows: [
+                                  Shadow(
+                                    blurRadius: 1.r,
+                                    color: Colors.black,
+                                    offset: const Offset(2, 2),
+                                  ),
+                                ],
+                              ),
+                            ),
                           ],
                         ),
                       ),

--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -400,7 +400,7 @@ class GameDetailsFooter extends StatelessWidget {
                           ),
                   ),
                 ),
-                SizedBox(width: 4.r),
+                SizedBox(width: 8.r),
                 // Progress bar and achievement count. When the legend is hidden
                 // the pill stretches, so let this column (and its bar) fill the
                 // extra width via Expanded; otherwise keep the fixed 70.r width.
@@ -424,8 +424,11 @@ class GameDetailsFooter extends StatelessWidget {
                         ),
                       ),
                       SizedBox(height: 4.r),
-                      SizedBox(
-                        width: double.infinity,
+                      // Hold the bar short of the pill's right edge so it
+                      // doesn't run all the way across — mirrors the grid/
+                      // carousel pill's right margin under the progress count.
+                      Padding(
+                        padding: EdgeInsets.only(right: 10.r),
                         child: ClipRRect(
                           borderRadius: BorderRadius.circular(4.r),
                           child: LinearProgressIndicator(

--- a/lib/screens/game_screen/game_settings_dialog/game_settings_manage_tab.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_manage_tab.dart
@@ -2,13 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:material_symbols_icons/symbols.dart';
-import 'package:provider/provider.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:neostation/models/game_model.dart';
 import 'package:neostation/models/system_model.dart';
 import 'package:neostation/providers/file_provider.dart';
 import 'package:neostation/providers/neo_sync_provider.dart';
-import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/repositories/game_repository.dart';
 import 'package:neostation/screens/settings_screen/new_settings_options/widgets/setting_row.dart';
 import 'package:neostation/services/logger_service.dart';
@@ -20,10 +18,10 @@ import 'package:neostation/widgets/custom_notification.dart';
 import 'package:neostation/widgets/custom_toggle_switch.dart';
 import 'package:neostation/widgets/delete_game_dialog.dart';
 
-import 'option_picker_overlay.dart';
 
-/// Manage tab for [GameSettingsDialog]: cloud sync, view mode selection,
-/// play-time reset, and permanent game deletion.
+/// Manage tab for [GameSettingsDialog]: cloud sync, grid size/style,
+/// play-time reset, and permanent game deletion. View mode is selected from the
+/// game view itself (X button), not here.
 class GameSettingsManageTab extends StatefulWidget {
   final GameModel game;
   final SystemModel system;
@@ -66,12 +64,9 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
   // Navigation layout. Indices are fixed so focus doesn't jump around when
   // cloud sync visibility or the grid options change.
   int get _cloudSyncIdx => 0;
-  int get _viewModeIdx => 1;
-  int get _gridSizeIdx => 2;
-  int get _gridStyleIdx => 3;
-  int get _playTimeIdx => 4;
-  int get _deleteIdx => 5;
-  int get _totalItems => 6;
+  int get _playTimeIdx => 1;
+  int get _deleteIdx => 2;
+  int get _totalItems => 3;
 
   bool get _showCloudSync => widget.syncProvider?.isAuthenticated == true;
 
@@ -84,7 +79,7 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
   void initState() {
     super.initState();
     _cloudSyncEnabled = widget.game.cloudSyncEnabled ?? true;
-    _selectedIndex = _showCloudSync ? _cloudSyncIdx : _viewModeIdx;
+    _selectedIndex = _showCloudSync ? _cloudSyncIdx : _playTimeIdx;
   }
 
   @override
@@ -94,48 +89,42 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
   }
 
   /// Returns whether [idx] can receive focus in the current state.
-  bool _isEnabledIndex(int idx, String viewMode) {
-    final isGrid = viewMode == 'grid';
-    final showCardStyle = isGrid || viewMode == 'carousel';
+  bool _isEnabledIndex(int idx) {
     if (idx == _cloudSyncIdx && !_showCloudSync) return false;
-    if (idx == _gridSizeIdx && !isGrid) return false;
-    if (idx == _gridStyleIdx && !showCardStyle) return false;
     return idx >= 0 && idx < _totalItems;
   }
 
-  int _previousEnabledIndex(String viewMode) {
+  int _previousEnabledIndex() {
     int idx = _selectedIndex;
     do {
       idx = (idx - 1).clamp(0, _totalItems - 1);
-      if (_isEnabledIndex(idx, viewMode)) return idx;
+      if (_isEnabledIndex(idx)) return idx;
     } while (idx != _selectedIndex);
     return _selectedIndex;
   }
 
-  int _nextEnabledIndex(String viewMode) {
+  int _nextEnabledIndex() {
     int idx = _selectedIndex;
     do {
       idx = (idx + 1).clamp(0, _totalItems - 1);
-      if (_isEnabledIndex(idx, viewMode)) return idx;
+      if (_isEnabledIndex(idx)) return idx;
     } while (idx != _selectedIndex);
     return _selectedIndex;
   }
 
-  void _ensureSelectedIndexEnabled(String viewMode) {
-    if (!_isEnabledIndex(_selectedIndex, viewMode)) {
-      _selectedIndex = _nextEnabledIndex(viewMode);
+  void _ensureSelectedIndexEnabled() {
+    if (!_isEnabledIndex(_selectedIndex)) {
+      _selectedIndex = _nextEnabledIndex();
     }
   }
 
   void moveUp() {
-    final viewMode = context.read<SqliteConfigProvider>().config.gameViewMode;
-    setState(() => _selectedIndex = _previousEnabledIndex(viewMode));
+    setState(() => _selectedIndex = _previousEnabledIndex());
     _scrollToSelectedItem();
   }
 
   void moveDown() {
-    final viewMode = context.read<SqliteConfigProvider>().config.gameViewMode;
-    setState(() => _selectedIndex = _nextEnabledIndex(viewMode));
+    setState(() => _selectedIndex = _nextEnabledIndex());
     _scrollToSelectedItem();
   }
 
@@ -143,12 +132,6 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
     final idx = _selectedIndex;
     if (_showCloudSync && idx == _cloudSyncIdx) {
       if (!_isUpdatingCloudSync) _toggleCloudSync(!_cloudSyncEnabled);
-    } else if (idx == _viewModeIdx) {
-      _showViewModePicker();
-    } else if (idx == _gridSizeIdx) {
-      _showGridSizePicker();
-    } else if (idx == _gridStyleIdx) {
-      _showGridStylePicker();
     } else if (idx == _playTimeIdx) {
       if ((widget.game.playTime ?? 0) > 0 && !_isResettingPlayTime) {
         _confirmResetPlayTime();
@@ -170,136 +153,6 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
         );
       }
     });
-  }
-
-  // ── Option pickers ──────────────────────────────────────────────────────
-
-  Future<String?> _showOptionPicker({
-    required int anchorIdx,
-    required String currentValue,
-    required List<OptionPickerItem> options,
-  }) async {
-    final box =
-        _itemKey(anchorIdx).currentContext?.findRenderObject() as RenderBox?;
-    final offset = box?.localToGlobal(Offset.zero) ?? Offset.zero;
-    final size = box?.size ?? Size.zero;
-
-    return showGeneralDialog<String>(
-      context: context,
-      barrierDismissible: true,
-      barrierLabel: 'Option Picker',
-      barrierColor: Colors.transparent,
-      pageBuilder: (context, animation, _) {
-        return FadeTransition(
-          opacity: animation,
-          child: OptionPickerOverlay(
-            anchorOffset: offset + Offset(size.width, size.height / 2),
-            currentValue: currentValue,
-            options: options,
-          ),
-        );
-      },
-    );
-  }
-
-  /// Displays the view-mode picker and closes the settings dialog afterwards.
-  ///
-  /// Closing the dialog avoids the focus fight between the dialog and the
-  /// rebuilt parent game list/grid.
-  Future<void> _showViewModePicker() async {
-    final currentMode = context
-        .read<SqliteConfigProvider>()
-        .config
-        .gameViewMode;
-    final result = await _showOptionPicker(
-      anchorIdx: _viewModeIdx,
-      currentValue: currentMode,
-      options: [
-        OptionPickerItem(
-          value: 'list',
-          label: AppLocale.listView.getString(context),
-        ),
-        OptionPickerItem(
-          value: 'grid',
-          label: AppLocale.gridView.getString(context),
-        ),
-        OptionPickerItem(
-          value: 'carousel',
-          label: AppLocale.carouselView.getString(context),
-        ),
-      ],
-    );
-
-    if (result != null && mounted) {
-      await context.read<SqliteConfigProvider>().updateGameViewMode(result);
-      if (mounted) {
-        SfxService().playBackSound();
-        Navigator.of(context).pop();
-      }
-    }
-  }
-
-  String _viewModeLabel(BuildContext context, String mode) {
-    switch (mode) {
-      case 'list':
-        return AppLocale.listView.getString(context);
-      case 'grid':
-        return AppLocale.gridView.getString(context);
-      case 'carousel':
-        return AppLocale.carouselView.getString(context);
-      default:
-        return mode;
-    }
-  }
-
-  /// Displays the grid-size picker.
-  Future<void> _showGridSizePicker() async {
-    final currentSize = context
-        .read<SqliteConfigProvider>()
-        .config
-        .gameGridColumns;
-    final result = await _showOptionPicker(
-      anchorIdx: _gridSizeIdx,
-      currentValue: currentSize,
-      options: const [
-        OptionPickerItem(value: 'S', label: 'S'),
-        OptionPickerItem(value: 'M', label: 'M'),
-        OptionPickerItem(value: 'L', label: 'L'),
-        OptionPickerItem(value: 'XL', label: 'XL'),
-      ],
-    );
-
-    if (result != null && mounted) {
-      await context.read<SqliteConfigProvider>().updateGameGridColumns(result);
-    }
-  }
-
-  /// Displays the grid card-style picker.
-  Future<void> _showGridStylePicker() async {
-    final currentStyle = context
-        .read<SqliteConfigProvider>()
-        .config
-        .gameCarouselCardStyle;
-    final result = await _showOptionPicker(
-      anchorIdx: _gridStyleIdx,
-      currentValue: currentStyle,
-      options: [
-        OptionPickerItem(
-          value: 'fanart',
-          label: AppLocale.fanartCard.getString(context),
-        ),
-        OptionPickerItem(
-          value: 'box',
-          label: AppLocale.boxCard.getString(context),
-        ),
-      ],
-    );
-
-    if (result != null && mounted) {
-      await context.read<SqliteConfigProvider>().updateGameCarouselCardStyle(
-        result,
-      );
-    }
   }
 
   // ── Cloud sync ──────────────────────────────────────────────────────────
@@ -428,74 +281,16 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
 
   // ── Build helpers ───────────────────────────────────────────────────────
 
-  Widget _buildSelectTrigger({
-    required String label,
-    required VoidCallback? onTap,
-    required bool enabled,
-  }) {
-    final theme = Theme.of(context);
-    final foreground = enabled
-        ? theme.colorScheme.primary
-        : theme.colorScheme.onSurface.withValues(alpha: 0.3);
-
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        padding: EdgeInsets.symmetric(horizontal: 10.r, vertical: 6.r),
-        decoration: BoxDecoration(
-          color: enabled
-              ? theme.colorScheme.primary.withValues(alpha: 0.15)
-              : theme.colorScheme.onSurface.withValues(alpha: 0.05),
-          borderRadius: BorderRadius.circular(6.r),
-          border: Border.all(
-            color: enabled
-                ? theme.colorScheme.primary.withValues(alpha: 0.4)
-                : theme.colorScheme.onSurface.withValues(alpha: 0.1),
-            width: 0.5.r,
-          ),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              label,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                fontSize: 9.r,
-                fontWeight: FontWeight.w400,
-                color: foreground,
-              ),
-            ),
-            SizedBox(width: 2.r),
-            Icon(
-              Symbols.arrow_drop_down_rounded,
-              size: 14.r,
-              color: foreground,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
   // ── Build ───────────────────────────────────────────────────────────────
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final config = context.select<SqliteConfigProvider, ConfigSnapshot>(
-      (p) => ConfigSnapshot(
-        gameViewMode: p.config.gameViewMode,
-        gameGridColumns: p.config.gameGridColumns,
-        gameGridCardStyle: p.config.gameCarouselCardStyle,
-      ),
-    );
-    final isGrid = config.gameViewMode == 'grid';
-    final showCardStyle = isGrid || config.gameViewMode == 'carousel';
     final canReset = (widget.game.playTime ?? 0) > 0 && !_isResettingPlayTime;
 
-    // If the current selection became disabled (e.g. switched out of grid),
-    // move to the nearest enabled row without triggering a scroll animation.
-    _ensureSelectedIndexEnabled(config.gameViewMode);
+    // If the current selection became disabled (e.g. cloud sync hidden), move to
+    // the nearest enabled row without triggering a scroll animation.
+    _ensureSelectedIndexEnabled();
 
     return SingleChildScrollView(
       controller: _scrollController,
@@ -544,78 +339,6 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
           else
             SizedBox.shrink(key: _itemKey(_cloudSyncIdx)),
           SizedBox(height: _showCloudSync ? 12.r : 0.r),
-
-          // View Mode select.
-          GestureDetector(
-            onTap: () {
-              SfxService().playNavSound();
-              setState(() => _selectedIndex = _viewModeIdx);
-              _showViewModePicker();
-            },
-            child: SettingRow(
-              key: _itemKey(_viewModeIdx),
-              focused: _selectedIndex == _viewModeIdx,
-              title: AppLocale.viewMode.getString(context),
-              subtitle: _viewModeLabel(context, config.gameViewMode),
-              trailing: _buildSelectTrigger(
-                label: _viewModeLabel(context, config.gameViewMode),
-                onTap: _showViewModePicker,
-                enabled: true,
-              ),
-            ),
-          ),
-
-          SizedBox(height: 12.r),
-
-          // Grid Size select.
-          GestureDetector(
-            onTap: isGrid
-                ? () {
-                    SfxService().playNavSound();
-                    setState(() => _selectedIndex = _gridSizeIdx);
-                    _showGridSizePicker();
-                  }
-                : null,
-            child: SettingRow(
-              key: _itemKey(_gridSizeIdx),
-              focused: isGrid && _selectedIndex == _gridSizeIdx,
-              title: AppLocale.cardSizeGroup.getString(context),
-              subtitle: isGrid ? config.gameGridColumns : '-',
-              trailing: _buildSelectTrigger(
-                label: config.gameGridColumns,
-                onTap: isGrid ? _showGridSizePicker : null,
-                enabled: isGrid,
-              ),
-            ),
-          ),
-
-          SizedBox(height: 12.r),
-
-          // Grid Style select.
-          GestureDetector(
-            onTap: showCardStyle
-                ? () {
-                    SfxService().playNavSound();
-                    setState(() => _selectedIndex = _gridStyleIdx);
-                    _showGridStylePicker();
-                  }
-                : null,
-            child: SettingRow(
-              key: _itemKey(_gridStyleIdx),
-              focused: showCardStyle && _selectedIndex == _gridStyleIdx,
-              title: AppLocale.cardStyleGroup.getString(context),
-              subtitle: showCardStyle
-                  ? _gridStyleLabel(context, config.gameGridCardStyle)
-                  : '-',
-              trailing: _buildSelectTrigger(
-                label: _gridStyleLabel(context, config.gameGridCardStyle),
-                onTap: showCardStyle ? _showGridStylePicker : null,
-                enabled: showCardStyle,
-              ),
-            ),
-          ),
-
-          SizedBox(height: 12.r),
 
           // Play-time reset.
           GestureDetector(
@@ -726,29 +449,4 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
       ),
     );
   }
-
-  String _gridStyleLabel(BuildContext context, String style) {
-    switch (style) {
-      case 'box':
-        return AppLocale.boxCard.getString(context);
-      case 'fanart':
-      default:
-        return AppLocale.fanartCard.getString(context);
-    }
-  }
-}
-
-/// Lightweight snapshot of config fields used by the Manage tab.
-///
-/// Keeps rebuilds scoped to the exact values the tab consumes.
-class ConfigSnapshot {
-  final String gameViewMode;
-  final String gameGridColumns;
-  final String gameGridCardStyle;
-
-  const ConfigSnapshot({
-    required this.gameViewMode,
-    required this.gameGridColumns,
-    required this.gameGridCardStyle,
-  });
 }

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -16,6 +16,7 @@ import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:neostation/screens/app_screen.dart';
 import 'package:neostation/widgets/game_view_mode_dropdown.dart';
 import 'package:neostation/widgets/game_action_buttons.dart';
+import 'package:neostation/services/game_legend_visibility.dart';
 import 'package:neostation/sync/sync_manager.dart';
 import 'package:neostation/widgets/native_carousel.dart';
 import 'package:neostation/widgets/game_view_footer.dart';
@@ -229,6 +230,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
     _currentIndex = widget.selectedIndex.clamp(0, _gamesLength - 1);
     _settledIndex = _currentIndex;
     _initializeGamepad();
+    GameLegendVisibility.hidden.addListener(_onLegendVisibilityChanged);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _scrollToCurrentLetter();
       _updateBackground();
@@ -265,6 +267,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
   void dispose() {
     _achievementsDebounce?.cancel();
     _settleTimer?.cancel();
+    GameLegendVisibility.hidden.removeListener(_onLegendVisibilityChanged);
     _cleanupGamepad();
     _letterBarController.dispose();
     super.dispose();
@@ -301,6 +304,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
       },
       onLeftStickClick: widget.onRandom,
       onSelectButton: widget.onScrape,
+      onSelectModifierB: _toggleLegend, // Select + B - Hide/show legend.
       onSettings: widget.onSettings,
       onPreviousTab: AppNavigation.previousTab,
       onNextTab: AppNavigation.nextTab,
@@ -383,24 +387,32 @@ class _GamesCarouselState extends State<GamesCarousel> {
       currentGameInfo: _currentGameInfo,
       onShowAchievements: _showAchievementsDialog,
     );
-    _chromeLegend = Positioned(
-      top: 12.r,
-      left: 12.r,
-      child: Consumer<SyncManager>(
-        builder: (context, syncManager, child) => GameActionButtons(
-          system: widget.system,
-          selectedGame: settledGame,
-          syncProvider: syncManager.active,
-          onBack: widget.onBack,
-          onFavorite: widget.onFavorite ?? () {},
-          onViewMode: () =>
-              GameViewModeDropdown.globalKey.currentState?.showDropdown(),
-          onSettings: widget.onSettings ?? () {},
-          onRandom: widget.onRandom,
-          onScrape: widget.onScrape,
-        ),
+    // Positioning/visibility is applied at the Stack level (AnimatedPositioned)
+    // so Select + B can slide it without invalidating this memoized subtree.
+    _chromeLegend = Consumer<SyncManager>(
+      builder: (context, syncManager, child) => GameActionButtons(
+        system: widget.system,
+        selectedGame: settledGame,
+        syncProvider: syncManager.active,
+        onBack: widget.onBack,
+        onFavorite: widget.onFavorite ?? () {},
+        onViewMode: () =>
+            GameViewModeDropdown.globalKey.currentState?.showDropdown(),
+        onSettings: widget.onSettings ?? () {},
+        onRandom: widget.onRandom,
+        onScrape: widget.onScrape,
       ),
     );
+  }
+
+  /// Select + B — toggles the (session-global) vertical action-button legend.
+  void _toggleLegend() {
+    SfxService().playNavSound();
+    GameLegendVisibility.toggle();
+  }
+
+  void _onLegendVisibilityChanged() {
+    if (mounted) setState(() {});
   }
 
   bool get _isAllMode =>
@@ -1053,8 +1065,20 @@ class _GamesCarouselState extends State<GamesCarousel> {
           ],
         ),
         // Vertical action-button legend (shared with the game list view);
-        // also memoized on the settled selection.
-        _chromeLegend!,
+        // also memoized on the settled selection. Select + B slides it off the
+        // left edge. The centered carousel itself is left in place (there is no
+        // left-gutter to reflow into for a centered PageView).
+        AnimatedPositioned(
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeOutCubic,
+          top: 12.r,
+          left: GameLegendVisibility.hidden.value ? -60.r : 12.r,
+          child: AnimatedOpacity(
+            duration: const Duration(milliseconds: 250),
+            opacity: GameLegendVisibility.hidden.value ? 0.0 : 1.0,
+            child: _chromeLegend!,
+          ),
+        ),
       ],
     );
   }

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -303,8 +303,9 @@ class _GamesCarouselState extends State<GamesCarousel> {
         } catch (_) {}
       },
       onLeftStickClick: widget.onRandom,
-      onSelectButton: widget.onScrape,
+      onSelectModifierA: widget.onScrape, // Select + A - Scrape.
       onSelectModifierB: _toggleLegend, // Select + B - Hide/show legend.
+      onSelectModifierY: widget.onRandom, // Select + Y - Random game.
       onSettings: widget.onSettings,
       onPreviousTab: AppNavigation.previousTab,
       onNextTab: AppNavigation.nextTab,

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -80,6 +80,20 @@ class _GamesCarouselState extends State<GamesCarousel> {
   // Debounce so RA loads once selection settles rather than on every move.
   Timer? _achievementsDebounce;
   static const Duration _achievementsSettleDelay = Duration(milliseconds: 280);
+
+  // Debounced "settled" selection driving the footer pill + action-button
+  // legend, so that expensive chrome isn't rebuilt on every fast-swipe page
+  // change. Memoized by signature (see _buildSettledChrome) so build() returns
+  // identical instances during a burst and Flutter skips those subtrees.
+  int _settledIndex = 0;
+  Timer? _settleTimer;
+  DateTime? _lastNavTime;
+  bool _isNavigatingFast = false;
+  static const Duration _fastNavThreshold = Duration(milliseconds: 150);
+  static const Duration _chromeSettleDelay = Duration(milliseconds: 160);
+  String? _chromeSig;
+  Widget? _chromeFooter;
+  Widget? _chromeLegend;
   final Map<String, double> _letterWidthCache = {};
   final Map<String, bool> _fileExistsCache = {};
   int _lastBgIndex = -1;
@@ -213,6 +227,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
   void initState() {
     super.initState();
     _currentIndex = widget.selectedIndex.clamp(0, _gamesLength - 1);
+    _settledIndex = _currentIndex;
     _initializeGamepad();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _scrollToCurrentLetter();
@@ -228,7 +243,9 @@ class _GamesCarouselState extends State<GamesCarousel> {
         widget.selectedIndex != _currentIndex) {
       setState(() {
         _currentIndex = widget.selectedIndex.clamp(0, _gamesLength - 1);
+        _settledIndex = _currentIndex; // external jump: settle immediately
       });
+      _settleTimer?.cancel();
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _carouselKey.currentState?.jumpToPage(_currentIndex);
         _scrollToCurrentLetter();
@@ -247,9 +264,17 @@ class _GamesCarouselState extends State<GamesCarousel> {
   @override
   void dispose() {
     _achievementsDebounce?.cancel();
+    _settleTimer?.cancel();
     _cleanupGamepad();
     _letterBarController.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Theme / MediaQuery / ScreenUtil may have changed; drop memoized chrome.
+    _chromeSig = null;
   }
 
   void _initializeGamepad() {
@@ -302,6 +327,11 @@ class _GamesCarouselState extends State<GamesCarousel> {
     if (reason == CarouselPageChangeReason.manual) {
       SfxService().playNavSound();
     }
+    final now = DateTime.now();
+    _isNavigatingFast =
+        _lastNavTime != null &&
+        now.difference(_lastNavTime!) < _fastNavThreshold;
+    _lastNavTime = now;
     setState(() {
       _currentIndex = index;
     });
@@ -309,8 +339,68 @@ class _GamesCarouselState extends State<GamesCarousel> {
       widget.onGameSelected(widget.games[index]);
     }
     _scheduleAchievementsLoad();
+    _scheduleChromeSettle();
     _scrollToCurrentLetter();
     _updateBackground();
+  }
+
+  /// Advances the footer/legend's settled selection. A single (slow) page
+  /// change updates it immediately; during a fast-swipe burst it is deferred
+  /// until navigation settles, so the chrome isn't rebuilt every frame.
+  void _scheduleChromeSettle() {
+    _settleTimer?.cancel();
+    if (!_isNavigatingFast) {
+      if (_settledIndex != _currentIndex) {
+        setState(() => _settledIndex = _currentIndex);
+      }
+      return;
+    }
+    _settleTimer = Timer(_chromeSettleDelay, () {
+      if (mounted && _settledIndex != _currentIndex) {
+        setState(() => _settledIndex = _currentIndex);
+      }
+    });
+  }
+
+  /// (Re)builds the footer pill + action-button legend only when the settled
+  /// selection or its achievement/favorite state changes, so a fast-swipe
+  /// burst reuses cached widget instances instead of rebuilding this chrome.
+  void _buildSettledChrome() {
+    final settledGame = widget.games[_settledIndex.clamp(0, _gamesLength - 1)];
+    final hasRa = _hasRetroAchievementsFor(settledGame);
+    final sig =
+        '$_settledIndex|${settledGame.romname}|${settledGame.isFavorite}'
+        '|$hasRa|$_isLoadingAchievements|${identityHashCode(_currentGameInfo)}';
+    if (sig == _chromeSig && _chromeFooter != null && _chromeLegend != null) {
+      return;
+    }
+    _chromeSig = sig;
+    _chromeFooter = GameViewFooter(
+      game: settledGame,
+      onPlay: widget.onPlay,
+      hasRetroAchievements: hasRa,
+      isLoadingAchievements: _isLoadingAchievements,
+      currentGameInfo: _currentGameInfo,
+      onShowAchievements: _showAchievementsDialog,
+    );
+    _chromeLegend = Positioned(
+      top: 12.r,
+      left: 12.r,
+      child: Consumer<SyncManager>(
+        builder: (context, syncManager, child) => GameActionButtons(
+          system: widget.system,
+          selectedGame: settledGame,
+          syncProvider: syncManager.active,
+          onBack: widget.onBack,
+          onFavorite: widget.onFavorite ?? () {},
+          onViewMode: () =>
+              GameViewModeDropdown.globalKey.currentState?.showDropdown(),
+          onSettings: widget.onSettings ?? () {},
+          onRandom: widget.onRandom,
+          onScrape: widget.onScrape,
+        ),
+      ),
+    );
   }
 
   bool get _isAllMode =>
@@ -858,6 +948,8 @@ class _GamesCarouselState extends State<GamesCarousel> {
       fontWeight: FontWeight.w800,
     );
 
+    _buildSettledChrome();
+
     return Stack(
       children: [
         Column(
@@ -953,38 +1045,16 @@ class _GamesCarouselState extends State<GamesCarousel> {
                 ),
               ),
             ),
-            GameViewFooter(
-              game: currentGame,
-              onPlay: widget.onPlay,
-              hasRetroAchievements:
-                  widget.games.isNotEmpty &&
-                  _hasRetroAchievementsFor(currentGame),
-              isLoadingAchievements: _isLoadingAchievements,
-              currentGameInfo: _currentGameInfo,
-              onShowAchievements: _showAchievementsDialog,
-            ),
+            // Footer pill driven by the debounced settled selection and
+            // memoized (see _buildSettledChrome) so it is not rebuilt on every
+            // fast-swipe frame.
+            _chromeFooter!,
             SizedBox(height: 8.r),
           ],
         ),
-        // Vertical action-button legend (shared with the game list view).
-        Positioned(
-          top: 12.r,
-          left: 12.r,
-          child: Consumer<SyncManager>(
-            builder: (context, syncManager, child) => GameActionButtons(
-              system: widget.system,
-              selectedGame: currentGame,
-              syncProvider: syncManager.active,
-              onBack: widget.onBack,
-              onFavorite: widget.onFavorite ?? () {},
-              onViewMode: () =>
-                  GameViewModeDropdown.globalKey.currentState?.showDropdown(),
-              onSettings: widget.onSettings ?? () {},
-              onRandom: widget.onRandom,
-              onScrape: widget.onScrape,
-            ),
-          ),
-        ),
+        // Vertical action-button legend (shared with the game list view);
+        // also memoized on the settled selection.
+        _chromeLegend!,
       ],
     );
   }

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -958,6 +958,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
             onViewMode: () =>
                 GameViewModeDropdown.globalKey.currentState?.showDropdown(),
             onSettings: widget.onSettings ?? () {},
+            onRandom: widget.onRandom,
           ),
         ),
       ],

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -991,12 +991,16 @@ class _GamesCarouselState extends State<GamesCarousel> {
                 ),
               ),
             ),
+            // Tight letter-bar box (chip height, no vertical slack) sits low
+            // against the footer. Reclaiming the old slack in real layout (vs a
+            // visual translate) lets the carousel above grow into it, so the
+            // artwork gets slightly bigger with no gap beneath it.
             SizedBox(
-              height: 36.r,
+              height: 30.r,
               child: SingleChildScrollView(
                 controller: _letterBarController,
                 scrollDirection: Axis.horizontal,
-                padding: EdgeInsets.symmetric(horizontal: 4.r, vertical: 2.r),
+                padding: EdgeInsets.symmetric(horizontal: 4.r),
                 child: Stack(
                   children: [
                     AnimatedPositioned(
@@ -1061,8 +1065,9 @@ class _GamesCarouselState extends State<GamesCarousel> {
             // Footer pill driven by the debounced settled selection and
             // memoized (see _buildSettledChrome) so it is not rebuilt on every
             // fast-swipe frame.
+            // Flush to the bottom (no trailing spacer) so the footer sits at
+            // the same vertical position as the grid view's footer.
             _chromeFooter!,
-            SizedBox(height: 8.r),
           ],
         ),
         // Vertical action-button legend (shared with the game list view);

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
@@ -5,23 +6,24 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 import 'package:neostation/models/game_model.dart';
-import 'package:neostation/models/retro_achievements_game_info.dart';
 import 'package:neostation/models/system_model.dart';
 import 'package:neostation/providers/file_provider.dart';
-import 'package:neostation/providers/retro_achievements_provider.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/providers/system_background_provider.dart';
 import 'package:neostation/services/game_service.dart';
-import 'package:neostation/services/retro_achievements_helper.dart';
 import 'package:neostation/services/sfx_service.dart';
-import 'package:neostation/screens/game_screen/game_details_card/dialogs/game_achievements_dialog.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
-import 'package:neostation/widgets/game_view_mode_dropdown.dart';
 import 'package:neostation/screens/app_screen.dart';
+import 'package:neostation/widgets/game_view_mode_dropdown.dart';
+import 'package:neostation/widgets/game_action_buttons.dart';
+import 'package:neostation/sync/sync_manager.dart';
 import 'package:neostation/widgets/native_carousel.dart';
 import 'package:neostation/widgets/game_view_footer.dart';
-import 'package:neostation/widgets/game_action_buttons.dart';
 import 'package:neostation/constants/system_folder_names.dart';
+import 'package:neostation/models/retro_achievements_game_info.dart';
+import 'package:neostation/providers/retro_achievements_provider.dart';
+import 'package:neostation/services/retro_achievements_helper.dart';
+import 'package:neostation/screens/game_screen/game_details_card/dialogs/game_achievements_dialog.dart';
 
 class GamesCarousel extends StatefulWidget {
   final SystemModel system;
@@ -34,8 +36,14 @@ class GamesCarousel extends StatefulWidget {
   final VoidCallback? onFavorite;
   final VoidCallback? onRandom;
   final VoidCallback? onSettings;
+  final VoidCallback? onScrape;
   final Set<String> scrapingGameRomnames;
   final Map<String, double> scrapeProgress;
+
+  /// No-op stub retained for API compatibility with the current scraping tab.
+  /// This pre-#188 carousel keeps no static artwork caches; the Flutter image
+  /// cache is evicted separately by the caller.
+  static void evictArtworkCaches(Iterable<String> paths) {}
 
   const GamesCarousel({
     super.key,
@@ -49,20 +57,13 @@ class GamesCarousel extends StatefulWidget {
     this.onFavorite,
     this.onRandom,
     this.onSettings,
+    this.onScrape,
     this.scrapingGameRomnames = const {},
     this.scrapeProgress = const {},
   });
 
   @override
   State<GamesCarousel> createState() => _GamesCarouselState();
-
-  /// Evicts memoized file-existence entries for [paths]. Call after replacing a
-  /// game's image files on disk so the carousel re-checks the fresh artwork.
-  static void evictArtworkCaches(Iterable<String> paths) {
-    for (final path in paths) {
-      _GamesCarouselState._fileExistsCache.remove(path);
-    }
-  }
 }
 
 class _GamesCarouselState extends State<GamesCarousel> {
@@ -71,19 +72,17 @@ class _GamesCarouselState extends State<GamesCarousel> {
 
   int _currentIndex = 0;
   late GamepadNavigation _gamepadNav;
-  final Map<String, double> _letterWidthCache = {};
-  static final Map<String, bool> _fileExistsCache = {};
-  int _lastBgIndex = -1;
 
-  /// Memoized `File.existsSync()` — synchronous disk stats on the UI thread
-  /// while cards build are a known jank source. Entries are evicted by
-  /// [GamesCarousel.evictArtworkCaches] when a scrape replaces artwork.
-  static bool _fileExists(String path) =>
-      _fileExistsCache.putIfAbsent(path, () => File(path).existsSync());
-
+  // RetroAchievements info for the selected game (shown in the footer pill).
   GameInfoAndUserProgress? _currentGameInfo;
   bool _isLoadingAchievements = false;
   String? _achievementsTargetRomname;
+  // Debounce so RA loads once selection settles rather than on every move.
+  Timer? _achievementsDebounce;
+  static const Duration _achievementsSettleDelay = Duration(milliseconds: 280);
+  final Map<String, double> _letterWidthCache = {};
+  final Map<String, bool> _fileExistsCache = {};
+  int _lastBgIndex = -1;
 
   static final Map<String, Size?> _imgSizeCache = {};
 
@@ -235,6 +234,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
         _scrollToCurrentLetter();
         _updateBackground();
       });
+      _scheduleAchievementsLoad();
     }
     if (widget.games != oldWidget.games) {
       _letterWidthCache.clear();
@@ -246,6 +246,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
 
   @override
   void dispose() {
+    _achievementsDebounce?.cancel();
     _cleanupGamepad();
     _letterBarController.dispose();
     super.dispose();
@@ -268,9 +269,13 @@ class _GamesCarouselState extends State<GamesCarousel> {
       },
       onBack: widget.onBack,
       onFavorite: widget.onFavorite,
-      onXButton: () =>
-          GameViewModeDropdown.globalKey.currentState?.showDropdown(),
-      onSelectModifierY: widget.onRandom, // Select + Y - Random.
+      onXButton: () {
+        try {
+          GameViewModeDropdown.globalKey.currentState?.showDropdown();
+        } catch (_) {}
+      },
+      onLeftStickClick: widget.onRandom,
+      onSelectButton: widget.onScrape,
       onSettings: widget.onSettings,
       onPreviousTab: AppNavigation.previousTab,
       onNextTab: AppNavigation.nextTab,
@@ -303,9 +308,108 @@ class _GamesCarouselState extends State<GamesCarousel> {
     if (index < widget.games.length) {
       widget.onGameSelected(widget.games[index]);
     }
+    _scheduleAchievementsLoad();
     _scrollToCurrentLetter();
     _updateBackground();
-    _loadAchievementsForSelectedGame();
+  }
+
+  bool get _isAllMode =>
+      widget.system.folderName == SystemFolderNames.all ||
+      widget.system.folderName == SystemFolderNames.favorites;
+
+  SystemModel _effectiveSystemFor(GameModel game) {
+    final systemFolderName = game.systemFolderName;
+    if (systemFolderName == null || !_isAllMode) return widget.system;
+    try {
+      final detectedSystems = context
+          .read<SqliteConfigProvider>()
+          .detectedSystems;
+      return detectedSystems.firstWhere(
+        (s) => s.folderName == systemFolderName,
+        orElse: () => widget.system,
+      );
+    } catch (e) {
+      return widget.system;
+    }
+  }
+
+  bool _hasRetroAchievementsFor(GameModel game) {
+    final system = _effectiveSystemFor(game);
+    return system.raId != null && system.raId != '0' && system.raId!.isNotEmpty;
+  }
+
+  /// Debounced entry point — coalesces rapid moves into a single load once the
+  /// user stops on a game.
+  void _scheduleAchievementsLoad() {
+    final selectedRomname = widget.games.isEmpty
+        ? null
+        : widget.games[_currentIndex.clamp(0, widget.games.length - 1)].romname;
+    if (selectedRomname != _achievementsTargetRomname) {
+      _achievementsTargetRomname = selectedRomname;
+      _currentGameInfo = null;
+      _isLoadingAchievements = true;
+    }
+    _achievementsDebounce?.cancel();
+    _achievementsDebounce = Timer(_achievementsSettleDelay, () {
+      if (mounted) _loadAchievementsForSelectedGame();
+    });
+  }
+
+  Future<void> _loadAchievementsForSelectedGame() async {
+    if (widget.games.isEmpty) return;
+    final game = widget.games[_currentIndex.clamp(0, widget.games.length - 1)];
+
+    if (!_hasRetroAchievementsFor(game)) {
+      if (mounted) {
+        setState(() {
+          _currentGameInfo = null;
+          _isLoadingAchievements = false;
+        });
+      }
+      return;
+    }
+
+    if (mounted) setState(() => _isLoadingAchievements = true);
+    _achievementsTargetRomname = game.romname;
+
+    try {
+      final provider = context.read<RetroAchievementsProvider>();
+      final info = await RetroAchievementsHelper.loadGameInfo(
+        game: game,
+        provider: provider,
+        effectiveSystem: _effectiveSystemFor(game),
+        isAllMode: _isAllMode,
+      );
+      if (mounted && _achievementsTargetRomname == game.romname) {
+        setState(() {
+          _currentGameInfo = info;
+          _isLoadingAchievements = false;
+        });
+      }
+    } catch (e) {
+      if (mounted && _achievementsTargetRomname == game.romname) {
+        setState(() {
+          _currentGameInfo = null;
+          _isLoadingAchievements = false;
+        });
+      }
+    }
+  }
+
+  void _showAchievementsDialog() {
+    if (widget.games.isEmpty) return;
+    final game = widget.games[_currentIndex.clamp(0, widget.games.length - 1)];
+    if (!_hasRetroAchievementsFor(game)) return;
+
+    SfxService().playNavSound();
+    showDialog(
+      context: context,
+      builder: (_) => GameAchievementsDialog(
+        game: game,
+        system: _effectiveSystemFor(game),
+        retroAchievementsProvider: context.read<RetroAchievementsProvider>(),
+      ),
+    );
   }
 
   void _updateBackground() {
@@ -348,97 +452,6 @@ class _GamesCarouselState extends State<GamesCarousel> {
     context.read<SystemBackgroundProvider>().updateImage(
       imageProvider,
       imagePath: imagePath,
-    );
-  }
-
-  bool get _isAllMode =>
-      widget.system.folderName == SystemFolderNames.all ||
-      widget.system.folderName == SystemFolderNames.favorites;
-
-  SystemModel _effectiveSystemFor(GameModel game) {
-    final systemFolderName = game.systemFolderName;
-    if (systemFolderName == null || !_isAllMode) return widget.system;
-    try {
-      final detectedSystems = context
-          .read<SqliteConfigProvider>()
-          .detectedSystems;
-      return detectedSystems.firstWhere(
-        (s) => s.folderName == systemFolderName,
-        orElse: () => widget.system,
-      );
-    } catch (e) {
-      return widget.system;
-    }
-  }
-
-  bool _hasRetroAchievementsFor(GameModel game) {
-    final system = _effectiveSystemFor(game);
-    return system.raId != null && system.raId != '0' && system.raId!.isNotEmpty;
-  }
-
-  Future<void> _loadAchievementsForSelectedGame() async {
-    if (widget.games.isEmpty) return;
-    final game = widget.games[_currentIndex.clamp(0, widget.games.length - 1)];
-
-    if (!_hasRetroAchievementsFor(game)) {
-      if (mounted) {
-        setState(() {
-          _currentGameInfo = null;
-          _isLoadingAchievements = false;
-        });
-      }
-      return;
-    }
-
-    // Clear the previous game's info immediately (not just after the async load
-    // returns) so fast scrolling never shows the prior game's achievement
-    // counts/icon while this load is pending.
-    _achievementsTargetRomname = game.romname;
-    if (mounted) {
-      setState(() {
-        _currentGameInfo = null;
-        _isLoadingAchievements = true;
-      });
-    }
-
-    try {
-      final provider = context.read<RetroAchievementsProvider>();
-      final info = await RetroAchievementsHelper.loadGameInfo(
-        game: game,
-        provider: provider,
-        effectiveSystem: _effectiveSystemFor(game),
-        isAllMode: _isAllMode,
-      );
-
-      if (mounted && _achievementsTargetRomname == game.romname) {
-        setState(() {
-          _currentGameInfo = info;
-          _isLoadingAchievements = false;
-        });
-      }
-    } catch (e) {
-      if (mounted && _achievementsTargetRomname == game.romname) {
-        setState(() {
-          _currentGameInfo = null;
-          _isLoadingAchievements = false;
-        });
-      }
-    }
-  }
-
-  void _showAchievementsDialog() {
-    if (widget.games.isEmpty) return;
-    final game = widget.games[_currentIndex.clamp(0, widget.games.length - 1)];
-    if (!_hasRetroAchievementsFor(game)) return;
-
-    SfxService().playNavSound();
-    showDialog(
-      context: context,
-      builder: (_) => GameAchievementsDialog(
-        game: game,
-        system: _effectiveSystemFor(game),
-        retroAchievementsProvider: context.read<RetroAchievementsProvider>(),
-      ),
     );
   }
 
@@ -512,7 +525,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
       imageType,
       widget.fileProvider,
     );
-    if (_fileExists(path)) return path;
+    if (File(path).existsSync()) return path;
     return '';
   }
 
@@ -520,13 +533,13 @@ class _GamesCarouselState extends State<GamesCarousel> {
     final theme = Theme.of(context);
     final folder = _folderForGame(game);
     final screenshotPath = game.getScreenshotPath(folder, widget.fileProvider);
-    final hasScreenshot = _fileExists(screenshotPath);
+    final hasScreenshot = File(screenshotPath).existsSync();
     final fanartPath = game.getImagePath(
       folder,
       'fanarts',
       widget.fileProvider,
     );
-    final hasFanart = _fileExists(fanartPath);
+    final hasFanart = File(fanartPath).existsSync();
     final bgPath = hasFanart
         ? fanartPath
         : (hasScreenshot ? screenshotPath : '');
@@ -849,9 +862,13 @@ class _GamesCarouselState extends State<GamesCarousel> {
       children: [
         Column(
           children: [
+            // #188 layout: drop the top spacer so the carousel gets the full
+            // height (bigger cards sit closer together). Pad symmetrically so
+            // the centered card stays centered on-screen while still clearing
+            // the vertical legend on the left.
             Expanded(
               child: Padding(
-                padding: EdgeInsets.only(left: 60.r),
+                padding: EdgeInsets.symmetric(horizontal: 60.r),
                 child: NativeCarousel(
                   key: _carouselKey,
                   itemCount: widget.games.length,
@@ -939,7 +956,9 @@ class _GamesCarouselState extends State<GamesCarousel> {
             GameViewFooter(
               game: currentGame,
               onPlay: widget.onPlay,
-              hasRetroAchievements: _hasRetroAchievementsFor(currentGame),
+              hasRetroAchievements:
+                  widget.games.isNotEmpty &&
+                  _hasRetroAchievementsFor(currentGame),
               isLoadingAchievements: _isLoadingAchievements,
               currentGameInfo: _currentGameInfo,
               onShowAchievements: _showAchievementsDialog,
@@ -947,18 +966,23 @@ class _GamesCarouselState extends State<GamesCarousel> {
             SizedBox(height: 8.r),
           ],
         ),
+        // Vertical action-button legend (shared with the game list view).
         Positioned(
           top: 12.r,
           left: 12.r,
-          child: GameActionButtons(
-            system: widget.system,
-            selectedGame: currentGame,
-            onBack: widget.onBack,
-            onFavorite: widget.onFavorite ?? () {},
-            onViewMode: () =>
-                GameViewModeDropdown.globalKey.currentState?.showDropdown(),
-            onSettings: widget.onSettings ?? () {},
-            onRandom: widget.onRandom,
+          child: Consumer<SyncManager>(
+            builder: (context, syncManager, child) => GameActionButtons(
+              system: widget.system,
+              selectedGame: currentGame,
+              syncProvider: syncManager.active,
+              onBack: widget.onBack,
+              onFavorite: widget.onFavorite ?? () {},
+              onViewMode: () =>
+                  GameViewModeDropdown.globalKey.currentState?.showDropdown(),
+              onSettings: widget.onSettings ?? () {},
+              onRandom: widget.onRandom,
+              onScrape: widget.onScrape,
+            ),
           ),
         ),
       ],

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -16,6 +16,7 @@ import 'package:neostation/services/retro_achievements_helper.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/screens/game_screen/game_details_card/dialogs/game_achievements_dialog.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/widgets/game_view_mode_dropdown.dart';
 import 'package:neostation/screens/app_screen.dart';
 import 'package:neostation/widgets/native_carousel.dart';
 import 'package:neostation/widgets/game_view_footer.dart';
@@ -267,7 +268,9 @@ class _GamesCarouselState extends State<GamesCarousel> {
       },
       onBack: widget.onBack,
       onFavorite: widget.onFavorite,
-      onXButton: widget.onRandom,
+      onXButton: () =>
+          GameViewModeDropdown.globalKey.currentState?.showDropdown(),
+      onSelectModifierY: widget.onRandom, // Select + Y - Random.
       onSettings: widget.onSettings,
       onPreviousTab: AppNavigation.previousTab,
       onNextTab: AppNavigation.nextTab,
@@ -952,7 +955,8 @@ class _GamesCarouselState extends State<GamesCarousel> {
             selectedGame: currentGame,
             onBack: widget.onBack,
             onFavorite: widget.onFavorite ?? () {},
-            onRandom: widget.onRandom ?? () {},
+            onViewMode: () =>
+                GameViewModeDropdown.globalKey.currentState?.showDropdown(),
             onSettings: widget.onSettings ?? () {},
           ),
         ),

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -14,6 +14,7 @@ import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/services/retro_achievements_helper.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/widgets/game_view_mode_dropdown.dart';
 import 'package:neostation/utils/game_utils.dart';
 import 'package:neostation/screens/game_screen/game_details_card/dialogs/game_achievements_dialog.dart';
 import 'package:neostation/services/game_service.dart';
@@ -555,7 +556,9 @@ class _GamesGridState extends State<GamesGrid> {
       onSelectItem: widget.onPlay,
       onBack: widget.onBack,
       onFavorite: widget.onFavorite,
-      onXButton: widget.onRandom,
+      onXButton: () =>
+          GameViewModeDropdown.globalKey.currentState?.showDropdown(),
+      onSelectModifierY: widget.onRandom, // Select + Y - Random.
       onSettings: widget.onSettings,
     );
   }
@@ -874,7 +877,8 @@ class _GamesGridState extends State<GamesGrid> {
                 : null,
             onBack: widget.onBack,
             onFavorite: widget.onFavorite,
-            onRandom: widget.onRandom,
+            onViewMode: () =>
+                GameViewModeDropdown.globalKey.currentState?.showDropdown(),
             onSettings: widget.onSettings ?? () {},
           ),
         ),

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -144,14 +144,6 @@ class _GamesGridState extends State<GamesGrid> {
   // is always brought back into view. Steady scroll and dpad nav never set it
   // (nav scrolls via _ensureSelectedVisible).
   bool _recenterAfterLayout = false;
-  // When the pending recenter is instant (jumpTo) vs animated (animateTo).
-  // Only a legend toggle sets this: it keeps the same column count, so the
-  // selected card barely moves and jumpTo lands it dead-centre in one frame.
-  // Column-count changes (card-size cycle, pinch) and fanart↔box2d switches
-  // move the card many rows — a far jump that jumpTo would clamp short against
-  // the SliverList's under-reported extent, so those animate through instead
-  // (the scroll builds the intermediate rows so the true target is reachable).
-  bool _recenterInstant = false;
 
   // Per-card height/width ratio (aspect), which is INDEPENDENT of the card
   // width. Measuring it is the expensive part of layout (file-header reads +
@@ -675,7 +667,6 @@ class _GamesGridState extends State<GamesGrid> {
   void _onLegendVisibilityChanged() {
     if (!mounted) return;
     _recenterAfterLayout = true;
-    _recenterInstant = true; // same-column reflow: snap instantly, no drift
     setState(() {});
   }
 
@@ -697,37 +688,25 @@ class _GamesGridState extends State<GamesGrid> {
     );
   }
 
-  /// Scrolls so the selected card sits at the vertical centre of the viewport.
-  /// The card (and its in-cell cursor) is the source of truth; this is how the
-  /// view follows it after any non-scroll layout change.
+  /// Smoothly scrolls so the selected card sits at the vertical centre of the
+  /// viewport. Used after any non-scroll layout change (legend toggle, card-size
+  /// cycle, pinch, fanart↔box2d switch).
   ///
-  /// Two modes, picked by [_recenterInstant]:
-  ///  • Instant (jumpTo) — a legend toggle. The column count is unchanged, so
-  ///    the selected card barely moves; snapping in the same frame keeps the
-  ///    cursor glued with no drift.
-  ///  • Animated (animateTo) — a card-size cycle, pinch, or fanart↔box2d
-  ///    switch. These move the card many rows (a far jump). jumpTo would be
-  ///    clamped short by the SliverList's under-reported max extent (it hasn't
-  ///    built the distant rows yet), landing on a view that doesn't even
-  ///    contain the card. animateTo scrolls THROUGH the intermediate offsets so
-  ///    the sliver builds rows along the way and its extent grows until the true
-  ///    centre is reachable — the same path wrap-around nav takes.
+  /// The target comes straight from the layout model (`_centerTargetFor`). This
+  /// is only correct because the list is a [SliverVariedExtentList] fed exact
+  /// per-row extents, so its absolute offsets match the model exactly — no lazy
+  /// estimate to diverge from. A single animateTo always lands.
   void _centerOnSelected() {
     if (!_scrollController.hasClients || _cardRects.isEmpty) return;
-    final instant = _recenterInstant;
-    _recenterInstant = false;
     final rect = _cardRects[_selectedIndex.clamp(0, _cardRects.length - 1)];
-    final viewportH = _scrollController.position.viewportDimension;
-    final target = _centerTargetFor(rect, viewportH);
-    if (instant) {
-      _scrollController.jumpTo(target);
-    } else {
-      _scrollController.animateTo(
-        target,
-        duration: const Duration(milliseconds: 350),
-        curve: Curves.easeOutCubic,
-      );
-    }
+    final pos = _scrollController.position;
+    final target = _centerTargetFor(rect, pos.viewportDimension);
+    if ((pos.pixels - target).abs() <= 1.0) return;
+    _scrollController.animateTo(
+      target,
+      duration: const Duration(milliseconds: 350),
+      curve: Curves.easeOutCubic,
+    );
   }
 
   @override
@@ -950,14 +929,13 @@ class _GamesGridState extends State<GamesGrid> {
   void _ensureSelectedVisible() {
     if (!_scrollController.hasClients || _cardRects.isEmpty) return;
     final rect = _cardRects[_selectedIndex.clamp(0, _cardRects.length - 1)];
-    final viewportH = _scrollController.position.viewportDimension;
-    final target = _centerTargetFor(rect, viewportH);
+    final pos = _scrollController.position;
+    final target = _centerTargetFor(rect, pos.viewportDimension);
     // During a fast-nav burst, jump instantly rather than firing a fresh
-    // animateTo per keypress. Repeated overlapping animations let the viewport
-    // fall far behind _selectedIndex, so the selected card trails the logical
-    // selection by many rows until the scroll finally catches up. A synchronous
-    // jump keeps the selected card centered every frame. The trailing (settled)
-    // move still animates smoothly.
+    // animateTo per keypress. Overlapping animations let the viewport trail the
+    // selection by many rows; a synchronous jump keeps the selected card centred
+    // every frame. The trailing (settled) move still animates smoothly.
+    // Exact model offsets (SliverVariedExtentList) make both land correctly.
     if (_isNavigatingFast) {
       _scrollController.jumpTo(target);
       return;
@@ -1148,8 +1126,23 @@ class _GamesGridState extends State<GamesGrid> {
                                   left: 16,
                                   right: 16,
                                 ),
-                                sliver: SliverList.builder(
+                                // Exact per-row extents (known from
+                                // _positionCards) let the sliver compute exact
+                                // absolute offsets and maxScrollExtent for the
+                                // WHOLE list without building rows — no lazy
+                                // estimate, so model-based centring
+                                // (_centerTargetFor) always lands. This is what
+                                // fixes the "selection off-screen after resize /
+                                // fast-scroll" divergence while keeping lazy row
+                                // rendering.
+                                sliver: SliverVariedExtentList.builder(
                                   itemCount: _rows.length,
+                                  itemExtentBuilder: (index, _) {
+                                    if (index < 0 || index >= _rows.length) {
+                                      return 0;
+                                    }
+                                    return _rows[index].height + _spY;
+                                  },
                                   itemBuilder: buildRow,
                                 ),
                               ),

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -68,7 +68,8 @@ class GamesGrid extends StatefulWidget {
   State<GamesGrid> createState() => _GamesGridState();
 }
 
-class _GamesGridState extends State<GamesGrid> {
+class _GamesGridState extends State<GamesGrid>
+    with SingleTickerProviderStateMixin {
   late GamepadNavigation _gamepadNav;
   final ScrollController _scrollController = ScrollController();
   int _selectedIndex = 0;
@@ -117,10 +118,25 @@ class _GamesGridState extends State<GamesGrid> {
   final Map<int, Widget> _rowCache = {};
   String? _rowCacheSig;
 
-  /// True while the Select+B reflow is in flight. During it the selection cursor
-  /// uses a plain Positioned that tracks the (per-frame changing) card rect
-  /// exactly, so it stays fitted to the card instead of lagging a frame behind.
-  bool _legendAnimating = false;
+  // Selection cursor. The border follows the *selected card's real rendered box*
+  // via a per-card LayerLink + CompositedTransformFollower, so it tracks the card
+  // through scrolling AND the Select+B reflow with zero manual coordinate math.
+  // This is what makes it correct at any scroll depth: a global-model overlay
+  // (selRect.top - scrollOffset) drifts because the culled SliverList doesn't
+  // re-lay off-screen rows when the cards grow, so its scroll accounting diverges
+  // from the model by an amount that accumulates per off-screen row. The follower
+  // sidesteps that entirely — it reads the leader layer's actual position. Links
+  // are created lazily per card index (only cards that get built get one).
+  final Map<int, LayerLink> _cardLinks = {};
+  // Cross-card glide: on a selection change the follower snaps to the new card,
+  // and this controller eases the border from the old card's rect to the new one
+  // (Transform + size) so the cursor still slides between cards. At rest (value 1)
+  // the border sits exactly on the followed card.
+  late final AnimationController _cursorGlide;
+  double _glideFromLeft = 0;
+  double _glideFromTop = 0;
+  double _glideFromWidth = 0;
+  double _glideFromHeight = 0;
 
   // Layout
   List<_CardRect> _cardRects = [];
@@ -448,6 +464,11 @@ class _GamesGridState extends State<GamesGrid> {
       (widget.games.length - 1).clamp(0, 999999),
     );
     _settledIndex = _selectedIndex;
+    _cursorGlide = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+      value: 1, // start settled on the initial card (no glide)
+    );
     _updateCrossAxisCount();
     _initializeGamepad();
     GameLegendVisibility.hidden.addListener(_onLegendVisibilityChanged);
@@ -593,6 +614,9 @@ class _GamesGridState extends State<GamesGrid> {
         0,
         (widget.games.length - 1).clamp(0, 999999),
       );
+      // External selection change (not a local nav): snap the cursor to the new
+      // card rather than gliding from a possibly-unrelated previous position.
+      _cursorGlide.value = 1;
       if (mounted && _scrollController.hasClients) {
         _ensureSelectedVisible();
       }
@@ -632,7 +656,11 @@ class _GamesGridState extends State<GamesGrid> {
   /// future external/DB update). Starts the reflow animation; the flag is
   /// cleared in AnimatedPadding.onEnd.
   void _onLegendVisibilityChanged() {
-    if (mounted) setState(() => _legendAnimating = true);
+    // Rebuild so AnimatedPadding picks up the new indent target and animates the
+    // reflow. The selection cursor needs no special handling here — it follows
+    // the selected card's real box via the LayerLink follower, so it stays fitted
+    // as the card grows/shrinks with no per-frame coordinate correction.
+    if (mounted) setState(() {});
   }
 
   @override
@@ -645,6 +673,7 @@ class _GamesGridState extends State<GamesGrid> {
     GamepadNavigationManager.popLayer('games_grid');
     _gamepadNav.dispose();
     _scrollController.dispose();
+    _cursorGlide.dispose();
     super.dispose();
   }
 
@@ -669,6 +698,7 @@ class _GamesGridState extends State<GamesGrid> {
   void _navDelta(int delta) {
     if (widget.games.isEmpty) return;
     final c = _cols;
+    final from = _selectedIndex;
     setState(() {
       int ni = _selectedIndex + delta;
       if (delta < 0 && ni < 0) {
@@ -684,6 +714,7 @@ class _GamesGridState extends State<GamesGrid> {
       _selectedIndex = ni.clamp(0, widget.games.length - 1);
       _updateFastNav();
     });
+    _beginCursorGlide(from);
     _ensureSelectedVisible();
     _onSelectionChanged();
     SfxService().playNavSound();
@@ -691,6 +722,7 @@ class _GamesGridState extends State<GamesGrid> {
 
   void _navHoriz(int dir) {
     if (widget.games.isEmpty) return;
+    final from = _selectedIndex;
     setState(() {
       int ni;
       if (dir < 0) {
@@ -709,9 +741,32 @@ class _GamesGridState extends State<GamesGrid> {
       _selectedIndex = ni.clamp(0, widget.games.length - 1);
       _updateFastNav();
     });
+    _beginCursorGlide(from);
     _ensureSelectedVisible();
     _onSelectionChanged();
     SfxService().playNavSound();
+  }
+
+  /// Kicks the selection cursor's cross-card glide: snapshot the card we moved
+  /// *from* (its rect, before layout changes) and run the controller. The
+  /// follower is already re-anchored to the new card on the next build, so the
+  /// glide interpolates the border from the old card's box to the new one; at
+  /// rest the border sits exactly on the followed card.
+  void _beginCursorGlide(int fromIndex) {
+    if (fromIndex == _selectedIndex) return;
+    if (fromIndex >= 0 && fromIndex < _cardRects.length) {
+      final r = _cardRects[fromIndex];
+      _glideFromLeft = r.left;
+      _glideFromTop = r.top;
+      _glideFromWidth = r.width;
+      _glideFromHeight = r.height;
+      _cursorGlide.duration = Duration(
+        milliseconds: _isNavigatingFast ? 120 : 300,
+      );
+      _cursorGlide.forward(from: 0);
+    } else {
+      _cursorGlide.value = 1;
+    }
   }
 
   void _onSelectionChanged() {
@@ -773,7 +828,9 @@ class _GamesGridState extends State<GamesGrid> {
     // (debounced) load is pending.
     final selectedRomname = widget.games.isEmpty
         ? null
-        : widget.games[_selectedIndex.clamp(0, widget.games.length - 1)].romname;
+        : widget
+              .games[_selectedIndex.clamp(0, widget.games.length - 1)]
+              .romname;
     if (selectedRomname != _achievementsTargetRomname) {
       _achievementsTargetRomname = selectedRomname;
       _currentGameInfo = null;
@@ -906,203 +963,244 @@ class _GamesGridState extends State<GamesGrid> {
               // the legend and animates this indent to 0 so the cards genuinely
               // reflow to fill the reclaimed 60.r. This drives _computeLayout
               // every frame, but only its cheap _positionCards pass runs (aspect
-              // ratios are cached in _cardHOverW), and the cursor tracks rigidly
-              // while _legendAnimating so it never chases a moving target.
+              // ratios are cached in _cardHOverW). The selection cursor needs no
+              // special handling during the reflow — it follows the selected
+              // card's real box via the LayerLink follower, so it stays fitted as
+              // the card grows with zero coordinate math.
               child: AnimatedPadding(
                 duration: const Duration(milliseconds: 250),
                 curve: Curves.easeOutCubic,
-                onEnd: () {
-                  if (_legendAnimating && mounted) {
-                    setState(() => _legendAnimating = false);
-                  }
-                },
-                padding: EdgeInsets.only(left: GameLegendVisibility.hidden.value ? 0 : 60.r),
+                padding: EdgeInsets.only(
+                  left: GameLegendVisibility.hidden.value ? 0 : 60.r,
+                ),
                 child: LayoutBuilder(
-                builder: (context, constraints) {
-                  _computeLayout(constraints.maxWidth);
+                  builder: (context, constraints) {
+                    _computeLayout(constraints.maxWidth);
 
-                  final theme = Theme.of(context);
-                  final fp = widget.fileProvider;
-                  // Quantize the decode resolution into buckets so the tiny
-                  // per-frame card-width changes during the legend reflow don't
-                  // thrash _GameCardImage into re-decoding every card each frame
-                  // (it reloads whenever targetWidth changes). Also a general win
-                  // for any width change (window resize, card-size cycling).
-                  const decodeBucket = 64;
-                  final bucketed =
-                      ((_cardWidth * 1.5) / decodeBucket).ceil() * decodeBucket;
-                  final targetWidth = bucketed < decodeBucket
-                      ? decodeBucket
-                      : bucketed;
+                    final theme = Theme.of(context);
+                    final fp = widget.fileProvider;
+                    // Quantize the decode resolution into buckets so the tiny
+                    // per-frame card-width changes during the legend reflow don't
+                    // thrash _GameCardImage into re-decoding every card each frame
+                    // (it reloads whenever targetWidth changes). Also a general win
+                    // for any width change (window resize, card-size cycling).
+                    const decodeBucket = 64;
+                    final bucketed =
+                        ((_cardWidth * 1.5) / decodeBucket).ceil() *
+                        decodeBucket;
+                    final targetWidth = bucketed < decodeBucket
+                        ? decodeBucket
+                        : bucketed;
 
-                  final selRect = _selectedIndex < _cardRects.length
-                      ? _cardRects[_selectedIndex]
-                      : _cardRects.first;
-                  final hlDuration = Duration(
-                    milliseconds: _isNavigatingFast ? 120 : 300,
-                  );
+                    final selRect = _selectedIndex < _cardRects.length
+                        ? _cardRects[_selectedIndex]
+                        : _cardRects.first;
 
-                  // Row-cache gate: when the layout/decode/theme signature is
-                  // unchanged, buildRow returns the exact same Row instances it
-                  // built last time, so a selection/settle/RA/legend setState
-                  // that re-runs build() does NOT rebuild the ~50 visible cards
-                  // (Flutter short-circuits identical child widgets). Any real
-                  // change (reflow bumps _layoutGen, width change moves
-                  // targetWidth, theme flips) rotates the signature and rebuilds.
-                  final rowSig =
-                      '$_layoutGen|$targetWidth|${theme.brightness.index}';
-                  if (rowSig != _rowCacheSig) {
-                    _rowCacheSig = rowSig;
-                    _rowCache.clear();
-                  }
+                    // Row-cache gate: when the layout/decode/theme signature is
+                    // unchanged, buildRow returns the exact same Row instances it
+                    // built last time, so a selection/settle/RA/legend setState
+                    // that re-runs build() does NOT rebuild the ~50 visible cards
+                    // (Flutter short-circuits identical child widgets). Any real
+                    // change (reflow bumps _layoutGen, width change moves
+                    // targetWidth, theme flips) rotates the signature and rebuilds.
+                    final rowSig =
+                        '$_layoutGen|$targetWidth|${theme.brightness.index}';
+                    if (rowSig != _rowCacheSig) {
+                      _rowCacheSig = rowSig;
+                      _rowCache.clear();
+                    }
 
-                  Widget buildRow(BuildContext ctx, int rowIndex) {
-                    final cached = _rowCache[rowIndex];
-                    if (cached != null) return cached;
-                    final row = _rows[rowIndex];
-                    final cards = <Widget>[];
-                    for (int j = 0; j < row.count; j++) {
-                      final idx = row.startIndex + j;
-                      final rect = _cardRects[idx];
-                      _ensureDims(idx);
-                      final card = _buildCard(
-                        idx,
-                        rect,
-                        fp,
-                        targetWidth,
-                        theme,
-                      );
-                      cards.add(
-                        SizedBox(
-                          width: rect.width,
-                          height: rect.height,
-                          child: card,
+                    Widget buildRow(BuildContext ctx, int rowIndex) {
+                      final cached = _rowCache[rowIndex];
+                      if (cached != null) return cached;
+                      final row = _rows[rowIndex];
+                      final cards = <Widget>[];
+                      for (int j = 0; j < row.count; j++) {
+                        final idx = row.startIndex + j;
+                        final rect = _cardRects[idx];
+                        _ensureDims(idx);
+                        final card = _buildCard(
+                          idx,
+                          rect,
+                          fp,
+                          targetWidth,
+                          theme,
+                        );
+                        cards.add(
+                          SizedBox(
+                            width: rect.width,
+                            height: rect.height,
+                            // Anchor a per-card LayerLink so the selection cursor
+                            // can follow this card's real rendered box. Links are
+                            // cached per index (stable identity across row-cache
+                            // rebuilds); only built cards get one.
+                            child: CompositedTransformTarget(
+                              link: _cardLinks.putIfAbsent(
+                                idx,
+                                () => LayerLink(),
+                              ),
+                              child: card,
+                            ),
+                          ),
+                        );
+                      }
+                      final built = SizedBox(
+                        height: row.height + _spY,
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: _interleaveSpacing(cards, _spX),
                         ),
                       );
+                      _rowCache[rowIndex] = built;
+                      return built;
                     }
-                    final built = SizedBox(
-                      height: row.height + _spY,
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: _interleaveSpacing(cards, _spX),
+
+                    final borderColor = theme.colorScheme.secondary;
+                    final selLink = _cardLinks[_selectedIndex];
+
+                    return Listener(
+                      onPointerDown: _handlePointerDown,
+                      onPointerMove: _handlePointerMove,
+                      onPointerUp: _handlePointerUp,
+                      onPointerCancel: _handlePointerCancel,
+                      behavior: HitTestBehavior.translucent,
+                      child: Stack(
+                        children: [
+                          CustomScrollView(
+                            controller: _scrollController,
+                            slivers: [
+                              SliverPadding(
+                                padding: EdgeInsets.only(
+                                  top: 12,
+                                  bottom: 80,
+                                  left: 16,
+                                  right: 16,
+                                ),
+                                sliver: SliverList.builder(
+                                  itemCount: _rows.length,
+                                  itemBuilder: buildRow,
+                                ),
+                              ),
+                            ],
+                          ),
+                          // Selection cursor. It follows the selected card's real
+                          // rendered box via a LayerLink, so it tracks the card
+                          // through scrolling AND the Select+B reflow (the card
+                          // grows, the leader layer moves, the border moves with it)
+                          // with no scroll-offset math — which is what kept the old
+                          // overlay drifting a row too low a few rows down. The
+                          // cross-card glide is driven by _cursorGlide: on selection
+                          // change the follower snaps to the new card and the border
+                          // eases from the old card's rect (Transform + size) to a
+                          // snug fit on the new one (translate 0, size == selRect).
+                          // Clip the cursor to the grid viewport. The follower's
+                          // render box is border-sized and sits at the Stack's
+                          // top-left; it only moves to the leader at composite time
+                          // via a layer transform, so the Stack's overflow-based
+                          // clip never fires and the border would otherwise paint
+                          // over the footer when a card scrolls past the bottom edge
+                          // during fast scrolling. An explicit ClipRect always
+                          // clips, regardless of the follower's reported size. The
+                          // Align fills the ClipRect (so it clips at the grid
+                          // bounds) while passing LOOSE constraints to the
+                          // follower — otherwise Positioned.fill's tight grid-sized
+                          // constraints would stretch the border Container to fill
+                          // the whole grid.
+                          if (selLink != null)
+                            Positioned.fill(
+                              child: IgnorePointer(
+                                child: ClipRect(
+                                  child: Align(
+                                    alignment: Alignment.topLeft,
+                                    child: CompositedTransformFollower(
+                                      link: selLink,
+                                      showWhenUnlinked: false,
+                                      targetAnchor: Alignment.topLeft,
+                                      followerAnchor: Alignment.topLeft,
+                                      child: AnimatedBuilder(
+                                        animation: _cursorGlide,
+                                        builder: (_, _) {
+                                          final t = Curves.easeOutQuart
+                                              .transform(_cursorGlide.value);
+                                          final inv = 1 - t;
+                                          final dx =
+                                              (_glideFromLeft - selRect.left) *
+                                              inv;
+                                          final dy =
+                                              (_glideFromTop - selRect.top) *
+                                              inv;
+                                          final w =
+                                              _glideFromWidth +
+                                              (selRect.width -
+                                                      _glideFromWidth) *
+                                                  t;
+                                          final h =
+                                              _glideFromHeight +
+                                              (selRect.height -
+                                                      _glideFromHeight) *
+                                                  t;
+                                          return Transform.translate(
+                                            offset: Offset(dx, dy),
+                                            child: Container(
+                                              width: w,
+                                              height: h,
+                                              decoration: BoxDecoration(
+                                                border: Border.all(
+                                                  color: borderColor,
+                                                  width: 4.r,
+                                                ),
+                                                borderRadius:
+                                                    BorderRadius.circular(12.r),
+                                              ),
+                                            ),
+                                          );
+                                        },
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ValueListenableBuilder<String?>(
+                            valueListenable: _cardSizeLabel,
+                            builder: (context, label, child) => AnimatedOpacity(
+                              opacity: label != null ? 1.0 : 0.0,
+                              duration: const Duration(milliseconds: 200),
+                              child: IgnorePointer(
+                                child: Center(
+                                  child: label != null
+                                      ? Container(
+                                          padding: EdgeInsets.symmetric(
+                                            horizontal: 20.r,
+                                            vertical: 10.r,
+                                          ),
+                                          decoration: BoxDecoration(
+                                            color: theme.colorScheme.primary
+                                                .withValues(alpha: 0.9),
+                                            borderRadius: BorderRadius.circular(
+                                              24.r,
+                                            ),
+                                          ),
+                                          child: Text(
+                                            label,
+                                            style: TextStyle(
+                                              color:
+                                                  theme.colorScheme.onPrimary,
+                                              fontSize: 18.r,
+                                              fontWeight: FontWeight.w800,
+                                              letterSpacing: 2.r,
+                                            ),
+                                          ),
+                                        )
+                                      : const SizedBox.shrink(),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     );
-                    _rowCache[rowIndex] = built;
-                    return built;
-                  }
-
-                  final cursorOverlay = ListenableBuilder(
-                    listenable: _scrollController,
-                    builder: (_, child) {
-                      final offset = _scrollController.hasClients
-                          ? _scrollController.offset
-                          : 0.0;
-                      return Transform.translate(
-                        offset: Offset(0, -offset),
-                        child: IgnorePointer(
-                          child: Container(
-                            decoration: BoxDecoration(
-                              border: Border.all(
-                                color: theme.colorScheme.secondary,
-                                width: 4.r,
-                              ),
-                              borderRadius: BorderRadius.circular(12.r),
-                            ),
-                          ),
-                        ),
-                      );
-                    },
-                  );
-
-                  return Listener(
-                    onPointerDown: _handlePointerDown,
-                    onPointerMove: _handlePointerMove,
-                    onPointerUp: _handlePointerUp,
-                    onPointerCancel: _handlePointerCancel,
-                    behavior: HitTestBehavior.translucent,
-                    child: Stack(
-                      children: [
-                        CustomScrollView(
-                          controller: _scrollController,
-                          slivers: [
-                            SliverPadding(
-                              padding: EdgeInsets.only(
-                                top: 12,
-                                bottom: 80,
-                                left: 16,
-                                right: 16,
-                              ),
-                              sliver: SliverList.builder(
-                                itemCount: _rows.length,
-                                itemBuilder: buildRow,
-                              ),
-                            ),
-                          ],
-                        ),
-                        // Selection cursor. During the reflow the card rect
-                        // changes every frame; a plain Positioned matches it
-                        // exactly, whereas AnimatedPositioned — even at zero
-                        // duration — evaluates through its controller and renders
-                        // a frame behind, looking mis-sized. Normal navigation
-                        // keeps the eased AnimatedPositioned.
-                        _legendAnimating
-                            ? Positioned(
-                                key: const ValueKey('game_selector'),
-                                left: selRect.left + 16,
-                                top: selRect.top + 12,
-                                width: selRect.width,
-                                height: selRect.height,
-                                child: cursorOverlay,
-                              )
-                            : AnimatedPositioned(
-                                key: const ValueKey('game_selector'),
-                                duration: hlDuration,
-                                curve: Curves.easeOutQuart,
-                                left: selRect.left + 16,
-                                top: selRect.top + 12,
-                                width: selRect.width,
-                                height: selRect.height,
-                                child: cursorOverlay,
-                              ),
-                        ValueListenableBuilder<String?>(
-                          valueListenable: _cardSizeLabel,
-                          builder: (context, label, child) => AnimatedOpacity(
-                            opacity: label != null ? 1.0 : 0.0,
-                            duration: const Duration(milliseconds: 200),
-                            child: IgnorePointer(
-                              child: Center(
-                                child: label != null
-                                    ? Container(
-                                        padding: EdgeInsets.symmetric(
-                                          horizontal: 20.r,
-                                          vertical: 10.r,
-                                        ),
-                                        decoration: BoxDecoration(
-                                          color: theme.colorScheme.primary
-                                              .withValues(alpha: 0.9),
-                                          borderRadius: BorderRadius.circular(
-                                            24.r,
-                                          ),
-                                        ),
-                                        child: Text(
-                                          label,
-                                          style: TextStyle(
-                                            color: theme.colorScheme.onPrimary,
-                                            fontSize: 18.r,
-                                            fontWeight: FontWeight.w800,
-                                            letterSpacing: 2.r,
-                                          ),
-                                        ),
-                                      )
-                                    : const SizedBox.shrink(),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  );
-                },
+                  },
                 ),
               ),
             ),
@@ -1156,18 +1254,18 @@ class _GamesGridState extends State<GamesGrid> {
     // Positioning/visibility is applied at the Stack level (AnimatedPositioned)
     // so Select + B can animate it without invalidating this memoized subtree.
     _chromeLegend = Consumer<SyncManager>(
-        builder: (context, syncManager, child) => GameActionButtons(
-          system: widget.system,
-          selectedGame: settledGame,
-          syncProvider: syncManager.active,
-          onBack: widget.onBack,
-          onFavorite: widget.onFavorite,
-          onViewMode: () =>
-              GameViewModeDropdown.globalKey.currentState?.showDropdown(),
-          onSettings: widget.onSettings ?? () {},
-          onRandom: widget.onRandom,
-          onScrape: widget.onScrape,
-        ),
+      builder: (context, syncManager, child) => GameActionButtons(
+        system: widget.system,
+        selectedGame: settledGame,
+        syncProvider: syncManager.active,
+        onBack: widget.onBack,
+        onFavorite: widget.onFavorite,
+        onViewMode: () =>
+            GameViewModeDropdown.globalKey.currentState?.showDropdown(),
+        onSettings: widget.onSettings ?? () {},
+        onRandom: widget.onRandom,
+        onScrape: widget.onScrape,
+      ),
     );
   }
 
@@ -1199,10 +1297,12 @@ class _GamesGridState extends State<GamesGrid> {
     return GestureDetector(
       key: ValueKey('game_${game.romname}'),
       onTap: () {
+        final from = _selectedIndex;
         setState(() {
           _selectedIndex = index;
           _settledIndex = index; // discrete tap: update chrome immediately
         });
+        _beginCursorGlide(from);
         _settleTimer?.cancel();
         widget.onGameSelected(game);
         _scheduleAchievementsLoad();
@@ -1316,10 +1416,12 @@ class _GamesGridState extends State<GamesGrid> {
     return GestureDetector(
       key: ValueKey('game_${game.romname}'),
       onTap: () {
+        final from = _selectedIndex;
         setState(() {
           _selectedIndex = index;
           _settledIndex = index; // discrete tap: update chrome immediately
         });
+        _beginCursorGlide(from);
         _settleTimer?.cancel();
         widget.onGameSelected(game);
         _scheduleAchievementsLoad();
@@ -1454,7 +1556,6 @@ class _GamesGridState extends State<GamesGrid> {
       ),
     );
   }
-
 }
 
 // ---- Card image with lazy loading ----

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -880,6 +880,7 @@ class _GamesGridState extends State<GamesGrid> {
             onViewMode: () =>
                 GameViewModeDropdown.globalKey.currentState?.showDropdown(),
             onSettings: widget.onSettings ?? () {},
+            onRandom: widget.onRandom,
           ),
         ),
       ],

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -144,6 +144,14 @@ class _GamesGridState extends State<GamesGrid> {
   // is always brought back into view. Steady scroll and dpad nav never set it
   // (nav scrolls via _ensureSelectedVisible).
   bool _recenterAfterLayout = false;
+  // When the pending recenter is instant (jumpTo) vs animated (animateTo).
+  // Only a legend toggle sets this: it keeps the same column count, so the
+  // selected card barely moves and jumpTo lands it dead-centre in one frame.
+  // Column-count changes (card-size cycle, pinch) and fanart↔box2d switches
+  // move the card many rows — a far jump that jumpTo would clamp short against
+  // the SliverList's under-reported extent, so those animate through instead
+  // (the scroll builds the intermediate rows so the true target is reachable).
+  bool _recenterInstant = false;
 
   // Per-card height/width ratio (aspect), which is INDEPENDENT of the card
   // width. Measuring it is the expensive part of layout (file-header reads +
@@ -667,6 +675,7 @@ class _GamesGridState extends State<GamesGrid> {
   void _onLegendVisibilityChanged() {
     if (!mounted) return;
     _recenterAfterLayout = true;
+    _recenterInstant = true; // same-column reflow: snap instantly, no drift
     setState(() {});
   }
 
@@ -688,15 +697,37 @@ class _GamesGridState extends State<GamesGrid> {
     );
   }
 
-  /// Jumps the scroll so the selected card sits at the vertical centre of the
-  /// viewport. The card (and its in-cell cursor) is the source of truth; this is
-  /// how the view follows it after any layout change. A card already centred
-  /// jumps to its own offset (a no-op), so there's no gratuitous movement.
+  /// Scrolls so the selected card sits at the vertical centre of the viewport.
+  /// The card (and its in-cell cursor) is the source of truth; this is how the
+  /// view follows it after any non-scroll layout change.
+  ///
+  /// Two modes, picked by [_recenterInstant]:
+  ///  • Instant (jumpTo) — a legend toggle. The column count is unchanged, so
+  ///    the selected card barely moves; snapping in the same frame keeps the
+  ///    cursor glued with no drift.
+  ///  • Animated (animateTo) — a card-size cycle, pinch, or fanart↔box2d
+  ///    switch. These move the card many rows (a far jump). jumpTo would be
+  ///    clamped short by the SliverList's under-reported max extent (it hasn't
+  ///    built the distant rows yet), landing on a view that doesn't even
+  ///    contain the card. animateTo scrolls THROUGH the intermediate offsets so
+  ///    the sliver builds rows along the way and its extent grows until the true
+  ///    centre is reachable — the same path wrap-around nav takes.
   void _centerOnSelected() {
     if (!_scrollController.hasClients || _cardRects.isEmpty) return;
+    final instant = _recenterInstant;
+    _recenterInstant = false;
     final rect = _cardRects[_selectedIndex.clamp(0, _cardRects.length - 1)];
     final viewportH = _scrollController.position.viewportDimension;
-    _scrollController.jumpTo(_centerTargetFor(rect, viewportH));
+    final target = _centerTargetFor(rect, viewportH);
+    if (instant) {
+      _scrollController.jumpTo(target);
+    } else {
+      _scrollController.animateTo(
+        target,
+        duration: const Duration(milliseconds: 350),
+        curve: Curves.easeOutCubic,
+      );
+    }
   }
 
   @override

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -100,6 +100,23 @@ class _GamesGridState extends State<GamesGrid> {
   Widget? _chromeFooter;
   Widget? _chromeLegend;
 
+  // Memoized grid rows. buildRow→_buildCard is a pure function of layout
+  // (`_layoutGen`), `targetWidth`, `theme`, and per-card favorite/scrape state —
+  // it never reads `_selectedIndex` (selection is drawn by the Positioned cursor
+  // overlay). So on a steady scroll the rows are identical across a settle /
+  // RA-load / legend-animating setState, yet an un-memoized SliverList.builder
+  // rebuilds all ~50 visible cards each time (profile-build VM timeline measured
+  // ~5 full-viewport rebuilds per scroll = 22–31 ms UI-thread BUILD spikes; the
+  // raster pipeline stays <5 ms). Cache built rows by index and gate on a cheap
+  // signature so those setStates return identical Row instances and Flutter
+  // skips the whole subtree. `_layoutGen` bumps whenever _positionCards actually
+  // re-runs (width/reflow/dim-reload), so the legend reflow still rebuilds while
+  // steady scroll does not. The cache is also cleared in didUpdateWidget when the
+  // game set or scrape state changes (favorite stars / scrape progress overlays).
+  int _layoutGen = 0;
+  final Map<int, Widget> _rowCache = {};
+  String? _rowCacheSig;
+
   /// True while the Select+B reflow is in flight. During it the selection cursor
   /// uses a plain Positioned that tracks the (per-frame changing) card rect
   /// exactly, so it stays fitted to the card instead of lagging a frame behind.
@@ -113,8 +130,16 @@ class _GamesGridState extends State<GamesGrid> {
   double _spY = 0;
   double? _lastLayoutWidth;
   int? _lastLayoutCols;
-  int? _lastLayoutGameCount;
   bool? _lastIsFanart;
+
+  // Per-card height/width ratio (aspect), which is INDEPENDENT of the card
+  // width. Measuring it is the expensive part of layout (file-header reads +
+  // string parsing per game), so it is cached here and only recomputed when the
+  // game set / column count / fanart mode / loaded dimensions change — never on
+  // a mere width change. That lets the Select+B reflow animate the width with
+  // cheap per-frame arithmetic instead of re-measuring every card each frame.
+  List<double> _cardHOverW = [];
+  bool _needsMeasure = true;
 
   // Image dimension cache
   static final Map<String, Size?> _imageSizeCache = {};
@@ -254,8 +279,12 @@ class _GamesGridState extends State<GamesGrid> {
     });
   }
 
-  double _cardHeightFor(int index) {
-    if (_isFanart) return _cardWidth;
+  /// Height/width ratio for a card, INDEPENDENT of the current card width.
+  /// This is the expensive lookup (DB string parse or image-header read) that
+  /// [_measureCards] caches into [_cardHOverW]. Note `_cardHeightFor(i)` equals
+  /// `_cardWidth * _heightRatioFor(i)`.
+  double _heightRatioFor(int index) {
+    if (_isFanart) return 1.0;
 
     final game = widget.games[index];
     // 1. From DB
@@ -265,7 +294,7 @@ class _GamesGridState extends State<GamesGrid> {
         final w = double.tryParse(parts[0]);
         final h = double.tryParse(parts[1]);
         if (w != null && h != null && w > 0 && h > 0) {
-          return _cardWidth / (w / h);
+          return h / w;
         }
       }
     }
@@ -276,27 +305,59 @@ class _GamesGridState extends State<GamesGrid> {
       // Save to DB for next time
       final ratio = '${size.width.toInt()}/${size.height.toInt()}';
       _scheduleAspectRatioSave(game, ratio);
-      return _cardWidth / (size.width / size.height);
+      return size.height / size.width;
     }
-    return _cardWidth; // 1:1 fallback
+    return 1.0; // 1:1 fallback
   }
 
-  // ---- Layout (computed once, cached) ----
-  bool _needsLayout(double w) =>
-      _lastLayoutWidth != w ||
-      _lastLayoutCols != _cols ||
-      _lastLayoutGameCount != widget.games.length ||
-      _lastIsFanart != _isFanart ||
-      _needsDimReload;
+  /// Measures every card's aspect ratio into [_cardHOverW]. This is the only
+  /// O(n) width-INDEPENDENT pass and is deliberately kept out of the per-frame
+  /// path so a width animation (Select+B reflow) never re-reads image headers.
+  void _measureCards() {
+    final n = widget.games.length;
+    _cardHOverW = List<double>.filled(n, 1.0);
+    _loadedDims.clear();
+    if (!_isFanart) {
+      for (int i = 0; i < n; i++) {
+        _cardHOverW[i] = _heightRatioFor(i);
+        if (_imageSizeCache.containsKey(_box2dPath(i))) _loadedDims.add(i);
+      }
+    }
+    _needsMeasure = false;
+  }
+
+  // ---- Layout ----
+  // Aspect ratios (the costly part) are measured/cached separately; positioning
+  // for a given width is cheap arithmetic so it can run every animation frame.
 
   void _computeLayout(double availableWidth) {
-    if (!_needsLayout(availableWidth)) return;
+    final measureChanged =
+        _needsMeasure ||
+        _cardHOverW.length != widget.games.length ||
+        _lastIsFanart != _isFanart ||
+        _needsDimReload;
+
+    if (!measureChanged &&
+        _lastLayoutWidth == availableWidth &&
+        _lastLayoutCols == _cols) {
+      return;
+    }
+
+    if (measureChanged) {
+      _measureCards();
+      _needsDimReload = false;
+    }
+
     _lastLayoutWidth = availableWidth;
     _lastLayoutCols = _cols;
-    _lastLayoutGameCount = widget.games.length;
     _lastIsFanart = _isFanart;
-    _needsDimReload = false;
 
+    _positionCards(availableWidth);
+  }
+
+  /// Cheap positioning pass: turns cached aspect ratios + a target width into
+  /// card rects and row bounds. No image reads, one allocation per card.
+  void _positionCards(double availableWidth) {
     final spX = 6.0.r;
     final spY = 6.0.r;
     _spX = spX;
@@ -305,64 +366,58 @@ class _GamesGridState extends State<GamesGrid> {
     final totalWidth = availableWidth - 32;
     _cardWidth = (totalWidth - (_cols - 1) * spX) / _cols;
     final n = widget.games.length;
-    _cardRects = List.generate(
-      n,
-      (_) => _CardRect(left: 0, top: 0, width: _cardWidth, height: _cardWidth),
-    ); // placeholder
-    _loadedDims.clear();
+    final rowCount = _cols > 0 ? (n + _cols - 1) ~/ _cols : 0;
 
-    if (_isFanart) {
-      double y = 0;
-      final rows = <_RowInfo>[];
-      for (int i = 0; i < n; i += _cols) {
-        final end = (i + _cols).clamp(0, n);
-        final count = end - i;
-        rows.add(
-          _RowInfo(topY: y, height: _cardWidth, startIndex: i, count: count),
-        );
-        for (int idx = i; idx < end; idx++) {
-          final col = idx % _cols;
-          _cardRects[idx] = _CardRect(
-            left: col * (_cardWidth + spX),
-            top: y + spY / 2,
-            width: _cardWidth,
-            height: _cardWidth,
-          );
-        }
-        y += _cardWidth + spY;
-      }
-      _rows = rows;
-      return; // fanart path done
+    // Reuse the existing buffers when the counts are unchanged (the common case
+    // while the reflow animates), mutating rects in place so a width change
+    // allocates nothing.
+    if (_cardRects.length != n) {
+      _cardRects = List.generate(
+        n,
+        (_) => _CardRect(left: 0, top: 0, width: 0, height: 0),
+      );
+    }
+    if (_rows.length != rowCount) {
+      _rows = List.generate(
+        rowCount,
+        (_) => _RowInfo(topY: 0, height: 0, startIndex: 0, count: 0),
+      );
     }
 
-    // First pass: use the static cache to get known dimensions fast
     double y = 0;
     int i = 0;
-    final rows = <_RowInfo>[];
+    int r = 0;
     while (i < n) {
-      double maxH = 0;
       final end = (i + _cols).clamp(0, n);
-      final count = end - i;
+      double maxH = 0;
       for (int idx = i; idx < end; idx++) {
-        final h = _cardHeightFor(idx);
+        final h = _cardHOverW[idx] * _cardWidth;
         if (h > maxH) maxH = h;
       }
-      rows.add(_RowInfo(topY: y, height: maxH, startIndex: i, count: count));
+      final row = _rows[r];
+      row.topY = y;
+      row.height = maxH;
+      row.startIndex = i;
+      row.count = end - i;
       for (int idx = i; idx < end; idx++) {
         final col = idx % _cols;
-        final h = _cardHeightFor(idx);
-        _cardRects[idx] = _CardRect(
-          left: col * (_cardWidth + spX),
-          top: y + (maxH + spY - h) / 2,
-          width: _cardWidth,
-          height: h,
-        );
-        if (_imageSizeCache.containsKey(_box2dPath(idx))) _loadedDims.add(idx);
+        final h = _cardHOverW[idx] * _cardWidth;
+        final rect = _cardRects[idx];
+        rect.left = col * (_cardWidth + spX);
+        rect.top = y + (maxH + spY - h) / 2;
+        rect.width = _cardWidth;
+        rect.height = h;
       }
       y += maxH + spY;
       i = end;
+      r++;
     }
-    _rows = rows;
+
+    // Card rects/rows just changed → any memoized row widgets are stale.
+    // Bumping the generation invalidates the row cache on the next build (see
+    // _rowCache). This runs on every reflow frame (intended) but NOT during a
+    // steady scroll, where _computeLayout early-returns without calling us.
+    _layoutGen++;
   }
 
   // Lazy dimension loading for newly visible cards
@@ -520,6 +575,18 @@ class _GamesGridState extends State<GamesGrid> {
     _updateCrossAxisCount();
     if (widget.games != oldWidget.games || _crossAxisCount != prevCols) {
       _lastLayoutWidth = null;
+      // Aspect-ratio cache is keyed by index; a changed game set (even at the
+      // same length) must be re-measured.
+      if (widget.games != oldWidget.games) _needsMeasure = true;
+    }
+    // Row memoization depends on per-card favorite/scrape state, which arrives
+    // via these props. Any change means the cached rows may be stale, so drop
+    // them (a changed game set / cols also invalidates via _layoutGen, but the
+    // scrape props do not touch layout — clear explicitly).
+    if (widget.games != oldWidget.games ||
+        widget.scrapingGameRomnames != oldWidget.scrapingGameRomnames ||
+        widget.scrapeProgress != oldWidget.scrapeProgress) {
+      _rowCache.clear();
     }
     if (widget.selectedIndex != oldWidget.selectedIndex) {
       _selectedIndex = widget.selectedIndex.clamp(
@@ -836,9 +903,11 @@ class _GamesGridState extends State<GamesGrid> {
             Expanded(
               // Indent the grid to clear the vertical legend on the left; the
               // reduced width makes the cards slightly smaller. Select + B hides
-              // the legend and animates this indent to 0 so the cards reflow to
-              // fill the reclaimed 60.r. The cursor tracks the card rect while
-              // _legendAnimating so it stays fitted during the reflow.
+              // the legend and animates this indent to 0 so the cards genuinely
+              // reflow to fill the reclaimed 60.r. This drives _computeLayout
+              // every frame, but only its cheap _positionCards pass runs (aspect
+              // ratios are cached in _cardHOverW), and the cursor tracks rigidly
+              // while _legendAnimating so it never chases a moving target.
               child: AnimatedPadding(
                 duration: const Duration(milliseconds: 250),
                 curve: Curves.easeOutCubic,
@@ -854,7 +923,17 @@ class _GamesGridState extends State<GamesGrid> {
 
                   final theme = Theme.of(context);
                   final fp = widget.fileProvider;
-                  final targetWidth = (_cardWidth * 1.5).toInt();
+                  // Quantize the decode resolution into buckets so the tiny
+                  // per-frame card-width changes during the legend reflow don't
+                  // thrash _GameCardImage into re-decoding every card each frame
+                  // (it reloads whenever targetWidth changes). Also a general win
+                  // for any width change (window resize, card-size cycling).
+                  const decodeBucket = 64;
+                  final bucketed =
+                      ((_cardWidth * 1.5) / decodeBucket).ceil() * decodeBucket;
+                  final targetWidth = bucketed < decodeBucket
+                      ? decodeBucket
+                      : bucketed;
 
                   final selRect = _selectedIndex < _cardRects.length
                       ? _cardRects[_selectedIndex]
@@ -863,7 +942,23 @@ class _GamesGridState extends State<GamesGrid> {
                     milliseconds: _isNavigatingFast ? 120 : 300,
                   );
 
+                  // Row-cache gate: when the layout/decode/theme signature is
+                  // unchanged, buildRow returns the exact same Row instances it
+                  // built last time, so a selection/settle/RA/legend setState
+                  // that re-runs build() does NOT rebuild the ~50 visible cards
+                  // (Flutter short-circuits identical child widgets). Any real
+                  // change (reflow bumps _layoutGen, width change moves
+                  // targetWidth, theme flips) rotates the signature and rebuilds.
+                  final rowSig =
+                      '$_layoutGen|$targetWidth|${theme.brightness.index}';
+                  if (rowSig != _rowCacheSig) {
+                    _rowCacheSig = rowSig;
+                    _rowCache.clear();
+                  }
+
                   Widget buildRow(BuildContext ctx, int rowIndex) {
+                    final cached = _rowCache[rowIndex];
+                    if (cached != null) return cached;
                     final row = _rows[rowIndex];
                     final cards = <Widget>[];
                     for (int j = 0; j < row.count; j++) {
@@ -885,13 +980,15 @@ class _GamesGridState extends State<GamesGrid> {
                         ),
                       );
                     }
-                    return SizedBox(
+                    final built = SizedBox(
                       height: row.height + _spY,
                       child: Row(
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: _interleaveSpacing(cards, _spX),
                       ),
                     );
+                    _rowCache[rowIndex] = built;
+                    return built;
                   }
 
                   final cursorOverlay = ListenableBuilder(
@@ -1376,6 +1473,13 @@ class _GameCardImage extends StatefulWidget {
 }
 
 class _GameCardImageState extends State<_GameCardImage> {
+  // Process-wide cache of box2d-path existence. Fast dpad scroll recreates a
+  // card's `_GameCardImage` every time it re-enters the viewport (keyed by
+  // romname), and each creation used to fire a synchronous `existsSync()`
+  // syscall on the UI thread. Caching the boolean keeps re-scroll off the
+  // filesystem entirely.
+  static final Map<String, bool> _existsCache = {};
+
   ImageProvider? _imageProvider;
   bool _exists = false;
   bool _checked = false;
@@ -1383,7 +1487,8 @@ class _GameCardImageState extends State<_GameCardImage> {
   @override
   void initState() {
     super.initState();
-    _resolve();
+    // Pre-first-build: resolve synchronously without a redundant setState.
+    _computeResolve();
   }
 
   @override
@@ -1398,21 +1503,28 @@ class _GameCardImageState extends State<_GameCardImage> {
     }
   }
 
+  /// Populate `_exists`/`_imageProvider` for the current box2d path. Returns
+  /// true if any field changed. Callers decide whether a setState is needed
+  /// (initState resolves before the first build, so it skips setState).
+  bool _computeResolve() {
+    if (_checked) return false;
+    final path = widget.box2dPath;
+    final exists = _existsCache[path] ??= File(path).existsSync();
+    _checked = true;
+    _exists = exists;
+    if (exists) {
+      _imageProvider = ResizeImage(
+        FileImage(File(path)),
+        width: widget.targetWidth,
+        allowUpscaling: false,
+      );
+    }
+    return true;
+  }
+
   void _resolve() {
-    if (_checked) return;
-    final exists = File(widget.box2dPath).existsSync();
-    if (!mounted) return;
-    setState(() {
-      _checked = true;
-      _exists = exists;
-      if (exists) {
-        _imageProvider = ResizeImage(
-          FileImage(File(widget.box2dPath)),
-          width: widget.targetWidth,
-          allowUpscaling: false,
-        );
-      }
-    });
+    if (!_computeResolve() || !mounted) return;
+    setState(() {});
   }
 
   @override
@@ -1484,12 +1596,14 @@ class _Placeholder extends StatelessWidget {
   }
 }
 
+// Mutable so [_positionCards] can update a reused buffer in place — a width
+// change (the Select+B reflow) then allocates nothing per frame.
 class _RowInfo {
-  final double topY;
-  final double height;
-  final int startIndex;
-  final int count;
-  const _RowInfo({
+  double topY;
+  double height;
+  int startIndex;
+  int count;
+  _RowInfo({
     required this.topY,
     required this.height,
     required this.startIndex,
@@ -1498,8 +1612,8 @@ class _RowInfo {
 }
 
 class _CardRect {
-  final double left, top, width, height;
-  const _CardRect({
+  double left, top, width, height;
+  _CardRect({
     required this.left,
     required this.top,
     required this.width,

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -14,6 +14,7 @@ import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:neostation/utils/game_utils.dart';
 import 'package:neostation/widgets/game_view_mode_dropdown.dart';
 import 'package:neostation/widgets/game_action_buttons.dart';
+import 'package:neostation/services/game_legend_visibility.dart';
 import 'package:neostation/sync/sync_manager.dart';
 import 'package:neostation/services/game_service.dart';
 import 'package:neostation/repositories/game_repository.dart';
@@ -98,6 +99,11 @@ class _GamesGridState extends State<GamesGrid> {
   String? _chromeSig;
   Widget? _chromeFooter;
   Widget? _chromeLegend;
+
+  /// True while the Select+B reflow is in flight. During it the selection cursor
+  /// uses a plain Positioned that tracks the (per-frame changing) card rect
+  /// exactly, so it stays fitted to the card instead of lagging a frame behind.
+  bool _legendAnimating = false;
 
   // Layout
   List<_CardRect> _cardRects = [];
@@ -230,6 +236,24 @@ class _GamesGridState extends State<GamesGrid> {
       context.read<SqliteConfigProvider>().config.gameCarouselCardStyle ==
       'fanart';
 
+  final Set<String> _pendingSaves = {};
+  void _scheduleAspectRatioSave(GameModel game, String ratio) {
+    final key = '${game.systemId}_${game.romname}';
+    if (_pendingSaves.contains(key)) return;
+    _pendingSaves.add(key);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _pendingSaves.remove(key);
+      if (game.systemId != null) {
+        GameRepository.updateBox2dAspectRatio(
+          game.systemId!,
+          game.romname,
+          ratio,
+        );
+      }
+    });
+  }
+
   double _cardHeightFor(int index) {
     if (_isFanart) return _cardWidth;
 
@@ -255,24 +279,6 @@ class _GamesGridState extends State<GamesGrid> {
       return _cardWidth / (size.width / size.height);
     }
     return _cardWidth; // 1:1 fallback
-  }
-
-  final Set<String> _pendingSaves = {};
-  void _scheduleAspectRatioSave(GameModel game, String ratio) {
-    final key = '${game.systemId}_${game.romname}';
-    if (_pendingSaves.contains(key)) return;
-    _pendingSaves.add(key);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      _pendingSaves.remove(key);
-      if (game.systemId != null) {
-        GameRepository.updateBox2dAspectRatio(
-          game.systemId!,
-          game.romname,
-          ratio,
-        );
-      }
-    });
   }
 
   // ---- Layout (computed once, cached) ----
@@ -389,6 +395,7 @@ class _GamesGridState extends State<GamesGrid> {
     _settledIndex = _selectedIndex;
     _updateCrossAxisCount();
     _initializeGamepad();
+    GameLegendVisibility.hidden.addListener(_onLegendVisibilityChanged);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -541,8 +548,24 @@ class _GamesGridState extends State<GamesGrid> {
       },
       onLeftStickClick: widget.onRandom,
       onSelectButton: widget.onScrape,
+      onSelectModifierB: _toggleLegend, // Select + B - Hide/show legend.
       onSettings: widget.onSettings,
     );
+  }
+
+  /// Select + B — toggles the (session-global) vertical action-button legend.
+  /// When hidden the legend slides off the left edge and the grid reflows into
+  /// the 60.r gutter.
+  void _toggleLegend() {
+    SfxService().playNavSound();
+    GameLegendVisibility.toggle();
+  }
+
+  /// Reacts to any change of the shared legend flag (this view's chord or a
+  /// future external/DB update). Starts the reflow animation; the flag is
+  /// cleared in AnimatedPadding.onEnd.
+  void _onLegendVisibilityChanged() {
+    if (mounted) setState(() => _legendAnimating = true);
   }
 
   @override
@@ -551,6 +574,7 @@ class _GamesGridState extends State<GamesGrid> {
     _achievementsDebounce?.cancel();
     _settleTimer?.cancel();
     _cardSizeLabel.dispose();
+    GameLegendVisibility.hidden.removeListener(_onLegendVisibilityChanged);
     GamepadNavigationManager.popLayer('games_grid');
     _gamepadNav.dispose();
     _scrollController.dispose();
@@ -811,9 +835,19 @@ class _GamesGridState extends State<GamesGrid> {
           children: [
             Expanded(
               // Indent the grid to clear the vertical legend on the left; the
-              // reduced width makes the cards slightly smaller.
-              child: Padding(
-                padding: EdgeInsets.only(left: 60.r),
+              // reduced width makes the cards slightly smaller. Select + B hides
+              // the legend and animates this indent to 0 so the cards reflow to
+              // fill the reclaimed 60.r. The cursor tracks the card rect while
+              // _legendAnimating so it stays fitted during the reflow.
+              child: AnimatedPadding(
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.easeOutCubic,
+                onEnd: () {
+                  if (_legendAnimating && mounted) {
+                    setState(() => _legendAnimating = false);
+                  }
+                },
+                padding: EdgeInsets.only(left: GameLegendVisibility.hidden.value ? 0 : 60.r),
                 child: LayoutBuilder(
                 builder: (context, constraints) {
                   _computeLayout(constraints.maxWidth);
@@ -860,6 +894,29 @@ class _GamesGridState extends State<GamesGrid> {
                     );
                   }
 
+                  final cursorOverlay = ListenableBuilder(
+                    listenable: _scrollController,
+                    builder: (_, child) {
+                      final offset = _scrollController.hasClients
+                          ? _scrollController.offset
+                          : 0.0;
+                      return Transform.translate(
+                        offset: Offset(0, -offset),
+                        child: IgnorePointer(
+                          child: Container(
+                            decoration: BoxDecoration(
+                              border: Border.all(
+                                color: theme.colorScheme.secondary,
+                                width: 4.r,
+                              ),
+                              borderRadius: BorderRadius.circular(12.r),
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  );
+
                   return Listener(
                     onPointerDown: _handlePointerDown,
                     onPointerMove: _handlePointerMove,
@@ -885,37 +942,31 @@ class _GamesGridState extends State<GamesGrid> {
                             ),
                           ],
                         ),
-                        AnimatedPositioned(
-                          key: const ValueKey('game_selector'),
-                          duration: hlDuration,
-                          curve: Curves.easeOutQuart,
-                          left: selRect.left + 16,
-                          top: selRect.top + 12,
-                          width: selRect.width,
-                          height: selRect.height,
-                          child: ListenableBuilder(
-                            listenable: _scrollController,
-                            builder: (_, child) {
-                              final offset = _scrollController.hasClients
-                                  ? _scrollController.offset
-                                  : 0.0;
-                              return Transform.translate(
-                                offset: Offset(0, -offset),
-                                child: IgnorePointer(
-                                  child: Container(
-                                    decoration: BoxDecoration(
-                                      border: Border.all(
-                                        color: theme.colorScheme.secondary,
-                                        width: 4.r,
-                                      ),
-                                      borderRadius: BorderRadius.circular(12.r),
-                                    ),
-                                  ),
-                                ),
-                              );
-                            },
-                          ),
-                        ),
+                        // Selection cursor. During the reflow the card rect
+                        // changes every frame; a plain Positioned matches it
+                        // exactly, whereas AnimatedPositioned — even at zero
+                        // duration — evaluates through its controller and renders
+                        // a frame behind, looking mis-sized. Normal navigation
+                        // keeps the eased AnimatedPositioned.
+                        _legendAnimating
+                            ? Positioned(
+                                key: const ValueKey('game_selector'),
+                                left: selRect.left + 16,
+                                top: selRect.top + 12,
+                                width: selRect.width,
+                                height: selRect.height,
+                                child: cursorOverlay,
+                              )
+                            : AnimatedPositioned(
+                                key: const ValueKey('game_selector'),
+                                duration: hlDuration,
+                                curve: Curves.easeOutQuart,
+                                left: selRect.left + 16,
+                                top: selRect.top + 12,
+                                width: selRect.width,
+                                height: selRect.height,
+                                child: cursorOverlay,
+                              ),
                         ValueListenableBuilder<String?>(
                           valueListenable: _cardSizeLabel,
                           builder: (context, label, child) => AnimatedOpacity(
@@ -965,8 +1016,19 @@ class _GamesGridState extends State<GamesGrid> {
           ],
         ),
         // Vertical action-button legend (shared with the game list view);
-        // also memoized on the settled selection.
-        _chromeLegend!,
+        // also memoized on the settled selection. Select + B slides it off the
+        // left edge (in sync with the grid's Transform slide).
+        AnimatedPositioned(
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeOutCubic,
+          top: 12.r,
+          left: GameLegendVisibility.hidden.value ? -60.r : 12.r,
+          child: AnimatedOpacity(
+            duration: const Duration(milliseconds: 250),
+            opacity: GameLegendVisibility.hidden.value ? 0.0 : 1.0,
+            child: _chromeLegend!,
+          ),
+        ),
       ],
     );
   }
@@ -994,10 +1056,9 @@ class _GamesGridState extends State<GamesGrid> {
       currentGameInfo: _currentGameInfo,
       onShowAchievements: _showAchievementsDialog,
     );
-    _chromeLegend = Positioned(
-      top: 12.r,
-      left: 12.r,
-      child: Consumer<SyncManager>(
+    // Positioning/visibility is applied at the Stack level (AnimatedPositioned)
+    // so Select + B can animate it without invalidating this memoized subtree.
+    _chromeLegend = Consumer<SyncManager>(
         builder: (context, syncManager, child) => GameActionButtons(
           system: widget.system,
           selectedGame: settledGame,
@@ -1010,7 +1071,6 @@ class _GamesGridState extends State<GamesGrid> {
           onRandom: widget.onRandom,
           onScrape: widget.onScrape,
         ),
-      ),
     );
   }
 

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -6,29 +6,25 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:neostation/models/game_model.dart';
-import 'package:neostation/models/retro_achievements_game_info.dart';
 import 'package:neostation/models/system_model.dart';
 import 'package:neostation/providers/file_provider.dart';
-import 'package:neostation/providers/retro_achievements_provider.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
-import 'package:neostation/services/retro_achievements_helper.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
-import 'package:neostation/widgets/game_view_mode_dropdown.dart';
 import 'package:neostation/utils/game_utils.dart';
-import 'package:neostation/screens/game_screen/game_details_card/dialogs/game_achievements_dialog.dart';
+import 'package:neostation/widgets/game_view_mode_dropdown.dart';
+import 'package:neostation/widgets/game_action_buttons.dart';
+import 'package:neostation/sync/sync_manager.dart';
 import 'package:neostation/services/game_service.dart';
 import 'package:neostation/repositories/game_repository.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/widgets/game_view_footer.dart';
-import 'package:neostation/widgets/game_action_buttons.dart';
 import 'package:neostation/constants/system_folder_names.dart';
-import 'package:neostation/widgets/selection_grid/grid_navigation.dart';
-import 'package:neostation/widgets/selection_grid/selection_grid.dart';
-import 'package:neostation/widgets/selection_grid/selection_grid_geometry.dart';
-
-import '../../themes/corner_radii.dart';
+import 'package:neostation/models/retro_achievements_game_info.dart';
+import 'package:neostation/providers/retro_achievements_provider.dart';
+import 'package:neostation/services/retro_achievements_helper.dart';
+import 'package:neostation/screens/game_screen/game_details_card/dialogs/game_achievements_dialog.dart';
 
 class GamesGrid extends StatefulWidget {
   final SystemModel system;
@@ -41,8 +37,14 @@ class GamesGrid extends StatefulWidget {
   final VoidCallback onFavorite;
   final VoidCallback onRandom;
   final VoidCallback? onSettings;
+  final VoidCallback? onScrape;
   final Set<String> scrapingGameRomnames;
   final Map<String, double> scrapeProgress;
+
+  /// No-op stub retained for API compatibility with the current scraping tab.
+  /// This pre-#188 grid keeps no static artwork caches; the Flutter image
+  /// cache is evicted separately by the caller.
+  static void evictArtworkCaches(Iterable<String> paths) {}
 
   const GamesGrid({
     super.key,
@@ -56,103 +58,46 @@ class GamesGrid extends StatefulWidget {
     required this.onFavorite,
     required this.onRandom,
     this.onSettings,
+    this.onScrape,
     this.scrapingGameRomnames = const {},
     this.scrapeProgress = const {},
   });
 
   @override
   State<GamesGrid> createState() => _GamesGridState();
-
-  /// Evicts memoized artwork entries (file-existence and image dimensions)
-  /// for [paths]. Call after replacing a game's image files on disk, e.g.
-  /// from the game settings dialog's artwork editor or a scrape.
-  static void evictArtworkCaches(Iterable<String> paths) {
-    _GamesGridState._evictArtworkCaches(paths);
-  }
 }
 
 class _GamesGridState extends State<GamesGrid> {
   late GamepadNavigation _gamepadNav;
+  final ScrollController _scrollController = ScrollController();
   int _selectedIndex = 0;
   int _crossAxisCount = 5;
-
-  // Bumped whenever card *content* (as opposed to selection) changes, so the
-  // SelectionGrid rebuilds its cached card widgets. A pure selection move
-  // deliberately leaves this untouched — the cards are then reused and only
-  // the highlight repositions.
-  int _gridRevision = 0;
   bool _isNavigatingFast = false;
 
+  // RetroAchievements info for the selected game (shown in the footer pill).
   GameInfoAndUserProgress? _currentGameInfo;
   bool _isLoadingAchievements = false;
   String? _achievementsTargetRomname;
-
-  // RetroAchievements info is loaded per selected game, but firing it (plus its
-  // setState churn) on every gamepad move floods the UI thread during fast
-  // navigation. Debounce so it loads once the selection settles.
+  // Loading RA (plus its setState churn) on every gamepad move floods the UI
+  // thread during fast navigation. Debounce so it loads once selection settles.
   Timer? _achievementsDebounce;
   static const Duration _achievementsSettleDelay = Duration(milliseconds: 280);
-
-  /// Debounced entry point for the navigation hot path — coalesces rapid moves
-  /// into a single load once the user stops on a game.
-  void _scheduleAchievementsLoad() {
-    // Reflect the new selection in the footer's RA indicator immediately, so
-    // fast navigation never shows the *previous* game's achievement counts/icon
-    // while the (debounced) load is pending. Fields are mutated directly — every
-    // caller already has a rebuild in flight (setState on the move, or a
-    // didUpdateWidget). The actual load below fills in the real data on settle.
-    final selectedRomname = widget.games.isEmpty
-        ? null
-        : widget
-              .games[_selectedIndex.clamp(0, widget.games.length - 1)]
-              .romname;
-    if (selectedRomname != _achievementsTargetRomname) {
-      _achievementsTargetRomname = selectedRomname;
-      _currentGameInfo = null;
-      _isLoadingAchievements = true;
-    }
-    _achievementsDebounce?.cancel();
-    _achievementsDebounce = Timer(_achievementsSettleDelay, () {
-      if (mounted) _loadAchievementsForSelectedGame();
-    });
-  }
-
   DateTime? _lastNavTime;
   static const Duration _fastNavThreshold = Duration(milliseconds: 150);
 
-  // Layout geometry — single source of truth shared by the cards and the
-  // selection highlight (see SelectionGrid). Cached and recomputed only when
-  // width / columns / game count / card style / artwork dimensions change.
-  SelectionGridGeometry? _geometry;
-  double? _geoWidth;
-  int? _geoCols;
-  int? _geoGameCount;
-  bool? _geoIsFanart;
+  // Layout
+  List<_CardRect> _cardRects = [];
+  List<_RowInfo> _rows = [];
+  double _cardWidth = 0;
+  double _spX = 0;
+  double _spY = 0;
+  double? _lastLayoutWidth;
+  int? _lastLayoutCols;
+  int? _lastLayoutGameCount;
+  bool? _lastIsFanart;
 
   // Image dimension cache
   static final Map<String, Size?> _imageSizeCache = {};
-
-  // File existence cache — calling existsSync on the UI thread while cards
-  // rebuild during scroll is a known jank source in image grids, so results
-  // are memoized. Entries are evicted when a scrape replaces artwork on disk
-  // (see didUpdateWidget).
-  static final Map<String, bool> _fileExistsCache = {};
-
-  static bool _fileExists(String path) {
-    final cached = _fileExistsCache[path];
-    if (cached != null) return cached;
-    final exists = File(path).existsSync();
-    _fileExistsCache[path] = exists;
-    return exists;
-  }
-
-  /// Backing implementation for [GamesGrid.evictArtworkCaches].
-  static void _evictArtworkCaches(Iterable<String> paths) {
-    for (final path in paths) {
-      _fileExistsCache.remove(path);
-      _imageSizeCache.remove(path);
-    }
-  }
 
   // Visible index tracking for lazy dimension loading
   final Set<int> _loadedDims = {};
@@ -253,11 +198,6 @@ class _GamesGridState extends State<GamesGrid> {
     );
   }
 
-  String _screenshotPath(int index) {
-    final game = widget.games[index];
-    return game.getScreenshotPath(_folderForGame(game), widget.fileProvider);
-  }
-
   String _wheelsPath(int index) {
     final game = widget.games[index];
     return game.getImagePath(
@@ -267,11 +207,18 @@ class _GamesGridState extends State<GamesGrid> {
     );
   }
 
+  String _screenshotPath(int index) {
+    final game = widget.games[index];
+    return game.getScreenshotPath(_folderForGame(game), widget.fileProvider);
+  }
+
   bool get _isFanart =>
       context.read<SqliteConfigProvider>().config.gameCarouselCardStyle ==
       'fanart';
 
-  double _box2dAspectRatio(int index) {
+  double _cardHeightFor(int index) {
+    if (_isFanart) return _cardWidth;
+
     final game = widget.games[index];
     // 1. From DB
     if (game.box2dAspectRatio != null && game.box2dAspectRatio!.isNotEmpty) {
@@ -279,7 +226,9 @@ class _GamesGridState extends State<GamesGrid> {
       if (parts.length == 2) {
         final w = double.tryParse(parts[0]);
         final h = double.tryParse(parts[1]);
-        if (w != null && h != null && w > 0 && h > 0) return w / h;
+        if (w != null && h != null && w > 0 && h > 0) {
+          return _cardWidth / (w / h);
+        }
       }
     }
     // 2. From file header
@@ -289,22 +238,10 @@ class _GamesGridState extends State<GamesGrid> {
       // Save to DB for next time
       final ratio = '${size.width.toInt()}/${size.height.toInt()}';
       _scheduleAspectRatioSave(game, ratio);
-      return size.width / size.height;
+      return _cardWidth / (size.width / size.height);
     }
-    return 1.0; // 1:1 fallback
+    return _cardWidth; // 1:1 fallback
   }
-
-  // ---- Card height strategies (one per card style) ----
-
-  /// Fanart cards show only the artwork, with just enough room for padding.
-  double _fanartCardHeight(int index, double cardWidth) => cardWidth;
-
-  /// Box2d cards derive their height from the artwork's aspect ratio.
-  ///
-  /// Content width = card width minus inner padding (4.r each side).
-  /// Outer padding is already accounted for by the row/cell layout.
-  double _box2dCardHeight(int index, double cardWidth) =>
-      (cardWidth - 8.r) / _box2dAspectRatio(index) + 12.r;
 
   final Set<String> _pendingSaves = {};
   void _scheduleAspectRatioSave(GameModel game, String ratio) {
@@ -324,35 +261,91 @@ class _GamesGridState extends State<GamesGrid> {
     });
   }
 
-  // ---- Layout geometry (cached; recomputed only on invalidating changes) ----
-  SelectionGridGeometry _geometryFor(double contentWidth) {
-    final isFanart = _isFanart;
-    final cached = _geometry;
-    if (cached != null &&
-        _geoWidth == contentWidth &&
-        _geoCols == _cols &&
-        _geoGameCount == widget.games.length &&
-        _geoIsFanart == isFanart &&
-        !_needsDimReload) {
-      return cached;
-    }
-    _geoWidth = contentWidth;
-    _geoCols = _cols;
-    _geoGameCount = widget.games.length;
-    _geoIsFanart = isFanart;
+  // ---- Layout (computed once, cached) ----
+  bool _needsLayout(double w) =>
+      _lastLayoutWidth != w ||
+      _lastLayoutCols != _cols ||
+      _lastLayoutGameCount != widget.games.length ||
+      _lastIsFanart != _isFanart ||
+      _needsDimReload;
+
+  void _computeLayout(double availableWidth) {
+    if (!_needsLayout(availableWidth)) return;
+    _lastLayoutWidth = availableWidth;
+    _lastLayoutCols = _cols;
+    _lastLayoutGameCount = widget.games.length;
+    _lastIsFanart = _isFanart;
     _needsDimReload = false;
+
+    final spX = 6.0.r;
+    final spY = 6.0.r;
+    _spX = spX;
+    _spY = spY;
+
+    final totalWidth = availableWidth - 32;
+    _cardWidth = (totalWidth - (_cols - 1) * spX) / _cols;
+    final n = widget.games.length;
+    _cardRects = List.generate(
+      n,
+      (_) => _CardRect(left: 0, top: 0, width: _cardWidth, height: _cardWidth),
+    ); // placeholder
     _loadedDims.clear();
-    return _geometry = computeSelectionGridGeometry(
-      itemCount: widget.games.length,
-      columns: _cols,
-      availableWidth: contentWidth,
-      spacingX: 6.0.r,
-      spacingY: 6.0.r,
-      itemHeightFor: isFanart ? _fanartCardHeight : _box2dCardHeight,
-    );
+
+    if (_isFanart) {
+      double y = 0;
+      final rows = <_RowInfo>[];
+      for (int i = 0; i < n; i += _cols) {
+        final end = (i + _cols).clamp(0, n);
+        final count = end - i;
+        rows.add(
+          _RowInfo(topY: y, height: _cardWidth, startIndex: i, count: count),
+        );
+        for (int idx = i; idx < end; idx++) {
+          final col = idx % _cols;
+          _cardRects[idx] = _CardRect(
+            left: col * (_cardWidth + spX),
+            top: y + spY / 2,
+            width: _cardWidth,
+            height: _cardWidth,
+          );
+        }
+        y += _cardWidth + spY;
+      }
+      _rows = rows;
+      return; // fanart path done
+    }
+
+    // First pass: use the static cache to get known dimensions fast
+    double y = 0;
+    int i = 0;
+    final rows = <_RowInfo>[];
+    while (i < n) {
+      double maxH = 0;
+      final end = (i + _cols).clamp(0, n);
+      final count = end - i;
+      for (int idx = i; idx < end; idx++) {
+        final h = _cardHeightFor(idx);
+        if (h > maxH) maxH = h;
+      }
+      rows.add(_RowInfo(topY: y, height: maxH, startIndex: i, count: count));
+      for (int idx = i; idx < end; idx++) {
+        final col = idx % _cols;
+        final h = _cardHeightFor(idx);
+        _cardRects[idx] = _CardRect(
+          left: col * (_cardWidth + spX),
+          top: y + (maxH + spY - h) / 2,
+          width: _cardWidth,
+          height: h,
+        );
+        if (_imageSizeCache.containsKey(_box2dPath(idx))) _loadedDims.add(idx);
+      }
+      y += maxH + spY;
+      i = end;
+    }
+    _rows = rows;
   }
 
-  // Lazy dimension loading for newly visible cards (box2d style only)
+  // Lazy dimension loading for newly visible cards
   void _ensureDims(int index) {
     if (_isFanart) return;
     if (_loadedDims.contains(index)) return;
@@ -390,6 +383,7 @@ class _GamesGridState extends State<GamesGrid> {
           onActivate: () => _gamepadNav.activate(),
           onDeactivate: () => _gamepadNav.deactivate(),
         );
+        _ensureSelectedVisible();
         _loadAchievementsForSelectedGame();
       }
     });
@@ -436,10 +430,12 @@ class _GamesGridState extends State<GamesGrid> {
         final newSize = sizes[newIndex];
         provider.updateGameGridColumns(newSize);
         _updateCrossAxisCount();
+        _lastLayoutWidth = null;
         _showCardSizeLabel(newSize);
-        // The geometry cache detects the column change on the next build and
-        // SelectionGrid re-centers the selection automatically.
         setState(() {});
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _ensureSelectedVisible();
+        });
       }
     } catch (_) {}
   }
@@ -495,54 +491,18 @@ class _GamesGridState extends State<GamesGrid> {
   @override
   void didUpdateWidget(GamesGrid oldWidget) {
     super.didUpdateWidget(oldWidget);
+    final prevCols = _crossAxisCount;
     _updateCrossAxisCount();
-    // Card *content* changed (not just selection) — bump the revision so the
-    // SelectionGrid rebuilds cached card widgets instead of reusing stale ones.
-    //   - games: gets a fresh list instance on favorite toggle / reorder /
-    //     update, and length changes on delete (which also re-keys geometry),
-    //     so an identity check catches those.
-    //   - scrape sets/maps are `final` and mutated in place (stable identity),
-    //     so bump while a scrape is active — or was on the previous frame — to
-    //     keep progress bars animating and to clear them when the scrape ends.
-    if (!identical(widget.games, oldWidget.games) ||
-        widget.scrapingGameRomnames.isNotEmpty ||
-        oldWidget.scrapingGameRomnames.isNotEmpty) {
-      _gridRevision++;
+    if (widget.games != oldWidget.games || _crossAxisCount != prevCols) {
+      _lastLayoutWidth = null;
     }
-    // Artwork replaced by a finished scrape must be re-checked on disk.
-    final finishedScrapes = oldWidget.scrapingGameRomnames.difference(
-      widget.scrapingGameRomnames,
-    );
-    if (finishedScrapes.isNotEmpty) {
-      _evictArtworkCachesFor(finishedScrapes);
-    }
-    // Skip the resync when the parent is only echoing back a selection this
-    // grid already reported — otherwise achievements load twice per move.
-    if (widget.selectedIndex != oldWidget.selectedIndex &&
-        widget.selectedIndex != _selectedIndex) {
+    if (widget.selectedIndex != oldWidget.selectedIndex) {
       _selectedIndex = widget.selectedIndex.clamp(
         0,
         (widget.games.length - 1).clamp(0, 999999),
       );
-      _scheduleAchievementsLoad();
-    }
-  }
-
-  /// Drops memoized existence/dimension entries for games whose artwork may
-  /// have changed on disk (e.g. after a scrape completed).
-  void _evictArtworkCachesFor(Set<String> romnames) {
-    for (final game in widget.games) {
-      if (!romnames.contains(game.romname)) continue;
-      final folder = _folderForGame(game);
-      final paths = [
-        game.getImagePath(folder, 'fanarts', widget.fileProvider),
-        game.getImagePath(folder, 'wheels', widget.fileProvider),
-        game.getImagePath(folder, 'box2d', widget.fileProvider),
-        game.getScreenshotPath(folder, widget.fileProvider),
-      ];
-      for (final path in paths) {
-        _fileExistsCache.remove(path);
-        _imageSizeCache.remove(path);
+      if (mounted && _scrollController.hasClients) {
+        _ensureSelectedVisible();
       }
     }
   }
@@ -556,9 +516,13 @@ class _GamesGridState extends State<GamesGrid> {
       onSelectItem: widget.onPlay,
       onBack: widget.onBack,
       onFavorite: widget.onFavorite,
-      onXButton: () =>
-          GameViewModeDropdown.globalKey.currentState?.showDropdown(),
-      onSelectModifierY: widget.onRandom, // Select + Y - Random.
+      onXButton: () {
+        try {
+          GameViewModeDropdown.globalKey.currentState?.showDropdown();
+        } catch (_) {}
+      },
+      onLeftStickClick: widget.onRandom,
+      onSelectButton: widget.onScrape,
       onSettings: widget.onSettings,
     );
   }
@@ -570,57 +534,72 @@ class _GamesGridState extends State<GamesGrid> {
     _cardSizeLabel.dispose();
     GamepadNavigationManager.popLayer('games_grid');
     _gamepadNav.dispose();
+    _scrollController.dispose();
     super.dispose();
   }
 
   int get _cols => _crossAxisCount.clamp(1, 10);
 
   void _navigateUp() {
-    _moveSelection(
-      gridMoveUp(
-        index: _selectedIndex,
-        columns: _cols,
-        itemCount: widget.games.length,
-      ),
-    );
+    _navDelta(-_cols);
   }
 
   void _navigateDown() {
-    _moveSelection(
-      gridMoveDown(
-        index: _selectedIndex,
-        columns: _cols,
-        itemCount: widget.games.length,
-      ),
-    );
+    _navDelta(_cols);
   }
 
   void _navigateLeft() {
-    _moveSelection(
-      gridMoveLeft(
-        index: _selectedIndex,
-        columns: _cols,
-        itemCount: widget.games.length,
-      ),
-    );
+    _navHoriz(-1);
   }
 
   void _navigateRight() {
-    _moveSelection(
-      gridMoveRight(
-        index: _selectedIndex,
-        columns: _cols,
-        itemCount: widget.games.length,
-      ),
-    );
+    _navHoriz(1);
   }
 
-  void _moveSelection(int newIndex) {
+  void _navDelta(int delta) {
     if (widget.games.isEmpty) return;
+    final c = _cols;
     setState(() {
-      _selectedIndex = newIndex.clamp(0, widget.games.length - 1);
+      int ni = _selectedIndex + delta;
+      if (delta < 0 && ni < 0) {
+        final col = _selectedIndex % c;
+        ni = ((widget.games.length / c).ceil() - 1) * c + col;
+        while (ni >= widget.games.length) {
+          ni -= c;
+        }
+        if (ni < 0) ni = _selectedIndex;
+      } else if (delta > 0 && ni >= widget.games.length) {
+        ni = _selectedIndex % c;
+      }
+      _selectedIndex = ni.clamp(0, widget.games.length - 1);
       _updateFastNav();
     });
+    _ensureSelectedVisible();
+    _onSelectionChanged();
+    SfxService().playNavSound();
+  }
+
+  void _navHoriz(int dir) {
+    if (widget.games.isEmpty) return;
+    setState(() {
+      int ni;
+      if (dir < 0) {
+        final wrapRight = (_selectedIndex ~/ _cols) * _cols + _cols - 1;
+        ni = _selectedIndex % _cols == 0
+            ? (wrapRight < widget.games.length - 1
+                  ? wrapRight
+                  : widget.games.length - 1)
+            : _selectedIndex - 1;
+      } else {
+        final next = _selectedIndex + 1;
+        ni = (next % _cols == 0 || next >= widget.games.length)
+            ? (_selectedIndex ~/ _cols) * _cols
+            : next;
+      }
+      _selectedIndex = ni.clamp(0, widget.games.length - 1);
+      _updateFastNav();
+    });
+    _ensureSelectedVisible();
     _onSelectionChanged();
     SfxService().playNavSound();
   }
@@ -628,16 +607,8 @@ class _GamesGridState extends State<GamesGrid> {
   void _onSelectionChanged() {
     if (_selectedIndex < widget.games.length) {
       widget.onGameSelected(widget.games[_selectedIndex]);
-      _scheduleAchievementsLoad();
     }
-  }
-
-  void _updateFastNav() {
-    final now = DateTime.now();
-    _isNavigatingFast =
-        _lastNavTime != null &&
-        now.difference(_lastNavTime!) < _fastNavThreshold;
-    _lastNavTime = now;
+    _scheduleAchievementsLoad();
   }
 
   bool get _isAllMode =>
@@ -665,6 +636,26 @@ class _GamesGridState extends State<GamesGrid> {
     return system.raId != null && system.raId != '0' && system.raId!.isNotEmpty;
   }
 
+  /// Debounced entry point for the navigation hot path — coalesces rapid moves
+  /// into a single load once the user stops on a game.
+  void _scheduleAchievementsLoad() {
+    // Reflect the new selection in the footer's RA indicator immediately so
+    // fast navigation never shows the previous game's counts while the
+    // (debounced) load is pending.
+    final selectedRomname = widget.games.isEmpty
+        ? null
+        : widget.games[_selectedIndex.clamp(0, widget.games.length - 1)].romname;
+    if (selectedRomname != _achievementsTargetRomname) {
+      _achievementsTargetRomname = selectedRomname;
+      _currentGameInfo = null;
+      _isLoadingAchievements = true;
+    }
+    _achievementsDebounce?.cancel();
+    _achievementsDebounce = Timer(_achievementsSettleDelay, () {
+      if (mounted) _loadAchievementsForSelectedGame();
+    });
+  }
+
   Future<void> _loadAchievementsForSelectedGame() async {
     if (widget.games.isEmpty) return;
     final game = widget.games[_selectedIndex.clamp(0, widget.games.length - 1)];
@@ -679,9 +670,7 @@ class _GamesGridState extends State<GamesGrid> {
       return;
     }
 
-    if (mounted) {
-      setState(() => _isLoadingAchievements = true);
-    }
+    if (mounted) setState(() => _isLoadingAchievements = true);
     _achievementsTargetRomname = game.romname;
 
     try {
@@ -692,7 +681,6 @@ class _GamesGridState extends State<GamesGrid> {
         effectiveSystem: _effectiveSystemFor(game),
         isAllMode: _isAllMode,
       );
-
       if (mounted && _achievementsTargetRomname == game.romname) {
         setState(() {
           _currentGameInfo = info;
@@ -722,6 +710,29 @@ class _GamesGridState extends State<GamesGrid> {
         system: _effectiveSystemFor(game),
         retroAchievementsProvider: context.read<RetroAchievementsProvider>(),
       ),
+    );
+  }
+
+  void _updateFastNav() {
+    final now = DateTime.now();
+    _isNavigatingFast =
+        _lastNavTime != null &&
+        now.difference(_lastNavTime!) < _fastNavThreshold;
+    _lastNavTime = now;
+  }
+
+  void _ensureSelectedVisible() {
+    if (!_scrollController.hasClients || _cardRects.isEmpty) return;
+    final rect = _cardRects[_selectedIndex.clamp(0, _cardRects.length - 1)];
+    final viewportH = _scrollController.position.viewportDimension;
+    final target = (rect.top - viewportH / 2 + rect.height / 2).clamp(
+      0.0,
+      _scrollController.position.maxScrollExtent,
+    );
+    _scrollController.animateTo(
+      target,
+      duration: Duration(milliseconds: _isNavigatingFast ? 220 : 500),
+      curve: Curves.easeOutQuart,
     );
   }
 
@@ -759,24 +770,55 @@ class _GamesGridState extends State<GamesGrid> {
         Column(
           children: [
             Expanded(
-              child: LayoutBuilder(
+              // Indent the grid to clear the vertical legend on the left; the
+              // reduced width makes the cards slightly smaller.
+              child: Padding(
+                padding: EdgeInsets.only(left: 60.r),
+                child: LayoutBuilder(
                 builder: (context, constraints) {
+                  _computeLayout(constraints.maxWidth);
+
                   final theme = Theme.of(context);
                   final fp = widget.fileProvider;
+                  final targetWidth = (_cardWidth * 1.5).toInt();
 
-                  // Single source of truth for the grid's outer insets —
-                  // consumed by BOTH the geometry and the scroll padding, so
-                  // the cards and the selector always share one coordinate
-                  // space and cannot drift apart.
-                  final padL = 60.0.r;
-                  final padR = 16.0.r;
-                  final padT = 12.0.r;
-                  final padB = 80.0.r;
-
-                  final geometry = _geometryFor(
-                    constraints.maxWidth - padL - padR,
+                  final selRect = _selectedIndex < _cardRects.length
+                      ? _cardRects[_selectedIndex]
+                      : _cardRects.first;
+                  final hlDuration = Duration(
+                    milliseconds: _isNavigatingFast ? 120 : 300,
                   );
-                  final targetWidth = (geometry.cardWidth * 1.5).toInt();
+
+                  Widget buildRow(BuildContext ctx, int rowIndex) {
+                    final row = _rows[rowIndex];
+                    final cards = <Widget>[];
+                    for (int j = 0; j < row.count; j++) {
+                      final idx = row.startIndex + j;
+                      final rect = _cardRects[idx];
+                      _ensureDims(idx);
+                      final card = _buildCard(
+                        idx,
+                        rect,
+                        fp,
+                        targetWidth,
+                        theme,
+                      );
+                      cards.add(
+                        SizedBox(
+                          width: rect.width,
+                          height: rect.height,
+                          child: card,
+                        ),
+                      );
+                    }
+                    return SizedBox(
+                      height: row.height + _spY,
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: _interleaveSpacing(cards, _spX),
+                      ),
+                    );
+                  }
 
                   return Listener(
                     onPointerDown: _handlePointerDown,
@@ -786,27 +828,53 @@ class _GamesGridState extends State<GamesGrid> {
                     behavior: HitTestBehavior.translucent,
                     child: Stack(
                       children: [
-                        SelectionGrid(
-                          geometry: geometry,
-                          padding: EdgeInsets.only(
-                            left: padL,
-                            right: padR,
-                            top: padT,
-                            bottom: padB,
+                        CustomScrollView(
+                          controller: _scrollController,
+                          slivers: [
+                            SliverPadding(
+                              padding: EdgeInsets.only(
+                                top: 12,
+                                bottom: 80,
+                                left: 16,
+                                right: 16,
+                              ),
+                              sliver: SliverList.builder(
+                                itemCount: _rows.length,
+                                itemBuilder: buildRow,
+                              ),
+                            ),
+                          ],
+                        ),
+                        AnimatedPositioned(
+                          key: const ValueKey('game_selector'),
+                          duration: hlDuration,
+                          curve: Curves.easeOutQuart,
+                          left: selRect.left + 16,
+                          top: selRect.top + 12,
+                          width: selRect.width,
+                          height: selRect.height,
+                          child: ListenableBuilder(
+                            listenable: _scrollController,
+                            builder: (_, child) {
+                              final offset = _scrollController.hasClients
+                                  ? _scrollController.offset
+                                  : 0.0;
+                              return Transform.translate(
+                                offset: Offset(0, -offset),
+                                child: IgnorePointer(
+                                  child: Container(
+                                    decoration: BoxDecoration(
+                                      border: Border.all(
+                                        color: theme.colorScheme.secondary,
+                                        width: 4.r,
+                                      ),
+                                      borderRadius: BorderRadius.circular(12.r),
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
                           ),
-                          selectedIndex: _selectedIndex,
-                          revision: _gridRevision,
-                          isNavigatingFast: _isNavigatingFast,
-                          // On a discontinuous layout change (density or card
-                          // style) the highlight re-creates and jumps to the
-                          // new rect instead of sliding across the screen.
-                          highlightKey: ValueKey(
-                            'games_grid_highlight_${geometry.columns}_$_isFanart',
-                          ),
-                          itemBuilder: (context, index, cellSize) {
-                            _ensureDims(index);
-                            return _buildCard(index, fp, targetWidth, theme);
-                          },
                         ),
                         ValueListenableBuilder<String?>(
                           valueListenable: _cardSizeLabel,
@@ -847,6 +915,7 @@ class _GamesGridState extends State<GamesGrid> {
                     ),
                   );
                 },
+                ),
               ),
             ),
             GameViewFooter(
@@ -867,156 +936,123 @@ class _GamesGridState extends State<GamesGrid> {
             ),
           ],
         ),
+        // Vertical action-button legend (shared with the game list view).
         Positioned(
           top: 12.r,
           left: 12.r,
-          child: GameActionButtons(
-            system: widget.system,
-            selectedGame: widget.games.isNotEmpty
-                ? widget.games[_selectedIndex.clamp(0, widget.games.length - 1)]
-                : null,
-            onBack: widget.onBack,
-            onFavorite: widget.onFavorite,
-            onViewMode: () =>
-                GameViewModeDropdown.globalKey.currentState?.showDropdown(),
-            onSettings: widget.onSettings ?? () {},
-            onRandom: widget.onRandom,
+          child: Consumer<SyncManager>(
+            builder: (context, syncManager, child) => GameActionButtons(
+              system: widget.system,
+              selectedGame:
+                  widget.games[_selectedIndex.clamp(0, widget.games.length - 1)],
+              syncProvider: syncManager.active,
+              onBack: widget.onBack,
+              onFavorite: widget.onFavorite,
+              onViewMode: () =>
+                  GameViewModeDropdown.globalKey.currentState?.showDropdown(),
+              onSettings: widget.onSettings ?? () {},
+              onRandom: widget.onRandom,
+              onScrape: widget.onScrape,
+            ),
           ),
         ),
       ],
     );
   }
 
-  // ---- Card builders (one per card style) ----
+  List<Widget> _interleaveSpacing(List<Widget> items, double spacing) {
+    if (items.isEmpty) return items;
+    final result = <Widget>[items.first];
+    for (int i = 1; i < items.length; i++) {
+      result.add(SizedBox(width: spacing));
+      result.add(items[i]);
+    }
+    return result;
+  }
 
   Widget _buildCard(
     int index,
+    _CardRect rect,
     FileProvider fp,
     int targetWidth,
     ThemeData theme,
   ) {
     final game = widget.games[index];
-    if (_isFanart) {
-      return _buildFanartGridCard(index, game, theme);
-    }
-    return _buildBox2dGridCard(index, game, fp, targetWidth, theme);
-  }
 
-  Widget _buildBox2dGridCard(
-    int index,
-    GameModel game,
-    FileProvider fp,
-    int targetWidth,
-    ThemeData theme,
-  ) {
+    if (_isFanart) {
+      return _buildFanartGridCard(index, rect, game, theme);
+    }
+
     final box2dPath = game.getImagePath(_folderForGame(game), 'box2d', fp);
-    final aspectRatio = _box2dAspectRatio(index);
 
     return GestureDetector(
       key: ValueKey('game_${game.romname}'),
       onTap: () {
         setState(() => _selectedIndex = index);
         widget.onGameSelected(game);
-        SfxService().playNavSound();
         _scheduleAchievementsLoad();
+        SfxService().playNavSound();
       },
       child: RepaintBoundary(
-        child: Padding(
-          padding: EdgeInsets.all(2.r),
-          child: Container(
-            decoration: BoxDecoration(
-              color: theme.colorScheme.surface,
-              borderRadius:
-                  Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-                  BorderRadius.circular(14.r),
-              border: Border.all(
-                color: Theme.of(context).colorScheme.outline,
-                width: 1.r,
+        child: Stack(
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12.r),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.25),
+                    blurRadius: 2.r,
+                    offset: Offset(2.r, 2.r),
+                  ),
+                ],
+              ),
+              clipBehavior: Clip.antiAlias,
+              child: _GameCardImage(
+                key: ValueKey('img_${game.romname}'),
+                box2dPath: box2dPath,
+                game: game,
+                targetWidth: targetWidth,
               ),
             ),
-            child: ClipRRect(
-              borderRadius:
-                  Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
-                  BorderRadius.circular(9.r),
-              child: InkWell(
-                canRequestFocus: false,
-                focusColor: Colors.transparent,
-                hoverColor: Colors.transparent,
-                highlightColor: Colors.transparent,
-                splashColor: Colors.transparent,
-                child: Padding(
-                  padding: EdgeInsets.all(4.r),
-                  child: AspectRatio(
-                    aspectRatio: aspectRatio,
-                    child: ClipRRect(
-                      borderRadius:
-                          Theme.of(
-                            context,
-                          ).extension<CornerRadii>()?.radiusInternal ??
-                          BorderRadius.circular(9.r),
-                      child: Stack(
-                        fit: StackFit.expand,
-                        children: [
-                          Image.file(
-                            File(box2dPath),
-                            key: ValueKey('box2d_${game.romname}'),
-                            fit: BoxFit.cover,
-                            cacheWidth: 384,
-                            gaplessPlayback: true,
-                            errorBuilder: (ctx, e, s) =>
-                                _buildFallbackCard(game, theme),
-                          ),
-                          if (game.isFavorite == true)
-                            Positioned(
-                              top: 4.r,
-                              right: 4.r,
-                              child: Container(
-                                width: 22.r,
-                                height: 22.r,
-                                decoration: BoxDecoration(
-                                  color: Colors.black.withValues(alpha: 0.45),
-                                  shape: BoxShape.circle,
-                                ),
-                                child: Icon(
-                                  Symbols.favorite_rounded,
-                                  size: 12.r,
-                                  color: Colors.redAccent,
-                                ),
-                              ),
-                            ),
-                          if (widget.scrapingGameRomnames.contains(
-                            game.romname,
-                          ))
-                            Positioned(
-                              left: 0,
-                              right: 0,
-                              bottom: 0,
-                              child: _buildScrapeProgress(game),
-                            ),
-                        ],
-                      ),
-                    ),
+            if (game.isFavorite == true)
+              Positioned(
+                top: 6.r,
+                right: 6.r,
+                child: Container(
+                  width: 22.r,
+                  height: 22.r,
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: 0.45),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Symbols.favorite_rounded,
+                    size: 12.r,
+                    color: Colors.redAccent,
                   ),
                 ),
               ),
-            ),
-          ),
+            if (widget.scrapingGameRomnames.contains(game.romname))
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: _buildScrapeProgress(game),
+              ),
+          ],
         ),
       ),
     );
   }
 
   Widget _buildScrapeProgress(GameModel game) {
-    final radii = Theme.of(context).extension<CornerRadii>() ?? CornerRadii.m();
     final progress = widget.scrapeProgress[game.romname] ?? 0.0;
     return Container(
       height: 20.r,
       decoration: BoxDecoration(
         color: Colors.black.withValues(alpha: 0.7),
-        borderRadius: BorderRadius.only(
-          bottomLeft: radii.radiusInternal.bottomLeft,
-          bottomRight: radii.radiusInternal.bottomRight,
-        ),
+        borderRadius: BorderRadius.vertical(bottom: Radius.circular(12.r)),
       ),
       padding: EdgeInsets.symmetric(horizontal: 8.r),
       child: Row(
@@ -1046,13 +1082,18 @@ class _GamesGridState extends State<GamesGrid> {
     );
   }
 
-  Widget _buildFanartGridCard(int index, GameModel game, ThemeData theme) {
+  Widget _buildFanartGridCard(
+    int index,
+    _CardRect rect,
+    GameModel game,
+    ThemeData theme,
+  ) {
     final fanartPath = _fanartPath(index);
     final screenshotPath = _screenshotPath(index);
     final wheelsPath = _wheelsPath(index);
-    final hasFanart = _fileExists(fanartPath);
-    final hasScreenshot = !hasFanart && _fileExists(screenshotPath);
-    final hasWheel = _fileExists(wheelsPath);
+    final hasFanart = File(fanartPath).existsSync();
+    final hasScreenshot = !hasFanart && File(screenshotPath).existsSync();
+    final hasWheel = File(wheelsPath).existsSync();
     final bgPath = hasFanart
         ? fanartPath
         : (hasScreenshot ? screenshotPath : '');
@@ -1062,139 +1103,98 @@ class _GamesGridState extends State<GamesGrid> {
       onTap: () {
         setState(() => _selectedIndex = index);
         widget.onGameSelected(game);
-        SfxService().playNavSound();
         _scheduleAchievementsLoad();
+        SfxService().playNavSound();
       },
       child: RepaintBoundary(
-        child: Padding(
-          padding: EdgeInsets.all(2.r),
-          child: Container(
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.surface,
-              borderRadius:
-                  Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-                  BorderRadius.circular(14.r),
-              border: Border.all(
-                color: Theme.of(context).colorScheme.outline,
-                width: 1.r,
+        child: Container(
+          clipBehavior: Clip.antiAlias,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12.r),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.25),
+                blurRadius: 2.r,
+                offset: Offset(2.r, 2.r),
               ),
-            ),
-            child: ClipRRect(
-              borderRadius:
-                  Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
-                  BorderRadius.circular(9.r),
-              child: InkWell(
-                canRequestFocus: false,
-                focusColor: Colors.transparent,
-                hoverColor: Colors.transparent,
-                highlightColor: Colors.transparent,
-                splashColor: Colors.transparent,
-                child: Padding(
-                  padding: EdgeInsets.all(4.r),
-                  child: Column(
-                    children: [
-                      AspectRatio(
-                        aspectRatio: 1,
-                        child: ClipRRect(
-                          borderRadius:
-                              Theme.of(
-                                context,
-                              ).extension<CornerRadii>()?.radiusInternal ??
-                              BorderRadius.circular(9.r),
-                          child: Stack(
-                            fit: StackFit.expand,
-                            children: [
-                              if (bgPath.isNotEmpty)
-                                Image.file(
-                                  File(bgPath),
-                                  key: ValueKey('fanart_bg_${game.romname}'),
-                                  fit: BoxFit.cover,
-                                  cacheWidth: 384,
-                                  gaplessPlayback: true,
-                                  errorBuilder: (ctx, e, s) =>
-                                      _buildFallbackCard(game, theme),
-                                )
-                              else
-                                _buildFallbackCard(game, theme),
-                              // Darkening gradient so the overlaid logo stays
-                              // legible against bright fanart.
-                              if (bgPath.isNotEmpty && hasWheel)
-                                const Positioned.fill(
-                                  child: DecoratedBox(
-                                    decoration: BoxDecoration(
-                                      gradient: LinearGradient(
-                                        begin: Alignment.topCenter,
-                                        end: Alignment.bottomCenter,
-                                        colors: [
-                                          Colors.transparent,
-                                          Colors.black54,
-                                          Colors.black87,
-                                        ],
-                                        stops: [0.5, 0.75, 1.0],
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              // Wheel/logo overlaid at the bottom (restores the
-                              // pre-#188 fanart look).
-                              if (hasWheel)
-                                Positioned(
-                                  left: 10.r,
-                                  right: 10.r,
-                                  bottom: 5.r,
-                                  child: Padding(
-                                    padding: EdgeInsets.symmetric(
-                                      horizontal: 6.r,
-                                      vertical: 4.r,
-                                    ),
-                                    child: Image.file(
-                                      File(wheelsPath),
-                                      key: ValueKey('wheel_${game.romname}'),
-                                      fit: BoxFit.contain,
-                                      cacheWidth: 384,
-                                      gaplessPlayback: true,
-                                      errorBuilder: (ctx, e, s) =>
-                                          const SizedBox.shrink(),
-                                    ),
-                                  ),
-                                ),
-                              if (game.isFavorite == true)
-                                Positioned(
-                                  top: 4.r,
-                                  right: 4.r,
-                                  child: Container(
-                                    width: 22.r,
-                                    height: 22.r,
-                                    decoration: BoxDecoration(
-                                      color: Colors.black.withValues(
-                                        alpha: 0.6,
-                                      ),
-                                      shape: BoxShape.circle,
-                                    ),
-                                    child: Icon(
-                                      Symbols.favorite_rounded,
-                                      size: 12.r,
-                                      color: Colors.redAccent,
-                                    ),
-                                  ),
-                                ),
-                              if (widget.scrapingGameRomnames.contains(
-                                game.romname,
-                              ))
-                                Positioned(
-                                  left: 0,
-                                  right: 0,
-                                  bottom: 0,
-                                  child: _buildScrapeProgress(game),
-                                ),
-                            ],
-                          ),
-                        ),
+            ],
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(12.r),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                if (bgPath.isNotEmpty)
+                  Image.file(
+                    File(bgPath),
+                    key: ValueKey('fanart_bg_${game.romname}'),
+                    fit: BoxFit.cover,
+                    cacheWidth: 388,
+                    errorBuilder: (ctx, e, s) =>
+                        _buildFallbackCard(game, theme),
+                  )
+                else
+                  _buildFallbackCard(game, theme),
+                if (bgPath.isNotEmpty)
+                  Container(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Colors.transparent,
+                          Colors.black.withValues(alpha: 0.5),
+                          Colors.black.withValues(alpha: 0.85),
+                        ],
+                        stops: const [0.5, 0.75, 1.0],
                       ),
-                    ],
+                    ),
                   ),
-                ),
-              ),
+                if (hasWheel)
+                  Positioned(
+                    left: 10.r,
+                    right: 10.r,
+                    bottom: 5.r,
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 6.r,
+                        vertical: 4.r,
+                      ),
+                      child: Image.file(
+                        File(wheelsPath),
+                        key: ValueKey('wheel_${game.romname}'),
+                        fit: BoxFit.contain,
+                        cacheWidth: 388,
+                        errorBuilder: (ctx, e, s) => const SizedBox.shrink(),
+                      ),
+                    ),
+                  ),
+                if (game.isFavorite == true)
+                  Positioned(
+                    top: 6.r,
+                    right: 6.r,
+                    child: Container(
+                      width: 22.r,
+                      height: 22.r,
+                      decoration: BoxDecoration(
+                        color: Colors.black.withValues(alpha: 0.45),
+                        shape: BoxShape.circle,
+                      ),
+                      child: Icon(
+                        Symbols.favorite_rounded,
+                        size: 12.r,
+                        color: Colors.redAccent,
+                      ),
+                    ),
+                  ),
+                if (widget.scrapingGameRomnames.contains(game.romname))
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    child: _buildScrapeProgress(game),
+                  ),
+              ],
             ),
           ),
         ),
@@ -1235,4 +1235,152 @@ class _GamesGridState extends State<GamesGrid> {
       ),
     );
   }
+
+}
+
+// ---- Card image with lazy loading ----
+class _GameCardImage extends StatefulWidget {
+  final String box2dPath;
+  final GameModel game;
+  final int targetWidth;
+  const _GameCardImage({
+    super.key,
+    required this.box2dPath,
+    required this.game,
+    required this.targetWidth,
+  });
+  @override
+  State<_GameCardImage> createState() => _GameCardImageState();
+}
+
+class _GameCardImageState extends State<_GameCardImage> {
+  ImageProvider? _imageProvider;
+  bool _exists = false;
+  bool _checked = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _resolve();
+  }
+
+  @override
+  void didUpdateWidget(covariant _GameCardImage old) {
+    super.didUpdateWidget(old);
+    if (old.box2dPath != widget.box2dPath ||
+        old.targetWidth != widget.targetWidth) {
+      _checked = false;
+      _exists = false;
+      _imageProvider = null;
+      _resolve();
+    }
+  }
+
+  void _resolve() {
+    if (_checked) return;
+    final exists = File(widget.box2dPath).existsSync();
+    if (!mounted) return;
+    setState(() {
+      _checked = true;
+      _exists = exists;
+      if (exists) {
+        _imageProvider = ResizeImage(
+          FileImage(File(widget.box2dPath)),
+          width: widget.targetWidth,
+          allowUpscaling: false,
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_checked) return const SizedBox.shrink();
+    if (_exists && _imageProvider != null) {
+      return Image(
+        image: _imageProvider!,
+        fit: BoxFit.contain,
+        frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+          if (wasSynchronouslyLoaded) return child;
+          return AnimatedOpacity(
+            opacity: frame == null ? 0 : 1,
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeIn,
+            child: child,
+          );
+        },
+        errorBuilder: (c, e, s) => _Placeholder(game: widget.game),
+      );
+    }
+    return _Placeholder(game: widget.game);
+  }
+}
+
+class _Placeholder extends StatelessWidget {
+  final GameModel game;
+  const _Placeholder({required this.game});
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(6.r),
+      ),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.videogame_asset_rounded,
+              size: 32.r,
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurface.withValues(alpha: 0.4),
+            ),
+            SizedBox(height: 4.r),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 4.r),
+              child: Text(
+                GameUtils.formatGameName(
+                  game.name.isNotEmpty ? game.name : game.romname,
+                ),
+                textAlign: TextAlign.center,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 7.r,
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.5),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RowInfo {
+  final double topY;
+  final double height;
+  final int startIndex;
+  final int count;
+  const _RowInfo({
+    required this.topY,
+    required this.height,
+    required this.startIndex,
+    required this.count,
+  });
+}
+
+class _CardRect {
+  final double left, top, width, height;
+  const _CardRect({
+    required this.left,
+    required this.top,
+    required this.width,
+    required this.height,
+  });
 }

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -646,8 +646,9 @@ class _GamesGridState extends State<GamesGrid> {
         } catch (_) {}
       },
       onLeftStickClick: widget.onRandom,
-      onSelectButton: widget.onScrape,
+      onSelectModifierA: widget.onScrape, // Select + A - Scrape.
       onSelectModifierB: _toggleLegend, // Select + B - Hide/show legend.
+      onSelectModifierY: widget.onRandom, // Select + Y - Random game.
       onSettings: widget.onSettings,
     );
   }

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -68,8 +68,7 @@ class GamesGrid extends StatefulWidget {
   State<GamesGrid> createState() => _GamesGridState();
 }
 
-class _GamesGridState extends State<GamesGrid>
-    with SingleTickerProviderStateMixin {
+class _GamesGridState extends State<GamesGrid> {
   late GamepadNavigation _gamepadNav;
   final ScrollController _scrollController = ScrollController();
   int _selectedIndex = 0;
@@ -118,25 +117,13 @@ class _GamesGridState extends State<GamesGrid>
   final Map<int, Widget> _rowCache = {};
   String? _rowCacheSig;
 
-  // Selection cursor. The border follows the *selected card's real rendered box*
-  // via a per-card LayerLink + CompositedTransformFollower, so it tracks the card
-  // through scrolling AND the Select+B reflow with zero manual coordinate math.
-  // This is what makes it correct at any scroll depth: a global-model overlay
-  // (selRect.top - scrollOffset) drifts because the culled SliverList doesn't
-  // re-lay off-screen rows when the cards grow, so its scroll accounting diverges
-  // from the model by an amount that accumulates per off-screen row. The follower
-  // sidesteps that entirely — it reads the leader layer's actual position. Links
-  // are created lazily per card index (only cards that get built get one).
-  final Map<int, LayerLink> _cardLinks = {};
-  // Cross-card glide: on a selection change the follower snaps to the new card,
-  // and this controller eases the border from the old card's rect to the new one
-  // (Transform + size) so the cursor still slides between cards. At rest (value 1)
-  // the border sits exactly on the followed card.
-  late final AnimationController _cursorGlide;
-  double _glideFromLeft = 0;
-  double _glideFromTop = 0;
-  double _glideFromWidth = 0;
-  double _glideFromHeight = 0;
+  // Selection cursor. The border is a scroll-compensated overlay positioned from
+  // the layout model (_cardRects[selectedIndex]) minus the live scroll offset,
+  // rebuilt every scroll tick. An earlier CompositedTransformFollower/LayerLink
+  // approach rendered a few rows north of the real card during scrolling because
+  // the leader (inside a RepaintBoundary-wrapped SliverList row) reports a stale
+  // composited transform. The cursor is now drawn inside the selected card's
+  // cell (see buildRow), which tracks the scroll content natively.
 
   // Layout
   List<_CardRect> _cardRects = [];
@@ -147,6 +134,16 @@ class _GamesGridState extends State<GamesGrid>
   double? _lastLayoutWidth;
   int? _lastLayoutCols;
   bool? _lastIsFanart;
+  // Exact laid-out height of all rows (set by _positionCards). See its use in
+  // _centerTargetFor for why we don't trust the SliverList's own estimate.
+  double _contentHeight = 0;
+
+  // Set just before any non-scroll layout change (legend toggle, card-size
+  // cycle, fanart↔box2d). The selected card is the source of truth: after the
+  // new layout is painted we scroll the view to centre that card, so the cursor
+  // is always brought back into view. Steady scroll and dpad nav never set it
+  // (nav scrolls via _ensureSelectedVisible).
+  bool _recenterAfterLayout = false;
 
   // Per-card height/width ratio (aspect), which is INDEPENDENT of the card
   // width. Measuring it is the expensive part of layout (file-header reads +
@@ -359,6 +356,13 @@ class _GamesGridState extends State<GamesGrid>
       return;
     }
 
+    // A fanart↔box2d switch is only observable here (card style is read from
+    // the config provider, not passed as a prop) — recentre on the selected card
+    // once relaid. Never on the first layout (_lastIsFanart == null).
+    if (_lastIsFanart != null && _lastIsFanart != _isFanart) {
+      _recenterAfterLayout = true;
+    }
+
     if (measureChanged) {
       _measureCards();
       _needsDimReload = false;
@@ -428,6 +432,11 @@ class _GamesGridState extends State<GamesGrid>
       i = end;
       r++;
     }
+    // Exact total height of all rows (each rendered as SizedBox(maxH + spY)).
+    // Used to clamp centre-scroll targets against the REAL content height rather
+    // than the SliverList's row-count estimate, which under-reports right after
+    // a relayout and would otherwise clamp a far jump short (selection off-screen).
+    _contentHeight = y;
 
     // Card rects/rows just changed → any memoized row widgets are stale.
     // Bumping the generation invalidates the row cache on the next build (see
@@ -464,11 +473,6 @@ class _GamesGridState extends State<GamesGrid>
       (widget.games.length - 1).clamp(0, 999999),
     );
     _settledIndex = _selectedIndex;
-    _cursorGlide = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 300),
-      value: 1, // start settled on the initial card (no glide)
-    );
     _updateCrossAxisCount();
     _initializeGamepad();
     GameLegendVisibility.hidden.addListener(_onLegendVisibilityChanged);
@@ -529,14 +533,14 @@ class _GamesGridState extends State<GamesGrid>
       final newIndex = (currentIndex + delta).clamp(0, sizes.length - 1);
       if (newIndex != currentIndex) {
         final newSize = sizes[newIndex];
+        // Recentre after relayout (pinch changes cols locally, so didUpdateWidget
+        // won't see a cols delta — set the flag here instead).
+        _recenterAfterLayout = true;
         provider.updateGameGridColumns(newSize);
         _updateCrossAxisCount();
         _lastLayoutWidth = null;
         _showCardSizeLabel(newSize);
         setState(() {});
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) _ensureSelectedVisible();
-        });
       }
     } catch (_) {}
   }
@@ -594,6 +598,11 @@ class _GamesGridState extends State<GamesGrid>
     super.didUpdateWidget(oldWidget);
     final prevCols = _crossAxisCount;
     _updateCrossAxisCount();
+    if (_crossAxisCount != prevCols) {
+      // Card-size cycled via the dropdown (cols changed) — recentre on the
+      // selected card after the relayout so the view follows the cursor.
+      _recenterAfterLayout = true;
+    }
     if (widget.games != oldWidget.games || _crossAxisCount != prevCols) {
       _lastLayoutWidth = null;
       // Aspect-ratio cache is keyed by index; a changed game set (even at the
@@ -614,9 +623,8 @@ class _GamesGridState extends State<GamesGrid>
         0,
         (widget.games.length - 1).clamp(0, 999999),
       );
-      // External selection change (not a local nav): snap the cursor to the new
-      // card rather than gliding from a possibly-unrelated previous position.
-      _cursorGlide.value = 1;
+      // External selection change: the cursor overlay glides to the new card's
+      // rect on rebuild; just bring it into view.
       if (mounted && _scrollController.hasClients) {
         _ensureSelectedVisible();
       }
@@ -653,14 +661,42 @@ class _GamesGridState extends State<GamesGrid>
   }
 
   /// Reacts to any change of the shared legend flag (this view's chord or a
-  /// future external/DB update). Starts the reflow animation; the flag is
-  /// cleared in AnimatedPadding.onEnd.
+  /// future external/DB update). Rebuilds so the grid reflows in one frame, then
+  /// the view recentres on the selected card (see build) so the cursor stays in
+  /// view.
   void _onLegendVisibilityChanged() {
-    // Rebuild so AnimatedPadding picks up the new indent target and animates the
-    // reflow. The selection cursor needs no special handling here — it follows
-    // the selected card's real box via the LayerLink follower, so it stays fitted
-    // as the card grows/shrinks with no per-frame coordinate correction.
-    if (mounted) setState(() {});
+    if (!mounted) return;
+    _recenterAfterLayout = true;
+    setState(() {});
+  }
+
+  /// Scroll offset that centres the selected card in the viewport, clamped to
+  /// the EXACT content height (12 top pad + rows + 80 bottom pad). Using our own
+  /// height instead of the SliverList's estimate is what makes a far jump land:
+  /// right after a size/mode relayout the sliver hasn't built the distant rows,
+  /// so its maxScrollExtent under-reports and would clamp the target short —
+  /// leaving the selection off-screen. jumpTo force-sets the offset here, and the
+  /// sliver then builds around it and its extent catches up.
+  double _centerTargetFor(_CardRect rect, double viewportH) {
+    final maxScroll = (12 + _contentHeight + 80 - viewportH).clamp(
+      0.0,
+      double.infinity,
+    );
+    return (12 + rect.top + rect.height / 2 - viewportH / 2).clamp(
+      0.0,
+      maxScroll,
+    );
+  }
+
+  /// Jumps the scroll so the selected card sits at the vertical centre of the
+  /// viewport. The card (and its in-cell cursor) is the source of truth; this is
+  /// how the view follows it after any layout change. A card already centred
+  /// jumps to its own offset (a no-op), so there's no gratuitous movement.
+  void _centerOnSelected() {
+    if (!_scrollController.hasClients || _cardRects.isEmpty) return;
+    final rect = _cardRects[_selectedIndex.clamp(0, _cardRects.length - 1)];
+    final viewportH = _scrollController.position.viewportDimension;
+    _scrollController.jumpTo(_centerTargetFor(rect, viewportH));
   }
 
   @override
@@ -673,7 +709,6 @@ class _GamesGridState extends State<GamesGrid>
     GamepadNavigationManager.popLayer('games_grid');
     _gamepadNav.dispose();
     _scrollController.dispose();
-    _cursorGlide.dispose();
     super.dispose();
   }
 
@@ -698,7 +733,6 @@ class _GamesGridState extends State<GamesGrid>
   void _navDelta(int delta) {
     if (widget.games.isEmpty) return;
     final c = _cols;
-    final from = _selectedIndex;
     setState(() {
       int ni = _selectedIndex + delta;
       if (delta < 0 && ni < 0) {
@@ -714,7 +748,6 @@ class _GamesGridState extends State<GamesGrid>
       _selectedIndex = ni.clamp(0, widget.games.length - 1);
       _updateFastNav();
     });
-    _beginCursorGlide(from);
     _ensureSelectedVisible();
     _onSelectionChanged();
     SfxService().playNavSound();
@@ -722,7 +755,6 @@ class _GamesGridState extends State<GamesGrid>
 
   void _navHoriz(int dir) {
     if (widget.games.isEmpty) return;
-    final from = _selectedIndex;
     setState(() {
       int ni;
       if (dir < 0) {
@@ -741,32 +773,9 @@ class _GamesGridState extends State<GamesGrid>
       _selectedIndex = ni.clamp(0, widget.games.length - 1);
       _updateFastNav();
     });
-    _beginCursorGlide(from);
     _ensureSelectedVisible();
     _onSelectionChanged();
     SfxService().playNavSound();
-  }
-
-  /// Kicks the selection cursor's cross-card glide: snapshot the card we moved
-  /// *from* (its rect, before layout changes) and run the controller. The
-  /// follower is already re-anchored to the new card on the next build, so the
-  /// glide interpolates the border from the old card's box to the new one; at
-  /// rest the border sits exactly on the followed card.
-  void _beginCursorGlide(int fromIndex) {
-    if (fromIndex == _selectedIndex) return;
-    if (fromIndex >= 0 && fromIndex < _cardRects.length) {
-      final r = _cardRects[fromIndex];
-      _glideFromLeft = r.left;
-      _glideFromTop = r.top;
-      _glideFromWidth = r.width;
-      _glideFromHeight = r.height;
-      _cursorGlide.duration = Duration(
-        milliseconds: _isNavigatingFast ? 120 : 300,
-      );
-      _cursorGlide.forward(from: 0);
-    } else {
-      _cursorGlide.value = 1;
-    }
   }
 
   void _onSelectionChanged() {
@@ -911,13 +920,20 @@ class _GamesGridState extends State<GamesGrid>
     if (!_scrollController.hasClients || _cardRects.isEmpty) return;
     final rect = _cardRects[_selectedIndex.clamp(0, _cardRects.length - 1)];
     final viewportH = _scrollController.position.viewportDimension;
-    final target = (rect.top - viewportH / 2 + rect.height / 2).clamp(
-      0.0,
-      _scrollController.position.maxScrollExtent,
-    );
+    final target = _centerTargetFor(rect, viewportH);
+    // During a fast-nav burst, jump instantly rather than firing a fresh
+    // animateTo per keypress. Repeated overlapping animations let the viewport
+    // fall far behind _selectedIndex, so the selected card trails the logical
+    // selection by many rows until the scroll finally catches up. A synchronous
+    // jump keeps the selected card centered every frame. The trailing (settled)
+    // move still animates smoothly.
+    if (_isNavigatingFast) {
+      _scrollController.jumpTo(target);
+      return;
+    }
     _scrollController.animateTo(
       target,
-      duration: Duration(milliseconds: _isNavigatingFast ? 220 : 500),
+      duration: const Duration(milliseconds: 500),
       curve: Curves.easeOutQuart,
     );
   }
@@ -958,24 +974,30 @@ class _GamesGridState extends State<GamesGrid>
         Column(
           children: [
             Expanded(
-              // Indent the grid to clear the vertical legend on the left; the
-              // reduced width makes the cards slightly smaller. Select + B hides
-              // the legend and animates this indent to 0 so the cards genuinely
-              // reflow to fill the reclaimed 60.r. This drives _computeLayout
-              // every frame, but only its cheap _positionCards pass runs (aspect
-              // ratios are cached in _cardHOverW). The selection cursor needs no
-              // special handling during the reflow — it follows the selected
-              // card's real box via the LayerLink follower, so it stays fitted as
-              // the card grows with zero coordinate math.
-              child: AnimatedPadding(
-                duration: const Duration(milliseconds: 250),
-                curve: Curves.easeOutCubic,
+              // Indent the grid to clear the vertical legend on the left. Select
+              // + B toggles the legend; the indent flips 60.r↔0 in a single frame
+              // (no animation) so there's no moving target to chase — the grid
+              // reflows once and the selected card is pinned in place by the
+              // scroll restore below. The reduced width makes the cards slightly
+              // smaller when the legend is shown.
+              child: Padding(
                 padding: EdgeInsets.only(
                   left: GameLegendVisibility.hidden.value ? 0 : 60.r,
                 ),
                 child: LayoutBuilder(
                   builder: (context, constraints) {
                     _computeLayout(constraints.maxWidth);
+
+                    // The layout just changed for a non-scroll reason (legend
+                    // toggle, size cycle, fanart↔box2d). Once this new layout is
+                    // painted, scroll so the selected card is centred — the view
+                    // follows the cursor.
+                    if (_recenterAfterLayout) {
+                      _recenterAfterLayout = false;
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (mounted) _centerOnSelected();
+                      });
+                    }
 
                     final theme = Theme.of(context);
                     final fp = widget.fileProvider;
@@ -992,9 +1014,7 @@ class _GamesGridState extends State<GamesGrid>
                         ? decodeBucket
                         : bucketed;
 
-                    final selRect = _selectedIndex < _cardRects.length
-                        ? _cardRects[_selectedIndex]
-                        : _cardRects.first;
+                    final borderColor = theme.colorScheme.secondary;
 
                     // Row-cache gate: when the layout/decode/theme signature is
                     // unchanged, buildRow returns the exact same Row instances it
@@ -1011,36 +1031,60 @@ class _GamesGridState extends State<GamesGrid>
                     }
 
                     Widget buildRow(BuildContext ctx, int rowIndex) {
-                      final cached = _rowCache[rowIndex];
-                      if (cached != null) return cached;
                       final row = _rows[rowIndex];
+                      // The selection cursor is a border drawn INSIDE the selected
+                      // card's cell, so it's part of the card's own coordinate
+                      // space — always pixel-exact on the card through scroll,
+                      // resize, mode switch and legend toggle, with no offset math
+                      // and no animation to lag. The one row holding the selection
+                      // therefore can't be memoized (its border must appear/vanish
+                      // with the selection), so we skip the cache for just that
+                      // row; every other row stays cached and the fast-scroll perf
+                      // is preserved.
+                      final hasSelection =
+                          _selectedIndex >= row.startIndex &&
+                          _selectedIndex < row.startIndex + row.count;
+                      if (!hasSelection) {
+                        final cached = _rowCache[rowIndex];
+                        if (cached != null) return cached;
+                      }
                       final cards = <Widget>[];
                       for (int j = 0; j < row.count; j++) {
                         final idx = row.startIndex + j;
                         final rect = _cardRects[idx];
                         _ensureDims(idx);
-                        final card = _buildCard(
+                        Widget cell = _buildCard(
                           idx,
                           rect,
                           fp,
                           targetWidth,
                           theme,
                         );
+                        if (idx == _selectedIndex) {
+                          cell = Stack(
+                            children: [
+                              cell,
+                              Positioned.fill(
+                                child: IgnorePointer(
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      border: Border.all(
+                                        color: borderColor,
+                                        width: 4.r,
+                                      ),
+                                      borderRadius: BorderRadius.circular(12.r),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          );
+                        }
                         cards.add(
                           SizedBox(
                             width: rect.width,
                             height: rect.height,
-                            // Anchor a per-card LayerLink so the selection cursor
-                            // can follow this card's real rendered box. Links are
-                            // cached per index (stable identity across row-cache
-                            // rebuilds); only built cards get one.
-                            child: CompositedTransformTarget(
-                              link: _cardLinks.putIfAbsent(
-                                idx,
-                                () => LayerLink(),
-                              ),
-                              child: card,
-                            ),
+                            child: cell,
                           ),
                         );
                       }
@@ -1051,12 +1095,9 @@ class _GamesGridState extends State<GamesGrid>
                           children: _interleaveSpacing(cards, _spX),
                         ),
                       );
-                      _rowCache[rowIndex] = built;
+                      if (!hasSelection) _rowCache[rowIndex] = built;
                       return built;
                     }
-
-                    final borderColor = theme.colorScheme.secondary;
-                    final selLink = _cardLinks[_selectedIndex];
 
                     return Listener(
                       onPointerDown: _handlePointerDown,
@@ -1083,84 +1124,7 @@ class _GamesGridState extends State<GamesGrid>
                               ),
                             ],
                           ),
-                          // Selection cursor. It follows the selected card's real
-                          // rendered box via a LayerLink, so it tracks the card
-                          // through scrolling AND the Select+B reflow (the card
-                          // grows, the leader layer moves, the border moves with it)
-                          // with no scroll-offset math — which is what kept the old
-                          // overlay drifting a row too low a few rows down. The
-                          // cross-card glide is driven by _cursorGlide: on selection
-                          // change the follower snaps to the new card and the border
-                          // eases from the old card's rect (Transform + size) to a
-                          // snug fit on the new one (translate 0, size == selRect).
-                          // Clip the cursor to the grid viewport. The follower's
-                          // render box is border-sized and sits at the Stack's
-                          // top-left; it only moves to the leader at composite time
-                          // via a layer transform, so the Stack's overflow-based
-                          // clip never fires and the border would otherwise paint
-                          // over the footer when a card scrolls past the bottom edge
-                          // during fast scrolling. An explicit ClipRect always
-                          // clips, regardless of the follower's reported size. The
-                          // Align fills the ClipRect (so it clips at the grid
-                          // bounds) while passing LOOSE constraints to the
-                          // follower — otherwise Positioned.fill's tight grid-sized
-                          // constraints would stretch the border Container to fill
-                          // the whole grid.
-                          if (selLink != null)
-                            Positioned.fill(
-                              child: IgnorePointer(
-                                child: ClipRect(
-                                  child: Align(
-                                    alignment: Alignment.topLeft,
-                                    child: CompositedTransformFollower(
-                                      link: selLink,
-                                      showWhenUnlinked: false,
-                                      targetAnchor: Alignment.topLeft,
-                                      followerAnchor: Alignment.topLeft,
-                                      child: AnimatedBuilder(
-                                        animation: _cursorGlide,
-                                        builder: (_, _) {
-                                          final t = Curves.easeOutQuart
-                                              .transform(_cursorGlide.value);
-                                          final inv = 1 - t;
-                                          final dx =
-                                              (_glideFromLeft - selRect.left) *
-                                              inv;
-                                          final dy =
-                                              (_glideFromTop - selRect.top) *
-                                              inv;
-                                          final w =
-                                              _glideFromWidth +
-                                              (selRect.width -
-                                                      _glideFromWidth) *
-                                                  t;
-                                          final h =
-                                              _glideFromHeight +
-                                              (selRect.height -
-                                                      _glideFromHeight) *
-                                                  t;
-                                          return Transform.translate(
-                                            offset: Offset(dx, dy),
-                                            child: Container(
-                                              width: w,
-                                              height: h,
-                                              decoration: BoxDecoration(
-                                                border: Border.all(
-                                                  color: borderColor,
-                                                  width: 4.r,
-                                                ),
-                                                borderRadius:
-                                                    BorderRadius.circular(12.r),
-                                              ),
-                                            ),
-                                          );
-                                        },
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
+                          // Selection cursor is drawn in-cell (see buildRow).
                           ValueListenableBuilder<String?>(
                             valueListenable: _cardSizeLabel,
                             builder: (context, label, child) => AnimatedOpacity(
@@ -1297,12 +1261,10 @@ class _GamesGridState extends State<GamesGrid>
     return GestureDetector(
       key: ValueKey('game_${game.romname}'),
       onTap: () {
-        final from = _selectedIndex;
         setState(() {
           _selectedIndex = index;
           _settledIndex = index; // discrete tap: update chrome immediately
         });
-        _beginCursorGlide(from);
         _settleTimer?.cancel();
         widget.onGameSelected(game);
         _scheduleAchievementsLoad();
@@ -1416,12 +1378,10 @@ class _GamesGridState extends State<GamesGrid>
     return GestureDetector(
       key: ValueKey('game_${game.romname}'),
       onTap: () {
-        final from = _selectedIndex;
         setState(() {
           _selectedIndex = index;
           _settledIndex = index; // discrete tap: update chrome immediately
         });
-        _beginCursorGlide(from);
         _settleTimer?.cancel();
         widget.onGameSelected(game);
         _scheduleAchievementsLoad();

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -85,6 +85,20 @@ class _GamesGridState extends State<GamesGrid> {
   DateTime? _lastNavTime;
   static const Duration _fastNavThreshold = Duration(milliseconds: 150);
 
+  // Debounced "settled" selection that drives the footer pill + action-button
+  // legend. Rebuilding that chrome on every fast-nav move floods the UI thread
+  // (measured: ~18% severe frame drops vs ~11% without it). Instead we only
+  // advance _settledIndex once rapid navigation stops, and memoize the built
+  // chrome by signature so build() returns identical instances during a burst
+  // (Flutter then skips those subtrees). The highlight cursor still tracks
+  // _selectedIndex every move for immediate feedback.
+  int _settledIndex = 0;
+  Timer? _settleTimer;
+  static const Duration _chromeSettleDelay = Duration(milliseconds: 160);
+  String? _chromeSig;
+  Widget? _chromeFooter;
+  Widget? _chromeLegend;
+
   // Layout
   List<_CardRect> _cardRects = [];
   List<_RowInfo> _rows = [];
@@ -372,6 +386,7 @@ class _GamesGridState extends State<GamesGrid> {
       0,
       (widget.games.length - 1).clamp(0, 999999),
     );
+    _settledIndex = _selectedIndex;
     _updateCrossAxisCount();
     _initializeGamepad();
 
@@ -416,6 +431,9 @@ class _GamesGridState extends State<GamesGrid> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    // Theme / MediaQuery / ScreenUtil may have changed; drop the memoized
+    // chrome so it rebuilds with fresh sizing on the next build.
+    _chromeSig = null;
     _updateCrossAxisCount();
   }
 
@@ -531,6 +549,7 @@ class _GamesGridState extends State<GamesGrid> {
   void dispose() {
     _cardSizeLabelTimer?.cancel();
     _achievementsDebounce?.cancel();
+    _settleTimer?.cancel();
     _cardSizeLabel.dispose();
     GamepadNavigationManager.popLayer('games_grid');
     _gamepadNav.dispose();
@@ -609,6 +628,25 @@ class _GamesGridState extends State<GamesGrid> {
       widget.onGameSelected(widget.games[_selectedIndex]);
     }
     _scheduleAchievementsLoad();
+    _scheduleChromeSettle();
+  }
+
+  /// Advances the footer/legend's settled selection. A single (slow) move
+  /// updates it immediately; during a fast-nav burst it is deferred until
+  /// navigation settles, so the expensive chrome isn't rebuilt every frame.
+  void _scheduleChromeSettle() {
+    _settleTimer?.cancel();
+    if (!_isNavigatingFast) {
+      if (_settledIndex != _selectedIndex) {
+        setState(() => _settledIndex = _selectedIndex);
+      }
+      return;
+    }
+    _settleTimer = Timer(_chromeSettleDelay, () {
+      if (mounted && _settledIndex != _selectedIndex) {
+        setState(() => _settledIndex = _selectedIndex);
+      }
+    });
   }
 
   bool get _isAllMode =>
@@ -765,6 +803,8 @@ class _GamesGridState extends State<GamesGrid> {
       );
     }
 
+    _buildSettledChrome();
+
     return Stack(
       children: [
         Column(
@@ -918,45 +958,59 @@ class _GamesGridState extends State<GamesGrid> {
                 ),
               ),
             ),
-            GameViewFooter(
-              game: widget
-                  .games[_selectedIndex.clamp(0, widget.games.length - 1)],
-              onPlay: widget.onPlay,
-              hasRetroAchievements:
-                  widget.games.isNotEmpty &&
-                  _hasRetroAchievementsFor(
-                    widget.games[_selectedIndex.clamp(
-                      0,
-                      widget.games.length - 1,
-                    )],
-                  ),
-              isLoadingAchievements: _isLoadingAchievements,
-              currentGameInfo: _currentGameInfo,
-              onShowAchievements: _showAchievementsDialog,
-            ),
+            // Footer pill is driven by the debounced settled selection and
+            // memoized (see _buildSettledChrome) so it is not rebuilt on every
+            // fast-nav frame.
+            _chromeFooter!,
           ],
         ),
-        // Vertical action-button legend (shared with the game list view).
-        Positioned(
-          top: 12.r,
-          left: 12.r,
-          child: Consumer<SyncManager>(
-            builder: (context, syncManager, child) => GameActionButtons(
-              system: widget.system,
-              selectedGame:
-                  widget.games[_selectedIndex.clamp(0, widget.games.length - 1)],
-              syncProvider: syncManager.active,
-              onBack: widget.onBack,
-              onFavorite: widget.onFavorite,
-              onViewMode: () =>
-                  GameViewModeDropdown.globalKey.currentState?.showDropdown(),
-              onSettings: widget.onSettings ?? () {},
-              onRandom: widget.onRandom,
-              onScrape: widget.onScrape,
-            ),
-          ),
-        ),
+        // Vertical action-button legend (shared with the game list view);
+        // also memoized on the settled selection.
+        _chromeLegend!,
       ],
+    );
+  }
+
+  /// (Re)builds the footer pill + action-button legend only when the settled
+  /// selection or its achievement/favorite state changes. During a fast-nav
+  /// burst the signature is stable, so build() reuses the same widget
+  /// instances and Flutter skips these (relatively expensive) subtrees.
+  void _buildSettledChrome() {
+    final settledGame =
+        widget.games[_settledIndex.clamp(0, widget.games.length - 1)];
+    final hasRa = _hasRetroAchievementsFor(settledGame);
+    final sig =
+        '$_settledIndex|${settledGame.romname}|${settledGame.isFavorite}'
+        '|$hasRa|$_isLoadingAchievements|${identityHashCode(_currentGameInfo)}';
+    if (sig == _chromeSig && _chromeFooter != null && _chromeLegend != null) {
+      return;
+    }
+    _chromeSig = sig;
+    _chromeFooter = GameViewFooter(
+      game: settledGame,
+      onPlay: widget.onPlay,
+      hasRetroAchievements: hasRa,
+      isLoadingAchievements: _isLoadingAchievements,
+      currentGameInfo: _currentGameInfo,
+      onShowAchievements: _showAchievementsDialog,
+    );
+    _chromeLegend = Positioned(
+      top: 12.r,
+      left: 12.r,
+      child: Consumer<SyncManager>(
+        builder: (context, syncManager, child) => GameActionButtons(
+          system: widget.system,
+          selectedGame: settledGame,
+          syncProvider: syncManager.active,
+          onBack: widget.onBack,
+          onFavorite: widget.onFavorite,
+          onViewMode: () =>
+              GameViewModeDropdown.globalKey.currentState?.showDropdown(),
+          onSettings: widget.onSettings ?? () {},
+          onRandom: widget.onRandom,
+          onScrape: widget.onScrape,
+        ),
+      ),
     );
   }
 
@@ -988,7 +1042,11 @@ class _GamesGridState extends State<GamesGrid> {
     return GestureDetector(
       key: ValueKey('game_${game.romname}'),
       onTap: () {
-        setState(() => _selectedIndex = index);
+        setState(() {
+          _selectedIndex = index;
+          _settledIndex = index; // discrete tap: update chrome immediately
+        });
+        _settleTimer?.cancel();
         widget.onGameSelected(game);
         _scheduleAchievementsLoad();
         SfxService().playNavSound();
@@ -1101,7 +1159,11 @@ class _GamesGridState extends State<GamesGrid> {
     return GestureDetector(
       key: ValueKey('game_${game.romname}'),
       onTap: () {
-        setState(() => _selectedIndex = index);
+        setState(() {
+          _selectedIndex = index;
+          _settledIndex = index; // discrete tap: update chrome immediately
+        });
+        _settleTimer?.cancel();
         widget.onGameSelected(game);
         _scheduleAchievementsLoad();
         SfxService().playNavSound();

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1052,6 +1052,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
       onFavorite: _toggleFavorite,
       onRandom: _showRandomGameDialog,
       onSettings: _openGameSettingsDialog,
+      onScrape: () => _scrapeAction?.call(),
       scrapingGameRomnames: _scrapingGameRomnames,
       scrapeProgress: _scrapeProgress,
     );
@@ -1076,6 +1077,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
       onFavorite: _toggleFavorite,
       onRandom: _showRandomGameDialog,
       onSettings: _openGameSettingsDialog,
+      onScrape: () => _scrapeAction?.call(),
       scrapingGameRomnames: _scrapingGameRomnames,
       scrapeProgress: _scrapeProgress,
     );

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1187,6 +1187,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
                   onViewMode: () =>
                       GameViewModeDropdown.globalKey.currentState?.showDropdown(),
                   onSettings: _openGameSettingsDialog,
+                  onRandom: _showRandomGameDialog,
+                  onScrape: () => _scrapeAction?.call(),
                 );
               },
             ),

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -148,6 +148,10 @@ class _SystemGamesListState extends State<SystemGamesList> {
   final Set<String> _scrapingGameRomnames = {};
   final Map<String, double> _scrapeProgress = {};
 
+  // Guards against re-entrant Select + A scrapes of the selected game (grid /
+  // carousel views, which have no details card to own the scrape).
+  bool _isScrapingSelectedGame = false;
+
   // Bumped whenever artwork is replaced so background/detail images rebuild.
   int _artworkVersion = 0;
 
@@ -1068,7 +1072,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
       onFavorite: _toggleFavorite,
       onRandom: _showRandomGameDialog,
       onSettings: _openGameSettingsDialog,
-      onScrape: () => _scrapeAction?.call(),
+      onScrape: _scrapeSelectedGame,
       scrapingGameRomnames: _scrapingGameRomnames,
       scrapeProgress: _scrapeProgress,
     );
@@ -1093,7 +1097,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
       onFavorite: _toggleFavorite,
       onRandom: _showRandomGameDialog,
       onSettings: _openGameSettingsDialog,
-      onScrape: () => _scrapeAction?.call(),
+      onScrape: _scrapeSelectedGame,
       scrapingGameRomnames: _scrapingGameRomnames,
       scrapeProgress: _scrapeProgress,
     );
@@ -1563,6 +1567,156 @@ class _SystemGamesListState extends State<SystemGamesList> {
       }
     } catch (e) {
       _log.e('Error updating game in list: $e');
+    }
+  }
+
+  /// Scrapes metadata/artwork for the currently selected game.
+  ///
+  /// The list view triggers scraping through the details card (which owns rich
+  /// tab/focus UX). Grid and carousel views have no details card, so this
+  /// view-mode-independent path drives the same [ScreenScraperService] flow and
+  /// feeds the [_scrapingGameRomnames]/[_scrapeProgress] overlay maps that those
+  /// grids already render. Bound to the Select + A chord in those views.
+  Future<void> _scrapeSelectedGame() async {
+    final game = _selectedGame;
+    if (game == null || _isScrapingSelectedGame) return;
+
+    final scrapeSystemId = widget.system.id;
+    if (scrapeSystemId == null) return;
+
+    if (!await ScreenScraperService.hasSavedCredentials()) {
+      if (!mounted) return;
+      AppNotification.showNotification(
+        context,
+        'Please log in to ScreenScraper in the Scraping tab first.',
+        type: NotificationType.info,
+      );
+      return;
+    }
+    if (!mounted) return;
+
+    _isScrapingSelectedGame = true;
+
+    // Pause any preview playback to avoid resource contention during scraping.
+    _resetVideoState();
+
+    final isAllMode =
+        widget.system.folderName == SystemFolderNames.all ||
+        widget.system.folderName == SystemFolderNames.favorites;
+    final targetSystemFolder = isAllMode && game.systemFolderName != null
+        ? game.systemFolderName!
+        : widget.system.primaryFolderName;
+
+    final secondaryState = context.read<SecondaryDisplayState?>();
+    final isSecondaryActive =
+        _secondaryDisplayState?.value?.isSecondaryActive ?? false;
+
+    setState(() {
+      _scrapingGameRomnames.add(game.romname);
+      _scrapeProgress[game.romname] = 0.0;
+    });
+
+    AppNotification.showNotification(
+      context,
+      AppLocale.scrapingGameData.getString(context),
+      type: NotificationType.info,
+    );
+
+    if (secondaryState != null && isSecondaryActive) {
+      secondaryState.updateState(
+        isScraping: true,
+        scrapeStatus: AppLocale.scrapingGameData.getString(context),
+        scrapeProgress: 0.0,
+      );
+    }
+
+    try {
+      // Mirror the card: overwrite existing metadata when a description is
+      // already present, otherwise only fill the gaps.
+      final forceOverwrite = game.getDescriptionForLanguage('en').trim().isNotEmpty;
+
+      final result = await ScreenScraperService.scrapeSingleGame(
+        appSystemId: scrapeSystemId,
+        romName: game.romname,
+        systemFolder: targetSystemFolder,
+        romPath: game.romPath ?? '',
+        gameName: game.name,
+        forceOverwrite: forceOverwrite,
+        onProgress: (statusKey, progress) {
+          if (!mounted) return;
+          setState(() {
+            _scrapeProgress[game.romname] = progress;
+          });
+          if (secondaryState != null && isSecondaryActive) {
+            secondaryState.updateState(
+              scrapeStatus: statusKey.getString(context),
+              scrapeProgress: progress,
+            );
+          }
+        },
+      );
+
+      if (!mounted) return;
+      if (result['success'] == true) {
+        // Evict cached artwork so the grid rebuilds with the new assets.
+        try {
+          final imagesToEvict = [
+            game.getScreenshotPath(targetSystemFolder, _fileProvider),
+            game.getImagePath(targetSystemFolder, 'wheels', _fileProvider),
+            game.getImagePath(targetSystemFolder, 'fanarts', _fileProvider),
+          ];
+          for (final imagePath in imagesToEvict) {
+            final imageFile = File(imagePath);
+            if (await imageFile.exists()) {
+              await FileImage(imageFile).evict();
+            }
+          }
+        } catch (e) {
+          _log.e('Image cache eviction failed: $e');
+        }
+
+        await _handleGameUpdated();
+        if (mounted) {
+          AppNotification.showNotification(
+            context,
+            AppLocale.scrapeSuccessful.getString(context),
+            type: NotificationType.success,
+          );
+        }
+      } else {
+        AppNotification.showNotification(
+          context,
+          result['message'].toString().getString(context),
+          type: NotificationType.error,
+        );
+      }
+    } catch (e) {
+      _log.e('Single game scrape (grid/carousel) failed: $e');
+      if (mounted) {
+        AppNotification.showNotification(
+          context,
+          AppLocale.scrapeErrorGame.getString(context),
+          type: NotificationType.error,
+        );
+      }
+    } finally {
+      _isScrapingSelectedGame = false;
+      if (mounted) {
+        setState(() {
+          _scrapingGameRomnames.remove(game.romname);
+          _scrapeProgress.remove(game.romname);
+        });
+        if (secondaryState != null && isSecondaryActive) {
+          // Latency buffer so file descriptors release before the secondary
+          // screen clears its scrape state.
+          await Future.delayed(const Duration(milliseconds: 250));
+          secondaryState.updateState(
+            isScraping: false,
+            clearScrapeProgress: true,
+            clearScrapeStatus: true,
+          );
+        }
+      }
     }
   }
 }

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -98,6 +98,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
   VoidCallback? _triggerOverlayAction;
   VoidCallback? _secondaryOverlayAction; // Maps to RB (Scrape/Refresh).
   VoidCallback? _selectButtonAction; // Maps to Select (View) for mute/refresh.
+  VoidCallback? _scrapeAction; // Maps to Select + A (scrape highlighted game).
   bool Function(bool isRight)?
   _tabNavigationAction; // Facilitates tab switching via bumpers.
   bool Function()? _isPlayingGameBlocked; // Validation for launch readiness.
@@ -1183,7 +1184,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
                   syncProvider: syncManager.active,
                   onBack: _goBack,
                   onFavorite: _toggleFavorite,
-                  onRandom: _showRandomGameDialog,
+                  onViewMode: () =>
+                      GameViewModeDropdown.globalKey.currentState?.showDropdown(),
                   onSettings: _openGameSettingsDialog,
                 );
               },
@@ -1417,6 +1419,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
         },
         onRegisterSelectButton: (action) {
           _selectButtonAction = action;
+        },
+        onRegisterScrapeAction: (action) {
+          _scrapeAction = action;
         },
         onRegisterIsPlayingGameBlocked: (isBlocked) {
           _isPlayingGameBlocked = isBlocked;

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -22,6 +22,7 @@ import '../../repositories/system_repository.dart';
 import '../../repositories/game_repository.dart';
 import '../../services/screenscraper_service.dart';
 import '../../services/secondary_achievements_controller.dart';
+import '../../services/game_legend_visibility.dart';
 import '../../utils/gamepad_nav.dart';
 import '../../providers/file_provider.dart';
 import '../../providers/sqlite_config_provider.dart';
@@ -180,6 +181,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
     _configProvider = context.read<SqliteConfigProvider>();
     _configProvider.addListener(_onConfigChanged);
 
+    GameLegendVisibility.hidden.addListener(_onLegendVisibilityChanged);
+
     _lastShowInfo = _configProvider.config.showGameInfo;
 
     MusicPlayerService().addListener(_onMusicPlayerStateChanged);
@@ -208,6 +211,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
     _configProvider.removeListener(_onConfigChanged);
     _databaseProvider.removeListener(_onDatabaseUpdated);
     MusicPlayerService().removeListener(_onMusicPlayerStateChanged);
+    GameLegendVisibility.hidden.removeListener(_onLegendVisibilityChanged);
 
     // Shared singleton — detach our listener, never dispose the instance.
     _secondaryDisplayState?.removeListener(_onSecondaryDisplayChanged);
@@ -328,6 +332,18 @@ class _SystemGamesListState extends State<SystemGamesList> {
   /// rebuild — [State.setState] is `@protected` and cannot be invoked from an
   /// extension. Behaviourally identical to calling `setState` directly.
   void rebuild(VoidCallback fn) => setState(fn);
+
+  /// Select + B — toggles the (session-global) vertical action-button legend.
+  /// When hidden the legend slides off the left edge and the list sidebar +
+  /// details reflow into the reclaimed 60.r gutter.
+  void _toggleLegend() {
+    SfxService().playNavSound();
+    GameLegendVisibility.toggle();
+  }
+
+  void _onLegendVisibilityChanged() {
+    if (mounted) setState(() {});
+  }
 
   /// Core logic for updating selection and managing rapid-scrolling UI state.
   void _updateSelectedGame(int newIndex) {
@@ -1123,10 +1139,16 @@ class _SystemGamesListState extends State<SystemGamesList> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Sidebar: Interactive list of games or music tracks.
-            Container(
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 250),
+              curve: Curves.easeOutCubic,
               width: 200.r,
               height: availableHeight,
-              margin: EdgeInsets.only(left: 60.r, top: 12.r, bottom: 12.r),
+              margin: EdgeInsets.only(
+                left: GameLegendVisibility.hidden.value ? 0 : 60.r,
+                top: 12.r,
+                bottom: 12.r,
+              ),
               decoration: BoxDecoration(
                 color: Theme.of(
                   context,
@@ -1173,12 +1195,18 @@ class _SystemGamesListState extends State<SystemGamesList> {
           ],
         ),
 
-        // Floating action buttons on the left side of the game list.
+        // Floating action buttons on the left side of the game list. Select + B
+        // slides this legend off the left edge (in sync with the sidebar margin).
         if (!isMusic)
-          Positioned(
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeOutCubic,
             top: 12.r,
-            left: 12.r,
-            child: Consumer<SyncManager>(
+            left: GameLegendVisibility.hidden.value ? -60.r : 12.r,
+            child: AnimatedOpacity(
+              duration: const Duration(milliseconds: 250),
+              opacity: GameLegendVisibility.hidden.value ? 0.0 : 1.0,
+              child: Consumer<SyncManager>(
               builder: (context, syncManager, child) {
                 return GameActionButtons(
                   system: widget.system,
@@ -1193,6 +1221,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
                   onScrape: () => _scrapeAction?.call(),
                 );
               },
+              ),
             ),
           ),
       ],

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1145,7 +1145,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
               width: 200.r,
               height: availableHeight,
               margin: EdgeInsets.only(
-                left: GameLegendVisibility.hidden.value ? 0 : 60.r,
+                left: GameLegendVisibility.hidden.value ? 12.r : 60.r,
                 top: 12.r,
                 bottom: 12.r,
               ),

--- a/lib/screens/game_screen/my_games_list/gamepad_nav.dart
+++ b/lib/screens/game_screen/my_games_list/gamepad_nav.dart
@@ -29,6 +29,24 @@ extension _GamepadNav on _SystemGamesListState {
     _selectButtonAction?.call();
   }
 
+  /// Handles the X button: opens the game view-mode picker (list/grid/carousel
+  /// + card size/style). For the music library, X keeps its shuffle toggle.
+  void _handleXButton() {
+    if (widget.system.folderName == 'music') {
+      final service = MusicPlayerService();
+      service.toggleShuffle();
+      AppNotification.showNotification(
+        context,
+        service.isShuffle
+            ? AppLocale.shuffleEnabled.getString(context)
+            : AppLocale.shuffleDisabled.getString(context),
+        type: NotificationType.info,
+      );
+      return;
+    }
+    GameViewModeDropdown.globalKey.currentState?.showDropdown();
+  }
+
   /// Registers gamepad and keyboard input mappings for the screen.
   void _initializeGamepad() {
     _gamepadNav = GamepadNavigation(
@@ -39,23 +57,11 @@ extension _GamepadNav on _SystemGamesListState {
       onSelectItem: _selectCurrentGame,
       onBack: _goBack,
       onFavorite: _toggleFavorite, // Button Y.
-      onXButton: () {
-        if (widget.system.folderName == 'music') {
-          final service = MusicPlayerService();
-          service.toggleShuffle();
-          AppNotification.showNotification(
-            context,
-            service.isShuffle
-                ? AppLocale.shuffleEnabled.getString(context)
-                : AppLocale.shuffleDisabled.getString(context),
-            type: NotificationType.info,
-          );
-        } else {
-          _showRandomGameDialog();
-        }
-      }, // Button X - Random.
+      onXButton: _handleXButton, // Button X - View mode picker (music: shuffle).
       onSettings: _openGameSettingsDialog, // Button Start.
-      onSelectButton: _handleSelectButton, // Button Select (View).
+      onSelectButton: _handleSelectButton, // Button Select (View) - tap.
+      onSelectModifierA: () => _scrapeAction?.call(), // Select + A - Scrape.
+      onSelectModifierY: _showRandomGameDialog, // Select + Y - Random.
       onRightStickClick: null,
       onLeftBumper: _handleLeftBumper,
       onRightBumper: _handleRightBumper,

--- a/lib/screens/game_screen/my_games_list/gamepad_nav.dart
+++ b/lib/screens/game_screen/my_games_list/gamepad_nav.dart
@@ -61,6 +61,7 @@ extension _GamepadNav on _SystemGamesListState {
       onSettings: _openGameSettingsDialog, // Button Start.
       onSelectButton: _handleSelectButton, // Button Select (View) - tap.
       onSelectModifierA: () => _scrapeAction?.call(), // Select + A - Scrape.
+      onSelectModifierB: _toggleLegend, // Select + B - Hide/show legend.
       onSelectModifierY: _showRandomGameDialog, // Select + Y - Random.
       onRightStickClick: null,
       onLeftBumper: _handleLeftBumper,

--- a/lib/services/game_legend_visibility.dart
+++ b/lib/services/game_legend_visibility.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/foundation.dart';
+
+/// Session-scoped visibility of the vertical action-button legend, shared across
+/// all game views (list, grid, carousel). Toggled by the Select + B chord.
+///
+/// In-memory only for now, so it resets each launch; a persisted user-config
+/// entry will back this later. Views listen to [hidden] so a toggle in one view
+/// is reflected when any other view is next shown within the session.
+class GameLegendVisibility {
+  GameLegendVisibility._();
+
+  /// True when the legend is hidden across every game view.
+  static final ValueNotifier<bool> hidden = ValueNotifier<bool>(false);
+
+  static void toggle() => hidden.value = !hidden.value;
+}

--- a/lib/services/game_legend_visibility.dart
+++ b/lib/services/game_legend_visibility.dart
@@ -1,16 +1,35 @@
 import 'package:flutter/foundation.dart';
 
-/// Session-scoped visibility of the vertical action-button legend, shared across
-/// all game views (list, grid, carousel). Toggled by the Select + B chord.
+/// Visibility of the vertical action-button legend, shared across all game views
+/// (list, grid, carousel). Toggled by the Select + B chord.
 ///
-/// In-memory only for now, so it resets each launch; a persisted user-config
-/// entry will back this later. Views listen to [hidden] so a toggle in one view
-/// is reflected when any other view is next shown within the session.
+/// The value is persisted to `user_config.legend_hidden` so a toggle survives
+/// restarts and upgrades. [bind] seeds the in-memory notifier from the loaded
+/// config and wires the persistence sink once during app startup. Views listen
+/// to [hidden] so a toggle in one view is reflected the next time any other view
+/// is shown.
 class GameLegendVisibility {
   GameLegendVisibility._();
 
   /// True when the legend is hidden across every game view.
   static final ValueNotifier<bool> hidden = ValueNotifier<bool>(false);
 
-  static void toggle() => hidden.value = !hidden.value;
+  /// Durable sink for [hidden]. Wired once via [bind]; `null` until then, so
+  /// early toggles simply stay in memory.
+  static Future<void> Function(bool hidden)? _persist;
+
+  /// Seeds [hidden] from persisted config and wires the persistence sink. Call
+  /// once during startup, after the config provider has loaded.
+  static void bind({
+    required bool initialHidden,
+    required Future<void> Function(bool hidden) persist,
+  }) {
+    hidden.value = initialHidden;
+    _persist = persist;
+  }
+
+  static void toggle() {
+    hidden.value = !hidden.value;
+    _persist?.call(hidden.value);
+  }
 }

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -64,6 +64,15 @@ class GamepadNavigation {
   final VoidCallback? onLeftBumper;
   final VoidCallback? onRightBumper;
 
+  /// Select (View) chord combos. The Select button is a pure modifier — on its
+  /// own it does nothing. While it is held (or within a short window of a pulse),
+  /// a face-button press fires the matching modifier callback instead of its
+  /// normal action, and suppresses that normal action.
+  final VoidCallback? onSelectModifierA;
+  final VoidCallback? onSelectModifierB;
+  final VoidCallback? onSelectModifierX;
+  final VoidCallback? onSelectModifierY;
+
   /// Optional override that reports whether a text field is currently focused
   /// in the active UI layer. When provided, it takes precedence over the global
   /// focus search, preventing off-stage text fields from blocking navigation.
@@ -108,6 +117,23 @@ class GamepadNavigation {
   static const int _throttleDelayMs = 128;
   bool _isActive = false;
 
+  /// True while the Select (View) button is reported as physically held down.
+  /// Not all controllers sustain this — many emit a brief down+up pulse even
+  /// while the button is held, which is why [_lastSelectDownTime] backs it up.
+  bool _selectHeld = false;
+
+  /// When Select was last pressed. A face button counts as a combo if it lands
+  /// while Select is still held OR within [_selectChordWindowMs] of this time,
+  /// so the pulse-emitting controllers above still register chords.
+  DateTime? _lastSelectDownTime;
+
+  /// Face buttons whose PRESS fired a combo and whose matching RELEASE must be
+  /// swallowed so the normal action never fires (Desktop dispatches on release).
+  final Set<GamepadInputType> _comboConsumed = {};
+
+  /// How long after a Select press a face button still counts as a chord.
+  static const int _selectChordWindowMs = 400;
+
   DateTime? _activationTime;
 
   /// Grace period after activation during which inputs are ignored (prevents accidental inputs from previous screens).
@@ -143,6 +169,10 @@ class GamepadNavigation {
     this.onSelectButton,
     this.onLeftBumper,
     this.onRightBumper,
+    this.onSelectModifierA,
+    this.onSelectModifierB,
+    this.onSelectModifierX,
+    this.onSelectModifierY,
     this.isTextFieldFocused,
   });
 
@@ -272,7 +302,41 @@ class GamepadNavigation {
   void deactivate() {
     _isActive = false;
     _activationTime = null;
+    _resetSelectModifier();
     cancelAllRepeatTimers();
+  }
+
+  /// Clears Select chord-modifier state so it can't leak across layer changes
+  /// (e.g. opening a dialog while Select is down).
+  void _resetSelectModifier() {
+    _selectHeld = false;
+    _lastSelectDownTime = null;
+    _comboConsumed.clear();
+  }
+
+  /// Whether a Select+face-button chord should register right now: Select is
+  /// still reported down, or it pulsed within the chord window.
+  bool _isSelectChordActive() {
+    if (_selectHeld) return true;
+    final t = _lastSelectDownTime;
+    if (t == null) return false;
+    return DateTime.now().difference(t).inMilliseconds < _selectChordWindowMs;
+  }
+
+  /// Maps a face button to its Select-modifier combo callback, if any.
+  VoidCallback? _selectModifierFor(GamepadInputType inputType) {
+    switch (inputType) {
+      case GamepadInputType.buttonA:
+        return onSelectModifierA;
+      case GamepadInputType.buttonB:
+        return onSelectModifierB;
+      case GamepadInputType.buttonX:
+        return onSelectModifierX;
+      case GamepadInputType.buttonY:
+        return onSelectModifierY;
+      default:
+        return null;
+    }
   }
 
   /// Cancels all active auto-repeat timers.
@@ -356,6 +420,7 @@ class GamepadNavigation {
   void dispose() {
     _subscription?.cancel();
     _subscription = null;
+    _resetSelectModifier();
     cancelAllRepeatTimers();
 
     if (_keyboardInitialized && isDesktop) {
@@ -408,6 +473,22 @@ class GamepadNavigation {
       }
 
       final now = DateTime.now();
+
+      // Select (View) chord modifier on Android: read the RAW key directly.
+      // This controller auto-repeats ACTION_DOWN (value 0.0) while the button is
+      // held and doesn't reliably emit a matching ACTION_UP, so edge-detection
+      // gets stuck. The raw value can't: 0.0 = down (incl. key-repeat) → held;
+      // 1.0 = up → released. Select is a pure modifier, so it never dispatches.
+      if (isAndroid && event.key.toLowerCase() == 'keycode_button_select') {
+        if (event.value < 0.5) {
+          _selectHeld = true;
+          _lastSelectDownTime = now;
+        } else {
+          _selectHeld = false;
+        }
+        return;
+      }
+
       final translatedEvent = _translator.translateEvent(event);
 
       if (translatedEvent == null) return;
@@ -443,12 +524,20 @@ class GamepadNavigation {
           }
           _lastShoulderEventTime = now;
         } else {
-          if (_lastActionEventTime != null &&
-              now.difference(_lastActionEventTime!).inMilliseconds <
-                  _actionDebounceMs) {
-            return;
+          // Select and any face button that lands during a Select chord bypass
+          // the action debounce so a quick chord isn't swallowed.
+          final isChordRelated =
+              translatedEvent.inputType == GamepadInputType.buttonSelect ||
+              (_isSelectChordActive() &&
+                  _selectModifierFor(translatedEvent.inputType) != null);
+          if (!isChordRelated) {
+            if (_lastActionEventTime != null &&
+                now.difference(_lastActionEventTime!).inMilliseconds <
+                    _actionDebounceMs) {
+              return;
+            }
+            _lastActionEventTime = now;
           }
-          _lastActionEventTime = now;
         }
 
         _lastEventTime = now;
@@ -474,6 +563,35 @@ class GamepadNavigation {
       };
       if (!allowedWhileTyping.contains(event.inputType)) return;
     }
+
+    // Select (View) is a PURE chord modifier: on its own it does nothing. Track
+    // its state — before the press/release gate below — so a face button pressed
+    // alongside it fires a combo. Some controllers only reliably report one edge
+    // of this button, so the timestamp is stamped on BOTH press and release.
+    if (event.inputType == GamepadInputType.buttonSelect) {
+      if (event.isPressed) {
+        _selectHeld = true;
+      } else if (event.isReleased) {
+        _selectHeld = false;
+      }
+      _lastSelectDownTime = DateTime.now();
+      return; // Select alone never triggers an action.
+    }
+
+    // A face-button PRESS fires its modifier combo when Select is still held or
+    // was seen within the chord window.
+    if (event.isPressed && _isSelectChordActive()) {
+      final modifier = _selectModifierFor(event.inputType);
+      if (modifier != null) {
+        _comboConsumed.add(event.inputType);
+        SfxService().playNavSound();
+        modifier();
+        return;
+      }
+    }
+    // Swallow the matching release so the normal action never fires for a button
+    // already consumed by a combo (order-independent of when Select is released).
+    if (event.isReleased && _comboConsumed.remove(event.inputType)) return;
 
     bool shouldProcess;
 
@@ -614,9 +732,8 @@ class GamepadNavigation {
         onSettings?.call();
         break;
 
-      case GamepadInputType.buttonSelect:
-        onSelectButton?.call();
-        break;
+      // buttonSelect is handled earlier as a held modifier (see _handleTranslatedEvent
+      // top): a plain tap fires onSelectButton on release, combos fire on press.
 
       case GamepadInputType.buttonLB:
         SfxService().playNavSound();

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -122,6 +122,17 @@ class GamepadNavigation {
   /// while the button is held, which is why [_lastSelectDownTime] backs it up.
   bool _selectHeld = false;
 
+  /// Broadcasts whether Select is currently held, so UI (e.g. the gamepad
+  /// legend) can reveal the Select+face-button chord shortcuts while it is down.
+  /// Only the active navigation layer drives this.
+  static final ValueNotifier<bool> selectHeldNotifier = ValueNotifier(false);
+
+  /// Updates both the local hold flag and the shared notifier in one place.
+  void _setSelectHeld(bool held) {
+    _selectHeld = held;
+    if (selectHeldNotifier.value != held) selectHeldNotifier.value = held;
+  }
+
   /// When Select was last pressed. A face button counts as a combo if it lands
   /// while Select is still held OR within [_selectChordWindowMs] of this time,
   /// so the pulse-emitting controllers above still register chords.
@@ -309,7 +320,7 @@ class GamepadNavigation {
   /// Clears Select chord-modifier state so it can't leak across layer changes
   /// (e.g. opening a dialog while Select is down).
   void _resetSelectModifier() {
-    _selectHeld = false;
+    _setSelectHeld(false);
     _lastSelectDownTime = null;
     _comboConsumed.clear();
   }
@@ -481,10 +492,10 @@ class GamepadNavigation {
       // 1.0 = up → released. Select is a pure modifier, so it never dispatches.
       if (isAndroid && event.key.toLowerCase() == 'keycode_button_select') {
         if (event.value < 0.5) {
-          _selectHeld = true;
+          _setSelectHeld(true);
           _lastSelectDownTime = now;
         } else {
-          _selectHeld = false;
+          _setSelectHeld(false);
         }
         return;
       }
@@ -570,9 +581,9 @@ class GamepadNavigation {
     // of this button, so the timestamp is stamped on BOTH press and release.
     if (event.inputType == GamepadInputType.buttonSelect) {
       if (event.isPressed) {
-        _selectHeld = true;
+        _setSelectHeld(true);
       } else if (event.isReleased) {
-        _selectHeld = false;
+        _setSelectHeld(false);
       }
       _lastSelectDownTime = DateTime.now();
       return; // Select alone never triggers an action.

--- a/lib/utils/gamepad_translator.dart
+++ b/lib/utils/gamepad_translator.dart
@@ -95,6 +95,16 @@ class GamepadEventTranslator {
   /// State cache used to determine press and release transitions.
   final Map<String, Map<GamepadInputType, double>> _previousStates = {};
 
+  /// Last ACTION_DOWN time per Android keycode button, keyed by
+  /// "gamepadId/inputType". Recovers from this controller's unreliable
+  /// ACTION_UP: when a release is dropped, [_previousStates] stays stuck
+  /// "pressed" and normal edge-detection swallows the next press forever.
+  /// Auto-repeat DOWNs arrive far faster than [_keycodeRepressGapMs], so a
+  /// DOWN after a longer gap is a genuine fresh press even without a prior
+  /// release event.
+  final Map<String, DateTime> _lastKeycodeDownTimes = {};
+  static const int _keycodeRepressGapMs = 200;
+
   /// Tracks the last active direction per key to ensure correct release detection on desktop platforms.
   final Map<String, GamepadInputType> _lastDirectionByKey = {};
 
@@ -160,12 +170,20 @@ class GamepadEventTranslator {
 
       // Android keycode buttons: ACTION_DOWN=0.0 (pressed), ACTION_UP=1.0
       // (released). Standardize to 1.0 = pressed / 0.0 = released so these fire
-      // on press rather than release. Applied to the dpad and the shoulder
-      // buttons (L1/R1) — the latter otherwise triggered tab switches on release.
+      // on press rather than release. Applied to the dpad, the shoulder buttons
+      // (L1/R1) and the face buttons (A/B/X/Y) — all of which otherwise fired
+      // their action on release instead of press.
+      final isAndroidKeycodeButton =
+          Platform.isAndroid &&
+          (key == 'keycode_button_l1' ||
+              key == 'keycode_button_r1' ||
+              key == 'keycode_button_a' ||
+              key == 'keycode_button_b' ||
+              key == 'keycode_button_x' ||
+              key == 'keycode_button_y');
+
       if (Platform.isAndroid &&
-          (key.startsWith('keycode_dpad_') ||
-              key == 'keycode_button_l1' ||
-              key == 'keycode_button_r1')) {
+          (key.startsWith('keycode_dpad_') || isAndroidKeycodeButton)) {
         value = (value == 0.0) ? 1.0 : 0.0;
       }
 
@@ -200,7 +218,23 @@ class GamepadEventTranslator {
           ? _isDpadPressed(value, isAnalog: isAnalog)
           : value > 0.5;
 
-      final isPressed = !wasPressed && isNowPressed;
+      // Recover from a dropped ACTION_UP: if a keycode button reports pressed
+      // again after a gap far longer than the auto-repeat cadence, treat it as
+      // a fresh press even though [previousState] is still stuck "pressed".
+      var forcePress = false;
+      if (isAndroidKeycodeButton && isNowPressed) {
+        final downKey = '$gamepadId/$inputType';
+        final lastDown = _lastKeycodeDownTimes[downKey];
+        if (wasPressed &&
+            (lastDown == null ||
+                timestamp.difference(lastDown).inMilliseconds >
+                    _keycodeRepressGapMs)) {
+          forcePress = true;
+        }
+        _lastKeycodeDownTimes[downKey] = timestamp;
+      }
+
+      final isPressed = (!wasPressed && isNowPressed) || forcePress;
       final isReleased = wasPressed && !isNowPressed;
 
       // Update state for future comparisons.
@@ -854,6 +888,7 @@ class GamepadEventTranslator {
   /// Clears all internal state caches.
   void clearStates() {
     _previousStates.clear();
+    _lastKeycodeDownTimes.clear();
     _connectionTypeCache.clear();
     _systemInfoCache.clear();
     _lastDirectionByKey.clear();

--- a/lib/utils/gamepad_translator.dart
+++ b/lib/utils/gamepad_translator.dart
@@ -158,9 +158,14 @@ class GamepadEventTranslator {
         eventType,
       );
 
-      // Android keycode_dpad: ACTION_DOWN=0.0 (pressed), ACTION_UP=1.0 (released).
-      // Standardize to 1.0 = pressed / 0.0 = released to match axis_hat behavior.
-      if (Platform.isAndroid && key.startsWith('keycode_dpad_')) {
+      // Android keycode buttons: ACTION_DOWN=0.0 (pressed), ACTION_UP=1.0
+      // (released). Standardize to 1.0 = pressed / 0.0 = released so these fire
+      // on press rather than release. Applied to the dpad and the shoulder
+      // buttons (L1/R1) — the latter otherwise triggered tab switches on release.
+      if (Platform.isAndroid &&
+          (key.startsWith('keycode_dpad_') ||
+              key == 'keycode_button_l1' ||
+              key == 'keycode_button_r1')) {
         value = (value == 0.0) ? 1.0 : 0.0;
       }
 

--- a/lib/widgets/game_action_buttons.dart
+++ b/lib/widgets/game_action_buttons.dart
@@ -11,16 +11,16 @@ import 'neo_sync_status_icon.dart';
 
 /// Vertical action button column shared by the game list, grid, and carousel.
 ///
-/// Renders back, favorite, random, an optional NeoSync status icon, and the
-/// game-settings shortcut as the last entry. Scraping and view-mode actions
-/// live inside the game settings dialog.
+/// Renders back, favorite, view-mode, an optional NeoSync status icon, and the
+/// game-settings shortcut as the last entry. Random is a Select + Y combo and
+/// scraping is a Select + A combo, so neither has a dedicated legend entry.
 class GameActionButtons extends StatelessWidget {
   final SystemModel system;
   final GameModel? selectedGame;
   final ISyncProvider? syncProvider;
   final VoidCallback onBack;
   final VoidCallback onFavorite;
-  final VoidCallback onRandom;
+  final VoidCallback onViewMode;
   final VoidCallback onSettings;
 
   const GameActionButtons({
@@ -30,7 +30,7 @@ class GameActionButtons extends StatelessWidget {
     this.syncProvider,
     required this.onBack,
     required this.onFavorite,
-    required this.onRandom,
+    required this.onViewMode,
     required this.onSettings,
   });
 
@@ -72,10 +72,10 @@ class GameActionButtons extends StatelessWidget {
           SizedBox(height: 6.r),
           GameActionButton(
             iconPath: 'assets/images/gamepad/Xbox_X_button.png',
-            symbol: Symbols.casino_rounded,
+            symbol: Symbols.grid_view_rounded,
             color: Theme.of(context).colorScheme.primary,
             foregroundColor: Theme.of(context).colorScheme.onPrimary,
-            onTap: onRandom,
+            onTap: onViewMode,
           ),
           SizedBox(height: 6.r),
           // Game settings — second-to-last option.

--- a/lib/widgets/game_action_buttons.dart
+++ b/lib/widgets/game_action_buttons.dart
@@ -130,12 +130,13 @@ class GameActionButtons extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
 
     return [
-      // A — scrape the highlighted game.
+      // A — scrape the highlighted game. Secondary colors mark these as the
+      // Select-held chord shortcuts, distinct from the primary default actions.
       GameActionButton(
         iconPath: 'assets/images/gamepad/Xbox_A_button.png',
         symbol: Symbols.cloud_download_rounded,
-        color: scheme.primary,
-        foregroundColor: scheme.onPrimary,
+        color: scheme.secondary,
+        foregroundColor: scheme.onSecondary,
         onTap: selectedGame != null ? onScrape : null,
       ),
       SizedBox(height: 6.r),
@@ -143,8 +144,8 @@ class GameActionButtons extends StatelessWidget {
       GameActionButton(
         iconPath: 'assets/images/gamepad/Xbox_Y_button.png',
         symbol: Symbols.casino_rounded,
-        color: scheme.primary,
-        foregroundColor: scheme.onPrimary,
+        color: scheme.secondary,
+        foregroundColor: scheme.onSecondary,
         onTap: onRandom,
       ),
       SizedBox(height: 6.r),

--- a/lib/widgets/game_action_buttons.dart
+++ b/lib/widgets/game_action_buttons.dart
@@ -6,14 +6,15 @@ import '../models/game_model.dart';
 import '../models/system_model.dart';
 import '../sync/i_sync_provider.dart';
 import '../themes/corner_radii.dart';
+import '../utils/gamepad_nav.dart';
 import 'game_action_button.dart';
 import 'neo_sync_status_icon.dart';
 
 /// Vertical action button column shared by the game list, grid, and carousel.
 ///
-/// Renders back, favorite, view-mode, an optional NeoSync status icon, and the
-/// game-settings shortcut as the last entry. Random is a Select + Y combo and
-/// scraping is a Select + A combo, so neither has a dedicated legend entry.
+/// Normally renders back, favorite, view-mode, an optional NeoSync status icon,
+/// and the game-settings shortcut. While Select (View) is held it swaps to the
+/// chord shortcuts it unlocks — A scrapes and Y picks a random game.
 class GameActionButtons extends StatelessWidget {
   final SystemModel system;
   final GameModel? selectedGame;
@@ -22,6 +23,12 @@ class GameActionButtons extends StatelessWidget {
   final VoidCallback onFavorite;
   final VoidCallback onViewMode;
   final VoidCallback onSettings;
+
+  /// Select + Y — random game. Optional; the row is a legend when unset.
+  final VoidCallback? onRandom;
+
+  /// Select + A — scrape the highlighted game. Optional (list view only).
+  final VoidCallback? onScrape;
 
   const GameActionButtons({
     super.key,
@@ -32,74 +39,115 @@ class GameActionButtons extends StatelessWidget {
     required this.onFavorite,
     required this.onViewMode,
     required this.onSettings,
+    this.onRandom,
+    this.onScrape,
   });
 
   @override
   Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: GamepadNavigation.selectHeldNotifier,
+      builder: (context, selectHeld, _) {
+        return Container(
+          padding: EdgeInsets.all(6.r),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
+            borderRadius:
+                Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
+                BorderRadius.circular(14.r),
+            border: Border.all(
+              color: Theme.of(context).colorScheme.outline,
+              width: 1.r,
+            ),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: selectHeld
+                ? _buildChordButtons(context)
+                : _buildDefaultButtons(context),
+          ),
+        );
+      },
+    );
+  }
+
+  List<Widget> _buildDefaultButtons(BuildContext context) {
     final selectedGame = this.selectedGame;
     final syncProvider = this.syncProvider;
+    final scheme = Theme.of(context).colorScheme;
 
-    return Container(
-      padding: EdgeInsets.all(6.r),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
-        borderRadius:
-            Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-            BorderRadius.circular(14.r),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline,
-          width: 1.r,
+    return [
+      GameActionButton(
+        iconPath: 'assets/images/gamepad/Xbox_B_button.png',
+        symbol: Symbols.arrow_back_rounded,
+        color: scheme.primary,
+        foregroundColor: scheme.onPrimary,
+        onTap: onBack,
+      ),
+      SizedBox(height: 6.r),
+      GameActionButton(
+        iconPath: 'assets/images/gamepad/Xbox_Y_button.png',
+        symbol: Symbols.favorite_rounded,
+        color: scheme.primary,
+        foregroundColor: scheme.onPrimary,
+        onTap: selectedGame != null ? onFavorite : null,
+      ),
+      SizedBox(height: 6.r),
+      GameActionButton(
+        iconPath: 'assets/images/gamepad/Xbox_X_button.png',
+        symbol: Symbols.grid_view_rounded,
+        color: scheme.primary,
+        foregroundColor: scheme.onPrimary,
+        onTap: onViewMode,
+      ),
+      SizedBox(height: 6.r),
+      // Game settings — second-to-last option.
+      GameActionButton(
+        iconPath: 'assets/images/gamepad/Xbox_Menu_button.png',
+        symbol: Symbols.settings_rounded,
+        color: scheme.primary,
+        foregroundColor: scheme.onPrimary,
+        onTap: selectedGame != null ? onSettings : null,
+      ),
+      // Compact NeoSync status indicator — always the last option.
+      if (syncProvider != null && selectedGame != null) ...[
+        SizedBox(height: 12.r),
+        NeoSyncStatusIcon(
+          system: system,
+          game: selectedGame,
+          syncProvider: syncProvider,
+          size: 24.0,
         ),
+        SizedBox(height: 6.r),
+      ] else
+        SizedBox(height: 6.r),
+    ];
+  }
+
+  /// Shown while Select (View) is held: the chord shortcuts it unlocks.
+  List<Widget> _buildChordButtons(BuildContext context) {
+    final selectedGame = this.selectedGame;
+    final scheme = Theme.of(context).colorScheme;
+
+    return [
+      // A — scrape the highlighted game.
+      GameActionButton(
+        iconPath: 'assets/images/gamepad/Xbox_A_button.png',
+        symbol: Symbols.cloud_download_rounded,
+        color: scheme.primary,
+        foregroundColor: scheme.onPrimary,
+        onTap: selectedGame != null ? onScrape : null,
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          GameActionButton(
-            iconPath: 'assets/images/gamepad/Xbox_B_button.png',
-            symbol: Symbols.arrow_back_rounded,
-            color: Theme.of(context).colorScheme.primary,
-            foregroundColor: Theme.of(context).colorScheme.onPrimary,
-            onTap: onBack,
-          ),
-          SizedBox(height: 6.r),
-          GameActionButton(
-            iconPath: 'assets/images/gamepad/Xbox_Y_button.png',
-            symbol: Symbols.favorite_rounded,
-            color: Theme.of(context).colorScheme.primary,
-            foregroundColor: Theme.of(context).colorScheme.onPrimary,
-            onTap: selectedGame != null ? onFavorite : null,
-          ),
-          SizedBox(height: 6.r),
-          GameActionButton(
-            iconPath: 'assets/images/gamepad/Xbox_X_button.png',
-            symbol: Symbols.grid_view_rounded,
-            color: Theme.of(context).colorScheme.primary,
-            foregroundColor: Theme.of(context).colorScheme.onPrimary,
-            onTap: onViewMode,
-          ),
-          SizedBox(height: 6.r),
-          // Game settings — second-to-last option.
-          GameActionButton(
-            iconPath: 'assets/images/gamepad/Xbox_Menu_button.png',
-            symbol: Symbols.settings_rounded,
-            color: Theme.of(context).colorScheme.primary,
-            foregroundColor: Theme.of(context).colorScheme.onPrimary,
-            onTap: selectedGame != null ? onSettings : null,
-          ),
-          // Compact NeoSync status indicator — always the last option.
-          if (syncProvider != null && selectedGame != null) ...[
-            SizedBox(height: 12.r),
-            NeoSyncStatusIcon(
-              system: system,
-              game: selectedGame,
-              syncProvider: syncProvider,
-              size: 24.0,
-            ),
-            SizedBox(height: 6.r),
-          ] else
-            SizedBox(height: 6.r),
-        ],
+      SizedBox(height: 6.r),
+      // Y — random game.
+      GameActionButton(
+        iconPath: 'assets/images/gamepad/Xbox_Y_button.png',
+        symbol: Symbols.casino_rounded,
+        color: scheme.primary,
+        foregroundColor: scheme.onPrimary,
+        onTap: onRandom,
       ),
-    );
+      SizedBox(height: 6.r),
+    ];
   }
 }

--- a/lib/widgets/game_action_buttons.dart
+++ b/lib/widgets/game_action_buttons.dart
@@ -110,17 +110,16 @@ class GameActionButtons extends StatelessWidget {
         onTap: selectedGame != null ? onSettings : null,
       ),
       // Compact NeoSync status indicator — always the last option.
-      if (syncProvider != null && selectedGame != null) ...[
-        SizedBox(height: 12.r),
+      // The icon renders nothing (SizedBox.shrink) when sync is unavailable
+      // for this system, so its top spacing lives inside the widget to avoid
+      // leaving a dangling gap below the settings button.
+      if (syncProvider != null && selectedGame != null)
         NeoSyncStatusIcon(
           system: system,
           game: selectedGame,
           syncProvider: syncProvider,
           size: 24.0,
         ),
-        SizedBox(height: 6.r),
-      ] else
-        SizedBox(height: 6.r),
     ];
   }
 
@@ -148,7 +147,6 @@ class GameActionButtons extends StatelessWidget {
         foregroundColor: scheme.onSecondary,
         onTap: onRandom,
       ),
-      SizedBox(height: 6.r),
     ];
   }
 }

--- a/lib/widgets/game_view_footer.dart
+++ b/lib/widgets/game_view_footer.dart
@@ -340,7 +340,7 @@ class _CompactAchievementsIndicator extends StatelessWidget {
         splashColor: theme.colorScheme.onSurface.withValues(alpha: 0.1),
         borderRadius: radii.radiusInternal,
         child: Container(
-          width: 98.r,
+          width: 101.r,
           height: 32.r,
           decoration: BoxDecoration(
             color: theme.colorScheme.surface.withValues(alpha: 0.9),
@@ -357,8 +357,8 @@ class _CompactAchievementsIndicator extends StatelessWidget {
           child: Padding(
             // Match the rating pill's 8.r horizontal inset so the trophy icon
             // doesn't hug the pill's left border (the pill's width above is
-            // widened to 98.r to absorb the extra padding without squeezing
-            // the 56.r text/progress column).
+            // widened to 101.r to absorb the padding + the 6.r icon→text gap
+            // without squeezing the 56.r text/progress column).
             padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 3.r),
             child: Row(
               children: [
@@ -385,7 +385,7 @@ class _CompactAchievementsIndicator extends StatelessWidget {
                           ),
                   ),
                 ),
-                SizedBox(width: 3.r),
+                SizedBox(width: 6.r),
                 Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -405,8 +405,11 @@ class _CompactAchievementsIndicator extends StatelessWidget {
                       ),
                     ),
                     SizedBox(height: 2.r),
+                    // Bar is deliberately narrower than the 56.r text row so it
+                    // doesn't run to the pill's right edge — leaves a right
+                    // margin under the progress count.
                     SizedBox(
-                      width: 56.r,
+                      width: 46.r,
                       child: ClipRRect(
                         borderRadius: radii.radiusInternal,
                         child: LinearProgressIndicator(

--- a/lib/widgets/game_view_footer.dart
+++ b/lib/widgets/game_view_footer.dart
@@ -248,13 +248,31 @@ class _SteamStyleRating extends StatelessWidget {
         children: [
           Icon(Symbols.star_rounded, color: ratingColor, size: 15.r),
           SizedBox(width: 4.r),
-          Text(
-            ratingValue.toStringAsFixed(1),
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurface,
-              fontSize: 13.r,
-              fontWeight: FontWeight.w900,
-            ),
+          // Reserve width for the widest possible value ("10.0") so the pill
+          // stays a static size regardless of the current score (e.g. "1.0"
+          // no longer renders narrower than "10.0"). Scale/font-independent.
+          Stack(
+            alignment: Alignment.centerLeft,
+            children: [
+              Opacity(
+                opacity: 0,
+                child: Text(
+                  '10.0',
+                  style: TextStyle(
+                    fontSize: 13.r,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              Text(
+                ratingValue.toStringAsFixed(1),
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurface,
+                  fontSize: 13.r,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -315,7 +333,7 @@ class _CompactAchievementsIndicator extends StatelessWidget {
         splashColor: theme.colorScheme.onSurface.withValues(alpha: 0.1),
         borderRadius: radii.radiusInternal,
         child: Container(
-          width: 88.r,
+          width: 98.r,
           height: 32.r,
           decoration: BoxDecoration(
             color: theme.colorScheme.surface.withValues(alpha: 0.9),
@@ -330,7 +348,11 @@ class _CompactAchievementsIndicator extends StatelessWidget {
             ],
           ),
           child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 3.r, vertical: 3.r),
+            // Match the rating pill's 8.r horizontal inset so the trophy icon
+            // doesn't hug the pill's left border (the pill's width above is
+            // widened to 98.r to absorb the extra padding without squeezing
+            // the 56.r text/progress column).
+            padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 3.r),
             child: Row(
               children: [
                 ClipRRect(

--- a/lib/widgets/game_view_footer.dart
+++ b/lib/widgets/game_view_footer.dart
@@ -111,6 +111,13 @@ class GameViewFooter extends StatelessWidget {
                   ),
                   SizedBox(width: 6.r),
                 ],
+                // Accumulated play time as its own pill to the left of PLAY
+                // (only once the game has been played), mirroring the details
+                // card footer.
+                if (GameUtils.formatPlayTime(game.playTime ?? 0) != '0s') ...[
+                  _PlayTimePill(game: game),
+                  SizedBox(width: 6.r),
+                ],
                 _buildPlayButton(context),
               ],
             ),
@@ -121,7 +128,6 @@ class GameViewFooter extends StatelessWidget {
   }
 
   Widget _buildPlayButton(BuildContext context) {
-    final playTimeText = GameUtils.formatPlayTime(game.playTime ?? 0);
     return Builder(
       builder: (context) {
         final radii =
@@ -172,35 +178,15 @@ class GameViewFooter extends StatelessWidget {
                       color: Theme.of(context).colorScheme.onPrimary,
                     ),
                     SizedBox(width: 5.r),
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          AppLocale.playButton.getString(context),
-                          style: TextStyle(
-                            color: Theme.of(context).colorScheme.onPrimary,
-                            fontWeight: FontWeight.w900,
-                            fontSize: 11.r,
-                            letterSpacing: 1.5,
-                            height: 1.0,
-                          ),
-                        ),
-                        if (playTimeText.isNotEmpty && playTimeText != '0s')
-                          Text(
-                            playTimeText.toUpperCase(),
-                            style: TextStyle(
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onPrimary.withValues(alpha: 0.8),
-                              fontSize: 7.r,
-                              fontWeight: FontWeight.bold,
-                              height: 1.2,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                      ],
+                    Text(
+                      AppLocale.playButton.getString(context),
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onPrimary,
+                        fontWeight: FontWeight.w900,
+                        fontSize: 11.r,
+                        letterSpacing: 1.5,
+                        height: 1.0,
+                      ),
                     ),
                   ],
                 ),
@@ -214,6 +200,67 @@ class GameViewFooter extends StatelessWidget {
 }
 
 /// A Steam-inspired rating badge that interpolates color based on the score intensity.
+/// Compact pill showing accumulated play time as a clock (HH:MM:SS), sized to
+/// match the rating / achievements pills in this footer.
+class _PlayTimePill extends StatelessWidget {
+  final GameModel game;
+
+  const _PlayTimePill({required this.game});
+
+  String _formatClock(int seconds) {
+    final h = seconds ~/ 3600;
+    final m = (seconds % 3600) ~/ 60;
+    final s = seconds % 60;
+    String pad(int v) => v.toString().padLeft(2, '0');
+    return '${pad(h)}:${pad(m)}:${pad(s)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final radii = Theme.of(context).extension<CornerRadii>() ?? CornerRadii.m();
+    return Container(
+      height: 32.r,
+      padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
+        borderRadius: radii.radiusExternal,
+        border: Border.all(
+          color: Theme.of(context).colorScheme.outline,
+          width: 1.r,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.5),
+            blurRadius: 3.r,
+            offset: Offset(2.0.r, 2.0.r),
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Icon(
+            Symbols.schedule_rounded,
+            color: Theme.of(context).colorScheme.onSurface,
+            size: 15.r,
+          ),
+          SizedBox(width: 4.r),
+          Text(
+            _formatClock(game.playTime ?? 0),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurface,
+              fontSize: 12.r,
+              fontWeight: FontWeight.w800,
+              fontFeatures: const [FontFeature.tabularFigures()],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _SteamStyleRating extends StatelessWidget {
   final GameModel game;
 
@@ -255,16 +302,16 @@ class _SteamStyleRating extends StatelessWidget {
         children: [
           Icon(Symbols.star_rounded, color: ratingColor, size: 15.r),
           SizedBox(width: 4.r),
-          // Reserve width for the widest possible value ("10.0") so the pill
-          // stays a static size regardless of the current score (e.g. "1.0"
-          // no longer renders narrower than "10.0"). Scale/font-independent.
+          // Reserve width for the widest possible value ("10") so the pill
+          // stays a static size regardless of the current score (e.g. "1"
+          // no longer renders narrower than "10"). Scale/font-independent.
           Stack(
             alignment: Alignment.centerLeft,
             children: [
               Opacity(
                 opacity: 0,
                 child: Text(
-                  '10.0',
+                  '10',
                   style: TextStyle(
                     fontSize: 13.r,
                     fontWeight: FontWeight.w900,
@@ -272,7 +319,7 @@ class _SteamStyleRating extends StatelessWidget {
                 ),
               ),
               Text(
-                ratingValue.toStringAsFixed(1),
+                ratingValue.toStringAsFixed(0),
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.onSurface,
                   fontSize: 13.r,

--- a/lib/widgets/game_view_footer.dart
+++ b/lib/widgets/game_view_footer.dart
@@ -63,25 +63,32 @@ class GameViewFooter extends StatelessWidget {
                     ],
                   ),
                 ),
-                if (game.showRomFileNameSubtitle) ...[
-                  Text(
-                    game.romname,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.72),
-                      fontSize: 12.r,
-                      fontWeight: FontWeight.w400,
-                      shadows: [
-                        Shadow(
-                          blurRadius: 2.r,
-                          color: Colors.black.withValues(alpha: 0.45),
-                          offset: const Offset(2, 2),
-                        ),
-                      ],
-                    ),
+                // Always reserve the ROM-filename subtitle's line height so the
+                // identity column stays a constant height. Unscraped games have
+                // no subtitle; without this reservation the shorter column
+                // re-centers the rating/RA pill + PLAY row upward. The empty
+                // string still lays out a full line box via the forced strut.
+                Text(
+                  game.showRomFileNameSubtitle ? game.romname : '',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  strutStyle: StrutStyle(
+                    fontSize: 12.r,
+                    forceStrutHeight: true,
                   ),
-                ],
+                  style: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.72),
+                    fontSize: 12.r,
+                    fontWeight: FontWeight.w400,
+                    shadows: [
+                      Shadow(
+                        blurRadius: 2.r,
+                        color: Colors.black.withValues(alpha: 0.45),
+                        offset: const Offset(2, 2),
+                      ),
+                    ],
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/widgets/games_footer.dart
+++ b/lib/widgets/games_footer.dart
@@ -40,16 +40,17 @@ class GamesFooter extends CoreFooter {
         textColor: Colors.white,
       ),
       SizedBox(width: 8.r),
+      // Select (View) held as a modifier: + A scrapes, + Y picks a random game.
       GamepadControl(
         iconPath: 'assets/images/gamepad/Xbox_View_button.png',
-        label: AppLocale.hintScrape.getString(context),
+        label: '+A ${AppLocale.hintScrape.getString(context)}',
         backgroundColor: theme.colorScheme.tertiaryContainer,
         textColor: theme.colorScheme.onTertiaryContainer,
       ),
       SizedBox(width: 8.r),
       GamepadControl(
-        iconPath: 'assets/images/gamepad/Left Stick Click.png',
-        label: AppLocale.hintRandom.getString(context),
+        iconPath: 'assets/images/gamepad/Xbox_View_button.png',
+        label: '+Y ${AppLocale.hintRandom.getString(context)}',
         backgroundColor: theme.colorScheme.errorContainer.withValues(
           alpha: 0.6,
         ),

--- a/lib/widgets/games_footer.dart
+++ b/lib/widgets/games_footer.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'core_footer.dart';
 
@@ -11,6 +12,24 @@ class GamesFooter extends CoreFooter {
 
   @override
   List<Widget> buildControls(BuildContext context) {
+    // Swap the legend while Select (View) is held so the chord shortcuts are
+    // revealed. Only the active navigation layer drives the notifier.
+    return [
+      ValueListenableBuilder<bool>(
+        valueListenable: GamepadNavigation.selectHeldNotifier,
+        builder: (context, selectHeld, _) {
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: selectHeld
+                ? _buildSelectChordControls(context)
+                : _buildDefaultControls(context),
+          );
+        },
+      ),
+    ];
+  }
+
+  List<Widget> _buildDefaultControls(BuildContext context) {
     final theme = Theme.of(context);
 
     return [
@@ -40,21 +59,12 @@ class GamesFooter extends CoreFooter {
         textColor: Colors.white,
       ),
       SizedBox(width: 8.r),
-      // Select (View) held as a modifier: + A scrapes, + Y picks a random game.
+      // Hint that holding Select (View) reveals more actions.
       GamepadControl(
         iconPath: 'assets/images/gamepad/Xbox_View_button.png',
-        label: '+A ${AppLocale.hintScrape.getString(context)}',
+        label: AppLocale.hintMoreActions.getString(context),
         backgroundColor: theme.colorScheme.tertiaryContainer,
         textColor: theme.colorScheme.onTertiaryContainer,
-      ),
-      SizedBox(width: 8.r),
-      GamepadControl(
-        iconPath: 'assets/images/gamepad/Xbox_View_button.png',
-        label: '+Y ${AppLocale.hintRandom.getString(context)}',
-        backgroundColor: theme.colorScheme.errorContainer.withValues(
-          alpha: 0.6,
-        ),
-        textColor: theme.colorScheme.onErrorContainer,
       ),
       SizedBox(width: 8.r),
       GamepadControl(
@@ -71,6 +81,35 @@ class GamesFooter extends CoreFooter {
           alpha: 0.3,
         ),
         textColor: theme.colorScheme.onSurface,
+      ),
+    ];
+  }
+
+  /// Controls shown while Select (View) is held — the chord shortcuts.
+  List<Widget> _buildSelectChordControls(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return [
+      // Select (View) shown as the active modifier.
+      GamepadControl(
+        iconPath: 'assets/images/gamepad/Xbox_View_button.png',
+        label: AppLocale.hintMoreActions.getString(context),
+        backgroundColor: theme.colorScheme.primary,
+        textColor: theme.colorScheme.onPrimary,
+      ),
+      SizedBox(width: 8.r),
+      GamepadControl(
+        iconPath: 'assets/images/gamepad/Xbox_A_button.png',
+        label: AppLocale.hintScrape.getString(context),
+        textColor: Colors.white,
+        backgroundColor: const Color(0xFF2ECC71),
+      ),
+      SizedBox(width: 8.r),
+      GamepadControl(
+        iconPath: 'assets/images/gamepad/Xbox_Y_button.png',
+        label: AppLocale.hintRandom.getString(context),
+        backgroundColor: theme.colorScheme.secondary.withValues(alpha: 0.8),
+        textColor: Colors.white,
       ),
     ];
   }

--- a/lib/widgets/marquee_text.dart
+++ b/lib/widgets/marquee_text.dart
@@ -34,7 +34,15 @@ class MarqueeText extends StatelessWidget {
 
         final bool overflows = textPainter.size.width > constraints.maxWidth;
         final double textHeight = textPainter.size.height;
-        final double contentHeight = height ?? textHeight;
+        // Some display fonts draw descenders (y, g, p) below their reported
+        // metric line height. The Marquee branch below scrolls inside a
+        // ListView, which clips to this box, so a box sized to exactly
+        // `textHeight` shears the bottoms off those glyphs. Add a small
+        // descender allowance (font-size relative) so the clip region covers
+        // them. Only applied when no explicit height is supplied.
+        final double descenderGuard = (effectiveStyle.fontSize ?? textHeight) *
+            0.2;
+        final double contentHeight = height ?? (textHeight + descenderGuard);
 
         return SizedBox(
           width: double.infinity,

--- a/lib/widgets/neo_sync_status_icon.dart
+++ b/lib/widgets/neo_sync_status_icon.dart
@@ -75,7 +75,9 @@ class _NeoSyncStatusIconState extends State<NeoSyncStatusIcon>
         theme.extension<CornerRadii>()?.radiusInternal ??
         BorderRadius.circular(8.r);
 
-    return AnimatedContainer(
+    return Padding(
+      padding: EdgeInsets.only(top: 12.r),
+      child: AnimatedContainer(
       duration: const Duration(milliseconds: 200),
       width: widget.size.r,
       height: widget.size.r,
@@ -107,6 +109,7 @@ class _NeoSyncStatusIconState extends State<NeoSyncStatusIcon>
             size: (widget.size * 0.6).r,
           ),
         ),
+      ),
       ),
     );
   }


### PR DESCRIPTION
> 🤖 This PR was authored with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

A cohesive overhaul of the **game view interaction model and footer layout** across the grid, carousel and list views, plus supporting gamepad and persistence fixes. The work groups into a few themes:

**Select-button modifier + view picker**
- **X** opens the game view picker (list/grid/carousel + card size/style) via the existing `GameViewModeDropdown`, matching the systems screen.
- **Select (View) held as a modifier**: `+A` scrapes the highlighted game, `+Y` opens the random-game dialog, `+B` hides the vertical legend. A plain Select tap still mutes / refreshes RetroAchievements.
- The legend live-reveals the held-Select chord shortcuts (rendered in the secondary color) while Select is down.
- Combo state is tracked on the raw event so it works on both Android (press) and Desktop (release), and is reset on deactivate/dispose.

**Legend visibility + persistence**
- **Select+B** slides the vertical action-button legend off-screen across all views.
- Visibility persists across restarts via a new versioned SQLite migration (**v103**, `legend_hidden` on `user_config`).

**Grid rendering performance & selection**
- Reverts the grid/carousel to the fast pre-#188 rendering path and adds debounce+memoization of the footer/legend so fast-nav frames don't rebuild chrome.
- Reworks the selection cursor into an in-cell border and keeps the selected card centered on resize, fast-scroll and legend toggle (instant recenter, exact row extents).

**Gamepad (Android)**
- Fires Android face buttons (A/B/X/Y) and shoulder buttons (L1/R1) on **press** instead of release by extending the existing keycode inversion.
- Recovers from the AYN Thor's dropped `ACTION_UP` events, which previously left buttons stuck "pressed" and swallowed subsequent presses.

**Footer polish** (grid/carousel + details card)
- Rating renders as an integer; accumulated play time moves into its own pill left of PLAY (shown only for played games).
- Tighter RA/rating pill spacing, symmetric padding, even gaps, and RA-badge fill when the legend is hidden.
- Anchored footer baseline for unscraped games, marquee descender clipping fix, and a fanart fallback for the random-game dialog background.

Fixes # (no linked issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Verified on-device (AYN Thor). Grid/carousel footer and legend behaviour confirmed via on-device screenshots during development.
