### PR TITLE
fix(nav): make L1/R1 tab switching reliable and add held repeat

### DIFF
--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -92,15 +92,43 @@ class GamepadNavigation {
 
   StreamSubscription<GamepadEvent>? _subscription;
   DateTime? _lastDirectionalEventTime;
-  DateTime? _lastShoulderEventTime;
   DateTime? _lastActionEventTime;
 
   /// Throttle duration for directional inputs to prevent "drifting" or excessive navigation.
   static const int _directionalThrottleMs = 128;
 
-  /// Throttle duration for shoulder buttons (tab switching).
-  /// Slightly shorter than the action debounce so rapid LB/RB presses feel snappier.
-  static const int _shoulderThrottleMs = 80;
+  // ---------------------------------------------------------------------
+  // Shoulder (L1/R1) tab-switch pacing.
+  //
+  // These are STATIC on purpose: switching a tab swaps the active navigation
+  // layer, so consecutive presses are seen by *different* GamepadNavigation
+  // instances. Per-instance timers would reset on every switch and let a held
+  // bumper run away through the tabs.
+  //
+  // Android delivers a held bumper as a stream of auto-repeat ACTION_DOWNs.
+  // A press that arrives without an intervening release is that stream (the
+  // button is HELD) and is paced at [_shoulderRepeatIntervalMs]; a press after
+  // a release is a fresh, deliberate TAP and only has to clear
+  // [_shoulderTapDebounceMs].
+  // ---------------------------------------------------------------------
+
+  /// Last shoulder press actually turned into a tab switch.
+  static DateTime? _lastShoulderDispatchTime;
+
+  /// True once a shoulder release has been seen, i.e. the next press starts a
+  /// new tap rather than continuing a hold.
+  static bool _shoulderReleasedSinceDispatch = true;
+
+  /// Cadence at which a HELD bumper walks the tabs (~3 tabs/second).
+  static const int _shoulderRepeatIntervalMs = 300;
+
+  /// Debounce between two separate bumper TAPS. Short, so deliberate rapid
+  /// taps to skip several tabs all register.
+  static const int _shoulderTapDebounceMs = 50;
+
+  /// Safety net for a dropped release: a gap this long means the button can't
+  /// still be held, so the next press counts as a fresh tap regardless.
+  static const int _shoulderHoldLapsedMs = 500;
 
   /// Debounce duration for action buttons to prevent double-presses.
   static const int _actionDebounceMs = 128;
@@ -147,8 +175,11 @@ class GamepadNavigation {
 
   DateTime? _activationTime;
 
-  /// Grace period after activation during which inputs are ignored (prevents accidental inputs from previous screens).
-  static const int _reactivationGraceMs = 256;
+  /// Grace period after activation during which inputs are ignored (prevents
+  /// accidental inputs from previous screens). Kept just long enough to cover
+  /// the in-flight events of the press that caused the layer change; the
+  /// shoulder buttons bypass it entirely (see [_handleGamepadEvent]).
+  static const int _reactivationGraceMs = 150;
 
   String? _currentGamepadId;
   String? _currentGamepadName;
@@ -302,11 +333,17 @@ class GamepadNavigation {
       _activationTime = DateTime.now();
       // Clear any stale repeat timers that may have survived a prior deactivation.
       cancelAllRepeatTimers();
+      // Drop remembered button states: a button held while this layer was
+      // deactivated never delivered its release here, so the translator would
+      // still think it is down and would ignore the next press of it.
+      _translator.clearButtonStates();
     }
     _lastEventTime = null;
     _lastDirectionalEventTime = null;
-    _lastShoulderEventTime = null;
     _lastActionEventTime = null;
+    // Shoulder pacing is deliberately NOT reset here — it is shared across
+    // layers so a held bumper keeps its cadence while tabs (and therefore
+    // layers) change underneath it.
   }
 
   /// Disables input processing and cancels any active auto-repeat timers.
@@ -459,12 +496,10 @@ class GamepadNavigation {
   void _handleGamepadEvent(GamepadEvent event) async {
     if (!_isActive) return;
 
-    // Discard events occurring within the reactivation grace period.
-    if (_activationTime != null &&
-        DateTime.now().difference(_activationTime!).inMilliseconds <
-            _reactivationGraceMs) {
-      return;
-    }
+    // NOTE: the reactivation grace period is applied AFTER translation (see
+    // below) so the translator still observes every edge while the grace is
+    // running. Discarding raw events here left its press/release state stuck
+    // and swallowed the next genuine press.
 
     try {
       // Auto-detect and switch to the device emitting the event.
@@ -504,6 +539,29 @@ class GamepadNavigation {
 
       if (translatedEvent == null) return;
 
+      final isShoulderInput =
+          translatedEvent.inputType == GamepadInputType.buttonLB ||
+          translatedEvent.inputType == GamepadInputType.buttonRB;
+
+      // Reactivation grace: swallow inputs that leak in from the screen we just
+      // came from. The shoulder buttons are exempt — every tab switch rebuilds
+      // a navigation layer, so each switch restarted the grace and ate the next
+      // L1/R1 press, which is why tabs often needed a second press. A stray
+      // bumper only moves one tab and is trivially undone, unlike a stray A/B.
+      if (!isShoulderInput &&
+          _activationTime != null &&
+          now.difference(_activationTime!).inMilliseconds <
+              _reactivationGraceMs) {
+        return;
+      }
+
+      // A shoulder release ends the hold, so the next press is a fresh tap.
+      // Tracked statically because the release often lands on a different
+      // navigation layer than the press that switched the tab.
+      if (isShoulderInput && translatedEvent.isReleased) {
+        _shoulderReleasedSinceDispatch = true;
+      }
+
       if (translatedEvent.isPressed) {
         final isDirectional = [
           GamepadInputType.dpadUp,
@@ -514,9 +572,7 @@ class GamepadNavigation {
           GamepadInputType.leftStickY,
         ].contains(translatedEvent.inputType);
 
-        final isShoulder =
-            translatedEvent.inputType == GamepadInputType.buttonLB ||
-            translatedEvent.inputType == GamepadInputType.buttonRB;
+        final isShoulder = isShoulderInput;
 
         if (isDirectional) {
           if (!isWindows) {
@@ -528,12 +584,25 @@ class GamepadNavigation {
           }
           _lastDirectionalEventTime = now;
         } else if (isShoulder) {
-          if (_lastShoulderEventTime != null &&
-              now.difference(_lastShoulderEventTime!).inMilliseconds <
-                  _shoulderThrottleMs) {
+          // No release since the last switch means the bumper is still held:
+          // pace the repeats. A press after a release is a tap — let it
+          // through immediately.
+          final holdLapsed =
+              _lastShoulderDispatchTime != null &&
+              now.difference(_lastShoulderDispatchTime!).inMilliseconds >
+                  _shoulderHoldLapsedMs;
+          final isHeldRepeat = !_shoulderReleasedSinceDispatch && !holdLapsed;
+
+          final minIntervalMs = isHeldRepeat
+              ? _shoulderRepeatIntervalMs
+              : _shoulderTapDebounceMs;
+          if (_lastShoulderDispatchTime != null &&
+              now.difference(_lastShoulderDispatchTime!).inMilliseconds <
+                  minIntervalMs) {
             return;
           }
-          _lastShoulderEventTime = now;
+          _lastShoulderDispatchTime = now;
+          _shoulderReleasedSinceDispatch = false;
         } else {
           // Select and any face button that lands during a Select chord bypass
           // the action debounce so a quick chord isn't swallowed.
@@ -806,7 +875,14 @@ class GamepadNavigation {
 
     final isKeyDown = event is KeyDownEvent;
 
-    if (_activationTime != null &&
+    // Q/E (tab switching) bypass the reactivation grace for the same reason the
+    // shoulder buttons do: switching tabs rebuilds a navigation layer, so the
+    // grace would eat the next tab key press.
+    final isTabKey =
+        event.logicalKey == LogicalKeyboardKey.keyQ ||
+        event.logicalKey == LogicalKeyboardKey.keyE;
+    if (!isTabKey &&
+        _activationTime != null &&
         DateTime.now().difference(_activationTime!).inMilliseconds <
             _reactivationGraceMs) {
       return false;

--- a/lib/utils/gamepad_translator.dart
+++ b/lib/utils/gamepad_translator.dart
@@ -187,6 +187,15 @@ class GamepadEventTranslator {
         value = (value == 0.0) ? 1.0 : 0.0;
       }
 
+      // A held shoulder button arrives as a stream of auto-repeat ACTION_DOWNs.
+      // Like the d-pad, those repeats are surfaced as continuous press events
+      // so holding L1/R1 keeps walking the tabs; the consumer paces them (see
+      // the shoulder pacing in GamepadNavigation). Without this the repeats
+      // were swallowed as "already pressed" and the hold stalled.
+      final isAndroidShoulderKeycode =
+          Platform.isAndroid &&
+          (key == 'keycode_button_l1' || key == 'keycode_button_r1');
+
       // LINUX: Invert Y-axis for analog sticks to follow standard conventions.
       if (Platform.isLinux &&
           (inputType == GamepadInputType.leftStickY ||
@@ -244,9 +253,11 @@ class GamepadEventTranslator {
       final isDirectional = GamepadEventTranslator.isDirectionalInput(
         inputType,
       );
-      if (isPressed || isReleased || (isDirectional && isNowPressed)) {
+      final isRepeatable = isDirectional || isAndroidShoulderKeycode;
+
+      if (isPressed || isReleased || (isRepeatable && isNowPressed)) {
         final effectiveIsPressed =
-            isPressed || (isDirectional && isNowPressed && !isReleased);
+            isPressed || (isRepeatable && isNowPressed && !isReleased);
         final effectiveIsReleased = isReleased;
 
         final translatedEvent = TranslatedGamepadEvent(
@@ -883,6 +894,18 @@ class GamepadEventTranslator {
     final vendorId = (_systemInfoCache[gamepadId]?['vendorId'] as String?)
         ?.toLowerCase();
     return vendorId == '054c';
+  }
+
+  /// Clears only the per-button press/release tracking, keeping the device
+  /// detection caches (mapping, connection type, names) intact.
+  ///
+  /// Used when a navigation layer is (re)activated: a button held while the
+  /// layer was inactive never delivers its release here, so the stale "still
+  /// pressed" state would swallow the next press of that button.
+  void clearButtonStates() {
+    _previousStates.clear();
+    _lastKeycodeDownTimes.clear();
+    _lastDirectionByKey.clear();
   }
 
   /// Clears all internal state caches.


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code) (Opus 5).

# Description

Switching the top-level tabs (Systems / NeoSync / RetroAchievements / Scraper / Settings) with **L1/R1** often needed two presses before the tab actually changed, and holding a bumper did not scroll through the tabs at all.

**Why the first press was lost.** Every tab switch swaps the active gamepad navigation layer, and each `activate()` starts a grace window in which all input is discarded, to stop stray presses leaking in from the screen you just left. The next L1/R1 press landed inside that window and was thrown away, so the tab only moved on the second press. The discard also ran *before* event translation, so the translator never observed the button's release edge and went on treating it as still held — swallowing the following press too, until a 200 ms recovery heuristic fired.

**Why holding did nothing.** A held bumper arrives from Android as a stream of auto-repeat `ACTION_DOWN`s, which the translator dropped as "already pressed".

Changes:

- Apply the reactivation grace **after** translation, so press/release state stays accurate while input is being suppressed, and exempt the shoulder buttons (and keyboard `Q`/`E`) from it — a stray bumper moves one tab and is trivially undone, unlike a stray A/B. Grace reduced 256 ms → 150 ms.
- Surface a held bumper's auto-repeat `ACTION_DOWN`s as continuous press events, exactly the way the d-pad already works, so holding L1/R1 keeps walking the tabs regardless of which layer is active.
- Pace those repeats off the **release edge** rather than inter-press timing: no release since the last switch means the button is still held (one tab per 300 ms); a press after a release is a tap (50 ms debounce). A 500 ms lapse guard keeps a dropped `ACTION_UP` from pinning it in hold mode. The pacing state is `static` because consecutive presses are handled by *different* `GamepadNavigation` instances as the layers swap — per-instance timers reset on every switch and let a hold run away.
- Clear the translator's per-button state on layer activation, through a new `clearButtonStates()` that leaves the device-detection caches (mapping, connection type, names) intact, so a button held while a layer was inactive cannot swallow its next press.

Worth flagging for review: L1/R1 now repeat while held **everywhere**, not only on the main tabs — any screen binding the bumpers (e.g. game-list paging) will repeat at the same 300 ms cadence. That looks right for paging, but I only exercised the top-level tabs on device.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. — the behaviour is timing- and platform-dependent (`Platform.isAndroid` auto-repeat streams) inside `GamepadNavigation`'s event handler, which has no existing test seam; verified on device instead. Existing suite passes (264 tests).
- [ ] I have updated the corresponding documentation. — no user-facing docs cover bumper navigation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. — no new assets.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable). — AYN Thor: single taps each move one tab immediately, holding walks the tabs continuously at a steady cadence.

## Screenshots (if applicable)

N/A — input timing change, nothing visual.
