### PR TITLE
fix: update systems from systems repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,10 @@ These packages are "vendored" within the /packages directory to ensure long-term
 
 ## Systems & Emulator Definitions
 
-NeoStation's system configurations, emulator definitions, and launch arguments are maintained in a separate repository.  
-**If you want to add new emulators, fix launch arguments, or update system configurations, please open a pull request in the dedicated systems repository:**
+NeoStation's system configurations, emulator definitions, and launch arguments are maintained in this repository under [`assets/systems/`](assets/systems/).  
+**If you want to add new emulators, fix launch arguments, or update system configurations, please open a pull request here.**
 
-👉 [**misobadev/neostation-systems**](https://github.com/misobadev/neostation-systems)
-
-Changes to these files are not accepted in this frontend repository.
+The bundled `assets/manifest.json` drives the over-the-air systems update mechanism, so compatible changes can be delivered to existing installs without requiring a full app release.
 
 ## Contributing
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.3"
+  "latest_version": "0.3.4"
 }

--- a/assets/systems/2600.json
+++ b/assets/systems/2600.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "2600",
+    "multidisc": false,
     "name": "Atari 2600",
     "short_name": "A2600",
     "details": {

--- a/assets/systems/32x.json
+++ b/assets/systems/32x.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "32x",
+    "multidisc": false,
     "name": "Sega 32X",
     "short_name": "32X",
     "details": {
@@ -19,7 +20,8 @@
       "Sega 32X",
       "THIRTYTWOX",
       "sega32xjp",
-      "sega32xna"
+      "sega32xna",
+      "sega32"
     ],
     "colors": [
       "#212121",

--- a/assets/systems/3ds.json
+++ b/assets/systems/3ds.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "3ds",
+    "multidisc": false,
     "name": "Nintendo 3DS",
     "short_name": "3DS",
     "details": {

--- a/assets/systems/5200.json
+++ b/assets/systems/5200.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "5200",
+    "multidisc": false,
     "name": "Atari 5200",
     "short_name": "A5200",
     "details": {

--- a/assets/systems/7800.json
+++ b/assets/systems/7800.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "7800",
+    "multidisc": false,
     "name": "Atari 7800",
     "short_name": "A7800",
     "details": {

--- a/assets/systems/a2.json
+++ b/assets/systems/a2.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "a2",
+    "multidisc": false,
     "name": "Apple II",
     "short_name": "A2",
     "details": {

--- a/assets/systems/a2001.json
+++ b/assets/systems/a2001.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "a2001",
+    "multidisc": false,
     "name": "Emerson Arcadia 2001",
     "short_name": "A2001",
     "details": {
@@ -17,7 +18,8 @@
       "a2001",
       "arcadia",
       "Emerson Arcadia 2001",
-      "Arcadia 2001"
+      "Arcadia 2001",
+      "arcadia-2001"
     ],
     "colors": [
       "#BDBDBD",

--- a/assets/systems/all.json
+++ b/assets/systems/all.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "all",
+    "multidisc": false,
     "name": "All Systems",
     "short_name": "All",
     "details": {

--- a/assets/systems/amazon.json
+++ b/assets/systems/amazon.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "amazon",
+    "multidisc": false,
     "name": "Amazon",
     "neosync": {
       "sync": false,

--- a/assets/systems/amiga.json
+++ b/assets/systems/amiga.json
@@ -22,7 +22,10 @@
       "amigacd32",
       "amiga500",
       "amiga4000",
-      "amigacdtv"
+      "amigacdtv",
+      "amiga-cd",
+      "amiga-cd32",
+      "commodore-cdtv"
     ],
     "colors": [
       "#E57373",

--- a/assets/systems/android.json
+++ b/assets/systems/android.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "android",
+    "multidisc": false,
     "name": "Android",
     "short_name": "Android",
     "details": {

--- a/assets/systems/arc.json
+++ b/assets/systems/arc.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "arc",
+    "multidisc": false,
     "name": "Arcade",
     "short_name": "Arcade",
     "details": {

--- a/assets/systems/ard.json
+++ b/assets/systems/ard.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "ard",
+    "multidisc": false,
     "name": "Arduboy",
     "short_name": "ARD",
     "details": {

--- a/assets/systems/ast.json
+++ b/assets/systems/ast.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "ast",
+    "multidisc": false,
     "name": "Atari ST",
     "short_name": "AST",
     "details": {
@@ -16,7 +17,8 @@
     "folders": [
       "ast",
       "atarist",
-      "Atari ST"
+      "Atari ST",
+      "atari-st"
     ],
     "colors": [
       "#BDBDBD",

--- a/assets/systems/aw.json
+++ b/assets/systems/aw.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "aw",
+    "multidisc": false,
     "name": "Atomiswave",
     "short_name": "AW",
     "details": {

--- a/assets/systems/bbcmicro.json
+++ b/assets/systems/bbcmicro.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "bbcmicro",
+    "multidisc": false,
     "name": "BBC Micro",
     "short_name": "BBCM",
     "details": {

--- a/assets/systems/c64.json
+++ b/assets/systems/c64.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "c64",
+    "multidisc": false,
     "name": "Commodore 64",
     "short_name": "C64",
     "details": {

--- a/assets/systems/cdi.json
+++ b/assets/systems/cdi.json
@@ -18,7 +18,8 @@
       "cdi",
       "cdimono1",
       "philipscdi",
-      "Philips CD-i"
+      "Philips CD-i",
+      "philips-cd-i"
     ],
     "colors": [
       "#B0BEC5",

--- a/assets/systems/chf.json
+++ b/assets/systems/chf.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "chf",
+    "multidisc": false,
     "name": "Fairchild Channel F",
     "short_name": "CHF",
     "details": {
@@ -17,7 +18,8 @@
       "chf",
       "channelf",
       "FAIRCHILD",
-      "Fairchild Channel F"
+      "Fairchild Channel F",
+      "fairchild-channel-f"
     ],
     "colors": [
       "#F5F5F5",

--- a/assets/systems/cpc.json
+++ b/assets/systems/cpc.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "cpc",
+    "multidisc": false,
     "name": "Amstrad CPC",
     "short_name": "CPC",
     "details": {
@@ -17,7 +18,9 @@
       "cpc",
       "amstradcpc",
       "Amstrad CPC",
-      "gx4000"
+      "gx4000",
+      "acpc",
+      "amstrad-gx4000"
     ],
     "colors": [
       "#42A5F5",

--- a/assets/systems/cps1.json
+++ b/assets/systems/cps1.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "cps1",
+    "multidisc": false,
     "name": "CP System I",
     "short_name": "CPSI",
     "details": {

--- a/assets/systems/cps2.json
+++ b/assets/systems/cps2.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "cps2",
+    "multidisc": false,
     "name": "CP System II",
     "short_name": "CPSII",
     "details": {

--- a/assets/systems/cps3.json
+++ b/assets/systems/cps3.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "cps3",
+    "multidisc": false,
     "name": "CP System III",
     "short_name": "CPSIII",
     "details": {

--- a/assets/systems/cv.json
+++ b/assets/systems/cv.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "cv",
+    "multidisc": false,
     "name": "ColecoVision",
     "short_name": "CV",
     "details": {
@@ -16,7 +17,8 @@
     "folders": [
       "cv",
       "coleco",
-      "ColecoVision"
+      "ColecoVision",
+      "colecovision"
     ],
     "colors": [
       "#424242",

--- a/assets/systems/ds.json
+++ b/assets/systems/ds.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "ds",
+    "multidisc": false,
     "name": "Nintendo DS",
     "short_name": "DS",
     "details": {

--- a/assets/systems/duck.json
+++ b/assets/systems/duck.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "duck",
+    "multidisc": false,
     "name": "Mega Duck",
     "short_name": "Duck",
     "details": {
@@ -15,7 +16,8 @@
     },
     "folders": [
       "megaduck",
-      "Mega Duck"
+      "Mega Duck",
+      "mega-duck-slash-cougar-boy"
     ],
     "colors": [
       "#FFF176",

--- a/assets/systems/epic.json
+++ b/assets/systems/epic.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "epic",
+    "multidisc": false,
     "name": "Epic Games",
     "neosync": {
       "sync": false,

--- a/assets/systems/favorites.json
+++ b/assets/systems/favorites.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "favorites",
+    "multidisc": false,
     "name": "Favorites",
     "short_name": "Fav",
     "details": {

--- a/assets/systems/fbneo.json
+++ b/assets/systems/fbneo.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "fbneo",
+    "multidisc": false,
     "name": "FinalBurn Neo",
     "short_name": "FBNeo",
     "details": {

--- a/assets/systems/fc.json
+++ b/assets/systems/fc.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "fc",
+    "multidisc": false,
     "name": "Family Computer",
     "short_name": "FC",
     "details": {
@@ -17,7 +18,8 @@
       "fc",
       "Famicom",
       "Family Computer",
-      "Nintendo Family Computer"
+      "Nintendo Family Computer",
+      "famicom"
     ],
     "colors": [
       "#D32F2F",

--- a/assets/systems/fds.json
+++ b/assets/systems/fds.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "fds",
+    "multidisc": false,
     "name": "Famicom Disk System",
     "short_name": "FDS",
     "details": {

--- a/assets/systems/gb-hacks.json
+++ b/assets/systems/gb-hacks.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gb-hacks",
+    "multidisc": false,
     "name": "Game Boy Hacks",
     "short_name": "GBH",
     "details": {

--- a/assets/systems/gb.json
+++ b/assets/systems/gb.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gb",
+    "multidisc": false,
     "name": "Game Boy",
     "short_name": "GB",
     "details": {

--- a/assets/systems/gba-hacks.json
+++ b/assets/systems/gba-hacks.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gba-hacks",
+    "multidisc": false,
     "name": "Game Boy Advance Hacks",
     "short_name": "GBAH",
     "details": {

--- a/assets/systems/gba.json
+++ b/assets/systems/gba.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gba",
+    "multidisc": false,
     "name": "Game Boy Advance",
     "short_name": "GBA",
     "details": {

--- a/assets/systems/gbc-hacks.json
+++ b/assets/systems/gbc-hacks.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gbc-hacks",
+    "multidisc": false,
     "name": "Game Boy Color Hacks",
     "short_name": "GBCH",
     "details": {

--- a/assets/systems/gbc.json
+++ b/assets/systems/gbc.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gbc",
+    "multidisc": false,
     "name": "Game Boy Color",
     "short_name": "GBC",
     "details": {

--- a/assets/systems/gc.json
+++ b/assets/systems/gc.json
@@ -17,7 +17,8 @@
     "folders": [
       "gc",
       "GameCube",
-      "Nintendo GameCube"
+      "Nintendo GameCube",
+      "ngc"
     ],
     "colors": [
       "#7E57C2",

--- a/assets/systems/genesis-hacks.json
+++ b/assets/systems/genesis-hacks.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gen-hacks",
+    "multidisc": false,
     "name": "Sega Genesis Hacks",
     "short_name": "GENH",
     "details": {

--- a/assets/systems/genesis.json
+++ b/assets/systems/genesis.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "genesis",
+    "multidisc": false,
     "name": "Sega Genesis",
     "short_name": "Genesis",
     "details": {

--- a/assets/systems/gg-hacks.json
+++ b/assets/systems/gg-hacks.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gg-hacks",
+    "multidisc": false,
     "name": "Sega Game Gear Hacks",
     "short_name": "GGH",
     "details": {

--- a/assets/systems/gg.json
+++ b/assets/systems/gg.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gg",
+    "multidisc": false,
     "name": "Sega Game Gear",
     "short_name": "GG",
     "details": {

--- a/assets/systems/gog.json
+++ b/assets/systems/gog.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gog",
+    "multidisc": false,
     "name": "GOG",
     "neosync": {
       "sync": false,

--- a/assets/systems/gw.json
+++ b/assets/systems/gw.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "gw",
+    "multidisc": false,
     "name": "Game & Watch",
     "short_name": "G&W",
     "details": {
@@ -16,7 +17,8 @@
     "folders": [
       "gw",
       "gameandwatch",
-      "Game & Watch"
+      "Game & Watch",
+      "g-and-w"
     ],
     "colors": [
       "#BDBDBD",

--- a/assets/systems/intv.json
+++ b/assets/systems/intv.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "intv",
+    "multidisc": false,
     "name": "Intellivision",
     "short_name": "INTV",
     "details": {

--- a/assets/systems/jag.json
+++ b/assets/systems/jag.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "jag",
+    "multidisc": false,
     "name": "Atari Jaguar",
     "short_name": "Jaguar",
     "details": {

--- a/assets/systems/jagcd.json
+++ b/assets/systems/jagcd.json
@@ -17,7 +17,8 @@
     "folders": [
       "jagcd",
       "atarijaguarcd",
-      "Atari Jaguar CD"
+      "Atari Jaguar CD",
+      "atari-jaguar-cd"
     ],
     "colors": [
       "#424242",

--- a/assets/systems/lynx.json
+++ b/assets/systems/lynx.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "lynx",
+    "multidisc": false,
     "name": "Atari Lynx",
     "short_name": "Lynx",
     "details": {

--- a/assets/systems/mame.json
+++ b/assets/systems/mame.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "mame",
+    "multidisc": false,
     "name": "M.A.M.E.",
     "short_name": "MAME",
     "details": {

--- a/assets/systems/mark3.json
+++ b/assets/systems/mark3.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "mark3",
+    "multidisc": false,
     "name": "Sega Mark III",
     "short_name": "Mark3",
     "details": {

--- a/assets/systems/mcd.json
+++ b/assets/systems/mcd.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "mcd",
+    "multidisc": false,
     "name": "Sega Mega-CD",
     "short_name": "MCD",
     "details": {

--- a/assets/systems/md-hacks.json
+++ b/assets/systems/md-hacks.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "md-hacks",
+    "multidisc": false,
     "name": "Sega Mega Drive Hacks",
     "short_name": "MDH",
     "details": {

--- a/assets/systems/md.json
+++ b/assets/systems/md.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "md",
+    "multidisc": false,
     "name": "Sega Mega Drive",
     "short_name": "MD",
     "details": {

--- a/assets/systems/mini.json
+++ b/assets/systems/mini.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "mini",
+    "multidisc": false,
     "name": "Pokémon Mini",
     "short_name": "Mini",
     "details": {

--- a/assets/systems/mo2.json
+++ b/assets/systems/mo2.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "mo2",
+    "multidisc": false,
     "name": "Magnavox Odyssey 2",
     "short_name": "MO2",
     "details": {
@@ -17,7 +18,8 @@
       "mo2",
       "odyssey2",
       "videopac",
-      "Magnavox Odyssey 2"
+      "Magnavox Odyssey 2",
+      "odyssey-2"
     ],
     "colors": [
       "#212121",

--- a/assets/systems/msx.json
+++ b/assets/systems/msx.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "msx",
+    "multidisc": false,
     "name": "MSX",
     "short_name": "MSX",
     "details": {
@@ -17,7 +18,9 @@
       "msx",
       "msx1",
       "msx2",
-      "msxturbor"
+      "msxturbor",
+      "msx-turbo",
+      "msx2plus"
     ],
     "colors": [
       "#30343f",

--- a/assets/systems/music.json
+++ b/assets/systems/music.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "music",
+    "multidisc": false,
     "name": "Music",
     "short_name": "Music",
     "details": {

--- a/assets/systems/n64.json
+++ b/assets/systems/n64.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "n64",
+    "multidisc": false,
     "name": "Nintendo 64",
     "short_name": "N64",
     "details": {
@@ -16,7 +17,8 @@
     "folders": [
       "n64",
       "Nintendo 64",
-      "n64dd"
+      "n64dd",
+      "64dd"
     ],
     "colors": [
       "#546e7a",

--- a/assets/systems/naomi.json
+++ b/assets/systems/naomi.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "naomi",
+    "multidisc": false,
     "name": "Sega Naomi",
     "short_name": "Naomi",
     "details": {

--- a/assets/systems/naomi2.json
+++ b/assets/systems/naomi2.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "naomi2",
+    "multidisc": false,
     "name": "Sega Naomi 2",
     "short_name": "Naomi 2",
     "details": {

--- a/assets/systems/naomigd.json
+++ b/assets/systems/naomigd.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "naomigd",
+    "multidisc": false,
     "name": "Sega Naomi GD-ROM",
     "short_name": "Naomi GD",
     "details": {

--- a/assets/systems/neogeo.json
+++ b/assets/systems/neogeo.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "neogeo",
+    "multidisc": false,
     "name": "Neo Geo",
     "short_name": "Neo Geo",
     "details": {
@@ -15,7 +16,9 @@
     },
     "folders": [
       "neogeo",
-      "Neo Geo"
+      "Neo Geo",
+      "neogeoaes",
+      "neogeomvs"
     ],
     "colors": [
       "#263238",

--- a/assets/systems/nes-hacks.json
+++ b/assets/systems/nes-hacks.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "nes-hacks",
+    "multidisc": false,
     "name": "Nintendo Entertainment System Hacks",
     "short_name": "NESH",
     "details": {

--- a/assets/systems/nes.json
+++ b/assets/systems/nes.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "nes",
+    "multidisc": false,
     "name": "Nintendo Entertainment System",
     "short_name": "NES",
     "details": {

--- a/assets/systems/ngcd.json
+++ b/assets/systems/ngcd.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "ngcd",
+    "multidisc": false,
     "name": "Neo Geo CD",
     "short_name": "NGCD",
     "details": {
@@ -17,7 +18,8 @@
       "ngcd",
       "neogeocd",
       "Neo Geo CD",
-      "neogeocdjp"
+      "neogeocdjp",
+      "neo-geo-cd"
     ],
     "colors": [
       "#E0E0E0",

--- a/assets/systems/ngp.json
+++ b/assets/systems/ngp.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "ngp",
+    "multidisc": false,
     "name": "NeoGeo Pocket",
     "short_name": "NGP",
     "details": {
@@ -18,7 +19,8 @@
       "Neo Geo Pocket",
       "NeoGeo Pocket",
       "Neo-Geo Pocket",
-      "SNK Neo Geo Pocket"
+      "SNK Neo Geo Pocket",
+      "neo-geo-pocket"
     ],
     "colors": [
       "#90A4AE",

--- a/assets/systems/ngpc.json
+++ b/assets/systems/ngpc.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "ngpc",
+    "multidisc": false,
     "name": "NeoGeo Pocket Color",
     "short_name": "NGPC",
     "details": {
@@ -18,7 +19,8 @@
       "Neo Geo Pocket Color",
       "NeoGeo Pocket Color",
       "Neo-Geo Pocket Color",
-      "SNK Neo Geo Pocket Color"
+      "SNK Neo Geo Pocket Color",
+      "neo-geo-pocket-color"
     ],
     "colors": [
       "#455A64",

--- a/assets/systems/palm.json
+++ b/assets/systems/palm.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "palm",
+    "multidisc": false,
     "name": "Palm OS",
     "short_name": "Palm",
     "details": {
@@ -15,7 +16,8 @@
     },
     "folders": [
       "palm",
-      "Palm OS"
+      "Palm OS",
+      "palm-os"
     ],
     "colors": [
       "#BDBDBD",

--- a/assets/systems/pc88.json
+++ b/assets/systems/pc88.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "pc88",
+    "multidisc": false,
     "name": "NEC PC-8801",
     "short_name": "PC88",
     "details": {
@@ -19,7 +20,8 @@
       "pc8000",
       "pc8800",
       "NEC PC-8000/8800",
-      "NEC PC-8801"
+      "NEC PC-8801",
+      "pc-8800-series"
     ],
     "colors": [
       "#F5F5DC",

--- a/assets/systems/pc98.json
+++ b/assets/systems/pc98.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "pc98",
+    "multidisc": false,
     "name": "NEC PC-9801",
     "short_name": "PC98",
     "details": {
@@ -16,7 +17,8 @@
     "folders": [
       "pc98",
       "NEC PC-98",
-      "PC-98"
+      "PC-98",
+      "pc-9800-series"
     ],
     "colors": [
       "#E0E0E0",

--- a/assets/systems/pce.json
+++ b/assets/systems/pce.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "pce",
+    "multidisc": false,
     "name": "PC Engine",
     "short_name": "PCE",
     "details": {

--- a/assets/systems/pcfx.json
+++ b/assets/systems/pcfx.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "pcfx",
+    "multidisc": false,
     "name": "NEC PC-FX",
     "short_name": "PC-FX",
     "details": {
@@ -15,7 +16,8 @@
     },
     "folders": [
       "pcfx",
-      "NEC PC-FX"
+      "NEC PC-FX",
+      "pc-fx"
     ],
     "colors": [
       "#F5F5F5",

--- a/assets/systems/pet.json
+++ b/assets/systems/pet.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "pet",
+    "multidisc": false,
     "name": "Commodore - PET",
     "short_name": "PET",
     "details": {
@@ -16,7 +17,8 @@
     "folders": [
       "pet",
       "Commodore PET",
-      "CommodorePET"
+      "CommodorePET",
+      "cpet"
     ],
     "colors": [
       "#BDBDBD",

--- a/assets/systems/pico.json
+++ b/assets/systems/pico.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "pico",
+    "multidisc": false,
     "name": "Sega Pico",
     "short_name": "Pico",
     "details": {
@@ -15,7 +16,8 @@
     },
     "folders": [
       "pico",
-      "Sega Pico"
+      "Sega Pico",
+      "sega-pico"
     ],
     "colors": [
       "#FFEB3B",

--- a/assets/systems/pico8.json
+++ b/assets/systems/pico8.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "pico8",
+    "multidisc": false,
     "name": "PICO-8",
     "short_name": "PICO-8",
     "details": {

--- a/assets/systems/plus4.json
+++ b/assets/systems/plus4.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "plus4",
+    "multidisc": false,
     "name": "Commodore - PLUS/4",
     "short_name": "Plus/4",
     "details": {
@@ -18,7 +19,8 @@
       "Commodore Plus/4",
       "CommodorePlus4",
       "Commodore - PLUS/4",
-      "cplus4"
+      "cplus4",
+      "c-plus-4"
     ],
     "colors": [
       "#424242",

--- a/assets/systems/ps2.json
+++ b/assets/systems/ps2.json
@@ -250,17 +250,6 @@
       }
     },
     {
-      "name": "Standalone ARMSX2 (Nightly)",
-      "unique_id": "ps2.com.nanodata.armsx2.debug",
-      "description": "Supported extensions: iso, chd, gz, mdf, bin, ciso, img.",
-      "is_retroachievements_compatible": false,
-      "platforms": {
-        "android": {
-          "launch_arguments": "-n come.nanodata.armsx2.debug/kr.co.iefriends.pcsx2.activities.MainActivity -a android.intent.action.VIEW -d \"{file.uri}\""
-        }
-      }
-    },
-    {
       "name": "Standalone ARMSX2 Refresh",
       "unique_id": "ps2.com.armsx2",
       "description": "Supported extensions: iso, chd, gz, mdf, bin, ciso, img.",
@@ -271,7 +260,17 @@
         }
       }
     },
-
+    {
+      "name": "Standalone ARMSX2 (Nightly)",
+      "unique_id": "ps2.com.nanodata.armsx2.debug",
+      "description": "Supported extensions: iso, chd, gz, mdf, bin, ciso, img.",
+      "is_retroachievements_compatible": false,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n come.nanodata.armsx2.debug/kr.co.iefriends.pcsx2.activities.MainActivity -a android.intent.action.VIEW -d \"{file.uri}\""
+        }
+      }
+    },
     {
       "name": "Standalone PCSX2",
       "unique_id": "ps2.net.pcsx2.android",

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "ps3",
+    "multidisc": false,
     "name": "Sony PlayStation 3",
     "short_name": "PS3",
     "details": {

--- a/assets/systems/pspminis.json
+++ b/assets/systems/pspminis.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "pspminis",
+    "multidisc": false,
     "name": "PlayStation Portable Minis",
     "short_name": "PSPM",
     "details": {

--- a/assets/systems/rpgmaker.json
+++ b/assets/systems/rpgmaker.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "rpgmaker",
+    "multidisc": false,
     "name": "RPG Maker",
     "short_name": "RPGM",
     "details": {

--- a/assets/systems/satellaview.json
+++ b/assets/systems/satellaview.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "satellaview",
+    "multidisc": false,
     "name": "Nintendo Satellaview",
     "short_name": "SV",
     "details": {

--- a/assets/systems/scummvm.json
+++ b/assets/systems/scummvm.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "scummvm",
+    "multidisc": false,
     "name": "ScummVM",
     "short_name": "ScummVM",
     "details": {

--- a/assets/systems/sfc-hacks.json
+++ b/assets/systems/sfc-hacks.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "sfc-hacks",
+    "multidisc": false,
     "name": "Super Family Computer Hacks",
     "short_name": "SFCH",
     "details": {

--- a/assets/systems/sfc.json
+++ b/assets/systems/sfc.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "sfc",
+    "multidisc": false,
     "name": "Super Family Computer",
     "short_name": "SFC",
     "details": {
@@ -15,7 +16,8 @@
     },
     "folders": [
       "sfc",
-      "Super Famicom"
+      "Super Famicom",
+      "sfam"
     ],
     "colors": [
       "#EEEEEE",

--- a/assets/systems/sg1k.json
+++ b/assets/systems/sg1k.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "sg1k",
+    "multidisc": false,
     "name": "Sega SG-1000",
     "short_name": "SG1K",
     "details": {

--- a/assets/systems/sharpx68000.json
+++ b/assets/systems/sharpx68000.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "sharpx68000",
+    "multidisc": false,
     "name": "Sharp X68000",
     "short_name": "X68K",
     "details": {
@@ -16,7 +17,8 @@
     "folders": [
       "sharpx68000",
       "Sharp X68000",
-      "x68000"
+      "x68000",
+      "sharp-x68000"
     ],
     "colors": [
       "#212121",

--- a/assets/systems/sms.json
+++ b/assets/systems/sms.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "sms",
+    "multidisc": false,
     "name": "Sega Master System",
     "short_name": "SMS",
     "details": {

--- a/assets/systems/snes-hacks.json
+++ b/assets/systems/snes-hacks.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "snes-hacks",
+    "multidisc": false,
     "name": "Super Nintendo Entertainment System Hacks",
     "short_name": "SNESH",
     "details": {

--- a/assets/systems/snes.json
+++ b/assets/systems/snes.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "snes",
+    "multidisc": false,
     "name": "Super Nintendo Entertainment System",
     "short_name": "SNES",
     "details": {

--- a/assets/systems/steam.json
+++ b/assets/systems/steam.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "steam",
+    "multidisc": false,
     "name": "Steam",
     "neosync": {
       "sync": false,

--- a/assets/systems/switch.json
+++ b/assets/systems/switch.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "switch",
+    "multidisc": false,
     "name": "Nintendo Switch",
     "short_name": "Switch",
     "details": {

--- a/assets/systems/tg16.json
+++ b/assets/systems/tg16.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "tg16",
+    "multidisc": false,
     "name": "TurboGrafx-16",
     "short_name": "TG-16",
     "details": {

--- a/assets/systems/tic80.json
+++ b/assets/systems/tic80.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "tic80",
+    "multidisc": false,
     "name": "TIC-80",
     "short_name": "TIC-80",
     "details": {

--- a/assets/systems/triforce.json
+++ b/assets/systems/triforce.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "triforce",
+    "multidisc": false,
     "name": "Triforce",
     "short_name": "Triforce",
     "details": {

--- a/assets/systems/uze.json
+++ b/assets/systems/uze.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "uze",
+    "multidisc": false,
     "name": "Uzebox",
     "short_name": "UZE",
     "details": {
@@ -15,7 +16,8 @@
     },
     "folders": [
       "uze",
-      "Uzebox"
+      "Uzebox",
+      "uzebox"
     ],
     "colors": [
       "#1976D2",

--- a/assets/systems/vb.json
+++ b/assets/systems/vb.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "vb",
+    "multidisc": false,
     "name": "Virtual Boy",
     "short_name": "VB",
     "details": {

--- a/assets/systems/vc4k.json
+++ b/assets/systems/vc4k.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "vc4k",
+    "multidisc": false,
     "name": "Interton VC 4000",
     "short_name": "VC4K",
     "details": {
@@ -17,7 +18,9 @@
       "vc4k",
       "Interton VC 4000",
       "VC 4000",
-      "vc4000"
+      "vc4000",
+      "interton-vc-4000",
+      "vc-4000"
     ],
     "colors": [
       "#FB8C00",

--- a/assets/systems/vect.json
+++ b/assets/systems/vect.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "vect",
+    "multidisc": false,
     "name": "Vectrex",
     "short_name": "Vect",
     "details": {

--- a/assets/systems/vic20.json
+++ b/assets/systems/vic20.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "vic20",
+    "multidisc": false,
     "name": "VIC-20",
     "short_name": "VIC-20",
     "details": {
@@ -16,7 +17,8 @@
     "folders": [
       "vic20",
       "Commodore VIC-20",
-      "VIC-20"
+      "VIC-20",
+      "vic-20"
     ],
     "colors": [
       "#F5F5F5",

--- a/assets/systems/vita.json
+++ b/assets/systems/vita.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "vita",
+    "multidisc": false,
     "name": "Sony PS Vita",
     "short_name": "Vita",
     "details": {

--- a/assets/systems/wasm4.json
+++ b/assets/systems/wasm4.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "wasm4",
+    "multidisc": false,
     "name": "WASM-4",
     "short_name": "WASM-4",
     "details": {

--- a/assets/systems/wiiu.json
+++ b/assets/systems/wiiu.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "wiiu",
+    "multidisc": false,
     "name": "Nintendo Wii U",
     "short_name": "Wii U",
     "details": {

--- a/assets/systems/ws.json
+++ b/assets/systems/ws.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "ws",
+    "multidisc": false,
     "name": "WonderSwan",
     "short_name": "WS",
     "details": {
@@ -17,7 +18,8 @@
       "ws",
       "Bandai WonderSwan",
       "WonderSwan",
-      "wswan"
+      "wswan",
+      "wonderswan"
     ],
     "colors": [
       "#B0BEC5",

--- a/assets/systems/wsc.json
+++ b/assets/systems/wsc.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "wsc",
+    "multidisc": false,
     "name": "WonderSwan Color",
     "short_name": "WSC",
     "details": {
@@ -18,7 +19,8 @@
       "WonderSwan Color",
       "Bandai WonderSwan Color",
       "WonderSwanColor",
-      "wswanc"
+      "wswanc",
+      "wonderswan-color"
     ],
     "colors": [
       "#EC407A",

--- a/assets/systems/wsv.json
+++ b/assets/systems/wsv.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "wsv",
+    "multidisc": false,
     "name": "Watara Supervision",
     "short_name": "WSV",
     "details": {

--- a/assets/systems/x1.json
+++ b/assets/systems/x1.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "x1",
+    "multidisc": false,
     "name": "Sharp X1",
     "short_name": "X1",
     "details": {

--- a/assets/systems/zx81.json
+++ b/assets/systems/zx81.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "zx81",
+    "multidisc": false,
     "name": "ZX 81",
     "short_name": "ZX81",
     "details": {

--- a/assets/systems/zxspectrum.json
+++ b/assets/systems/zxspectrum.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "id": "zxspectrum",
+    "multidisc": false,
     "name": "ZX Spectrum",
     "short_name": "ZXS",
     "details": {
@@ -18,7 +19,8 @@
       "ZX Spectrum",
       "ZX",
       "ZXS",
-      "Spectrum"
+      "Spectrum",
+      "zxs"
     ],
     "colors": [
       "#212121",

--- a/lib/services/systems_update_service.dart
+++ b/lib/services/systems_update_service.dart
@@ -9,11 +9,11 @@ import 'logger_service.dart';
 import '../data/datasources/sqlite_service.dart';
 
 const _manifestUrl =
-    'https://raw.githubusercontent.com/misobadev/neostation-systems/main/manifest.json';
+    'https://raw.githubusercontent.com/misobadev/neostation-frontend/main/assets/manifest.json';
 const _baseRawUrl =
-    'https://raw.githubusercontent.com/misobadev/neostation-systems/main/systems';
+    'https://raw.githubusercontent.com/misobadev/neostation-frontend/main/assets/systems';
 const _githubApiUrl =
-    'https://api.github.com/repos/misobadev/neostation-systems/contents/systems';
+    'https://api.github.com/repos/misobadev/neostation-frontend/contents/assets/systems';
 
 final _log = LoggerService.instance;
 
@@ -38,7 +38,7 @@ class SystemsUpdateInfo {
 }
 
 /// Service that keeps the bundled system JSON configs up-to-date from the
-/// neostation-systems GitHub repository.
+/// main NeoStation frontend repository.
 ///
 /// On startup, it compares the remote manifest version against the locally
 /// stored version. If a newer version is available, it downloads all system

--- a/scripts/check_unique_ids.py
+++ b/scripts/check_unique_ids.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+
+def main():
+    systems_dir = Path(__file__).parent / "assets/systems"
+    seen = {}  # unique_id -> source file
+    duplicates = []
+
+    for json_file in sorted(systems_dir.glob("*.json")):
+        try:
+            data = json.loads(json_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            print(f"ERROR: invalid JSON in {json_file.name}: {e}")
+            sys.exit(1)
+
+        emulators = data.get("emulators", [])
+        for emulator in emulators:
+            uid = emulator.get("unique_id")
+            if not uid:
+                continue
+            if uid in seen:
+                duplicates.append((uid, seen[uid], json_file.name))
+            else:
+                seen[uid] = json_file.name
+
+    if duplicates:
+        print(f"FAIL: found {len(duplicates)} duplicate unique_id(s):\n")
+        for uid, first, second in duplicates:
+            print(f"  '{uid}'")
+            print(f"    first:  {first}")
+            print(f"    second: {second}")
+        sys.exit(1)
+
+    print(f"OK: {len(seen)} unique_id(s) checked, no duplicates found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/format_json.py
+++ b/scripts/format_json.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+
+def format_file(json_file: Path) -> bool:
+    original = json_file.read_text(encoding="utf-8")
+    try:
+        data = json.loads(original)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: invalid JSON in {json_file.name}: {e}")
+        return "error"
+
+    formatted = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    if original != formatted:
+        json_file.write_text(formatted, encoding="utf-8")
+        print(f"  formatted: {json_file.name}")
+        return "changed"
+    return "ok"
+
+
+def main():
+    systems_dir = Path(__file__).parent / "assets/systems"
+    files = sorted(systems_dir.glob("*.json"))
+
+    changed = 0
+    errors = 0
+    for json_file in files:
+        result = format_file(json_file)
+        if result == "changed":
+            changed += 1
+        elif result == "error":
+            errors += 1
+
+    print(f"\n{changed}/{len(files)} files reformatted.")
+    if errors:
+        print(f"{errors} file(s) with errors.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Deprecates the external `misobadev/neostation-systems` repository and consolidates the OTA systems-update mechanism in the main NeoStation frontend repository.

Changes:
- Updates `SystemsUpdateService` endpoints to fetch `manifest.json` and system JSONs from `misobadev/neostation-frontend/main/assets/...` instead of
   `misobadev/neostation-systems/main/...`.
- Updates the `SystemsUpdateService` class documentation to reflect the new source.
- Rewrites the README "Systems & Emulator Definitions" section so contributors know that system configs now live in this repo under `assets/systems/` and PRs should be opened here.

The existing manifest versioning, caching, and SQLite `systems_version` logic remain unchanged, so existing installs will continue to receive over-the-air system updates without requiring a full app release.

Fixes #230

 ## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

N/A — no UI changes.