### PR TITLE
fix(game-settings): prevent Manage-tab nav hang on d-pad up

### DIFF
--- a/lib/screens/game_screen/game_settings_dialog/game_settings_manage_tab.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_manage_tab.dart
@@ -8,6 +8,7 @@ import 'package:neostation/models/system_model.dart';
 import 'package:neostation/providers/file_provider.dart';
 import 'package:neostation/providers/neo_sync_provider.dart';
 import 'package:neostation/repositories/game_repository.dart';
+import 'package:neostation/utils/enabled_index_nav.dart';
 import 'package:neostation/screens/settings_screen/new_settings_options/widgets/setting_row.dart';
 import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/services/sfx_service.dart';
@@ -17,7 +18,6 @@ import 'package:neostation/widgets/confirm_action_dialog.dart';
 import 'package:neostation/widgets/custom_notification.dart';
 import 'package:neostation/widgets/custom_toggle_switch.dart';
 import 'package:neostation/widgets/delete_game_dialog.dart';
-
 
 /// Manage tab for [GameSettingsDialog]: cloud sync, grid size/style,
 /// play-time reset, and permanent game deletion. View mode is selected from the
@@ -94,21 +94,12 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
     return idx >= 0 && idx < _totalItems;
   }
 
-  int _previousEnabledIndex() {
-    // Clamp at the top like the other tabs (no wrap); just skip disabled rows.
-    for (int idx = _selectedIndex - 1; idx >= 0; idx--) {
-      if (_isEnabledIndex(idx)) return idx;
-    }
-    return _selectedIndex;
-  }
+  // Clamp at the ends like the other tabs (no wrap); just skip disabled rows.
+  int _previousEnabledIndex() =>
+      previousEnabledIndex(_selectedIndex, _totalItems, _isEnabledIndex);
 
-  int _nextEnabledIndex() {
-    // Clamp at the bottom like the other tabs (no wrap); just skip disabled rows.
-    for (int idx = _selectedIndex + 1; idx < _totalItems; idx++) {
-      if (_isEnabledIndex(idx)) return idx;
-    }
-    return _selectedIndex;
-  }
+  int _nextEnabledIndex() =>
+      nextEnabledIndex(_selectedIndex, _totalItems, _isEnabledIndex);
 
   void _ensureSelectedIndexEnabled() {
     if (!_isEnabledIndex(_selectedIndex)) {

--- a/lib/screens/game_screen/game_settings_dialog/game_settings_manage_tab.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_manage_tab.dart
@@ -95,20 +95,18 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
   }
 
   int _previousEnabledIndex() {
-    int idx = _selectedIndex;
-    do {
-      idx = (idx - 1).clamp(0, _totalItems - 1);
+    // Clamp at the top like the other tabs (no wrap); just skip disabled rows.
+    for (int idx = _selectedIndex - 1; idx >= 0; idx--) {
       if (_isEnabledIndex(idx)) return idx;
-    } while (idx != _selectedIndex);
+    }
     return _selectedIndex;
   }
 
   int _nextEnabledIndex() {
-    int idx = _selectedIndex;
-    do {
-      idx = (idx + 1).clamp(0, _totalItems - 1);
+    // Clamp at the bottom like the other tabs (no wrap); just skip disabled rows.
+    for (int idx = _selectedIndex + 1; idx < _totalItems; idx++) {
       if (_isEnabledIndex(idx)) return idx;
-    } while (idx != _selectedIndex);
+    }
     return _selectedIndex;
   }
 

--- a/lib/utils/enabled_index_nav.dart
+++ b/lib/utils/enabled_index_nav.dart
@@ -1,0 +1,27 @@
+/// Directional selection helpers for gamepad/d-pad list navigation.
+///
+/// Used where some
+/// rows may be disabled (skipped) and the ends clamp instead of wrapping.
+///
+/// Both functions are bounded by [total], so a fully-disabled list can never
+/// spin forever — the previous clamp-in-a-`do/while` implementation could loop
+/// indefinitely when the clamped index landed on a disabled row (see #217).
+library;
+
+/// Returns the nearest enabled index strictly above [current], or [current]
+/// itself when there is no enabled row above it (clamps at the top, no wrap).
+int previousEnabledIndex(int current, int total, bool Function(int) isEnabled) {
+  for (int idx = current - 1; idx >= 0; idx--) {
+    if (isEnabled(idx)) return idx;
+  }
+  return current;
+}
+
+/// Returns the nearest enabled index strictly below [current], or [current]
+/// itself when there is no enabled row below it (clamps at the bottom, no wrap).
+int nextEnabledIndex(int current, int total, bool Function(int) isEnabled) {
+  for (int idx = current + 1; idx < total; idx++) {
+    if (isEnabled(idx)) return idx;
+  }
+  return current;
+}

--- a/test/enabled_index_nav_test.dart
+++ b/test/enabled_index_nav_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/enabled_index_nav.dart';
+
+void main() {
+  // Mirrors the per-game-settings Manage tab: 3 rows (cloudSync=0, playTime=1,
+  // delete=2) where row 0 is disabled when cloud sync is hidden (#217).
+  const total = 3;
+  bool allEnabled(int _) => true;
+  bool cloudSyncHidden(int idx) => idx != 0; // row 0 disabled
+
+  group('previousEnabledIndex', () {
+    test(
+      'cloud sync hidden: up from playTime clamps (no wrap onto disabled)',
+      () {
+        // Regression for #217: previously spun forever clamping onto disabled 0.
+        expect(previousEnabledIndex(1, total, cloudSyncHidden), 1);
+      },
+    );
+
+    test('cloud sync hidden: up from delete lands on playTime', () {
+      expect(previousEnabledIndex(2, total, cloudSyncHidden), 1);
+    });
+
+    test('all enabled: up from playTime lands on cloudSync', () {
+      expect(previousEnabledIndex(1, total, allEnabled), 0);
+    });
+
+    test('all enabled: up from top clamps (no wrap)', () {
+      expect(previousEnabledIndex(0, total, allEnabled), 0);
+    });
+  });
+
+  group('nextEnabledIndex', () {
+    test('down from playTime lands on delete', () {
+      expect(nextEnabledIndex(1, total, cloudSyncHidden), 2);
+    });
+
+    test('down from bottom clamps (no wrap)', () {
+      expect(nextEnabledIndex(2, total, cloudSyncHidden), 2);
+    });
+
+    test('all enabled: down from cloudSync lands on playTime', () {
+      expect(nextEnabledIndex(0, total, allEnabled), 1);
+    });
+  });
+
+  test(
+    'fully-disabled list is bounded and returns current (no infinite loop)',
+    () {
+      bool noneEnabled(int _) => false;
+      expect(previousEnabledIndex(2, total, noneEnabled), 2);
+      expect(nextEnabledIndex(0, total, noneEnabled), 0);
+    },
+  );
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code) (Opus 4.8).

# Description

Pressing **up** on the d-pad in the per-game settings **Manage** tab hung/ANR'd the app instead of moving the cursor.

`_previousEnabledIndex()`/`_nextEnabledIndex()` used `.clamp()` inside a `do/while` whose exit condition (`idx != _selectedIndex`) could never be met once the clamped index pinned on a disabled row. When cloud sync is hidden (user not authenticated), row 0 (Cloud Sync) is disabled and selection starts on Play Time (index 1). Pressing up clamped `idx` to `0` every iteration — disabled, and never equal to `_selectedIndex` — so the loop spun the main isolate forever → hang, recoverable only by swiping the app away.

The fix replaces the clamp-in-a-loop with a bounded directional scan that stops at the list ends (no wrap, matching the Emulator and Scraping tabs) while skipping disabled rows.

Fixes #217

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

N/A — navigation behavior fix. Verified on-device (AYN Thor, dev channel): up/down now clamp at the ends and skip the hidden Cloud Sync row without hanging.

