### PR TITLE
fix(game-view): restore Select-tap mute and correct its button hints

### DIFF
--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -442,9 +442,12 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
   }
 
   void _handleSelectAction() {
+    // Achievements owns Select for its refresh; everywhere else the preview
+    // video is what's playing, so Select mutes it (the general tab included —
+    // that's where the video is usually watched).
     if (_currentTab == DetailTab.achievements) {
       refreshAchievements();
-    } else if (_currentTab == DetailTab.gameInfo) {
+    } else {
       _toggleVideoMute();
     }
   }

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -307,6 +307,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
       onLetterJump: _letterJump, // Held D-pad left/right → alphabet skipping.
       letterJumpAxis: LetterJumpAxis.horizontal,
       onLeftStickClick: widget.onRandom,
+      onSelectButton: _toggleVideoMute, // Select tap - Mute preview video.
       onSelectModifierA: widget.onScrape, // Select + A - Scrape.
       onSelectModifierB: _toggleLegend, // Select + B - Hide/show legend.
       onSelectModifierY: widget.onRandom, // Select + Y - Random game.
@@ -345,6 +346,14 @@ class _GamesCarouselState extends State<GamesCarousel> {
     // across dozens of entries would still be running when the next hop fires.
     _carouselKey.currentState?.jumpToPage(target);
     return true;
+  }
+
+  /// Select tap — toggles global video sound. The preview plays on the
+  /// secondary display in this view; the config mutator propagates the new
+  /// mute state to it, so there is nothing local to re-apply.
+  void _toggleVideoMute() {
+    if (!mounted) return;
+    context.read<SqliteConfigProvider>().toggleVideoSound();
   }
 
   void _cleanupGamepad() {
@@ -411,6 +420,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
       isLoadingAchievements: _isLoadingAchievements,
       currentGameInfo: _currentGameInfo,
       onShowAchievements: _showAchievementsDialog,
+      onToggleMute: _toggleVideoMute,
     );
     // Positioning/visibility is applied at the Stack level (AnimatedPositioned)
     // so Select + B can slide it without invalidating this memoized subtree.

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -647,11 +647,20 @@ class _GamesGridState extends State<GamesGrid> {
         } catch (_) {}
       },
       onLeftStickClick: widget.onRandom,
+      onSelectButton: _toggleVideoMute, // Select tap - Mute preview video.
       onSelectModifierA: widget.onScrape, // Select + A - Scrape.
       onSelectModifierB: _toggleLegend, // Select + B - Hide/show legend.
       onSelectModifierY: widget.onRandom, // Select + Y - Random game.
       onSettings: widget.onSettings,
     );
+  }
+
+  /// Select tap — toggles global video sound. The preview plays on the
+  /// secondary display in this view; the config mutator propagates the new
+  /// mute state to it, so there is nothing local to re-apply.
+  void _toggleVideoMute() {
+    if (!mounted) return;
+    context.read<SqliteConfigProvider>().toggleVideoSound();
   }
 
   /// Select + B — toggles the (session-global) vertical action-button legend.
@@ -1242,6 +1251,7 @@ class _GamesGridState extends State<GamesGrid> {
       isLoadingAchievements: _isLoadingAchievements,
       currentGameInfo: _currentGameInfo,
       onShowAchievements: _showAchievementsDialog,
+      onToggleMute: _toggleVideoMute,
     );
     // Positioning/visibility is applied at the Stack level (AnimatedPositioned)
     // so Select + B can animate it without invalidating this memoized subtree.

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -873,8 +873,11 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                     child: Row(
                                       mainAxisSize: MainAxisSize.min,
                                       children: [
+                                        // Select (View), not Start — mute is a
+                                        // Select tap, matching the primary
+                                        // screen's hint.
                                         Image.asset(
-                                          'assets/images/gamepad/Xbox_Menu_button.png',
+                                          'assets/images/gamepad/Xbox_View_button.png',
                                           width: 32.r,
                                           height: 32.r,
                                           color: Colors.white,

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -215,6 +215,74 @@ class GamepadNavigation {
   /// How long after a Select press a face button still counts as a chord.
   static const int _selectChordWindowMs = 400;
 
+  /// When the current Select hold began (null while Select is up). Only set on
+  /// the up→down edge, so Android key-repeat while held doesn't restart it.
+  DateTime? _selectPressStart;
+
+  /// Whether a chord fired during the current Select hold. A hold that unlocked
+  /// a combo must not also fire the plain-tap action on release.
+  bool _selectChordUsed = false;
+
+  /// A Select press shorter than this, with no chord fired, counts as a tap and
+  /// dispatches [onSelectButton] (mute / refresh) on release.
+  static const int _selectTapMaxMs = 500;
+
+  /// Handles the Select press edge shared by the raw-Android and translated
+  /// paths. Repeat presses while already held are ignored.
+  void _onSelectDown(DateTime now) {
+    // A press landing inside the chord window of the previous one is Android
+    // key-repeat or a pulse-controller re-assert, not a fresh press: keep the
+    // original press time (so a long hold can't look like a tap) and the
+    // chord-used flag (so a fired chord isn't forgotten mid-hold).
+    final last = _lastSelectDownTime;
+    final isContinuation =
+        _selectHeld ||
+        (last != null &&
+            now.difference(last).inMilliseconds < _selectChordWindowMs);
+    if (!isContinuation) {
+      _selectPressStart = now;
+      _selectChordUsed = false;
+    }
+    _selectTapTimer?.cancel();
+    _selectTapTimer = null;
+    _setSelectHeld(true);
+    _lastSelectDownTime = now;
+  }
+
+  /// Pending tap dispatch, cancelled if a chord fires inside the chord window.
+  Timer? _selectTapTimer;
+
+  /// Handles the Select release edge. Fires [onSelectButton] when the hold was
+  /// a short tap that unlocked no chord, so Select keeps its tap action (e.g.
+  /// mute the playing video) while still working as the chord modifier.
+  ///
+  /// The dispatch is deferred by [_selectChordWindowMs] because the controllers
+  /// described above pulse down+up while the button is still physically held —
+  /// firing immediately would mute the video at the start of every chord. Any
+  /// chord landing inside that window cancels the pending tap.
+  void _onSelectUp(DateTime now) {
+    final start = _selectPressStart;
+    final wasTap =
+        !_selectChordUsed &&
+        start != null &&
+        now.difference(start).inMilliseconds <= _selectTapMaxMs;
+    _setSelectHeld(false);
+    _selectPressStart = null;
+    // Keep the chord window alive across the pulse-release so a face button
+    // pressed just after it still registers as a combo.
+    _lastSelectDownTime = now;
+    if (!wasTap) return;
+    _selectTapTimer?.cancel();
+    _selectTapTimer = Timer(
+      const Duration(milliseconds: _selectChordWindowMs),
+      () {
+        _selectTapTimer = null;
+        if (_selectChordUsed || _selectHeld) return;
+        onSelectButton?.call();
+      },
+    );
+  }
+
   DateTime? _activationTime;
 
   /// Grace period after activation during which inputs are ignored (prevents
@@ -404,6 +472,10 @@ class GamepadNavigation {
   void _resetSelectModifier() {
     _setSelectHeld(false);
     _lastSelectDownTime = null;
+    _selectPressStart = null;
+    _selectChordUsed = false;
+    _selectTapTimer?.cancel();
+    _selectTapTimer = null;
     _comboConsumed.clear();
   }
 
@@ -569,13 +641,13 @@ class GamepadNavigation {
       // This controller auto-repeats ACTION_DOWN (value 0.0) while the button is
       // held and doesn't reliably emit a matching ACTION_UP, so edge-detection
       // gets stuck. The raw value can't: 0.0 = down (incl. key-repeat) → held;
-      // 1.0 = up → released. Select is a pure modifier, so it never dispatches.
+      // 1.0 = up → released. A hold that fires a chord dispatches nothing of its
+      // own; a short tap that fires none dispatches [onSelectButton] on release.
       if (isAndroid && event.key.toLowerCase() == 'keycode_button_select') {
         if (event.value < 0.5) {
-          _setSelectHeld(true);
-          _lastSelectDownTime = now;
+          _onSelectDown(now);
         } else {
-          _setSelectHeld(false);
+          _onSelectUp(now);
         }
         return;
       }
@@ -694,13 +766,13 @@ class GamepadNavigation {
     // alongside it fires a combo. Some controllers only reliably report one edge
     // of this button, so the timestamp is stamped on BOTH press and release.
     if (event.inputType == GamepadInputType.buttonSelect) {
+      final now = DateTime.now();
       if (event.isPressed) {
-        _setSelectHeld(true);
+        _onSelectDown(now);
       } else if (event.isReleased) {
-        _setSelectHeld(false);
+        _onSelectUp(now);
       }
-      _lastSelectDownTime = DateTime.now();
-      return; // Select alone never triggers an action.
+      return; // Select alone only ever fires its tap action, on release.
     }
 
     // A face-button PRESS fires its modifier combo when Select is still held or
@@ -708,6 +780,11 @@ class GamepadNavigation {
     if (event.isPressed && _isSelectChordActive()) {
       final modifier = _selectModifierFor(event.inputType);
       if (modifier != null) {
+        // This hold unlocked a chord, so its release must not also fire the
+        // plain Select tap action.
+        _selectChordUsed = true;
+        _selectTapTimer?.cancel();
+        _selectTapTimer = null;
         _comboConsumed.add(event.inputType);
         SfxService().playNavSound();
         modifier();

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -8,6 +8,7 @@ import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/services/sfx_service.dart';
 import '../responsive.dart';
 import 'gamepad_translator.dart';
+import 'select_tap.dart';
 import '../main.dart' show FullscreenNotifier;
 
 /// Metadata for a connected gamepad device.
@@ -187,100 +188,54 @@ class GamepadNavigation {
   static const int _throttleDelayMs = 128;
   bool _isActive = false;
 
-  /// True while the Select (View) button is reported as physically held down.
-  /// Not all controllers sustain this — many emit a brief down+up pulse even
-  /// while the button is held, which is why [_lastSelectDownTime] backs it up.
-  bool _selectHeld = false;
-
   /// Broadcasts whether Select is currently held, so UI (e.g. the gamepad
   /// legend) can reveal the Select+face-button chord shortcuts while it is down.
   /// Only the active navigation layer drives this.
   static final ValueNotifier<bool> selectHeldNotifier = ValueNotifier(false);
 
-  /// Updates both the local hold flag and the shared notifier in one place.
-  void _setSelectHeld(bool held) {
-    _selectHeld = held;
+  /// Tap-vs-chord decisions for Select. See [SelectTap] for the rules.
+  final SelectTap _selectTap = SelectTap();
+
+  /// Mirrors [SelectTap.held] onto the shared notifier for the legend UI.
+  void _publishSelectHeld() {
+    final held = _selectTap.held;
     if (selectHeldNotifier.value != held) selectHeldNotifier.value = held;
   }
-
-  /// When Select was last pressed. A face button counts as a combo if it lands
-  /// while Select is still held OR within [_selectChordWindowMs] of this time,
-  /// so the pulse-emitting controllers above still register chords.
-  DateTime? _lastSelectDownTime;
 
   /// Face buttons whose PRESS fired a combo and whose matching RELEASE must be
   /// swallowed so the normal action never fires (Desktop dispatches on release).
   final Set<GamepadInputType> _comboConsumed = {};
 
-  /// How long after a Select press a face button still counts as a chord.
-  static const int _selectChordWindowMs = 400;
-
-  /// When the current Select hold began (null while Select is up). Only set on
-  /// the up→down edge, so Android key-repeat while held doesn't restart it.
-  DateTime? _selectPressStart;
-
-  /// Whether a chord fired during the current Select hold. A hold that unlocked
-  /// a combo must not also fire the plain-tap action on release.
-  bool _selectChordUsed = false;
-
-  /// A Select press shorter than this, with no chord fired, counts as a tap and
-  /// dispatches [onSelectButton] (mute / refresh) on release.
-  static const int _selectTapMaxMs = 500;
-
-  /// Handles the Select press edge shared by the raw-Android and translated
-  /// paths. Repeat presses while already held are ignored.
-  void _onSelectDown(DateTime now) {
-    // A press landing inside the chord window of the previous one is Android
-    // key-repeat or a pulse-controller re-assert, not a fresh press: keep the
-    // original press time (so a long hold can't look like a tap) and the
-    // chord-used flag (so a fired chord isn't forgotten mid-hold).
-    final last = _lastSelectDownTime;
-    final isContinuation =
-        _selectHeld ||
-        (last != null &&
-            now.difference(last).inMilliseconds < _selectChordWindowMs);
-    if (!isContinuation) {
-      _selectPressStart = now;
-      _selectChordUsed = false;
-    }
-    _selectTapTimer?.cancel();
-    _selectTapTimer = null;
-    _setSelectHeld(true);
-    _lastSelectDownTime = now;
-  }
-
   /// Pending tap dispatch, cancelled if a chord fires inside the chord window.
   Timer? _selectTapTimer;
 
-  /// Handles the Select release edge. Fires [onSelectButton] when the hold was
-  /// a short tap that unlocked no chord, so Select keeps its tap action (e.g.
-  /// mute the playing video) while still working as the chord modifier.
-  ///
-  /// The dispatch is deferred by [_selectChordWindowMs] because the controllers
-  /// described above pulse down+up while the button is still physically held —
-  /// firing immediately would mute the video at the start of every chord. Any
-  /// chord landing inside that window cancels the pending tap.
-  void _onSelectUp(DateTime now) {
-    final start = _selectPressStart;
-    final wasTap =
-        !_selectChordUsed &&
-        start != null &&
-        now.difference(start).inMilliseconds <= _selectTapMaxMs;
-    _setSelectHeld(false);
-    _selectPressStart = null;
-    // Keep the chord window alive across the pulse-release so a face button
-    // pressed just after it still registers as a combo.
-    _lastSelectDownTime = now;
-    if (!wasTap) return;
+  /// Handles the Select press edge shared by the raw-Android and translated
+  /// paths.
+  void _onSelectDown(DateTime now) {
+    _selectTap.press(now);
     _selectTapTimer?.cancel();
-    _selectTapTimer = Timer(
-      const Duration(milliseconds: _selectChordWindowMs),
-      () {
-        _selectTapTimer = null;
-        if (_selectChordUsed || _selectHeld) return;
-        onSelectButton?.call();
-      },
-    );
+    _selectTapTimer = null;
+    _publishSelectHeld();
+  }
+
+  /// Handles the Select release edge, dispatching [onSelectButton] when the
+  /// hold was a plain tap so Select keeps its own action (e.g. mute the playing
+  /// video) while still working as the chord modifier.
+  ///
+  /// The dispatch is deferred by [SelectTap.chordWindow] because the
+  /// pulse-emitting controllers release Select while it is still physically
+  /// held — firing immediately would mute the video at the start of every
+  /// chord. Any chord landing inside that window invalidates the pending tap.
+  void _onSelectUp(DateTime now) {
+    final schedulesTap = _selectTap.releaseSchedulesTap(now);
+    _publishSelectHeld();
+    if (!schedulesTap) return;
+    _selectTapTimer?.cancel();
+    _selectTapTimer = Timer(SelectTap.chordWindow, () {
+      _selectTapTimer = null;
+      if (!_selectTap.tapStillValid) return;
+      onSelectButton?.call();
+    });
   }
 
   DateTime? _activationTime;
@@ -470,10 +425,8 @@ class GamepadNavigation {
   /// Clears Select chord-modifier state so it can't leak across layer changes
   /// (e.g. opening a dialog while Select is down).
   void _resetSelectModifier() {
-    _setSelectHeld(false);
-    _lastSelectDownTime = null;
-    _selectPressStart = null;
-    _selectChordUsed = false;
+    _selectTap.reset();
+    _publishSelectHeld();
     _selectTapTimer?.cancel();
     _selectTapTimer = null;
     _comboConsumed.clear();
@@ -481,12 +434,7 @@ class GamepadNavigation {
 
   /// Whether a Select+face-button chord should register right now: Select is
   /// still reported down, or it pulsed within the chord window.
-  bool _isSelectChordActive() {
-    if (_selectHeld) return true;
-    final t = _lastSelectDownTime;
-    if (t == null) return false;
-    return DateTime.now().difference(t).inMilliseconds < _selectChordWindowMs;
-  }
+  bool _isSelectChordActive() => _selectTap.isChordActive(DateTime.now());
 
   /// Maps a face button to its Select-modifier combo callback, if any.
   VoidCallback? _selectModifierFor(GamepadInputType inputType) {
@@ -782,7 +730,7 @@ class GamepadNavigation {
       if (modifier != null) {
         // This hold unlocked a chord, so its release must not also fire the
         // plain Select tap action.
-        _selectChordUsed = true;
+        _selectTap.chordFired();
         _selectTapTimer?.cancel();
         _selectTapTimer = null;
         _comboConsumed.add(event.inputType);

--- a/lib/utils/select_tap.dart
+++ b/lib/utils/select_tap.dart
@@ -1,0 +1,105 @@
+/// Decides what a Select (View) press means: a chord modifier, a plain tap, or
+/// nothing at all.
+///
+/// Select does double duty — held, it unlocks the Select+face-button chords
+/// (scrape / legend / random); tapped, it fires its own action (mute the
+/// preview video). Telling those apart is fiddly enough to live on its own,
+/// away from the event plumbing in `GamepadNavigation`:
+///
+/// * Android delivers a held button as a stream of auto-repeat presses, and
+///   some controllers *pulse* down+up while the button is still physically
+///   held. So neither "a press means a new hold" nor "a release means the
+///   button is up" can be taken at face value — a press or release landing
+///   inside [chordWindow] of the last one continues the current hold.
+/// * A hold that unlocked a chord must not also fire the tap action when it
+///   ends, or every scrape would toggle the sound too.
+/// * Because of the pulsing, a tap can only be dispatched once [chordWindow]
+///   has passed with no chord — see [releaseSchedulesTap] and [tapStillValid].
+///
+/// This type is pure: it holds no timers and reads no clock. The caller passes
+/// the current time in and owns the deferred dispatch, which is what makes the
+/// rules above testable.
+class SelectTap {
+  /// How long after a Select press a face button still counts as a chord, and
+  /// equally how long a pending tap waits to see whether one arrives.
+  static const Duration chordWindow = Duration(milliseconds: 400);
+
+  /// A Select press shorter than this, having fired no chord, is a tap.
+  static const Duration tapMax = Duration(milliseconds: 500);
+
+  bool _held = false;
+
+  /// When Select was last pressed *or* released. Both edges refresh it so the
+  /// chord window survives a pulse-release.
+  DateTime? _lastEdge;
+
+  /// When the current hold began — not restarted by key-repeat or a pulse.
+  DateTime? _pressStart;
+
+  bool _chordUsed = false;
+
+  /// Whether Select is currently down, as far as this state machine can tell.
+  bool get held => _held;
+
+  /// Whether a chord fired during the current hold.
+  bool get chordUsed => _chordUsed;
+
+  /// Records a Select press. Presses that merely continue the current hold
+  /// (key-repeat, pulse re-assert) keep the original press time and chord flag.
+  void press(DateTime now) {
+    if (!_isContinuation(now)) {
+      _pressStart = now;
+      _chordUsed = false;
+    }
+    _held = true;
+    _lastEdge = now;
+  }
+
+  /// Records a Select release and reports whether it should schedule a deferred
+  /// tap dispatch. The caller waits [chordWindow] and then re-checks
+  /// [tapStillValid] before actually firing, because the release may turn out
+  /// to have been a pulse in the middle of a chord.
+  bool releaseSchedulesTap(DateTime now) {
+    final start = _pressStart;
+    final wasTap =
+        !_chordUsed && start != null && now.difference(start) <= tapMax;
+    _held = false;
+    _pressStart = null;
+    _lastEdge = now;
+    return wasTap;
+  }
+
+  /// Whether a face button pressed now should fire its Select chord: Select is
+  /// still down, or was seen within [chordWindow] (the pulse case).
+  bool isChordActive(DateTime now) {
+    if (_held) return true;
+    final last = _lastEdge;
+    return last != null && now.difference(last) < chordWindow;
+  }
+
+  /// Marks that a chord fired during this hold, which cancels any pending tap.
+  void chordFired() {
+    _chordUsed = true;
+  }
+
+  /// Whether a tap scheduled earlier should still be dispatched. False once a
+  /// chord has fired, or if Select has gone back down (the release was a pulse).
+  bool get tapStillValid => !_chordUsed && !_held;
+
+  /// Clears all state so a hold can't leak across navigation-layer changes
+  /// (e.g. opening a dialog while Select is down).
+  void reset() {
+    _held = false;
+    _lastEdge = null;
+    _pressStart = null;
+    _chordUsed = false;
+  }
+
+  /// A press landing while held, or inside [chordWindow] of the last edge, is
+  /// the same physical hold rather than a fresh press.
+  bool _isContinuation(DateTime now) {
+    if (_held) return true;
+    final last = _lastEdge;
+    return last != null && now.difference(last) < chordWindow;
+  }
+}

--- a/lib/widgets/game_view_footer.dart
+++ b/lib/widgets/game_view_footer.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/models/game_model.dart';
 import 'package:neostation/models/retro_achievements_game_info.dart';
 import 'package:neostation/services/sfx_service.dart';
@@ -24,6 +26,12 @@ class GameViewFooter extends StatelessWidget {
   final GameInfoAndUserProgress? currentGameInfo;
   final VoidCallback? onShowAchievements;
 
+  /// Toggles global video sound. The grid and carousel have no video surface of
+  /// their own — the preview plays on the secondary display — so this pill is
+  /// their only mute affordance, mirroring the Select hint on the details card.
+  /// Omit it to hide the pill.
+  final VoidCallback? onToggleMute;
+
   const GameViewFooter({
     super.key,
     required this.game,
@@ -32,6 +40,7 @@ class GameViewFooter extends StatelessWidget {
     this.isLoadingAchievements = false,
     this.currentGameInfo,
     this.onShowAchievements,
+    this.onToggleMute,
   });
 
   @override
@@ -99,6 +108,10 @@ class GameViewFooter extends StatelessWidget {
           ExcludeFocus(
             child: Row(
               children: [
+                if (onToggleMute != null) ...[
+                  _MuteHintPill(onToggleMute: onToggleMute!),
+                  SizedBox(width: 6.r),
+                ],
                 if (game.rating > 0) ...[
                   _SteamStyleRating(game: game),
                   SizedBox(width: 6.r),
@@ -474,6 +487,67 @@ class _CompactAchievementsIndicator extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Select-tap hint + current sound state for the preview video, tappable for
+/// touchscreen users. Watches the config provider on its own so the memoized
+/// footer instance around it never has to rebuild when sound is toggled.
+class _MuteHintPill extends StatelessWidget {
+  final VoidCallback onToggleMute;
+
+  const _MuteHintPill({required this.onToggleMute});
+
+  @override
+  Widget build(BuildContext context) {
+    final radii = Theme.of(context).extension<CornerRadii>() ?? CornerRadii.m();
+    final scheme = Theme.of(context).colorScheme;
+
+    return Selector<SqliteConfigProvider, bool>(
+      selector: (_, provider) => !provider.config.videoSound,
+      builder: (context, isMuted, _) {
+        return Material(
+          color: scheme.surface.withValues(alpha: 0.9),
+          borderRadius: radii.radiusExternal,
+          child: InkWell(
+            onTap: () {
+              SfxService().playNavSound();
+              onToggleMute();
+            },
+            canRequestFocus: false,
+            borderRadius: radii.radiusExternal,
+            child: Container(
+              height: 32.r,
+              padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
+              decoration: BoxDecoration(
+                borderRadius: radii.radiusExternal,
+                border: Border.all(color: scheme.outline, width: 1.r),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Image.asset(
+                    'assets/images/gamepad/Xbox_View_button.png',
+                    width: 15.r,
+                    height: 15.r,
+                    color: scheme.onSurface,
+                  ),
+                  SizedBox(width: 4.r),
+                  Icon(
+                    isMuted
+                        ? Symbols.volume_off_rounded
+                        : Symbols.volume_up_rounded,
+                    size: 15.r,
+                    color: scheme.onSurface,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/test/select_tap_test.dart
+++ b/test/select_tap_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/select_tap.dart';
+
+/// Fixed origin for the fake clock. [SelectTap] only ever compares times, so
+/// the absolute value is arbitrary.
+final DateTime t0 = DateTime(2026, 1, 1);
+
+/// `t(120)` = 120ms after the origin.
+DateTime t(int ms) => t0.add(Duration(milliseconds: ms));
+
+void main() {
+  late SelectTap tap;
+
+  setUp(() => tap = SelectTap());
+
+  group('a plain tap', () {
+    test('schedules a tap and stays valid when nothing else happens', () {
+      tap.press(t(0));
+      expect(tap.releaseSchedulesTap(t(80)), isTrue);
+      expect(tap.tapStillValid, isTrue);
+    });
+
+    test('a press just under the tap ceiling still counts', () {
+      tap.press(t(0));
+      expect(
+        tap.releaseSchedulesTap(t(SelectTap.tapMax.inMilliseconds)),
+        isTrue,
+      );
+    });
+
+    test('a hold longer than the tap ceiling does not', () {
+      tap.press(t(0));
+      expect(
+        tap.releaseSchedulesTap(t(SelectTap.tapMax.inMilliseconds + 1)),
+        isFalse,
+      );
+    });
+
+    test('a release with no press at all schedules nothing', () {
+      // Can happen after reset() drops a hold mid-press.
+      expect(tap.releaseSchedulesTap(t(10)), isFalse);
+    });
+  });
+
+  group('a chord', () {
+    test('suppresses the tap on release', () {
+      tap.press(t(0));
+      expect(tap.isChordActive(t(50)), isTrue);
+      tap.chordFired();
+      expect(tap.releaseSchedulesTap(t(80)), isFalse);
+    });
+
+    test('landing after the release still invalidates the pending tap', () {
+      // The dispatch is deferred precisely so this can't fire the tap action:
+      // the chord arrives while the tap is still waiting out the chord window.
+      tap.press(t(0));
+      expect(tap.releaseSchedulesTap(t(60)), isTrue);
+      expect(tap.isChordActive(t(90)), isTrue, reason: 'pulse-release window');
+      tap.chordFired();
+      expect(tap.tapStillValid, isFalse);
+    });
+
+    test('is not active once the chord window has elapsed', () {
+      tap.press(t(0));
+      tap.releaseSchedulesTap(t(10));
+      expect(
+        tap.isChordActive(t(SelectTap.chordWindow.inMilliseconds + 10)),
+        isFalse,
+      );
+    });
+
+    test('stays active for as long as Select is genuinely held', () {
+      tap.press(t(0));
+      expect(tap.isChordActive(t(5000)), isTrue);
+    });
+  });
+
+  group('key-repeat and pulse continuations', () {
+    test(
+      'repeat presses do not restart the hold, so a long hold is not a tap',
+      () {
+        // Android streams auto-repeat presses while the button is held. If each
+        // one reset the press time, releasing after 2s would look like a tap.
+        for (var ms = 0; ms <= 2000; ms += 100) {
+          tap.press(t(ms));
+        }
+        expect(tap.releaseSchedulesTap(t(2050)), isFalse);
+      },
+    );
+
+    test('a pulse down-up-down keeps the original press time', () {
+      // Controller pulses while the button is physically held the whole time.
+      // The final release is within tapMax of the *second* press but not of the
+      // first, so this only passes if the hold is still measured from t0.
+      tap.press(t(0));
+      tap.releaseSchedulesTap(t(20));
+      tap.press(t(300));
+      expect(
+        tap.releaseSchedulesTap(t(SelectTap.tapMax.inMilliseconds + 60)),
+        isFalse,
+        reason: 'the hold began at t0, not at the second press',
+      );
+    });
+
+    test('a chord is not forgotten across a pulse within the same hold', () {
+      // Regression guard: resetting chordUsed on every pulse-press would let a
+      // held Select fire the tap action between chords.
+      tap.press(t(0));
+      tap.chordFired();
+      tap.releaseSchedulesTap(t(20));
+      tap.press(t(40));
+      expect(tap.chordUsed, isTrue);
+      expect(tap.releaseSchedulesTap(t(60)), isFalse);
+    });
+
+    test('a genuinely separate press after the window is a fresh tap', () {
+      tap.press(t(0));
+      tap.chordFired();
+      tap.releaseSchedulesTap(t(20));
+
+      final second = SelectTap.chordWindow.inMilliseconds + 100;
+      tap.press(t(second));
+      expect(tap.chordUsed, isFalse, reason: 'new hold, chord flag cleared');
+      expect(tap.releaseSchedulesTap(t(second + 50)), isTrue);
+    });
+
+    test('a pending tap is invalid while Select is back down', () {
+      tap.press(t(0));
+      expect(tap.releaseSchedulesTap(t(30)), isTrue);
+      tap.press(t(50));
+      expect(tap.tapStillValid, isFalse);
+    });
+  });
+
+  group('held state', () {
+    test('tracks the press and release edges', () {
+      expect(tap.held, isFalse);
+      tap.press(t(0));
+      expect(tap.held, isTrue);
+      tap.releaseSchedulesTap(t(30));
+      expect(tap.held, isFalse);
+    });
+  });
+
+  group('reset', () {
+    test('drops the hold, the chord flag and the chord window', () {
+      tap.press(t(0));
+      tap.chordFired();
+      tap.reset();
+
+      expect(tap.held, isFalse);
+      expect(tap.chordUsed, isFalse);
+      expect(tap.isChordActive(t(10)), isFalse);
+      expect(tap.tapStillValid, isTrue);
+    });
+
+    test('a press after reset starts a fresh hold', () {
+      tap.press(t(0));
+      tap.reset();
+      tap.press(t(10));
+      expect(tap.releaseSchedulesTap(t(60)), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was created with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

Muting the preview video was unreachable on a gamepad.

Select (View) became a pure chord modifier (Select+A scrape / +B legend / +Y random), and both dispatch paths in `GamepadNavigation` returned early on it — the Android raw-key path and the translated path. `onSelectButton` was still declared and still wired through to the mute action, but nothing ever invoked it. A stale comment claimed a plain tap fired it on release.

**Select now distinguishes a tap from a hold:**

- A press landing inside the chord window is treated as key-repeat or a pulse re-assert, i.e. a continuation of the same hold — so a long hold can't be mistaken for a tap.
- A short press that fires no chord dispatches `onSelectButton`, but **deferred by the chord window**: several controllers (the AYN Thor included) pulse Select down+up while the button is still physically held, so firing immediately would mute the video at the start of every chord. Any chord landing inside that window invalidates the pending tap.

**Three follow-on fixes to the same feature:**

- **Details card** — mute was gated to the Game Info tab, but the video is normally watched on the General tab, where Select did nothing. Achievements keeps its refresh; every other tab mutes.
- **Secondary screen** — the mute pill rendered the Start glyph (`Xbox_Menu_button.png`); mute is Select.
- **Grid + carousel** — mute wasn't wired at all. The preview plays on the secondary display in these views, so Select now toggles global video sound, and `GameViewFooter` gained an optional mute pill. Both footers are memoized by signature to avoid the per-nav rebuild jank from ceae0b5, so the pill subscribes to the config provider itself via `Selector` rather than the parent reading it — toggling sound rebuilds only the pill and leaves the memoized footer instance intact.

**Second commit** extracts the tap/chord rules into a pure `lib/utils/select_tap.dart` — no clock, no timers; the caller passes the time in and owns the deferred dispatch. That mirrors how #223 extracted `LetterJump`, and it's what makes the rules testable: they were previously unreachable from a test, which is how the original regression went unnoticed. `GamepadNavigation` keeps only the timer, the dispatch and the held-state notifier. Behaviour is unchanged.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

### Tests

16 new tests in `test/select_tap_test.dart` over a fake clock, pinning the rules that break silently: repeat/pulse presses continue a hold rather than restarting it, a chord suppresses the tap both before and after the release, the chord-window boundary, and reset.

They were mutation-checked rather than just run green — which caught a weak test of my own (the pulse case initially passed even with the continuation rule gutted, because both the correct and broken versions landed outside `tapMax`; retimed so they diverge). Breaking the continuation rule now fails two tests, breaking chord suppression fails one.

Full suite: 293 passing, up from 277. `flutter analyze lib/ test/` clean.

### Verified on device

Built and run on the AYN Thor (dev flavour) after each change, and again after rebasing onto current `main` — which brought in #223's hold-to-accelerate/letter-jumping work touching the same file. Checked there that a Select tap mutes, that Select+A/B/Y fire their chords without also toggling sound, that the legend still flips to the chord layer while Select is held, and that letter jumping still works.

## Screenshots (if applicable)

n/a — the visible changes are the glyph on the secondary-screen mute pill (Start → Select) and the new mute pill in the grid/carousel footers.
