### PR TITLE
feat(game-view): touchscreen controls for the vertical legend

### DIFF
--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -16,6 +16,7 @@ import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:neostation/screens/app_screen.dart';
 import 'package:neostation/widgets/game_view_mode_dropdown.dart';
 import 'package:neostation/widgets/game_action_buttons.dart';
+import 'package:neostation/widgets/legend_edge_reshow_zone.dart';
 import 'package:neostation/services/game_legend_visibility.dart';
 import 'package:neostation/sync/sync_manager.dart';
 import 'package:neostation/widgets/native_carousel.dart';
@@ -1085,6 +1086,8 @@ class _GamesCarouselState extends State<GamesCarousel> {
             child: _chromeLegend!,
           ),
         ),
+        // Touch: swipe-right from the left edge reveals a hidden legend.
+        const LegendEdgeReshowZone(),
       ],
     );
   }

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -14,6 +14,7 @@ import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:neostation/utils/game_utils.dart';
 import 'package:neostation/widgets/game_view_mode_dropdown.dart';
 import 'package:neostation/widgets/game_action_buttons.dart';
+import 'package:neostation/widgets/legend_edge_reshow_zone.dart';
 import 'package:neostation/services/game_legend_visibility.dart';
 import 'package:neostation/sync/sync_manager.dart';
 import 'package:neostation/services/game_service.dart';
@@ -1213,6 +1214,8 @@ class _GamesGridState extends State<GamesGrid> {
             child: _chromeLegend!,
           ),
         ),
+        // Touch: swipe-right from the left edge reveals a hidden legend.
+        const LegendEdgeReshowZone(),
       ],
     );
   }

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -42,6 +42,7 @@ import '../../providers/system_background_provider.dart';
 import '../../models/secondary_display_state.dart';
 import '../../widgets/game_view_mode_dropdown.dart';
 import '../../widgets/game_action_buttons.dart';
+import '../../widgets/legend_edge_reshow_zone.dart';
 import '../../constants/system_folder_names.dart';
 import '../../utils/game_list_update.dart';
 import '../../themes/corner_radii.dart';
@@ -1212,23 +1213,27 @@ class _SystemGamesListState extends State<SystemGamesList> {
               duration: const Duration(milliseconds: 250),
               opacity: GameLegendVisibility.hidden.value ? 0.0 : 1.0,
               child: Consumer<SyncManager>(
-              builder: (context, syncManager, child) {
-                return GameActionButtons(
-                  system: widget.system,
-                  selectedGame: _selectedGame,
-                  syncProvider: syncManager.active,
-                  onBack: _goBack,
-                  onFavorite: _toggleFavorite,
-                  onViewMode: () =>
-                      GameViewModeDropdown.globalKey.currentState?.showDropdown(),
-                  onSettings: _openGameSettingsDialog,
-                  onRandom: _showRandomGameDialog,
-                  onScrape: () => _scrapeAction?.call(),
-                );
-              },
+                builder: (context, syncManager, child) {
+                  return GameActionButtons(
+                    system: widget.system,
+                    selectedGame: _selectedGame,
+                    syncProvider: syncManager.active,
+                    onBack: _goBack,
+                    onFavorite: _toggleFavorite,
+                    onViewMode: () => GameViewModeDropdown
+                        .globalKey
+                        .currentState
+                        ?.showDropdown(),
+                    onSettings: _openGameSettingsDialog,
+                    onRandom: _showRandomGameDialog,
+                    onScrape: () => _scrapeAction?.call(),
+                  );
+                },
               ),
             ),
           ),
+        // Touch: swipe-right from the left edge reveals a hidden legend.
+        const LegendEdgeReshowZone(),
       ],
     );
   }
@@ -1632,7 +1637,10 @@ class _SystemGamesListState extends State<SystemGamesList> {
     try {
       // Mirror the card: overwrite existing metadata when a description is
       // already present, otherwise only fill the gaps.
-      final forceOverwrite = game.getDescriptionForLanguage('en').trim().isNotEmpty;
+      final forceOverwrite = game
+          .getDescriptionForLanguage('en')
+          .trim()
+          .isNotEmpty;
 
       final result = await ScreenScraperService.scrapeSingleGame(
         appSystemId: scrapeSystemId,

--- a/lib/services/game_legend_visibility.dart
+++ b/lib/services/game_legend_visibility.dart
@@ -28,8 +28,18 @@ class GameLegendVisibility {
     _persist = persist;
   }
 
-  static void toggle() {
-    hidden.value = !hidden.value;
-    _persist?.call(hidden.value);
+  static void toggle() => _set(!hidden.value);
+
+  /// Hides the legend (e.g. swipe-left on touch). No-op if already hidden.
+  static void hide() => _set(true);
+
+  /// Reveals the legend (e.g. swipe-right from the screen edge on touch).
+  /// No-op if already visible.
+  static void show() => _set(false);
+
+  static void _set(bool value) {
+    if (hidden.value == value) return;
+    hidden.value = value;
+    _persist?.call(value);
   }
 }

--- a/lib/widgets/game_action_buttons.dart
+++ b/lib/widgets/game_action_buttons.dart
@@ -4,10 +4,12 @@ import 'package:material_symbols_icons/symbols.dart';
 
 import '../models/game_model.dart';
 import '../models/system_model.dart';
+import '../services/game_legend_visibility.dart';
 import '../sync/i_sync_provider.dart';
 import '../themes/corner_radii.dart';
 import '../utils/gamepad_nav.dart';
 import 'game_action_button.dart';
+import 'horizontal_swipe.dart';
 import 'neo_sync_status_icon.dart';
 
 /// Vertical action button column shared by the game list, grid, and carousel.
@@ -43,32 +45,76 @@ class GameActionButtons extends StatelessWidget {
     this.onScrape,
   });
 
+  /// Whether the Select (View) chord layer has any shortcuts to reveal.
+  bool get _hasChordActions => onScrape != null || onRandom != null;
+
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<bool>(
       valueListenable: GamepadNavigation.selectHeldNotifier,
       builder: (context, selectHeld, _) {
-        return Container(
-          padding: EdgeInsets.all(6.r),
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
-            borderRadius:
-                Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-                BorderRadius.circular(14.r),
-            border: Border.all(
-              color: Theme.of(context).colorScheme.outline,
-              width: 1.r,
+        return HorizontalSwipe(
+          // Swipe left on the legend to hide it (touchscreen users have no
+          // Select+B chord). Reshow is a swipe-right from the screen edge,
+          // handled by the host view. Hiding slides the column off-screen via
+          // GameLegendVisibility.
+          onSwipeLeft: GameLegendVisibility.hide,
+          child: Container(
+            padding: EdgeInsets.all(6.r),
+            decoration: BoxDecoration(
+              color: Theme.of(
+                context,
+              ).colorScheme.surface.withValues(alpha: 0.9),
+              borderRadius:
+                  Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
+                  BorderRadius.circular(14.r),
+              border: Border.all(
+                color: Theme.of(context).colorScheme.outline,
+                width: 1.r,
+              ),
             ),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: selectHeld
-                ? _buildChordButtons(context)
-                : _buildDefaultButtons(context),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // Touch affordance for the Select (View) modifier: tapping it
+                // latches the chord layer on/off, mirroring holding Select on a
+                // gamepad, so touchscreen users can reach the chord shortcuts.
+                if (_hasChordActions) ...[
+                  _buildViewToggle(context, active: selectHeld),
+                  SizedBox(height: 6.r),
+                ],
+                ...(selectHeld
+                    ? _buildChordButtons(context)
+                    : _buildDefaultButtons(context)),
+              ],
+            ),
           ),
         );
       },
     );
+  }
+
+  /// The tappable Select (View) pill. Latches the shared [selectHeldNotifier]
+  /// so both this column and the footer legend flip to the chord layer.
+  Widget _buildViewToggle(BuildContext context, {required bool active}) {
+    final scheme = Theme.of(context).colorScheme;
+    return GameActionButton(
+      iconPath: 'assets/images/gamepad/Xbox_View_button.png',
+      symbol: active ? Symbols.close_rounded : Symbols.more_horiz_rounded,
+      color: active ? scheme.secondary : scheme.primary,
+      foregroundColor: active ? scheme.onSecondary : scheme.onPrimary,
+      onTap: () => GamepadNavigation.selectHeldNotifier.value = !active,
+    );
+  }
+
+  /// Wraps a chord action so tapping it auto-reverts the latched chord layer
+  /// back to the default buttons (matches releasing Select on a gamepad).
+  VoidCallback? _withRevert(VoidCallback? action) {
+    if (action == null) return null;
+    return () {
+      action();
+      GamepadNavigation.selectHeldNotifier.value = false;
+    };
   }
 
   List<Widget> _buildDefaultButtons(BuildContext context) {
@@ -136,7 +182,7 @@ class GameActionButtons extends StatelessWidget {
         symbol: Symbols.cloud_download_rounded,
         color: scheme.secondary,
         foregroundColor: scheme.onSecondary,
-        onTap: selectedGame != null ? onScrape : null,
+        onTap: selectedGame != null ? _withRevert(onScrape) : null,
       ),
       SizedBox(height: 6.r),
       // Y — random game.
@@ -145,7 +191,7 @@ class GameActionButtons extends StatelessWidget {
         symbol: Symbols.casino_rounded,
         color: scheme.secondary,
         foregroundColor: scheme.onSecondary,
-        onTap: onRandom,
+        onTap: _withRevert(onRandom),
       ),
     ];
   }

--- a/lib/widgets/horizontal_swipe.dart
+++ b/lib/widgets/horizontal_swipe.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+/// Detects a deliberate horizontal swipe on [child] and fires [onSwipeLeft] /
+/// [onSwipeRight]. Triggers on EITHER a short travel distance OR a fast fling,
+/// so a slow drag works as well as a quick flick (velocity-only detection feels
+/// stiff — the user has to flick fast for it to register).
+class HorizontalSwipe extends StatefulWidget {
+  final Widget child;
+  final VoidCallback? onSwipeLeft;
+  final VoidCallback? onSwipeRight;
+  final HitTestBehavior behavior;
+
+  /// Travel past this many logical px (in one direction) fires regardless of
+  /// speed.
+  final double distanceThreshold;
+
+  /// Fling faster than this (logical px/s) fires even on a short travel.
+  final double velocityThreshold;
+
+  const HorizontalSwipe({
+    super.key,
+    required this.child,
+    this.onSwipeLeft,
+    this.onSwipeRight,
+    this.behavior = HitTestBehavior.opaque,
+    this.distanceThreshold = 36.0,
+    this.velocityThreshold = 120.0,
+  });
+
+  @override
+  State<HorizontalSwipe> createState() => _HorizontalSwipeState();
+}
+
+class _HorizontalSwipeState extends State<HorizontalSwipe> {
+  double _dx = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: widget.behavior,
+      onHorizontalDragStart: (_) => _dx = 0,
+      onHorizontalDragUpdate: (d) => _dx += d.delta.dx,
+      onHorizontalDragEnd: (d) {
+        final v = d.primaryVelocity ?? 0;
+        final left =
+            _dx <= -widget.distanceThreshold || v <= -widget.velocityThreshold;
+        final right =
+            _dx >= widget.distanceThreshold || v >= widget.velocityThreshold;
+        if (left) {
+          widget.onSwipeLeft?.call();
+        } else if (right) {
+          widget.onSwipeRight?.call();
+        }
+      },
+      child: widget.child,
+    );
+  }
+}

--- a/lib/widgets/legend_edge_reshow_zone.dart
+++ b/lib/widgets/legend_edge_reshow_zone.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../services/game_legend_visibility.dart';
+import 'horizontal_swipe.dart';
+
+/// Invisible left-edge gesture strip that reveals the action-button legend on a
+/// swipe-right, for touchscreen users who hid it with a swipe-left (the legend
+/// itself is off-screen when hidden, so the reshow affordance has to live here).
+///
+/// Place it as a direct child of the game view's [Stack]. It only claims a hit
+/// region while the legend is hidden; otherwise it collapses to nothing so it
+/// never intercepts taps on the visible legend or the content behind it.
+class LegendEdgeReshowZone extends StatelessWidget {
+  const LegendEdgeReshowZone({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: GameLegendVisibility.hidden,
+      builder: (context, hidden, _) {
+        if (!hidden) return const SizedBox.shrink();
+        return Positioned(
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: 28.r,
+          child: HorizontalSwipe(
+            behavior: HitTestBehavior.translucent,
+            onSwipeRight: GameLegendVisibility.show,
+            child: const SizedBox.expand(),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
> 🤖 This PR was authored with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

Makes the vertical action-button legend fully usable on a touchscreen (phones), where there's no gamepad to hold **Select (View)** or press the **Select+B** chord. Builds directly on the Select-modifier / legend work from #214.

**Reach the chord layer without a gamepad**
- A latching **View** pill at the top of the legend column mirrors holding Select. Tapping it flips the column to the chord shortcuts (**A** scrape, **Y** random); tapping a chord action runs it and auto-reverts.
- It drives the shared `selectHeldNotifier`, so the footer legend flips with it — one source of truth, no per-input-method duplication.

**Hide / reveal by swipe**
- **Swipe-left** on the legend hides it (the touch equivalent of Select+B), reusing the existing off-screen slide + `legend_hidden` persistence.
- **Swipe-right from the left screen edge** reveals it again, via a new `LegendEdgeReshowZone` added to the list/grid/carousel stacks (only claims a hit region while the legend is hidden, so it never blocks the visible legend or carousel swipes).
- Swipe detection (`HorizontalSwipe`) fires on **either** a short travel distance **or** a fast fling, so a slow deliberate drag works as well as a quick flick.
- `GameLegendVisibility` gains idempotent `hide()`/`show()` alongside `toggle()`.

Fixes # (n/a)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable). Existing Select-hold / Select+B paths unchanged; touch controls share the same state.

## Screenshots (if applicable)

Verified on the AYN Thor (dev channel): View pill flips to the A/Y chord layer, swipe-left hides the legend, swipe-right from the edge restores it.