### PR TITLE
fix(startup): follow-ups to #225 — locale crash, one-shot storage wait, RA key deletion, log redaction

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -37,6 +37,9 @@ mixin AppLocale {
   static const String stop = 'stop';
   static const String reset = 'reset';
   static const String startupLoading = 'startup_loading';
+  static const String startupStorageUnavailable = 'startup_storage_unavailable';
+  static const String startupStorageRetry = 'startup_storage_retry';
+  static const String startupStorageUseDefault = 'startup_storage_use_default';
 
   // ---------------------------------------------------------------------------
   // Game / Playback

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.download: 'Herunterladen',
   AppLocale.stop: 'Stoppen',
   AppLocale.reset: 'Zurücksetzen',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation konnte den Ordner mit deinen Daten nicht erreichen. Prüfe, ob die SD-Karte oder das Laufwerk angeschlossen ist.',
+  AppLocale.startupStorageRetry: 'Erneut versuchen',
+  AppLocale.startupStorageUseDefault: 'Ohne fortfahren',
   AppLocale.startupLoading:
       'NeoStation wird vorbereitet. Warte auf Speicher und Dienste…',
 

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.download: 'Download',
   AppLocale.stop: 'Stop',
   AppLocale.reset: 'Reset',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation could not reach the folder where your data is stored. Check that the SD card or drive is connected.',
+  AppLocale.startupStorageRetry: 'Retry',
+  AppLocale.startupStorageUseDefault: 'Continue without it',
   AppLocale.startupLoading:
       'Preparing NeoStation. Waiting for storage and services...',
 

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.download: 'Descargar',
   AppLocale.stop: 'Detener',
   AppLocale.reset: 'Restablecer',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation no pudo acceder a la carpeta donde se guardan tus datos. Comprueba que la tarjeta SD o la unidad esté conectada.',
+  AppLocale.startupStorageRetry: 'Reintentar',
+  AppLocale.startupStorageUseDefault: 'Continuar sin ella',
   AppLocale.startupLoading:
       'Preparando NeoStation. Esperando al almacenamiento y los servicios...',
 

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.download: 'Télécharger',
   AppLocale.stop: 'Arrêter',
   AppLocale.reset: 'Réinitialiser',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation n\'a pas pu accéder au dossier où vos données sont enregistrées. Vérifiez que la carte SD ou le lecteur est connecté.',
+  AppLocale.startupStorageRetry: 'Réessayer',
+  AppLocale.startupStorageUseDefault: 'Continuer sans',
   AppLocale.startupLoading:
       'Préparation de NeoStation. En attente du stockage et des services…',
 

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.download: 'Unduh',
   AppLocale.stop: 'Berhenti',
   AppLocale.reset: 'Atur Ulang',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation tidak dapat mengakses folder tempat data Anda disimpan. Pastikan kartu SD atau drive terpasang.',
+  AppLocale.startupStorageRetry: 'Coba lagi',
+  AppLocale.startupStorageUseDefault: 'Lanjutkan tanpa itu',
   AppLocale.startupLoading:
       'Menyiapkan NeoStation. Menunggu penyimpanan dan layanan...',
 

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.download: 'Scarica',
   AppLocale.stop: 'Ferma',
   AppLocale.reset: 'Ripristina',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation non è riuscito ad accedere alla cartella in cui sono salvati i tuoi dati. Verifica che la scheda SD o l\'unità sia collegata.',
+  AppLocale.startupStorageRetry: 'Riprova',
+  AppLocale.startupStorageUseDefault: 'Continua senza',
   AppLocale.startupLoading:
       'Preparazione di NeoStation. In attesa di archiviazione e servizi…',
 

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.download: 'ダウンロード',
   AppLocale.stop: '停止',
   AppLocale.reset: 'リセット',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation はデータの保存先フォルダーにアクセスできませんでした。SD カードまたはドライブが接続されているか確認してください。',
+  AppLocale.startupStorageRetry: '再試行',
+  AppLocale.startupStorageUseDefault: 'このまま続行',
   AppLocale.startupLoading: 'NeoStation を準備中です。ストレージとサービスを待機しています…',
 
   AppLocale.play: 'プレイ',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.download: '다운로드',
   AppLocale.stop: '중지',
   AppLocale.reset: '재설정',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation이 데이터가 저장된 폴더에 접근하지 못했습니다. SD 카드나 드라이브가 연결되어 있는지 확인하세요.',
+  AppLocale.startupStorageRetry: '다시 시도',
+  AppLocale.startupStorageUseDefault: '이대로 계속',
   AppLocale.startupLoading: 'NeoStation을 준비 중입니다. 저장소와 서비스를 기다리고 있습니다…',
 
   AppLocale.play: '플레이',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.download: 'Baixar',
   AppLocale.stop: 'Parar',
   AppLocale.reset: 'Redefinir',
+  AppLocale.startupStorageUnavailable:
+      'O NeoStation não conseguiu acessar a pasta onde seus dados estão guardados. Verifique se o cartão SD ou a unidade está conectado.',
+  AppLocale.startupStorageRetry: 'Tentar novamente',
+  AppLocale.startupStorageUseDefault: 'Continuar sem ela',
   AppLocale.startupLoading:
       'Preparando o NeoStation. A aguardar pelo armazenamento e pelos serviços...',
 

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.download: 'Скачать',
   AppLocale.stop: 'Стоп',
   AppLocale.reset: 'Сбросить',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation не удалось получить доступ к папке с вашими данными. Убедитесь, что SD-карта или накопитель подключены.',
+  AppLocale.startupStorageRetry: 'Повторить',
+  AppLocale.startupStorageUseDefault: 'Продолжить без неё',
   AppLocale.startupLoading:
       'Подготовка NeoStation. Ожидание хранилища и служб...',
 

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.download: '下载',
   AppLocale.stop: '停止',
   AppLocale.reset: '重置',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation 无法访问保存数据的文件夹。请确认 SD 卡或存储设备已连接。',
+  AppLocale.startupStorageRetry: '重试',
+  AppLocale.startupStorageUseDefault: '继续（不使用）',
   AppLocale.startupLoading: '正在准备 NeoStation，等待存储和服务就绪…',
 
   AppLocale.play: '开始游戏',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -18,6 +18,10 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.download: '下載',
   AppLocale.stop: '停止',
   AppLocale.reset: '重置',
+  AppLocale.startupStorageUnavailable:
+      'NeoStation 無法存取儲存資料的資料夾。請確認 SD 卡或儲存裝置已連接。',
+  AppLocale.startupStorageRetry: '重試',
+  AppLocale.startupStorageUseDefault: '繼續（不使用）',
   AppLocale.startupLoading: '正在準備 NeoStation，等待儲存空間與服務就緒…',
 
   AppLocale.play: '開始遊戲',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:neostation/widgets/permission_check_wrapper.dart';
 import 'package:neostation/utils/custom_scroll_behavior.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/services/config_service.dart';
 import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:flutter/material.dart';
@@ -32,6 +33,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
+import 'dart:async';
 import 'dart:io';
 import 'package:fvp/fvp.dart';
 import 'package:fullscreen_window/fullscreen_window.dart';
@@ -188,6 +190,12 @@ void main() async {
   final log = LoggerService.instance;
   await log.init();
   log.i('Starting NeoStation...');
+
+  // Resolve the user-data location before anything reads it, so the cold-boot
+  // wait happens once (behind the loading screen) rather than once per caller.
+  if (Platform.isAndroid) {
+    await _awaitUserDataStorage();
+  }
 
   // Inicializar window_manager para desktop con tamano minimo 640x480
   if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
@@ -373,86 +381,241 @@ void main() async {
   });
 }
 
-/// Lightweight root displayed while the app waits for its persisted data.
-/// It reads the device locale directly because the saved app language is in
-/// the database that may still be on a mounting SD card.
-class StartupLoadingApp extends StatelessWidget {
-  const StartupLoadingApp({super.key});
+/// Startup strings for the current device locale.
+///
+/// The startup screens run before [FlutterLocalization] is initialized (the
+/// saved app language lives in the database, which may still be on a mounting
+/// SD card), so they read the raw locale maps directly. Unsupported device
+/// locales fall back to English — the same default the app itself uses — and
+/// missing keys degrade to an empty string rather than crashing the very
+/// first frame.
+Map<String, dynamic> _startupStrings() {
+  final locale = WidgetsBinding.instance.platformDispatcher.locale;
+  final languageTag = locale.toLanguageTag().replaceAll('-', '_');
+  const translations = <String, Map<String, dynamic>>{
+    'en': appLocaleEn,
+    'es': appLocaleEs,
+    'pt': appLocalePt,
+    'ru': appLocaleRu,
+    'zh': appLocaleZh,
+    'zh_Hant': appLocaleZhHant,
+    'fr': appLocaleFr,
+    'de': appLocaleDe,
+    'it': appLocaleIt,
+    'id': appLocaleId,
+    'ja': appLocaleJa,
+    'ko': appLocaleKo,
+  };
+  return translations[languageTag] ??
+      translations[locale.languageCode] ??
+      appLocaleEn;
+}
+
+String _startupString(String key) {
+  final value = _startupStrings()[key];
+  return value is String ? value : '';
+}
+
+/// Shared chrome for the pre-initialization screens: logo, wordmark and a
+/// caller-supplied status area.
+class _StartupScaffold extends StatelessWidget {
+  const _StartupScaffold({required this.children, this.onKeyEvent});
+
+  final List<Widget> children;
+
+  /// Raw key handler used by the error screen. The gamepad navigation manager
+  /// is not running this early, so gamepad buttons are read straight from the
+  /// key events instead.
+  final KeyEventResult Function(KeyEvent)? onKeyEvent;
 
   @override
   Widget build(BuildContext context) {
-    final locale = WidgetsBinding.instance.platformDispatcher.locale;
-    final languageTag = locale.toLanguageTag().replaceAll('-', '_');
-    final translations = <String, Map<String, dynamic>>{
-      'en': appLocaleEn,
-      'es': appLocaleEs,
-      'pt': appLocalePt,
-      'ru': appLocaleRu,
-      'zh': appLocaleZh,
-      'zh_Hant': appLocaleZhHant,
-      'fr': appLocaleFr,
-      'de': appLocaleDe,
-      'it': appLocaleIt,
-      'id': appLocaleId,
-      'ja': appLocaleJa,
-      'ko': appLocaleKo,
-    };
-    final strings =
-        translations[languageTag] ?? translations[locale.languageCode]!;
-    final message = strings[AppLocale.startupLoading] as String;
-
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       home: Scaffold(
         backgroundColor: const Color(0xFF090B10),
-        body: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(32),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Image.asset(
-                  'assets/images/logo_transparent.png',
-                  width: 112,
-                  height: 112,
-                ),
-                const SizedBox(height: 24),
-                const Text(
-                  'NeoStation',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 28,
-                    fontWeight: FontWeight.w600,
-                    letterSpacing: 1.2,
+        body: Focus(
+          autofocus: onKeyEvent != null,
+          onKeyEvent: onKeyEvent == null
+              ? null
+              : (_, event) => onKeyEvent!(event),
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Image.asset(
+                    'assets/images/logo_transparent.png',
+                    width: 112,
+                    height: 112,
                   ),
-                ),
-                const SizedBox(height: 24),
-                const SizedBox(
-                  width: 28,
-                  height: 28,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 3,
-                    color: Color(0xFF70C8FF),
-                  ),
-                ),
-                const SizedBox(height: 20),
-                ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 440),
-                  child: Text(
-                    message,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      color: Color(0xFFC4CBD6),
-                      fontSize: 16,
+                  const SizedBox(height: 24),
+                  const Text(
+                    'NeoStation',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 28,
+                      fontWeight: FontWeight.w600,
+                      letterSpacing: 1.2,
                     ),
                   ),
-                ),
-              ],
+                  const SizedBox(height: 24),
+                  ...children,
+                ],
+              ),
             ),
           ),
         ),
       ),
     );
+  }
+}
+
+/// Lightweight root displayed while the app waits for its persisted data.
+class StartupLoadingApp extends StatelessWidget {
+  const StartupLoadingApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return _StartupScaffold(
+      children: [
+        const SizedBox(
+          width: 28,
+          height: 28,
+          child: CircularProgressIndicator(
+            strokeWidth: 3,
+            color: Color(0xFF70C8FF),
+          ),
+        ),
+        const SizedBox(height: 20),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 440),
+          child: Text(
+            _startupString(AppLocale.startupLoading),
+            textAlign: TextAlign.center,
+            style: const TextStyle(color: Color(0xFFC4CBD6), fontSize: 16),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Shown when the configured user-data volume never appeared. Without this the
+/// failure was swallowed by the catch-alls in `main()` and the app booted onto
+/// an empty database, looking freshly installed.
+class StartupStorageErrorApp extends StatelessWidget {
+  const StartupStorageErrorApp({
+    super.key,
+    required this.storagePath,
+    required this.onRetry,
+    required this.onUseDefault,
+  });
+
+  final String? storagePath;
+  final VoidCallback onRetry;
+  final VoidCallback onUseDefault;
+
+  KeyEventResult _handleKey(KeyEvent event) {
+    if (event is! KeyDownEvent) return KeyEventResult.ignored;
+    final key = event.logicalKey;
+    if (key == LogicalKeyboardKey.gameButtonA ||
+        key == LogicalKeyboardKey.enter ||
+        key == LogicalKeyboardKey.select ||
+        key == LogicalKeyboardKey.space) {
+      onRetry();
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.gameButtonB ||
+        key == LogicalKeyboardKey.escape) {
+      onUseDefault();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _StartupScaffold(
+      onKeyEvent: _handleKey,
+      children: [
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                _startupString(AppLocale.startupStorageUnavailable),
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: Color(0xFFC4CBD6), fontSize: 16),
+              ),
+              if (storagePath != null && storagePath!.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                Text(
+                  storagePath!,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Color(0xFF8A93A3),
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 24),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ElevatedButton(
+                    onPressed: onRetry,
+                    child: Text(_startupString(AppLocale.startupStorageRetry)),
+                  ),
+                  const SizedBox(width: 16),
+                  TextButton(
+                    onPressed: onUseDefault,
+                    child: Text(
+                      _startupString(AppLocale.startupStorageUseDefault),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Resolves the user-data location once, up front, while the loading screen is
+/// on screen.
+///
+/// [ConfigService.getUserDataPath] has a dozen call sites; before this, each
+/// one could serially block for the full cold-boot timeout. Doing it here means
+/// the wait happens exactly once and its failure is visible to the user
+/// instead of being degraded into an empty library by downstream catch-alls.
+Future<void> _awaitUserDataStorage() async {
+  while (!await ConfigService.ensureUserDataStorageReady()) {
+    final decision = Completer<void>();
+    var useDefault = false;
+    runApp(
+      StartupStorageErrorApp(
+        storagePath: ConfigService.unavailableStoragePath,
+        onRetry: () {
+          ConfigService.resetStorageAvailability();
+          if (!decision.isCompleted) decision.complete();
+        },
+        onUseDefault: () {
+          useDefault = true;
+          if (!decision.isCompleted) decision.complete();
+        },
+      ),
+    );
+    await decision.future;
+    runApp(const StartupLoadingApp());
+    if (useDefault) {
+      ConfigService.continueWithDefaultUserDataPath();
+      return;
+    }
   }
 }
 

--- a/lib/providers/retro_achievements_credentials.dart
+++ b/lib/providers/retro_achievements_credentials.dart
@@ -1,0 +1,62 @@
+/// Pure credential-state logic for RetroAchievements auto-login.
+///
+/// Kept free of database, secure-storage and network dependencies so the
+/// decision that can *destroy* a stored API key is directly testable.
+library;
+
+/// The outcome of reading one persisted credential.
+///
+/// [value] is only meaningful when [ok] is true. A failed read must never be
+/// collapsed into `null`: "the database was not readable yet" and "the user
+/// never signed in" are different states, and treating the first as the second
+/// is how a cold boot used to delete a valid API key.
+class CredentialRead {
+  const CredentialRead.ok(this.value) : ok = true;
+  const CredentialRead.failed() : ok = false, value = null;
+
+  /// Whether the underlying storage was readable at all.
+  final bool ok;
+
+  /// The stored credential, or null when nothing was stored.
+  final String? value;
+
+  /// True only when the storage was readable and held a non-blank value.
+  bool get hasValue => ok && (value?.trim().isNotEmpty ?? false);
+}
+
+/// What [RetroAchievementsProvider.tryAutoLogin] should do with the
+/// credentials it just read.
+enum RaAutoLoginAction {
+  /// Both credentials are present — authenticate with them.
+  attemptLogin,
+
+  /// A key is stored with no username. Older builds persisted the maintainer's
+  /// shared API key that way and authenticated everyone's traffic with it; the
+  /// v94 migration cleared the username to force a personal-key login. Since
+  /// credentials are now always saved and cleared as a pair, this can only be
+  /// that orphaned legacy key, so it is dropped.
+  clearOrphanedKey,
+
+  /// Nothing usable, or the credentials could not be read. Change nothing.
+  skip,
+}
+
+/// Decides how to act on the credentials read at startup.
+///
+/// The critical rule: [RaAutoLoginAction.clearOrphanedKey] is returned only
+/// when *both* reads succeeded, so a transient storage failure can never be
+/// mistaken for an orphaned legacy key and erase a working account.
+RaAutoLoginAction resolveRaAutoLoginAction({
+  required CredentialRead user,
+  required CredentialRead apiKey,
+}) {
+  if (!user.ok || !apiKey.ok) return RaAutoLoginAction.skip;
+  if (user.hasValue) {
+    return apiKey.hasValue
+        ? RaAutoLoginAction.attemptLogin
+        : RaAutoLoginAction.skip;
+  }
+  return apiKey.hasValue
+      ? RaAutoLoginAction.clearOrphanedKey
+      : RaAutoLoginAction.skip;
+}

--- a/lib/providers/retro_achievements_provider.dart
+++ b/lib/providers/retro_achievements_provider.dart
@@ -10,6 +10,7 @@ import '../models/retro_achievements_dashboard_models.dart';
 import '../models/retro_achievements_game_info.dart';
 import '../models/retro_achievements_gotw.dart';
 import '../models/retro_achievements_user_awards.dart';
+import 'retro_achievements_credentials.dart';
 import 'retroachievements/strategy_factory.dart';
 
 /// Provider responsible for managing the integration with RetroAchievements.org.
@@ -465,14 +466,14 @@ class RetroAchievementsProvider extends ChangeNotifier {
           return;
         }
 
-        final savedUsername = await _loadRAUserFromConfig();
-        final savedApiKey = await _loadRAApiKeyFromConfig();
-        if (savedUsername == null ||
-            savedUsername.isEmpty ||
-            RetroAchievementsService.resolveApiKey(
-              savedApiKey,
-            ).trim().isEmpty ||
-            attempt == maxAttempts) {
+        final user = await _readRAUserFromConfig();
+        final apiKey = await _readRAApiKeyFromConfig();
+        // Keep retrying while a stored account exists — or while we cannot yet
+        // tell, because unreadable storage is exactly the cold-boot case this
+        // retry is here for.
+        final worthRetrying =
+            !user.ok || !apiKey.ok || (user.hasValue && apiKey.hasValue);
+        if (!worthRetrying || attempt == maxAttempts) {
           return;
         }
 
@@ -489,40 +490,42 @@ class RetroAchievementsProvider extends ChangeNotifier {
   /// Attempts to re-authenticate using the username persisted in the local configuration.
   Future<bool> tryAutoLogin() async {
     try {
-      final savedUsername = await _loadRAUserFromConfig();
-      final savedApiKey = await _loadRAApiKeyFromConfig();
+      final user = await _readRAUserFromConfig();
+      final apiKey = await _readRAApiKeyFromConfig();
 
-      if (savedUsername != null && savedUsername.isNotEmpty) {
-        if (RetroAchievementsService.resolveApiKey(
-          savedApiKey,
-        ).trim().isEmpty) {
-          _log.i(
-            'Skipping RetroAchievements auto-login for $savedUsername: no API key available',
-          );
-          return false;
-        }
+      switch (resolveRaAutoLoginAction(user: user, apiKey: apiKey)) {
+        case RaAutoLoginAction.attemptLogin:
+          final success = await connect(user.value!, apiKey: apiKey.value);
+          if (!success) {
+            _log.e(
+              'Auto-login failed for: ${user.value} (user preserved for retry)',
+            );
+          }
+          return success;
 
-        final success = await connect(savedUsername, apiKey: savedApiKey);
-        if (!success) {
-          _log.e(
-            'Auto-login failed for: $savedUsername (user preserved for retry)',
-          );
-        }
-        return success;
-      } else {
-        // No saved username. Older builds persisted the maintainer's shared
-        // API key here and authenticated everyone's traffic with it; the v94
-        // migration cleared the username to force a personal-key login. Since
-        // credentials are now always saved/cleared as a pair, a key with no
-        // username can only be that orphaned legacy key — drop it so it can
-        // never be reused.
-        if (savedApiKey != null && savedApiKey.isNotEmpty) {
+        case RaAutoLoginAction.clearOrphanedKey:
           await RetroAchievementsRepository.clearRAApiKey();
           _log.i(
             'Cleared orphaned RetroAchievements API key (legacy shared key)',
           );
-        }
-        return false;
+          return false;
+
+        case RaAutoLoginAction.skip:
+          if (!user.ok || !apiKey.ok) {
+            // Credential storage was unreadable — on a cold boot the database
+            // may still be on a mounting volume. Change nothing and let the
+            // caller retry; treating this as "signed out" would delete a valid
+            // account.
+            _log.w(
+              'Skipping RetroAchievements auto-login: credential storage '
+              'unreadable (credentials preserved)',
+            );
+          } else if (user.hasValue) {
+            _log.i(
+              'Skipping RetroAchievements auto-login for ${user.value}: no API key available',
+            );
+          }
+          return false;
       }
     } catch (e) {
       _log.e('Error loading user: $e (user preserved for retry)');
@@ -640,24 +643,26 @@ class RetroAchievementsProvider extends ChangeNotifier {
     }
   }
 
-  /// Retrieves the persisted RetroAchievements username from the configuration table.
-  Future<String?> _loadRAUserFromConfig() async {
+  /// Retrieves the persisted RetroAchievements username from the configuration
+  /// table, reporting whether the read itself succeeded.
+  Future<CredentialRead> _readRAUserFromConfig() async {
     try {
-      return await RetroAchievementsRepository.getRAUser();
+      return CredentialRead.ok(await RetroAchievementsRepository.getRAUser());
     } catch (e) {
       _log.e('Error loading RA user from DB: $e');
+      return const CredentialRead.failed();
     }
-    return null;
   }
 
-  /// Retrieves the persisted RetroAchievements API key from secure storage.
-  Future<String?> _loadRAApiKeyFromConfig() async {
+  /// Retrieves the persisted RetroAchievements API key from secure storage,
+  /// reporting whether the read itself succeeded.
+  Future<CredentialRead> _readRAApiKeyFromConfig() async {
     try {
-      return await RetroAchievementsRepository.getRAApiKey();
+      return CredentialRead.ok(await RetroAchievementsRepository.getRAApiKey());
     } catch (e) {
       _log.e('Error loading RA API key from secure storage: $e');
+      return const CredentialRead.failed();
     }
-    return null;
   }
 
   /// Removes the RetroAchievements username from persistent storage.

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/services.dart';
@@ -35,6 +36,61 @@ class ConfigService {
   static const Duration _androidStorageRetryDelay = Duration(seconds: 3);
   static const int _androidStorageMaxAttempts = 20;
 
+  /// In-flight Android cold-boot wait, shared by every concurrent caller so the
+  /// retry loop runs once instead of once per consumer.
+  static Future<String>? _androidStorageWait;
+
+  /// Set when the retry loop has already given up on [_unavailableStoragePath].
+  /// Later callers then fail fast instead of each blocking for another full
+  /// timeout — `getUserDataPath()` has a dozen call sites, and serialising
+  /// their waits used to stall startup for minutes.
+  static bool _androidStorageUnavailable = false;
+  static String? _unavailableStoragePath;
+
+  /// Session-only opt-out: the user explicitly chose to continue with the
+  /// platform default location after the configured volume never appeared.
+  static bool _useDefaultPathFallback = false;
+
+  /// Whether the configured user-data volume was declared unreachable this
+  /// session. UI may use this to explain the state instead of silently
+  /// presenting an empty library.
+  static bool get storageUnavailable => _androidStorageUnavailable;
+
+  /// The configured path that [storageUnavailable] refers to, if any.
+  static String? get unavailableStoragePath => _unavailableStoragePath;
+
+  /// Clears the cached "unavailable" verdict so the next resolution retries
+  /// from scratch. Call after the configured path changes or when the user
+  /// asks to retry.
+  static void resetStorageAvailability() {
+    _androidStorageUnavailable = false;
+    _unavailableStoragePath = null;
+    _useDefaultPathFallback = false;
+  }
+
+  /// Abandons the configured custom path for the remainder of this session and
+  /// resolves to the platform default instead. This is the user's explicit
+  /// escape hatch from an unmountable volume; it is deliberately not persisted.
+  static void continueWithDefaultUserDataPath() {
+    _log.w('User opted to continue with the default user-data path');
+    _androidStorageUnavailable = false;
+    _useDefaultPathFallback = true;
+  }
+
+  /// Resolves the user-data path once, up front, so the cold-boot wait happens
+  /// while a loading UI is visible rather than piecemeal inside later callers.
+  ///
+  /// Returns false when the configured volume never became available.
+  static Future<bool> ensureUserDataStorageReady() async {
+    try {
+      await getUserDataPath();
+      return true;
+    } catch (e) {
+      _log.e('User-data storage is not ready: $e');
+      return false;
+    }
+  }
+
   /// Resolves the absolute path to the user's local data directory.
   ///
   /// Checks for a user-configured custom path first (stored in SharedPreferences).
@@ -42,7 +98,9 @@ class ConfigService {
   static Future<String> getUserDataPath() async {
     final prefs = await SharedPreferences.getInstance();
     final customPath = prefs.getString(_customPathKey);
-    if (customPath != null && customPath.isNotEmpty) {
+    if (customPath != null &&
+        customPath.isNotEmpty &&
+        !_useDefaultPathFallback) {
       final dir = Directory(customPath);
       if (await dir.exists()) {
         return customPath;
@@ -53,31 +111,14 @@ class ConfigService {
         // the user data is still mounting. Falling back to the app-private
         // default here creates a second, empty database and makes the whole
         // app look freshly installed. Wait for the configured volume instead.
-        for (
-          var attempt = 1;
-          attempt <= _androidStorageMaxAttempts;
-          attempt++
-        ) {
-          if (await dir.exists()) return customPath;
-
-          // A missing last directory is safe to create only once its parent
-          // volume is available. Do not create a lookalike path before that.
-          if (await dir.parent.exists()) {
-            await dir.create(recursive: true);
-            return customPath;
-          }
-
-          if (attempt < _androidStorageMaxAttempts) {
-            _log.i(
-              'Waiting for custom user-data storage ($attempt/$_androidStorageMaxAttempts): $customPath',
-            );
-            await Future<void>.delayed(_androidStorageRetryDelay);
-          }
+        if (_androidStorageUnavailable &&
+            _unavailableStoragePath == customPath) {
+          throw StateError(
+            'Configured user-data storage is unavailable: $customPath',
+          );
         }
 
-        throw StateError(
-          'Configured user-data storage is unavailable: $customPath',
-        );
+        return _androidStorageWait ??= _startAndroidStorageWait(customPath);
       }
 
       // Directory missing — try to create it (first-run on new device or new location).
@@ -95,6 +136,50 @@ class ConfigService {
       }
     }
     return getDefaultUserDataPath();
+  }
+
+  /// Runs the Android cold-boot retry loop for [customPath] and clears the
+  /// shared in-flight slot once it settles. A success does not need caching —
+  /// the `exists()` check in [getUserDataPath] is cheap — while a failure is
+  /// remembered via [_androidStorageUnavailable] so later callers fail fast.
+  static Future<String> _startAndroidStorageWait(String customPath) {
+    final wait = _waitForAndroidStorage(customPath);
+    unawaited(
+      wait
+          .then((_) {}, onError: (Object _) {})
+          .whenComplete(() => _androidStorageWait = null),
+    );
+    return wait;
+  }
+
+  /// Waits for the volume holding [customPath] to appear, creating the final
+  /// directory only once its parent volume is mounted. Throws a [StateError]
+  /// (and latches [storageUnavailable]) when it never shows up.
+  static Future<String> _waitForAndroidStorage(String customPath) async {
+    final dir = Directory(customPath);
+    for (var attempt = 1; attempt <= _androidStorageMaxAttempts; attempt++) {
+      if (await dir.exists()) return customPath;
+
+      // A missing last directory is safe to create only once its parent
+      // volume is available. Do not create a lookalike path before that.
+      if (await dir.parent.exists()) {
+        await dir.create(recursive: true);
+        return customPath;
+      }
+
+      if (attempt < _androidStorageMaxAttempts) {
+        _log.i(
+          'Waiting for custom user-data storage ($attempt/$_androidStorageMaxAttempts): $customPath',
+        );
+        await Future<void>.delayed(_androidStorageRetryDelay);
+      }
+    }
+
+    _androidStorageUnavailable = true;
+    _unavailableStoragePath = customPath;
+    throw StateError(
+      'Configured user-data storage is unavailable: $customPath',
+    );
   }
 
   /// Returns the platform default user-data path, ignoring any custom override.

--- a/lib/services/logger_service.dart
+++ b/lib/services/logger_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:logger/logger.dart';
 import 'package:neostation/services/config_service.dart';
+import 'package:neostation/utils/log_redaction.dart';
 
 /// Supported log severity levels.
 enum LogLevel { info, warning, error, debug }
@@ -19,7 +20,7 @@ class LoggerService {
 
   LoggerService._internal()
     : _logger = Logger(
-        printer: SimplePrinter(colors: true),
+        printer: RedactingPrinter(SimplePrinter(colors: true)),
         filter: ProductionFilter(),
         output: MultiOutput([ConsoleOutput()]),
       );
@@ -52,7 +53,7 @@ class LoggerService {
 
       _logger = Logger(
         level: Level.info,
-        printer: SimplePrinter(colors: true),
+        printer: RedactingPrinter(SimplePrinter(colors: true)),
         filter: CustomProductionFilter(),
         output: MultiOutput([
           ConsoleOutput(),
@@ -103,6 +104,24 @@ class LoggerService {
   /// Logs an error-level message with optional error object and stack trace.
   void e(String message, {Object? error, StackTrace? stackTrace}) =>
       log(message, level: LogLevel.error, error: error, stackTrace: stackTrace);
+}
+
+/// Strips credentials from every formatted log line before it reaches an
+/// output.
+///
+/// This wraps the printer rather than the log call sites on purpose: the worst
+/// leaks come from error objects we never format ourselves — an HTTP client
+/// exception carries the full request URI, query string included — so
+/// redaction has to happen after the event is rendered and before it is
+/// written to the console or the log file.
+class RedactingPrinter extends LogPrinter {
+  RedactingPrinter(this._inner);
+
+  final LogPrinter _inner;
+
+  @override
+  List<String> log(LogEvent event) =>
+      _inner.log(event).map(redactSecrets).toList();
 }
 
 /// Custom log filter that permits INFO level logs even in production/release environments.

--- a/lib/services/user_data_location_service.dart
+++ b/lib/services/user_data_location_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:neostation/services/config_service.dart';
 import 'package:neostation/services/logger_service.dart';
 
 class UserDataLocationService {
@@ -17,11 +18,15 @@ class UserDataLocationService {
   static Future<void> setCustomPath(String customPath) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(customPathKey, customPath);
+    // A new location invalidates any "storage unavailable" verdict cached for
+    // the previous one, which would otherwise fail fast for the whole session.
+    ConfigService.resetStorageAvailability();
   }
 
   static Future<void> clearCustomPath() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(customPathKey);
+    ConfigService.resetStorageAvailability();
   }
 
   /// Counts top-level entries in [dirPath].

--- a/lib/utils/log_redaction.dart
+++ b/lib/utils/log_redaction.dart
@@ -1,0 +1,101 @@
+/// Secret redaction for anything written to the application log.
+///
+/// The log file lives on shared external storage and users routinely attach it
+/// to public bug reports, so credentials must never reach it. Redaction is
+/// applied centrally in [LoggerService] rather than at call sites: the leaks
+/// that matter come from error objects we do not format ourselves — an HTTP
+/// client exception, for example, embeds the full request URI including its
+/// query string.
+///
+/// Kept pure and dependency-free so the patterns can be tested directly.
+library;
+
+/// Placeholder substituted for every redacted value.
+const String redactedPlaceholder = '<redacted>';
+
+/// Query-string parameters whose values are credentials.
+///
+/// `y` is the RetroAchievements web API key; `devpassword`/`sspassword` and
+/// `devid`/`ssid` are the ScreenScraper developer and user credentials. The
+/// rest are generic names used across the HTTP clients.
+const List<String> _sensitiveParams = [
+  'y',
+  'api_key',
+  'apikey',
+  'access_token',
+  'refresh_token',
+  'auth',
+  'devid',
+  'devpassword',
+  'key',
+  'pass',
+  'passwd',
+  'password',
+  'secret',
+  'session',
+  'sig',
+  'signature',
+  'ssid',
+  'sspassword',
+  'token',
+];
+
+/// `?y=abc` / `&password=abc` — keeps the parameter name, drops the value.
+/// The value stops at the next separator so the rest of the URI is preserved.
+final RegExp _queryParamPattern = RegExp(
+  '([?&](?:${_sensitiveParams.join('|')})=)([^&\\s"\'<>)\\]}]+)',
+  caseSensitive: false,
+);
+
+/// `"password": "abc"` / `password: abc` in JSON or map/toString output.
+///
+/// The unquoted value must also stop at `&` and `<`: without that it runs past
+/// the end of a query parameter and swallows the remainder of a URL, and it
+/// re-matches an already-substituted `<redacted>`, breaking idempotence.
+final RegExp _jsonFieldPattern = RegExp(
+  '(["\']?(?:${_sensitiveParams.join('|')})["\']?\\s*[:=]\\s*)'
+  '(["\'][^"\']*["\']|[^,\\s}\\]&<>"\']+)',
+  caseSensitive: false,
+);
+
+/// `Authorization: Bearer abc` and `Basic dXNlcjpwYXNz`.
+final RegExp _authHeaderPattern = RegExp(
+  r'((?:Bearer|Basic|Token)\s+)([A-Za-z0-9\-._~+/]+=*)',
+  caseSensitive: false,
+);
+
+/// A JWT anywhere in the text, including ones we never named.
+final RegExp _jwtPattern = RegExp(
+  r'eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]+',
+);
+
+/// Credentials embedded in a URL's userinfo: `https://user:pass@host`.
+final RegExp _urlUserInfoPattern = RegExp(r'(://)[^/\s:@]+:[^/\s@]+@');
+
+/// Returns [text] with every recognised credential replaced by
+/// [redactedPlaceholder].
+///
+/// Non-secret content is left untouched so the log stays useful for debugging:
+/// usernames, hosts, paths and endpoint names all survive.
+String redactSecrets(String text) {
+  if (text.isEmpty) return text;
+
+  var result = text.replaceAllMapped(
+    _queryParamPattern,
+    (m) => '${m[1]}$redactedPlaceholder',
+  );
+  result = result.replaceAllMapped(
+    _jsonFieldPattern,
+    (m) => '${m[1]}$redactedPlaceholder',
+  );
+  result = result.replaceAllMapped(
+    _authHeaderPattern,
+    (m) => '${m[1]}$redactedPlaceholder',
+  );
+  result = result.replaceAll(_jwtPattern, redactedPlaceholder);
+  result = result.replaceAllMapped(
+    _urlUserInfoPattern,
+    (m) => '${m[1]}$redactedPlaceholder@',
+  );
+  return result;
+}

--- a/test/log_redaction_test.dart
+++ b/test/log_redaction_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/log_redaction.dart';
+
+void main() {
+  group('redactSecrets — the observed leak', () {
+    test('strips the RetroAchievements web API key from a request URI', () {
+      // Verbatim shape of the line seen in app.log on the Thor: the key is in
+      // the URI carried by an http ClientException, not in our own message.
+      const line =
+          'Error getting user profile: ClientException with SocketException: '
+          'Failed host lookup, uri=https://retroachievements.org/API/'
+          'API_GetUserProfile.php?u=SomeUser&y=9lUpeq4qAbNeIdtGlGk7D4Co9xPinq2O';
+
+      final redacted = redactSecrets(line);
+
+      expect(redacted, isNot(contains('9lUpeq4qAbNeIdtGlGk7D4Co9xPinq2O')));
+      expect(redacted, contains('y=<redacted>'));
+      // Everything needed to debug the failure survives.
+      expect(redacted, contains('u=SomeUser'));
+      expect(redacted, contains('API_GetUserProfile.php'));
+      expect(redacted, contains('Failed host lookup'));
+    });
+
+    test('strips ScreenScraper developer and user credentials', () {
+      const line =
+          'GET https://api.screenscraper.fr/api2/jeuInfos.php?devid=neo'
+          '&devpassword=s3cr3t&softname=NeoStation&ssid=someone'
+          '&sspassword=hunter2&output=json';
+
+      final redacted = redactSecrets(line);
+
+      expect(redacted, isNot(contains('s3cr3t')));
+      expect(redacted, isNot(contains('hunter2')));
+      expect(redacted, isNot(contains('=neo&')));
+      expect(redacted, contains('devpassword=<redacted>'));
+      expect(redacted, contains('sspassword=<redacted>'));
+      expect(redacted, contains('softname=NeoStation'));
+      expect(redacted, contains('output=json'));
+    });
+  });
+
+  group('redactSecrets — other credential shapes', () {
+    test('redacts a bearer token', () {
+      final redacted = redactSecrets(
+        'headers: {Authorization: Bearer abc123DEF456ghi}',
+      );
+      expect(redacted, isNot(contains('abc123DEF456ghi')));
+      expect(redacted, contains('Bearer <redacted>'));
+    });
+
+    test('redacts a JWT anywhere in the text', () {
+      const jwt =
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
+          '.eyJzdWIiOiIxMjM0NTY3ODkwIn0'
+          '.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+      final redacted = redactSecrets('NeoSync session restored: $jwt');
+      expect(redacted, isNot(contains('eyJhbGci')));
+      expect(redacted, contains('<redacted>'));
+      expect(redacted, contains('NeoSync session restored'));
+    });
+
+    test('redacts credentials embedded in a URL', () {
+      final redacted = redactSecrets(
+        'RomM: connecting to https://user:hunter2@romm.local/api/roms',
+      );
+      expect(redacted, isNot(contains('hunter2')));
+      expect(redacted, contains('https://<redacted>@romm.local/api/roms'));
+    });
+
+    test('redacts credential-shaped JSON fields', () {
+      final redacted = redactSecrets(
+        'body: {"username": "someone", "password": "hunter2", '
+        '"token": "abc.def"}',
+      );
+      expect(redacted, isNot(contains('hunter2')));
+      expect(redacted, isNot(contains('abc.def')));
+      expect(redacted, contains('someone'));
+    });
+
+    test('is case-insensitive about parameter names', () {
+      final redacted = redactSecrets('?API_KEY=abc123&Password=xyz789');
+      expect(redacted, isNot(contains('abc123')));
+      expect(redacted, isNot(contains('xyz789')));
+    });
+  });
+
+  group('redactSecrets — leaves ordinary logs alone', () {
+    test('does not touch a normal message', () {
+      const line = 'Database loaded: 35 systems with games';
+      expect(redactSecrets(line), line);
+    });
+
+    test('does not touch a plain path or non-secret query', () {
+      const line =
+          'Scanning /storage/emulated/0/roms/nes — '
+          'https://example.com/manifest.json?v=2&platform=android';
+      expect(redactSecrets(line), line);
+    });
+
+    test('handles an empty string', () {
+      expect(redactSecrets(''), '');
+    });
+
+    test('redaction is idempotent', () {
+      const line = 'uri=https://retroachievements.org/API/x.php?u=me&y=SECRET';
+      final once = redactSecrets(line);
+      expect(redactSecrets(once), once);
+    });
+  });
+}

--- a/test/retro_achievements_credentials_test.dart
+++ b/test/retro_achievements_credentials_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/providers/retro_achievements_credentials.dart';
+
+void main() {
+  group('resolveRaAutoLoginAction', () {
+    test('logs in when both credentials are stored', () {
+      expect(
+        resolveRaAutoLoginAction(
+          user: const CredentialRead.ok('player'),
+          apiKey: const CredentialRead.ok('key'),
+        ),
+        RaAutoLoginAction.attemptLogin,
+      );
+    });
+
+    test('clears an orphaned key only when the reads actually succeeded', () {
+      expect(
+        resolveRaAutoLoginAction(
+          user: const CredentialRead.ok(null),
+          apiKey: const CredentialRead.ok('legacy-shared-key'),
+        ),
+        RaAutoLoginAction.clearOrphanedKey,
+      );
+    });
+
+    test('never clears the key when the username read failed', () {
+      // The cold-boot regression: the database was unreadable, so the username
+      // came back null. Treating that as "no account" used to delete a valid
+      // API key and force the user to re-enter it after every reboot.
+      expect(
+        resolveRaAutoLoginAction(
+          user: const CredentialRead.failed(),
+          apiKey: const CredentialRead.ok('valid-key'),
+        ),
+        RaAutoLoginAction.skip,
+      );
+    });
+
+    test('never clears the key when the key read failed', () {
+      expect(
+        resolveRaAutoLoginAction(
+          user: const CredentialRead.failed(),
+          apiKey: const CredentialRead.failed(),
+        ),
+        RaAutoLoginAction.skip,
+      );
+    });
+
+    test('does not log in when the username read failed', () {
+      expect(
+        resolveRaAutoLoginAction(
+          user: const CredentialRead.failed(),
+          apiKey: const CredentialRead.ok('key'),
+        ),
+        RaAutoLoginAction.skip,
+      );
+    });
+
+    test('skips when a username is stored without a key', () {
+      expect(
+        resolveRaAutoLoginAction(
+          user: const CredentialRead.ok('player'),
+          apiKey: const CredentialRead.ok(null),
+        ),
+        RaAutoLoginAction.skip,
+      );
+    });
+
+    test('treats blank credentials as absent', () {
+      expect(
+        resolveRaAutoLoginAction(
+          user: const CredentialRead.ok('   '),
+          apiKey: const CredentialRead.ok('  '),
+        ),
+        RaAutoLoginAction.skip,
+      );
+      expect(
+        resolveRaAutoLoginAction(
+          user: const CredentialRead.ok('   '),
+          apiKey: const CredentialRead.ok('key'),
+        ),
+        RaAutoLoginAction.clearOrphanedKey,
+      );
+    });
+
+    test('skips when nothing is stored at all', () {
+      expect(
+        resolveRaAutoLoginAction(
+          user: const CredentialRead.ok(null),
+          apiKey: const CredentialRead.ok(null),
+        ),
+        RaAutoLoginAction.skip,
+      );
+    });
+  });
+
+  group('CredentialRead', () {
+    test('a failed read never reports a value', () {
+      const read = CredentialRead.failed();
+      expect(read.ok, isFalse);
+      expect(read.value, isNull);
+      expect(read.hasValue, isFalse);
+    });
+
+    test('hasValue is false for a successful empty read', () {
+      expect(const CredentialRead.ok('').hasValue, isFalse);
+      expect(const CredentialRead.ok(null).hasValue, isFalse);
+      expect(const CredentialRead.ok('x').hasValue, isTrue);
+    });
+  });
+}

--- a/test/startup_locale_test.dart
+++ b/test/startup_locale_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/l10n/app_locale.dart';
+
+/// The startup screens run before FlutterLocalization is initialized and read
+/// the raw locale maps directly, so a missing key there is a crash on the very
+/// first frame rather than a fallback string.
+void main() {
+  const startupKeys = <String>[
+    AppLocale.startupLoading,
+    AppLocale.startupStorageUnavailable,
+    AppLocale.startupStorageRetry,
+    AppLocale.startupStorageUseDefault,
+  ];
+
+  const locales = <String, Map<String, dynamic>>{
+    'en': appLocaleEn,
+    'es': appLocaleEs,
+    'pt': appLocalePt,
+    'ru': appLocaleRu,
+    'zh': appLocaleZh,
+    'zh_Hant': appLocaleZhHant,
+    'fr': appLocaleFr,
+    'de': appLocaleDe,
+    'it': appLocaleIt,
+    'id': appLocaleId,
+    'ja': appLocaleJa,
+    'ko': appLocaleKo,
+  };
+
+  for (final entry in locales.entries) {
+    test('${entry.key} defines every startup string', () {
+      for (final key in startupKeys) {
+        final value = entry.value[key];
+        expect(
+          value,
+          isA<String>().having((s) => s.isNotEmpty, 'isNotEmpty', isTrue),
+          reason: '$key missing from app_locale_${entry.key}.dart',
+        );
+      }
+    });
+  }
+}


### PR DESCRIPTION
> 🤖 PR prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Four follow-up fixes to #225 (issue #224). #225 fixed the right things, but a review of the merged diff turned up one crash it introduced, two paths that can still lose the user's data, and a credential leak in the log we ask users to send us — including one that reproduces the reported "RetroAchievements credentials are gone after a reboot" symptom exactly.

### 1. Startup crash on any unsupported device locale

`StartupLoadingApp` resolved the device locale with `translations[locale.languageCode]!`. Any device whose locale is not one of the twelve supported ones (nl, sv, pl, tr, ar, hi, cs…) throws on the **first frame of `main()`** — before `FlutterError.onError` is installed and outside every `try`. The app cannot start at all.

**Why it matters:** #225 put this screen in front of *every* launch on *every* platform, so this is a hard launch failure for a whole class of users, not a degraded path. The app itself already defaults to `en` when a locale is unsupported; the startup screen just didn't.

Locale resolution now falls back exact tag → language code → English, and a missing key degrades to an empty string instead of throwing. `test/startup_locale_test.dart` asserts all 12 locale maps define every startup key.

### 2. The cold-boot storage wait ran once *per caller*, and its failure was invisible

`ConfigService.getUserDataPath()` has ~12 call sites and none of them shared the new retry loop (20 × 3 s). On a genuinely unavailable volume, `FileProvider.initialize()`, the language read, `SqliteConfigProvider.initialize()` and `SqliteService` each block for the **full 60 s in series** — minutes on the loading screen. Each is wrapped in its own `try/catch`, so the `StateError` that #225 added to prevent opening a wrong empty database was swallowed by all of them and the app booted onto an empty library anyway.

**Why it matters:** the throw was the mechanism protecting the user's library, and nothing downstream honoured it. The failure mode it was meant to replace (looks freshly installed) still happened, just after a much longer wait, and the user had no way to tell what was wrong or to get out of it.

- The retry loop moved behind a shared in-flight future with a latched "unavailable" verdict, so the wait happens once and later callers fail fast.
- `main()` now resolves the path once, up front, while the loading screen is visible.
- On failure the user gets a localized screen naming the path, with **Retry** (loops until storage appears) and **Continue without it** (session-only fallback to the default location). Gamepad-reachable: A/Enter retries, B/Escape continues, since `GamepadNavigationManager` isn't running that early.
- `setCustomPath`/`clearCustomPath` reset the latch so a newly chosen location isn't fast-failed by the old verdict.

### 3. A cold boot could permanently delete the RetroAchievements API key

This is the still-live cause of the credentials half of #224.

`_loadRAUserFromConfig()` caught any database error and returned `null`, which `tryAutoLogin()` could not distinguish from "the user never signed in". It therefore took the orphaned-legacy-key branch and called `clearRAApiKey()` — a permanent `delete` from secure storage. Once the database became readable the username was still there, but the key was gone for good.

**Why it matters:** this is unrecoverable data loss triggered by a *transient* condition, and it is exactly the reported symptom — credentials must be re-entered after every reboot rather than merely showing as signed-out until restart. The username lives in `user_config.ra_user` (on the user-data path, so subject to the mount race) while the key lives in app-private secure storage, which is why both appear to vanish together. #225's `resetOnError: false` closed the Keystore-wipe cause; this closes the one in our own code.

- Credential reads now report whether the read itself succeeded (`CredentialRead`).
- The destructive decision moved into a pure, dependency-free helper (`resolveRaAutoLoginAction`) that returns `clearOrphanedKey` **only when both reads demonstrably succeeded**.
- `initialize()`'s retry gate keeps retrying while storage is unreadable, instead of reading `null` as "no account" and giving up on the first attempt — the same conflation in the other direction.
- 10 unit tests, including the named regression: unreadable username + valid key → `skip`, never `clearOrphanedKey`.

Genuine legacy-shared-key cleanup, blank-credential handling and the username-without-key case are all unchanged.

**Note for affected users:** anyone whose key was already deleted by the old code has to enter it once more — it is gone from secure storage and cannot be recovered. It should stick from then on.

### 4. The app log was publishing users' credentials

The log file lives on shared external storage and users routinely attach it to public bug reports, so anything written there is effectively published. It was carrying secrets: a failed RetroAchievements request logs its `ClientException`, which embeds the full request URI **including the user's web API key** — observed verbatim in `app.log` during the on-device testing for this PR. ScreenScraper `devid`/`devpassword`, bearer tokens and JWTs would leak the same way.

**Why it matters:** this is a credential disclosure that we actively ask users to send us. It is unrelated to the reboot bug but was found by reading the log while verifying the fix above, and it affects every channel on every platform.

Redaction wraps the *printer* in `LoggerService` rather than the call sites, because the leaking text comes from error objects the app never formats itself — it has to be stripped after the event is rendered and before it reaches the console or the file, which also covers logging from packages. Sensitive query parameters, credential-shaped JSON fields, `Authorization` headers, JWTs and URL userinfo become `<redacted>`; usernames, hosts, paths and endpoint names are preserved so the log stays useful. Verified against the real leaked line captured from the device.

Two limits worth stating: this does not clean logs that already exist (any key previously written is still in users' files and should be treated as compromised), and it only covers `LoggerService` — a bare `print()` would bypass it.

- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** — the only new interactive UI is the storage-error screen, which did not appear on the test device (see below).

## Testing

`flutter analyze` clean; `flutter test` 310 passing (34 new).

Validated on an **AYN Thor, dev channel, release build, set as the home launcher, across a real device reboot** — the exact scenario from #224. Captured from logcat and the on-device `app.log`, ~6 s after boot:

```
11:40:00.698  Database loaded: 35 systems with games            <- library intact
11:40:00.749  initial startup scan started
11:40:00.793  Error getting user profile: SocketException:
              Failed host lookup: 'retroachievements.org'       <- DNS not up yet
11:40:00.793  Auto-login failed for: <user> (user preserved for retry)
11:40:00.796  RetroAchievements auto-login attempt 1 failed; retrying
```

DNS was not ready, so RA, the theme fetch and the update check all failed host lookup together — the race this PR is about. What matters is what is **absent**: no `Cleared orphaned RetroAchievements API key`, so fix 3 held and the key was never deleted, and no second failure line, so attempt 2 (~4 s later) signed in on its own. Credentials survived the reboot and recovered unattended. **The reported bug did not reproduce.** No crash from the app; the only `FATAL` in the log is an unrelated `com.google.android.gms` SafetyCenter exception.

Fix 1 ran on every launch (the loading screen is now on the startup path for all platforms). Fix 4 was verified by running the real leaked line captured from the device through the redactor.

**Not covered on device:** fix 2's wait, error screen and gamepad handling never executed, because the test device uses the default Android user-data path and `getUserDataPath()` only waits when a *custom* path is set. Reproducing it needs user-data relocated to removable storage that is genuinely slow or absent at boot. Worth flagging separately: on Android the default location is already on external storage, so #225's wait does not protect the default configuration at all — it only helps users who explicitly relocated their data.

## Screenshots (if applicable)

n/a — the new storage-error screen only appears when the configured user-data volume never mounts.
