### PR TITLE
fix(esde-import): parse malformed gamelists, import playtime, skip hidden

### DIFF
--- a/lib/services/esde_import_service.dart
+++ b/lib/services/esde_import_service.dart
@@ -26,8 +26,12 @@ class EsdeImportResult {
   /// Number of `<game>` entries with no matching scanned ROM (skipped).
   final int gamesUnmatched;
 
-  /// Number of games whose favorite / last-played flags were updated.
+  /// Number of games whose favorite / play-stat fields were updated.
   final int statsUpdated;
+
+  /// Number of `<game>` entries marked `<hidden>true</hidden>` in ES-DE and
+  /// therefore not imported at all.
+  final int gamesHidden;
 
   /// Whether a `gamelists/` directory was found under the picked folder. When
   /// false, the selected folder is almost certainly not an ES-DE installation.
@@ -40,6 +44,7 @@ class EsdeImportResult {
     this.gamesImported = 0,
     this.gamesUnmatched = 0,
     this.statsUpdated = 0,
+    this.gamesHidden = 0,
     this.gamelistsDirFound = true,
   });
 
@@ -50,6 +55,7 @@ class EsdeImportResult {
     int gamesImported = 0,
     int gamesUnmatched = 0,
     int statsUpdated = 0,
+    int gamesHidden = 0,
   }) {
     return EsdeImportResult(
       systemsMatched: this.systemsMatched + systemsMatched,
@@ -58,6 +64,7 @@ class EsdeImportResult {
       gamesImported: this.gamesImported + gamesImported,
       gamesUnmatched: this.gamesUnmatched + gamesUnmatched,
       statsUpdated: this.statsUpdated + statsUpdated,
+      gamesHidden: this.gamesHidden + gamesHidden,
       gamelistsDirFound: gamelistsDirFound,
     );
   }
@@ -143,7 +150,8 @@ class EsdeImportService {
     _log.i(
       'ES-DE import done: systems matched=${result.systemsMatched} '
       'unmatched=${result.systemsUnmatched} skipped=${result.systemsSkipped}, '
-      'games imported=${result.gamesImported} noRomMatch=${result.gamesUnmatched}, '
+      'games imported=${result.gamesImported} noRomMatch=${result.gamesUnmatched} '
+      'hidden=${result.gamesHidden}, '
       'stats updated=${result.statsUpdated}',
     );
     return result;
@@ -181,9 +189,14 @@ class EsdeImportService {
     required EsdeImportResult accumulator,
   }) async {
     var result = accumulator;
-    XmlDocument doc;
+    // Parsed as a fragment, not a document: when the user picks a non-default
+    // emulator for a system, ES-DE writes an `<alternativeEmulator>` element as
+    // a SECOND root alongside `<gameList>`. That is invalid XML which ES-DE's
+    // own (lenient) parser accepts, and `XmlDocument.parse` rejects outright
+    // with "Unexpected root element" — silently skipping every such system.
+    XmlDocumentFragment doc;
     try {
-      doc = XmlDocument.parse(await gamelistFile.readAsString());
+      doc = XmlDocumentFragment.parse(await gamelistFile.readAsString());
     } catch (e) {
       _log.e('ES-DE import: failed to parse ${gamelistFile.path}: $e');
       return result._add(systemsSkipped: 1);
@@ -196,6 +209,15 @@ class EsdeImportService {
     for (final game in _selectGames(doc, esdeRoot, esdeDirName)) {
       final rawPath = _text(game, 'path');
       if (rawPath == null || rawPath.isEmpty) continue;
+
+      // `<hidden>true</hidden>` means the user deliberately hid the game in
+      // ES-DE. Importing its metadata would surface it in NeoStation, so drop
+      // the entry entirely — no metadata, no favorite/stat fill.
+      if (_flag(game, 'hidden')) {
+        result = result._add(gamesHidden: 1);
+        continue;
+      }
+
       final normalizedPath = rawPath.replaceAll('\\', '/');
       final filename = path.basename(normalizedPath);
       // ES-DE mirrors the ROM's subfolder (relative to the system's ROM dir)
@@ -207,7 +229,7 @@ class EsdeImportService {
       // Only import for ROMs NeoStation has already scanned.
       final rom = await db.query(
         'user_roms',
-        columns: ['filename', 'is_favorite', 'last_played'],
+        columns: ['filename', 'is_favorite', 'last_played', 'play_time'],
         where: 'app_system_id = ? AND filename = ? COLLATE NOCASE',
         whereArgs: [appSystemId, filename],
         limit: 1,
@@ -248,8 +270,8 @@ class EsdeImportService {
       );
       if (wroteMeta) result = result._add(gamesImported: 1);
 
-      // --- Favorites / last-played (fill-gaps into user_roms) ---
-      final favorite = _text(game, 'favorite')?.toLowerCase() == 'true';
+      // --- Favorites / play stats (fill-gaps into user_roms) ---
+      final favorite = _flag(game, 'favorite');
       final lastPlayed = _parseEsdeDateTime(_text(game, 'lastplayed'));
       final update = <String, dynamic>{};
 
@@ -263,6 +285,16 @@ class EsdeImportService {
           (curLastPlayed is num && curLastPlayed == 0);
       if (lastPlayed != null && lastPlayedEmpty) {
         update['last_played'] = lastPlayed.toIso8601String();
+      }
+
+      // ES-DE's `<playtime>` is in seconds, same unit as user_roms.play_time.
+      // Only fill when NeoStation has never timed this ROM, so an import can
+      // never overwrite (or double-count onto) time the user accrued here.
+      final esdePlayTime = int.tryParse(_text(game, 'playtime') ?? '');
+      final curPlayTime =
+          int.tryParse(rom.first['play_time']?.toString() ?? '0') ?? 0;
+      if (esdePlayTime != null && esdePlayTime > 0 && curPlayTime == 0) {
+        update['play_time'] = esdePlayTime;
       }
 
       if (update.isNotEmpty) {
@@ -380,7 +412,7 @@ class EsdeImportService {
   /// filename, preferring whichever subfolder actually holds downloaded media so
   /// the artwork fallback resolves correctly; otherwise keep the first seen.
   static List<XmlElement> _selectGames(
-    XmlDocument doc,
+    XmlNode doc,
     String esdeRoot,
     String esdeDirName,
   ) {
@@ -453,6 +485,11 @@ class EsdeImportService {
     return dir.startsWith('/') ? dir.substring(1) : dir;
   }
 
+  /// Reads an ES-DE boolean metadata tag (`<favorite>`, `<hidden>`, …).
+  /// ES-DE writes these as the literal strings `true` / `false`.
+  static bool _flag(XmlElement parent, String tag) =>
+      _text(parent, tag)?.toLowerCase() == 'true';
+
   static String? _text(XmlElement parent, String tag) {
     final el = parent.getElement(tag);
     if (el == null) return null;
@@ -477,7 +514,7 @@ class EsdeImportService {
 
   @visibleForTesting
   static List<XmlElement> selectGamesForTest(
-    XmlDocument doc,
+    XmlNode doc,
     String esdeRoot,
     String esdeDirName,
   ) => _selectGames(doc, esdeRoot, esdeDirName);

--- a/test/esde_import_service_test.dart
+++ b/test/esde_import_service_test.dart
@@ -98,6 +98,28 @@ void main() {
         );
         expect(chosen.length, 2);
       });
+
+      test('reads a gamelist with a second <alternativeEmulator> root', () {
+        // ES-DE writes the per-system emulator override as a SECOND root
+        // element ahead of <gameList>, which is invalid XML that only a
+        // lenient parser accepts. Parsing as a fragment must still see the
+        // games.
+        final doc = XmlDocumentFragment.parse('''<?xml version="1.0"?>
+<alternativeEmulator>
+    <label>FinalBurn Neo</label>
+</alternativeEmulator>
+<gameList>
+    <game><path>./fbneo/sonicwi2.zip</path><name>Aero Fighters 2</name></game>
+    <game><path>./mame/dkong.zip</path><name>Donkey Kong</name></game>
+</gameList>
+''');
+        final chosen = EsdeImportService.selectGamesForTest(
+          doc,
+          '/no/such/root',
+          'arcade',
+        );
+        expect(chosen.length, 2);
+      });
     });
   });
 
@@ -175,5 +197,123 @@ void main() {
         expect(rows.first['real_name'], 'Sonic the Hedgehog');
       },
     );
+
+    test(
+      'import handles a gamelist with an <alternativeEmulator> root',
+      () async {
+        await db.execute(
+          "INSERT INTO user_roms (filename, rom_path, app_system_id) VALUES ('sonic.smc', '/roms/snes/sonic.smc', 'snes')",
+        );
+
+        final tempRoot = Directory.systemTemp.createTempSync('esde_test_');
+        addTearDown(() => tempRoot.deleteSync(recursive: true));
+        final systemDir = Directory('${tempRoot.path}/gamelists/snes')
+          ..createSync(recursive: true);
+        // Exactly what ES-DE writes once the user picks a non-default emulator
+        // for the system: two root elements in one file.
+        File('${systemDir.path}/gamelist.xml').writeAsStringSync(
+          '''<?xml version="1.0"?>
+<alternativeEmulator>
+    <label>Snes9x - Current</label>
+</alternativeEmulator>
+<gameList>
+    <game>
+        <path>./sonic.smc</path>
+        <name>Sonic the Hedgehog</name>
+        <altemulator>Snes9x - Current</altemulator>
+    </game>
+</gameList>
+''',
+        );
+
+        final result = await EsdeImportService.import(tempRoot.path);
+        expect(result.systemsSkipped, 0);
+        expect(result.systemsMatched, 1);
+        expect(result.gamesImported, 1);
+      },
+    );
+
+    test('import skips games ES-DE marks hidden', () async {
+      await db.execute(
+        "INSERT INTO user_roms (filename, rom_path, app_system_id) VALUES ('sonic.smc', '/roms/snes/sonic.smc', 'snes')",
+      );
+      await db.execute(
+        "INSERT INTO user_roms (filename, rom_path, app_system_id) VALUES ('secret.smc', '/roms/snes/secret.smc', 'snes')",
+      );
+
+      final tempRoot = Directory.systemTemp.createTempSync('esde_test_');
+      addTearDown(() => tempRoot.deleteSync(recursive: true));
+      final systemDir = Directory('${tempRoot.path}/gamelists/snes')
+        ..createSync(recursive: true);
+      File('${systemDir.path}/gamelist.xml').writeAsStringSync('''
+        <gameList>
+          <game>
+            <path>./sonic.smc</path>
+            <name>Sonic the Hedgehog</name>
+          </game>
+          <game>
+            <path>./secret.smc</path>
+            <name>Hidden Game</name>
+            <hidden>true</hidden>
+            <favorite>true</favorite>
+          </game>
+        </gameList>
+      ''');
+
+      final result = await EsdeImportService.import(tempRoot.path);
+      expect(result.gamesImported, 1);
+      expect(result.gamesHidden, 1);
+
+      // No metadata row, and the hidden entry's favorite flag is not applied.
+      final rows = await db.rawQuery(
+        'SELECT filename FROM user_screenscraper_metadata',
+      );
+      expect(rows.map((r) => r['filename']), ['sonic.smc']);
+      final hiddenRom = await db.rawQuery(
+        "SELECT is_favorite FROM user_roms WHERE filename = 'secret.smc'",
+      );
+      expect(hiddenRom.first['is_favorite'], 0);
+    });
+
+    test('import fills play_time only when NeoStation has none', () async {
+      // sonic has never been played here; streets already has local playtime
+      // that the import must not clobber.
+      await db.execute(
+        "INSERT INTO user_roms (filename, rom_path, app_system_id, play_time) VALUES ('sonic.smc', '/roms/snes/sonic.smc', 'snes', 0)",
+      );
+      await db.execute(
+        "INSERT INTO user_roms (filename, rom_path, app_system_id, play_time) VALUES ('streets.smc', '/roms/snes/streets.smc', 'snes', 900)",
+      );
+
+      final tempRoot = Directory.systemTemp.createTempSync('esde_test_');
+      addTearDown(() => tempRoot.deleteSync(recursive: true));
+      final systemDir = Directory('${tempRoot.path}/gamelists/snes')
+        ..createSync(recursive: true);
+      File('${systemDir.path}/gamelist.xml').writeAsStringSync('''
+        <gameList>
+          <game>
+            <path>./sonic.smc</path>
+            <name>Sonic the Hedgehog</name>
+            <playcount>3</playcount>
+            <playtime>47</playtime>
+          </game>
+          <game>
+            <path>./streets.smc</path>
+            <name>Streets of Rage</name>
+            <playtime>12</playtime>
+          </game>
+        </gameList>
+      ''');
+
+      await EsdeImportService.import(tempRoot.path);
+
+      final rows = await db.rawQuery(
+        'SELECT filename, play_time FROM user_roms ORDER BY filename',
+      );
+      expect(rows[0]['filename'], 'sonic.smc');
+      expect(rows[0]['play_time'], 47);
+      expect(rows[1]['filename'], 'streets.smc');
+      expect(rows[1]['play_time'], 900);
+    });
   });
 }


### PR DESCRIPTION
> 🤖 This PR was authored with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

ES-DE import was silently dropping entire systems. When a user picks a non-default emulator for a system, ES-DE prepends an `<alternativeEmulator>` element as a **second root** alongside `<gameList>`:

```xml
<?xml version="1.0"?>
<alternativeEmulator>
    <label>FinalBurn Neo</label>
</alternativeEmulator>
<gameList>
    ...
```

XML permits exactly one root, so `XmlDocument.parse` rejects the whole file with `Unexpected root element at 5:1`. ES-DE's own pugixml reader looks *both* roots up by name off the document (`doc.child("gameList")`, `doc.child("alternativeEmulator")`), so it never notices — and the writer uses `prepend_child`, so this is what it always emits. It's tracked upstream as [es-de#1740](https://gitlab.com/es-de/emulationstation-de/-/issues/1740) and is still unfixed.

Every affected system was counted as `skipped (unreadable)` in the import summary and dropped — no metadata, and no `esde_media_dir`, which is what wires up the read-time `downloaded_media/` artwork fallback. **That is the media symptom in #211**: the systems the reporter was looking at had an emulator override set, so the import never recorded their media dir. One user's log showed 16 systems lost this way, exactly the ones where they'd chosen a non-default emulator.

The fix parses gamelists as an `XmlDocumentFragment`, which permits multiple roots while still resolving `<game>` entries via `findAllElements`. The alt-emulator block itself is ignored — ES-DE's emulator labels are its own `es_systems.xml` strings and are platform-specific (see [es-de#1720](https://gitlab.com/es-de/emulationstation-de/-/work_items/1720)), so mapping them onto NeoStation emulators would belong in `neostation-systems`, not here.

ES-DE ships no XSD/DTD/RelaxNG for gamelist.xml — the field list in `es-app/src/MetaData.cpp` is the only canonical definition — and its user guide explicitly disclaims that processed gamelists are usable outside ES-DE. So the importer should stay defensive by policy, not just for this one case.

Two smaller metadata wins while in there:

- **`<playtime>`** now fills `user_roms.play_time` (same unit, seconds). Fill-gaps only — applied only when NeoStation has never timed the ROM, so a re-run can neither clobber nor double-count locally accrued time.
- **`<hidden>true</hidden>`** entries are now dropped before the ROM lookup, so a game the user deliberately hid in ES-DE brings across no metadata, favorite, last-played or playtime. Tallied as `EsdeImportResult.gamesHidden` and reported in the completion log.

`<playcount>` was considered and deliberately skipped: there is no play-count column in the schema, and adding one is a versioned migration plus model/query/NeoSync surface for a value nothing currently renders.

### ⚠️ Note on #211 — one symptom is not covered

#211 reports two things. This PR fixes the first (imported ES-DE media not applied). It does **not** touch the second — *"even going into game settings to manually browse for the media, it doesn't apply to the ROM at all"* — which is a separate path through the manual media picker and likely a distinct bug. Worth splitting into its own issue rather than assuming this closes it.

Fixes # (issue) 211

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

### Testing

Four new tests in `test/esde_import_service_test.dart` (16 pass, `flutter analyze` clean):

- `selectGames` unit case over a two-root gamelist shaped like a real ES-DE `arcade` list.
- End-to-end `import` over a two-root gamelist, asserting `systemsSkipped == 0` / `gamesImported == 1` — this is the regression that would have caught #211.
- Hidden games: no metadata row written, and the hidden entry's `favorite` flag is not applied.
- Playtime: filled when local `play_time` is 0, left alone when the user already has time on the ROM.

**On-device caveat:** the dev build was deployed to an AYN Thor and verified to build, install and launch, but the fix itself was **not** exercised there — that device has no ES-DE installation, so there was no gamelist to import. Conclusive validation is the #211 reporter re-running their import and seeing `skipped (unreadable): 0`.
