### PR TITLE
fix(nav): detect L1/R1 release at the raw key level

### DIFF
--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -157,6 +157,12 @@ class GamepadNavigation {
   /// Debounce duration for action buttons to prevent double-presses.
   static const int _actionDebounceMs = 128;
 
+  /// True for the raw Android keycodes of the L1/R1 bumpers.
+  static bool _isAndroidShoulderKeycode(String key) {
+    final k = key.toLowerCase();
+    return k == 'keycode_button_l1' || k == 'keycode_button_r1';
+  }
+
   /// Delay before the first repeat event occurs when a button is held.
   static const Duration _initialRepeatDelay = Duration(milliseconds: 300);
 
@@ -598,6 +604,22 @@ class GamepadNavigation {
           _onSelectUp(now);
         }
         return;
+      }
+
+      // Shoulder RELEASE is read from the RAW key, before translation, for the
+      // same reason Select is (above). A tab switch activates a new navigation
+      // layer, which clears its translator's button states; the release that
+      // follows then looks like "no edge" to that layer and is dropped, so
+      // [_shoulderReleasedSinceDispatch] stayed false and the next deliberate
+      // TAP was misclassified as a held auto-repeat and paced at
+      // [_shoulderRepeatIntervalMs] — a quick second tab switch was swallowed.
+      // The raw event reaches every layer regardless of translator state.
+      // A genuine hold emits no ACTION_UP, so held pacing is unaffected.
+      // Values are inverted on this platform: 0.0 = down, 1.0 = up.
+      if (isAndroid &&
+          _isAndroidShoulderKeycode(event.key) &&
+          event.value > 0.5) {
+        _shoulderReleasedSinceDispatch = true;
       }
 
       final translatedEvent = _translator.translateEvent(event);


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code).

# Description

Follow-up to #222. That PR made held L1/R1 walk the tabs and stopped the reactivation grace from eating bumper presses, but tab switching still intermittently needed a **second press** — most often when tapping quickly.

**Root cause.** `activate()` clears the new layer's translator button states (`gamepad_nav.dart`), because a button held across a layer change never delivers its release there. A tab switch swaps the active navigation layer, so the bumper **release** that follows lands on a freshly-cleared translator: `wasPressed` is false, so `isReleased` is false and `translateEvent` returns `null` (`gamepad_translator.dart`). The release is never seen.

Because the release is lost, the static `_shoulderReleasedSinceDispatch` stays `false`, and #222's pacing classifies the **next deliberate tap** as a held auto-repeat — pacing it at `_shoulderRepeatIntervalMs` (300 ms) instead of `_shoulderTapDebounceMs` (50 ms). Any tap landing inside that window is silently swallowed. Slower taps survive only because they clear 300 ms, or because the 500 ms `holdLapsed` safety net rescues them; that's what made it feel random.

**Fix.** Read the bumper release from the **raw** keycode before translation, exactly as the Select modifier already does (added in #232) for the same class of lost-edge problem. The raw event reaches every layer regardless of translator state, and the flag is static, so it survives the tab switch. A genuine hold emits no `ACTION_UP`, so held-bumper pacing is untouched.

## Measurements

Instrumented every gate a bumper input passes through and captured logcat on an AYN Thor, before and after:

| | before | after |
|---|---|---|
| physical L1/R1 presses | 54 | 111 |
| tab switches dispatched | 50 | **111** |
| taps silently dropped | **4 (7.4 %)** | **0** |

All four dropped taps were the fastest ones (release→press gap 127–129 ms) and failed identically:

```
PACING buttonRB gap=265ms min=300ms heldRepeat=true releasedSinceDispatch=false -> SWALLOWED
```

The baseline trace also shows the lost release directly, 30 times:

```
TRANSLATE key=KEYCODE_BUTTON_R1 value=1.00 -> DROP(no edge; translator state says no change)
```

After the fix, taps register at press gaps as low as 2 ms, and **held** bumpers still behave as #222 intended — three deliberate holds produced 8, 6 and 5 switches over 2256 / 1793 / 1510 ms, i.e. the designed ~3 tabs per second.

The instrumentation is **not** part of this PR; only the 22-line fix is.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. — the behaviour is a raw-`GamepadEvent` stream interaction across two navigation layers with static pacing state; verified on device with the before/after traces above instead. The existing 297 tests pass.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. — no new assets.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable). — AYN Thor, both taps and holds, L1 and R1.

## Screenshots (if applicable)

N/A — input timing behaviour, captured as traces above.
