### PR TITLE
fix(update): tolerate flavor suffixes and release tags in version comparison

### DIFF
--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -10,6 +10,7 @@ import 'package:archive/archive_io.dart';
 import 'package:neostation/services/logger_service.dart';
 
 import 'package:neostation/services/permission_service.dart';
+import 'package:neostation/utils/version_compare.dart';
 
 /// Service responsible for orchestrating the over-the-air (OTA) update lifecycle.
 ///
@@ -46,11 +47,17 @@ class UpdateService {
 
       final releaseData = json.decode(response.body) as Map<String, dynamic>;
 
-      // Standardize version tag by removing 'v' prefix and build metadata.
-      final latestVersion = releaseData['tag_name']
-          .toString()
-          .replaceFirst('v', '')
-          .split('+')[0];
+      // Standardize the tag for display: strip a leading 'v' and the build
+      // metadata. replaceFirst('v', '') would have removed a 'v' anywhere in
+      // the string, so only a genuine prefix is dropped here. The comparison
+      // below normalizes independently and tolerates either form.
+      final rawTag = releaseData['tag_name'].toString().trim();
+      final latestVersion =
+          (rawTag.startsWith('v') || rawTag.startsWith('V')
+                  ? rawTag.substring(1)
+                  : rawTag)
+              .split('+')
+              .first;
 
       // 3. Perform semantic version comparison.
       if (_isNewerVersion(currentVersion, latestVersion)) {
@@ -94,21 +101,19 @@ class UpdateService {
   }
 
   /// Performs a semantic comparison between two version strings.
+  ///
+  /// Both sides carry decoration that plain integer parsing chokes on: the
+  /// Android dev and feature-test flavors add a `-dev` / `-feature`
+  /// versionNameSuffix, and release tags carry `v` and `+build` metadata.
   static bool _isNewerVersion(String current, String latest) {
-    try {
-      final currentParts = current.split('.').map(int.parse).toList();
-      final latestParts = latest.split('.').map(int.parse).toList();
-
-      for (int i = 0; i < 3; i++) {
-        if (latestParts[i] > currentParts[i]) return true;
-        if (latestParts[i] < currentParts[i]) return false;
-      }
-
-      return false; // Versions are identical or current is newer.
-    } catch (e) {
-      _log.e('UpdateService: Version comparison failure', error: e);
+    if (parseVersion(current) == null || parseVersion(latest) == null) {
+      _log.w(
+        'UpdateService: unparseable version (current="$current", '
+        'latest="$latest"); skipping update check',
+      );
       return false;
     }
+    return isNewerVersion(current, latest);
   }
 
   /// Identifies the correct release asset based on the current execution environment.

--- a/lib/utils/version_compare.dart
+++ b/lib/utils/version_compare.dart
@@ -1,0 +1,61 @@
+/// Version parsing for the OTA update check.
+///
+/// Kept pure and dependency-free so the comparison can be tested directly.
+///
+/// Release tags and on-device version names are not plain `major.minor.patch`:
+/// GitHub tags carry a `v` prefix and Flutter build metadata (`v0.9.7+121`),
+/// and the Android flavors append a channel suffix (`0.9.7-dev`,
+/// `0.9.7-feature`). Anything that cannot be read as a number is treated as
+/// "cannot compare" rather than throwing.
+library;
+
+/// Parses [raw] into exactly three components, padding missing ones with 0.
+///
+/// Returns null when the string holds no usable numeric version. Build
+/// metadata (`+121`) and pre-release/channel suffixes (`-dev`, `-rc.1`) are
+/// discarded before parsing.
+List<int>? parseVersion(String raw) {
+  var value = raw.trim();
+  if (value.isEmpty) return null;
+
+  if (value.startsWith('v') || value.startsWith('V')) {
+    value = value.substring(1);
+  }
+  value = value.split('+').first.split('-').first.trim();
+  if (value.isEmpty) return null;
+
+  final parts = value.split('.');
+  final parsed = <int>[];
+  for (var i = 0; i < 3; i++) {
+    if (i >= parts.length) {
+      parsed.add(0);
+      continue;
+    }
+    final component = int.tryParse(parts[i].trim());
+    if (component == null || component < 0) return null;
+    parsed.add(component);
+  }
+  return parsed;
+}
+
+/// Whether [latest] is a strictly newer release than [current].
+///
+/// Returns false when either version is unparseable — an update check that
+/// cannot read its own inputs must not offer an update.
+///
+/// Channel suffixes are stripped before comparing, so a dev or feature-test
+/// build of the same version is treated as up to date. That is deliberate:
+/// those channels are separate applicationIds and must never be offered the
+/// production APK as an update.
+bool isNewerVersion(String current, String latest) {
+  final currentParts = parseVersion(current);
+  final latestParts = parseVersion(latest);
+  if (currentParts == null || latestParts == null) return false;
+
+  for (var i = 0; i < 3; i++) {
+    if (latestParts[i] != currentParts[i]) {
+      return latestParts[i] > currentParts[i];
+    }
+  }
+  return false;
+}

--- a/test/version_compare_test.dart
+++ b/test/version_compare_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/version_compare.dart';
+
+void main() {
+  group('parseVersion', () {
+    test('parses a plain version', () {
+      expect(parseVersion('0.9.7'), [0, 9, 7]);
+    });
+
+    test('strips a v prefix and build metadata (GitHub release tag)', () {
+      expect(parseVersion('v0.9.7+121'), [0, 9, 7]);
+      expect(parseVersion('V1.10.2'), [1, 10, 2]);
+    });
+
+    test('strips the Android flavor versionNameSuffix', () {
+      // The regression: the dev and feature-test flavors ship versionName
+      // "0.9.7-dev" / "0.9.7-feature", which int.parse could not read.
+      expect(parseVersion('0.9.7-dev'), [0, 9, 7]);
+      expect(parseVersion('0.9.7-feature'), [0, 9, 7]);
+      expect(parseVersion('v1.0.0-rc.1'), [1, 0, 0]);
+    });
+
+    test('pads missing components', () {
+      expect(parseVersion('1'), [1, 0, 0]);
+      expect(parseVersion('1.2'), [1, 2, 0]);
+    });
+
+    test('ignores extra components beyond patch', () {
+      expect(parseVersion('1.2.3.4'), [1, 2, 3]);
+    });
+
+    test('returns null for unusable input instead of throwing', () {
+      expect(parseVersion(''), isNull);
+      expect(parseVersion('   '), isNull);
+      expect(parseVersion('v'), isNull);
+      expect(parseVersion('nightly'), isNull);
+      expect(parseVersion('1.x.3'), isNull);
+      expect(parseVersion('-1.2.3'), isNull);
+    });
+  });
+
+  group('isNewerVersion', () {
+    test('detects a newer release', () {
+      expect(isNewerVersion('0.9.7', '0.9.8'), isTrue);
+      expect(isNewerVersion('0.9.7', '0.10.0'), isTrue);
+      expect(isNewerVersion('0.9.7', '1.0.0'), isTrue);
+    });
+
+    test('compares components numerically, not lexically', () {
+      expect(isNewerVersion('0.9.9', '0.10.0'), isTrue);
+      expect(isNewerVersion('0.10.0', '0.9.9'), isFalse);
+    });
+
+    test('identical versions are not newer', () {
+      expect(isNewerVersion('0.9.7', '0.9.7'), isFalse);
+      expect(isNewerVersion('0.9.7', 'v0.9.7+121'), isFalse);
+    });
+
+    test('older remote is not newer', () {
+      expect(isNewerVersion('1.0.0', '0.9.9'), isFalse);
+    });
+
+    test('a dev build is not offered the production APK', () {
+      // Separate applicationIds — a channel suffix must not read as "older".
+      expect(isNewerVersion('0.9.7-dev', 'v0.9.7+121'), isFalse);
+      expect(isNewerVersion('0.9.7-feature', 'v0.9.7+121'), isFalse);
+    });
+
+    test('a dev build still sees a genuinely newer release', () {
+      expect(isNewerVersion('0.9.7-dev', 'v0.9.8+130'), isTrue);
+    });
+
+    test('unparseable input never offers an update', () {
+      expect(isNewerVersion('0.9.7', 'nightly'), isFalse);
+      expect(isNewerVersion('garbage', '1.0.0'), isFalse);
+      expect(isNewerVersion('', ''), isFalse);
+    });
+
+    test('short versions compare against full ones', () {
+      expect(isNewerVersion('1.2', '1.2.1'), isTrue);
+      expect(isNewerVersion('1.2.1', '1.2'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
> 🤖 PR prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Fixes the `UpdateService` version comparison, which threw on any version string carrying decoration. Found in the Thor's log while verifying #233 — it appears on every launch of a dev or feature-test build:

```
UpdateService: Version comparison failure  ERROR: FormatException: Invalid radix-10 number (at character 1)
```

### The cause

`_isNewerVersion()` parsed each dot-separated component with `int.parse`:

```dart
final currentParts = current.split('.').map(int.parse).toList();
```

The `dev` and `featuretest` flavors set a `versionNameSuffix` (`android/app/build.gradle.kts`), so `packageInfo.version` is `0.9.7-dev`, and `int.parse('7-dev')` throws — at character 1, the `-`, exactly matching the logged message. Confirmed on device with `dumpsys package`: `versionName=0.9.7-dev`.

Two further faults in the same block: the loop indexed `latestParts[i]` for `i < 3` with no length check, so a two-component version (`1.2`) threw `RangeError`; and the call site's `replaceFirst('v', '')` stripped a `v` from anywhere in the tag rather than only a leading prefix.

### Why it matters

The failure is silent and fails closed. All three faults land in the same `catch`, which returns `false` — and `false` means "no update available", which is indistinguishable from "you are up to date". Nothing surfaces to the user; the only trace is a log line.

Today that means the update check is simply dead on the dev and feature-test channels, which is low impact on its own. The real exposure is the production channel: the current tag (`v0.9.7+121`) parses only by luck of the present convention. The moment a release is tagged with a pre-release suffix — `v1.0.0-rc.1`, `v1.0.0-beta`, the natural choice for a staged rollout — production breaks identically and **every user's update check silently starts reporting "up to date" forever**. Since this service is how the Windows, Linux and macOS builds self-update (and Android via APK OTA), users would sit on an old build with no signal that anything failed, and the symptom would be the *absence* of update prompts — very hard to notice or report.

### The change

Parsing moved to a pure, dependency-free helper (`lib/utils/version_compare.dart`) that strips a `v`/`V` prefix, `+build` metadata and `-suffix`, pads missing components, and returns null instead of throwing. `_isNewerVersion()` still returns false when it cannot parse — an update check that cannot read its own inputs must not offer an update — but now logs a warning naming both version strings, so a future failure is diagnosable rather than mysterious.

One deliberate behaviour: a channel suffix compares *equal* to the plain version, so `0.9.7-dev` vs `v0.9.7+121` is "no update". A dev build must never be offered the production APK — it is a different `applicationId`, so installing it would be a second app rather than an upgrade. A genuinely newer release (`0.9.7-dev` vs `v0.9.8+130`) is still detected.

- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable) — n/a, no UI change.

## Testing

`flutter analyze` clean; `flutter test` 291 passing (14 new), covering the flavor suffixes, tag forms (`v0.9.7+121`), numeric-not-lexical ordering (`0.9.9` -> `0.10.0`), short versions, and unparseable input.

Verified on an AYN Thor (dev channel, release build, `versionName=0.9.7-dev`) by counting the failure in the on-device `app.log`:

| | |
|---|---|
| Occurrences accumulated before the fix | **38** (one per launch, most recently at `11:34:39` and `11:39:12`) |
| Occurrences after 3 launches of the fixed build | **38** — unchanged |

The counter is frozen, and the `FormatException` no longer appears for any post-fix process. At least one of those launches reached the GitHub API successfully (no `Unexpected error during update check` logged for it), which is the path that previously threw — before the fix, reaching a 200 response was precisely what led into the failing comparison. The comparison now completes silently and correctly reports no update, since `0.9.7-dev` and the latest tag `v0.9.7+121` are the same release.

## Screenshots (if applicable)

n/a — no UI change.
