### PR TITLE
feat(game-list): hold-to-accelerate and alphabetical letter jumping

### DIFF
--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -13,6 +13,7 @@ import 'package:neostation/providers/system_background_provider.dart';
 import 'package:neostation/services/game_service.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/utils/letter_jump.dart';
 import 'package:neostation/screens/app_screen.dart';
 import 'package:neostation/widgets/game_view_mode_dropdown.dart';
 import 'package:neostation/widgets/game_action_buttons.dart';
@@ -303,6 +304,8 @@ class _GamesCarouselState extends State<GamesCarousel> {
           GameViewModeDropdown.globalKey.currentState?.showDropdown();
         } catch (_) {}
       },
+      onLetterJump: _letterJump, // Held D-pad left/right → alphabet skipping.
+      letterJumpAxis: LetterJumpAxis.horizontal,
       onLeftStickClick: widget.onRandom,
       onSelectModifierA: widget.onScrape, // Select + A - Scrape.
       onSelectModifierB: _toggleLegend, // Select + B - Hide/show legend.
@@ -322,6 +325,26 @@ class _GamesCarouselState extends State<GamesCarousel> {
         onDeactivate: () => _gamepadNav.deactivate(),
       );
     });
+  }
+
+  /// Skips to the neighbouring alphabetical group once left/right has been
+  /// held long enough (ES-DE style). Returns false at the ends of the alphabet
+  /// so the caller falls back to a normal page step.
+  bool _letterJump(bool forward) {
+    if (widget.games.isEmpty) return false;
+
+    final target = LetterJump.targetIndex(
+      length: widget.games.length,
+      currentIndex: _currentIndex,
+      forward: forward,
+      letterAt: (index) => _getLetterForGame(widget.games[index]),
+    );
+    if (target == null) return false;
+
+    // Jump rather than animate: at letter-jump cadence an animated page slide
+    // across dozens of entries would still be running when the next hop fires.
+    _carouselKey.currentState?.jumpToPage(target);
+    return true;
   }
 
   void _cleanupGamepad() {

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -24,6 +24,7 @@ import '../../services/screenscraper_service.dart';
 import '../../services/secondary_achievements_controller.dart';
 import '../../services/game_legend_visibility.dart';
 import '../../utils/gamepad_nav.dart';
+import '../../utils/letter_jump.dart';
 import '../../providers/file_provider.dart';
 import '../../providers/sqlite_config_provider.dart';
 import '../../providers/sqlite_database_provider.dart';
@@ -43,6 +44,7 @@ import '../../models/secondary_display_state.dart';
 import '../../widgets/game_view_mode_dropdown.dart';
 import '../../widgets/game_action_buttons.dart';
 import '../../widgets/legend_edge_reshow_zone.dart';
+import '../../widgets/letter_indicator.dart';
 import '../../constants/system_folder_names.dart';
 import '../../utils/game_list_update.dart';
 import '../../themes/corner_radii.dart';
@@ -75,7 +77,6 @@ class SystemGamesList extends StatefulWidget {
 
 class _SystemGamesListState extends State<SystemGamesList> {
   static final _log = LoggerService.instance;
-  static final _letterRegex = RegExp(r'[A-Z0-9]');
 
   // Dataset management.
   List<GameModel> _games = [];
@@ -139,9 +140,21 @@ class _SystemGamesListState extends State<SystemGamesList> {
 
   // Rapid navigation state.
   bool _isNavigatingFast = false;
+
+  // True only while a held direction is skipping letter-to-letter. The letter
+  // overlay is tied to this rather than to _isNavigatingFast: an ordinary fast
+  // scroll shows the game names themselves, so throwing a big letter over them
+  // the moment the scroll speeds up is just noise.
+  bool _isLetterJumping = false;
   String? _currentLetter;
   DateTime? _lastNavTime;
   static const Duration _fastNavThreshold = Duration(milliseconds: 150);
+
+  // How long after the last move a rapid-scroll burst is considered over. The
+  // letter-jump variant must exceed the dwell between two jumps (see
+  // GamepadNavigation) so a held direction reads as one continuous burst.
+  static const Duration _fastNavEndDelay = Duration(milliseconds: 300);
+  static const Duration _letterJumpEndDelay = Duration(milliseconds: 600);
 
   // Media controllers.
   VideoPlayerController? _videoController;
@@ -352,12 +365,17 @@ class _SystemGamesListState extends State<SystemGamesList> {
   }
 
   /// Core logic for updating selection and managing rapid-scrolling UI state.
-  void _updateSelectedGame(int newIndex) {
+  ///
+  /// [forceFast] keeps the rapid-scroll UI (deferred heavy loading) engaged
+  /// regardless of timing, and raises the letter overlay — used by letter
+  /// jumps, whose dwell between hops is deliberately longer than
+  /// [_fastNavThreshold].
+  void _updateSelectedGame(int newIndex, {bool forceFast = false}) {
     _resetVideoState();
 
     final now = DateTime.now();
-    bool isFast = false;
-    if (_lastNavTime != null) {
+    bool isFast = forceFast;
+    if (!isFast && _lastNavTime != null) {
       final delta = now.difference(_lastNavTime!);
       if (delta < _fastNavThreshold) {
         isFast = true;
@@ -367,45 +385,39 @@ class _SystemGamesListState extends State<SystemGamesList> {
 
     // Resolve current alphabetical letter for navigation overlays.
     final game = _games[newIndex];
-    String? letter;
-    final displayName = game.name.isNotEmpty ? game.name : game.romname;
-    if (displayName.isNotEmpty) {
-      String cleanName = displayName.trim().toUpperCase();
-      if (cleanName.startsWith('THE ')) cleanName = cleanName.substring(4);
-
-      if (cleanName.isNotEmpty) {
-        final firstChar = cleanName[0];
-        if (_letterRegex.hasMatch(firstChar)) {
-          letter = firstChar;
-        } else {
-          letter = '#';
-        }
-      }
-    }
+    final letter = LetterJump.letterFor(game);
 
     setState(() {
       _selectedGameIndex = newIndex;
       _selectedGame = game;
       _isNavigatingFast = isFast;
+      _isLetterJumping = forceFast;
       _currentLetter = letter;
     });
 
-    // Debounce rapid navigation end to resume heavy resource loading.
+    // Debounce rapid navigation end to resume heavy resource loading. Letter
+    // jumps dwell longer than this debounce, so they get a window wider than
+    // one hop — otherwise the burst would "end" between every jump and the
+    // letter overlay would flash out and back in on each one.
     _fastNavEndTimer?.cancel();
-    _fastNavEndTimer = Timer(const Duration(milliseconds: 300), () {
-      if (mounted) {
-        setState(() {
-          _isNavigatingFast = false;
-        });
-        _performBackgroundOperationsForSelectedGame(force: true);
+    _fastNavEndTimer = Timer(
+      forceFast ? _letterJumpEndDelay : _fastNavEndDelay,
+      () {
+        if (mounted) {
+          setState(() {
+            _isNavigatingFast = false;
+            _isLetterJumping = false;
+          });
+          _performBackgroundOperationsForSelectedGame(force: true);
 
-        Timer(const Duration(milliseconds: 200), () {
-          if (mounted && !_isNavigatingFast) {
-            setState(() => _currentLetter = null);
-          }
-        });
-      }
-    });
+          Timer(const Duration(milliseconds: 200), () {
+            if (mounted && !_isNavigatingFast) {
+              setState(() => _currentLetter = null);
+            }
+          });
+        }
+      },
+    );
 
     _performBackgroundOperationsForSelectedGame();
   }
@@ -579,49 +591,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
 
   /// Renders a large, semi-transparent alphabetical indicator for high-speed navigation.
   Widget _buildLetterIndicator() {
-    return AnimatedOpacity(
-      duration: const Duration(milliseconds: 150),
-      opacity: _isNavigatingFast ? 1.0 : 0.0,
-      child: RepaintBoundary(
-        child: Center(
-          child: Container(
-            width: 120.r,
-            height: 120.r,
-            decoration: BoxDecoration(
-              color: Theme.of(
-                context,
-              ).colorScheme.surface.withValues(alpha: 0.9),
-              borderRadius:
-                  Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-                  BorderRadius.circular(14.r),
-              border: Border.all(
-                color: Theme.of(context).colorScheme.outline,
-                width: 1.r,
-              ),
-              boxShadow: [
-                BoxShadow(
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.shadow.withValues(alpha: 0.5),
-                  blurRadius: 3.r,
-                  offset: Offset(2.r, 2.r),
-                ),
-              ],
-            ),
-            child: Center(
-              child: Text(
-                _currentLetter!,
-                style: TextStyle(
-                  fontSize: 72.r,
-                  fontWeight: FontWeight.w900,
-                  color: Theme.of(context).colorScheme.onSurface,
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
+    return LetterIndicator(letter: _currentLetter!, visible: _isLetterJumping);
   }
 
   /// Visual placeholder for initial data hydration.

--- a/lib/screens/game_screen/my_games_list/gamepad_nav.dart
+++ b/lib/screens/game_screen/my_games_list/gamepad_nav.dart
@@ -54,10 +54,13 @@ extension _GamepadNav on _SystemGamesListState {
       onNavigateDown: _navigateDown,
       onNavigateLeft: _navigateLeft, // Page Up (10 items).
       onNavigateRight: _navigateRight, // Page Down (10 items).
+      onLetterJump: _letterJump, // Held D-pad up/down → alphabet skipping.
+      accelerateRepeats: true, // Text-only rows keep up with a ramping repeat.
       onSelectItem: _selectCurrentGame,
       onBack: _goBack,
       onFavorite: _toggleFavorite, // Button Y.
-      onXButton: _handleXButton, // Button X - View mode picker (music: shuffle).
+      onXButton:
+          _handleXButton, // Button X - View mode picker (music: shuffle).
       onSettings: _openGameSettingsDialog, // Button Start.
       onSelectButton: _handleSelectButton, // Button Select (View) - tap.
       onSelectModifierA: () => _scrapeAction?.call(), // Select + A - Scrape.
@@ -106,6 +109,26 @@ extension _GamepadNav on _SystemGamesListState {
 
     _resetVideoState();
     _updateSelectedGame((_selectedGameIndex + 1) % _games.length);
+  }
+
+  /// Skips to the neighbouring alphabetical group once up/down has been held
+  /// long enough (ES-DE style). Returns false when there is no further letter
+  /// in that direction, letting the caller fall back to a normal step so the
+  /// selection still wraps at the ends of the list.
+  bool _letterJump(bool forward) {
+    if (_games.isEmpty) return false;
+    if (_isAchievementsOpen != null && _isAchievementsOpen!()) return false;
+
+    final target = LetterJump.targetIndex(
+      length: _games.length,
+      currentIndex: _selectedGameIndex,
+      forward: forward,
+      letterAt: (index) => LetterJump.letterFor(_games[index]),
+    );
+    if (target == null) return false;
+
+    _updateSelectedGame(target, forceFast: true);
+    return true;
   }
 
   /// Jumps back by 10 games (Page Up logic).

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -43,6 +43,12 @@ class GamepadInfo {
   }
 }
 
+/// Axis whose held-direction repeats escalate into alphabetical letter jumps.
+///
+/// This is the axis the *items* run along in a given view: vertical for the
+/// list and grid, horizontal for the carousel.
+enum LetterJumpAxis { vertical, horizontal }
+
 /// Core service for managing gamepad and keyboard navigation within the application.
 ///
 /// Handles input translation, debouncing, auto-repeat logic, and callback dispatching.
@@ -72,6 +78,23 @@ class GamepadNavigation {
   final VoidCallback? onSelectModifierB;
   final VoidCallback? onSelectModifierX;
   final VoidCallback? onSelectModifierY;
+
+  /// ES-DE style alphabetical jumping. Once a direction on [letterJumpAxis] has
+  /// been held for longer than `_letterJumpAfter`, each repeat calls this with
+  /// `true` for forward (down / right) instead of moving one item, and then
+  /// dwells on the new letter so the user can release in time. Return `false`
+  /// to decline the jump (e.g. no further letter), which falls back to the
+  /// normal accelerated step repeat for that tick.
+  final bool Function(bool forward)? onLetterJump;
+
+  /// Axis [onLetterJump] applies to. Ignored when [onLetterJump] is null.
+  final LetterJumpAxis letterJumpAxis;
+
+  /// Whether held directions speed up the longer they are held (see
+  /// `_rampedRepeatInterval`). Off by default: in artwork-heavy views the
+  /// accelerated cadence outruns image loading, so the cards lag behind the
+  /// cursor — a fixed cadence there stays in step with the cache.
+  final bool accelerateRepeats;
 
   /// Optional override that reports whether a text field is currently focused
   /// in the active UI layer. When provided, it takes precedence over the global
@@ -108,8 +131,27 @@ class GamepadNavigation {
   /// Delay before the first repeat event occurs when a button is held.
   static const Duration _initialRepeatDelay = Duration(milliseconds: 300);
 
-  /// Interval between subsequent repeat events when a button is held.
+  /// Interval between the first few repeat events when a button is held.
   static const Duration _repeatInterval = Duration(milliseconds: 80);
+
+  /// Fastest repeat interval reached while a direction stays held. The interval
+  /// ramps from [_repeatInterval] down to this over [_rampRepeats] repeats, so
+  /// a long hold accelerates instead of crawling at a fixed speed.
+  static const Duration _minRepeatInterval = Duration(milliseconds: 35);
+
+  /// Repeats taken to ramp from [_repeatInterval] to [_minRepeatInterval].
+  static const int _rampRepeats = 14;
+
+  /// How long a direction must be held before repeats escalate from stepping
+  /// item-by-item to ES-DE style alphabetical jumping (see [onLetterJump]).
+  /// Long enough that the accelerated step scroll (~30 items by this point) is
+  /// the normal way to browse, and letter jumping only takes over on a
+  /// deliberate hold.
+  static const Duration _letterJumpAfter = Duration(milliseconds: 1600);
+
+  /// Dwell time on each letter while letter jumping — long enough to read the
+  /// letter and release on it, short enough to cross the alphabet quickly.
+  static const Duration _letterJumpInterval = Duration(milliseconds: 360);
 
   final Map<dynamic, Timer?> _repeatTimers = {};
 
@@ -184,6 +226,9 @@ class GamepadNavigation {
     this.onSelectModifierB,
     this.onSelectModifierX,
     this.onSelectModifierY,
+    this.onLetterJump,
+    this.letterJumpAxis = LetterJumpAxis.vertical,
+    this.accelerateRepeats = false,
     this.isTextFieldFocused,
   });
 
@@ -1028,26 +1073,93 @@ class GamepadNavigation {
   }
 
   /// Internal auto-repeat logic for held buttons.
+  ///
+  /// Repeats are self-rescheduling rather than a fixed [Timer.periodic] so the
+  /// cadence can change while the button stays down: the interval ramps from
+  /// [_repeatInterval] to [_minRepeatInterval], and after [_letterJumpAfter] a
+  /// direction on [letterJumpAxis] switches to alphabetical jumps that dwell
+  /// for [_letterJumpInterval] each.
   void _startRepeatTimer(dynamic key, Function action) {
     _repeatTimers[key]?.cancel();
 
-    _repeatTimers[key] = Timer(_initialRepeatDelay, () {
-      // Guard: if the key was removed (by _stopRepeatTimer or _cancelAllRepeatTimers)
-      // before this callback ran, do not create a periodic timer.
-      if (!_repeatTimers.containsKey(key)) return;
+    final heldSince = DateTime.now();
+    final bool canLetterJump =
+        onLetterJump != null && _isLetterJumpKey(key) != null;
+    final bool forward = _isLetterJumpKey(key) ?? false;
+    var repeats = 0;
 
-      _repeatTimers[key] = Timer.periodic(_repeatInterval, (timer) {
+    void schedule(Duration delay) {
+      _repeatTimers[key] = Timer(delay, () {
+        // Guard: if the key was removed (by _stopRepeatTimer or
+        // cancelAllRepeatTimers) before this callback ran, stop here.
+        if (!_repeatTimers.containsKey(key)) return;
         if (!_isActive) {
-          timer.cancel();
           _repeatTimers.remove(key);
+          return;
+        }
+
+        final held = DateTime.now().difference(heldSince);
+        if (canLetterJump &&
+            held >= _letterJumpAfter &&
+            onLetterJump!(forward)) {
+          SfxService().playNavSound();
+          schedule(_letterJumpInterval);
           return;
         }
 
         if (_runNavAction(action, true)) {
           SfxService().playNavSound();
         }
+        repeats++;
+        schedule(
+          accelerateRepeats ? _rampedRepeatInterval(repeats) : _repeatInterval,
+        );
       });
-    });
+    }
+
+    schedule(_initialRepeatDelay);
+  }
+
+  /// Repeat interval after [repeats] repeats, easing linearly from
+  /// [_repeatInterval] down to [_minRepeatInterval].
+  static Duration _rampedRepeatInterval(int repeats) {
+    if (repeats >= _rampRepeats) return _minRepeatInterval;
+
+    final from = _repeatInterval.inMilliseconds;
+    final to = _minRepeatInterval.inMilliseconds;
+    return Duration(
+      milliseconds: from + ((to - from) * repeats / _rampRepeats).round(),
+    );
+  }
+
+  /// Whether [key] is a direction on [letterJumpAxis], and if so whether it
+  /// points forward (down / right). Returns null for any other key.
+  bool? _isLetterJumpKey(dynamic key) {
+    if (letterJumpAxis == LetterJumpAxis.vertical) {
+      if (key == GamepadInputType.dpadDown ||
+          key == LogicalKeyboardKey.arrowDown ||
+          key == LogicalKeyboardKey.keyS) {
+        return true;
+      }
+      if (key == GamepadInputType.dpadUp ||
+          key == LogicalKeyboardKey.arrowUp ||
+          key == LogicalKeyboardKey.keyW) {
+        return false;
+      }
+      return null;
+    }
+
+    if (key == GamepadInputType.dpadRight ||
+        key == LogicalKeyboardKey.arrowRight ||
+        key == LogicalKeyboardKey.keyD) {
+      return true;
+    }
+    if (key == GamepadInputType.dpadLeft ||
+        key == LogicalKeyboardKey.arrowLeft ||
+        key == LogicalKeyboardKey.keyA) {
+      return false;
+    }
+    return null;
   }
 
   /// Cancels an active repeat timer for a specific key.

--- a/lib/utils/letter_jump.dart
+++ b/lib/utils/letter_jump.dart
@@ -1,0 +1,84 @@
+import 'package:neostation/models/game_model.dart';
+
+/// ES-DE style alphabetical "letter jump" helpers.
+///
+/// When a direction is held long enough the game views stop stepping one item
+/// at a time and start hopping between alphabetical groups instead, dwelling on
+/// each group briefly so the user can release on the letter they want. The
+/// grouping rules live here so the list, grid and carousel all agree on what
+/// counts as a letter boundary.
+class LetterJump {
+  LetterJump._();
+
+  static final RegExp _alphaNumeric = RegExp(r'[A-Z0-9]');
+
+  /// Label shown for games whose name starts with punctuation or a symbol.
+  static const String other = '#';
+
+  /// The alphabetical bucket a [game] belongs to: its first character upper
+  /// cased, with a leading English article ignored, and anything that isn't a
+  /// letter or digit collapsed into [other].
+  static String letterFor(GameModel game) {
+    final displayName = game.name.isNotEmpty ? game.name : game.romname;
+    return letterForName(displayName);
+  }
+
+  /// [letterFor] for a bare display name. Returns [other] for empty names.
+  static String letterForName(String displayName) {
+    var cleanName = displayName.trim().toUpperCase();
+    if (cleanName.startsWith('THE ')) cleanName = cleanName.substring(4).trim();
+    if (cleanName.isEmpty) return other;
+
+    final firstChar = cleanName[0];
+    return _alphaNumeric.hasMatch(firstChar) ? firstChar : other;
+  }
+
+  /// Index of the first item of the neighbouring alphabetical group, or `null`
+  /// when there is no further group in that direction.
+  ///
+  /// The scan is purely positional — it compares adjacent items rather than
+  /// assuming a sorted A→Z run — so a favourites-first ordering simply reads as
+  /// its own set of groups and the jump still lands on group boundaries.
+  ///
+  /// Going [forward] lands on the first item whose letter differs from the
+  /// current one. Going backwards lands on the *start* of the current group
+  /// first (the usual "rewind to the top of this letter" behaviour), and only
+  /// steps into the previous group once the cursor is already there.
+  static int? targetIndex({
+    required int length,
+    required int currentIndex,
+    required bool forward,
+    required String Function(int index) letterAt,
+  }) {
+    if (length <= 0 || currentIndex < 0 || currentIndex >= length) return null;
+
+    final current = letterAt(currentIndex);
+
+    if (forward) {
+      for (var i = currentIndex + 1; i < length; i++) {
+        if (letterAt(i) != current) return i;
+      }
+      return null;
+    }
+
+    final groupStart = _groupStart(currentIndex, current, letterAt);
+    if (groupStart < currentIndex) return groupStart;
+
+    final previous = currentIndex - 1;
+    if (previous < 0) return null;
+    return _groupStart(previous, letterAt(previous), letterAt);
+  }
+
+  /// First index of the contiguous run of [letter] that contains [index].
+  static int _groupStart(
+    int index,
+    String letter,
+    String Function(int index) letterAt,
+  ) {
+    var start = index;
+    while (start > 0 && letterAt(start - 1) == letter) {
+      start--;
+    }
+    return start;
+  }
+}

--- a/lib/widgets/letter_indicator.dart
+++ b/lib/widgets/letter_indicator.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../themes/corner_radii.dart';
+
+/// Large, semi-transparent alphabetical indicator shown while the user scrolls
+/// a game view rapidly or skips through the alphabet by holding a direction.
+///
+/// Fades itself in and out via [visible] so callers only have to keep the
+/// current [letter] up to date.
+class LetterIndicator extends StatelessWidget {
+  final String letter;
+  final bool visible;
+
+  const LetterIndicator({
+    super.key,
+    required this.letter,
+    required this.visible,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      duration: const Duration(milliseconds: 150),
+      opacity: visible ? 1.0 : 0.0,
+      child: RepaintBoundary(
+        child: Center(
+          child: Container(
+            width: 120.r,
+            height: 120.r,
+            decoration: BoxDecoration(
+              color: Theme.of(
+                context,
+              ).colorScheme.surface.withValues(alpha: 0.9),
+              borderRadius:
+                  Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
+                  BorderRadius.circular(14.r),
+              border: Border.all(
+                color: Theme.of(context).colorScheme.outline,
+                width: 1.r,
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.shadow.withValues(alpha: 0.5),
+                  blurRadius: 3.r,
+                  offset: Offset(2.r, 2.r),
+                ),
+              ],
+            ),
+            child: Center(
+              child: Text(
+                letter,
+                style: TextStyle(
+                  fontSize: 72.r,
+                  fontWeight: FontWeight.w900,
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/letter_jump_test.dart
+++ b/test/letter_jump_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/letter_jump.dart';
+
+/// Builds a `letterAt` accessor over a compact "AABBC" style layout, where each
+/// character is one item's alphabetical group.
+String Function(int) lettersOf(String layout) =>
+    (index) => layout[index];
+
+void main() {
+  group('LetterJump.letterForName', () {
+    test('upper cases the first character', () {
+      expect(LetterJump.letterForName('sonic the hedgehog'), 'S');
+    });
+
+    test('ignores a leading English article', () {
+      expect(LetterJump.letterForName('The Legend of Zelda'), 'L');
+    });
+
+    test('keeps digits as their own group', () {
+      expect(LetterJump.letterForName('1942'), '1');
+    });
+
+    test('collapses symbols and empty names into #', () {
+      expect(LetterJump.letterForName('[BIOS] Something'), LetterJump.other);
+      expect(LetterJump.letterForName('   '), LetterJump.other);
+    });
+  });
+
+  group('LetterJump.targetIndex', () {
+    test('forward lands on the first item of the next group', () {
+      expect(
+        LetterJump.targetIndex(
+          length: 5,
+          currentIndex: 0,
+          forward: true,
+          letterAt: lettersOf('AABBC'),
+        ),
+        2,
+      );
+    });
+
+    test('forward from mid-group still lands on the next group', () {
+      expect(
+        LetterJump.targetIndex(
+          length: 5,
+          currentIndex: 1,
+          forward: true,
+          letterAt: lettersOf('AABBC'),
+        ),
+        2,
+      );
+    });
+
+    test('forward returns null in the last group', () {
+      expect(
+        LetterJump.targetIndex(
+          length: 5,
+          currentIndex: 4,
+          forward: true,
+          letterAt: lettersOf('AABBC'),
+        ),
+        isNull,
+      );
+    });
+
+    test('backward rewinds to the start of the current group first', () {
+      expect(
+        LetterJump.targetIndex(
+          length: 5,
+          currentIndex: 3,
+          forward: false,
+          letterAt: lettersOf('AABBC'),
+        ),
+        2,
+      );
+    });
+
+    test('backward from a group start steps into the previous group', () {
+      expect(
+        LetterJump.targetIndex(
+          length: 5,
+          currentIndex: 2,
+          forward: false,
+          letterAt: lettersOf('AABBC'),
+        ),
+        0,
+      );
+    });
+
+    test('backward returns null at the very first item', () {
+      expect(
+        LetterJump.targetIndex(
+          length: 5,
+          currentIndex: 0,
+          forward: false,
+          letterAt: lettersOf('AABBC'),
+        ),
+        isNull,
+      );
+    });
+
+    test('treats a favourites block as its own group', () {
+      // '*' = favourites pinned above the alphabetical run.
+      const layout = '**ABB';
+      expect(
+        LetterJump.targetIndex(
+          length: 5,
+          currentIndex: 1,
+          forward: true,
+          letterAt: lettersOf(layout),
+        ),
+        2,
+      );
+      expect(
+        LetterJump.targetIndex(
+          length: 5,
+          currentIndex: 2,
+          forward: false,
+          letterAt: lettersOf(layout),
+        ),
+        0,
+      );
+    });
+
+    test('handles an empty or out-of-range list', () {
+      expect(
+        LetterJump.targetIndex(
+          length: 0,
+          currentIndex: 0,
+          forward: true,
+          letterAt: (_) => 'A',
+        ),
+        isNull,
+      );
+      expect(
+        LetterJump.targetIndex(
+          length: 3,
+          currentIndex: 7,
+          forward: true,
+          letterAt: (_) => 'A',
+        ),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was created with the help of [Claude Code](https://claude.com/claude-code).

# Description

Holding D-pad up/down in the game list crawled at a fixed 80&nbsp;ms repeat, which makes a large library tedious to cross. This adds the ES-DE style two-stage hold behaviour to the **list view**:

1. **Hold** — the repeat accelerates from 80&nbsp;ms down to 35&nbsp;ms over 14 repeats, so a long hold speeds up instead of crawling.
2. **Keep holding (1.6&nbsp;s)** — repeats escalate to skipping the alphabet one letter group at a time, dwelling 360&nbsp;ms on each so you can release on the letter you want. The existing letter overlay stays up for the whole hold.

The **carousel** also letter-jumps on a held left/right (its item axis, matching its letter bar). The **grid** deliberately keeps `main`'s fixed cadence and does not letter-jump: at the accelerated rate the artwork loading cannot keep up and the cards lag behind the cursor.

Notable details:

- Acceleration is opt-in per navigation layer (`accelerateRepeats`, default `false`), so no other screen in the app changes behaviour.
- Letter grouping is **positional** — it compares adjacent items rather than assuming a sorted A→Z run — so the favourites-first ordering reads as its own group instead of breaking the scan.
- Backwards hops rewind to the top of the current letter first, then step into the previous one.
- At the ends of the alphabet a jump is declined and falls back to a normal step, preserving the existing wrap-around.
- The letter overlay is now tied to letter jumping rather than to any fast scroll (it previously appeared from the second repeat of any hold), and is extracted into a shared `LetterIndicator` widget.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

Tested on an AYN Thor (dev channel) against a large library, with each timing tuned on device and A/B'd against `main`. `test/letter_jump_test.dart` covers the bucketing and the group-boundary scan (276 tests passing).

## Screenshots (if applicable)

n/a — timing/interaction change; the letter overlay itself is unchanged visually.
