### PR TITLE
fix(emulator): make the system default single-valued and stop silent emulator substitution

### DIFF
--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -318,6 +318,9 @@ class SqliteMigrations {
       case 104:
         await _migrateToVersion104(db);
         break;
+      case 105:
+        await _migrateToVersion105(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -4995,6 +4998,60 @@ class SqliteMigrations {
       _log.i('Migration v104 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v104: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v105: Collapse duplicate system-default emulators.
+  ///
+  /// `user_emulator_config.is_user_default` is the user's explicit "this is the
+  /// emulator for this system" pick, and [getUserDefaultEmulatorForSystem] reads
+  /// it with a `LIMIT 1`. `setDefaultCore` *set* that flag but never cleared it
+  /// for a previously-chosen core, so switching emulators left two winners on the
+  /// same system and the unordered read returned the *oldest* one — pick a core,
+  /// then a standalone, and the core still launches (and vice versa for
+  /// core → core). The setters now clear every competing marker first, but that
+  /// only helps the next selection: installs already carrying two flagged rows
+  /// stay broken until the persisted state is repaired. That is this migration.
+  ///
+  /// For each system we keep the most recently updated flagged emulator and
+  /// clear the rest. `updated_at` is stamped on every user selection, so the
+  /// keeper is the user's latest choice — exactly what they expect to launch.
+  /// Config rows with no matching `app_emulators` entry are left alone: they
+  /// belong to no system, so they can't be part of a per-system conflict.
+  static Future<void> _migrateToVersion105(Database db) async {
+    _log.i('Migration v105: Collapsing duplicate system-default emulators');
+    try {
+      db.execute('DROP TABLE IF EXISTS temp._emu_default_keepers');
+
+      // Bare-column-with-MAX(): SQLite guarantees the non-aggregate columns come
+      // from the row holding the max, so `uid` is the latest pick per system.
+      db.execute('''
+        CREATE TEMP TABLE _emu_default_keepers AS
+        SELECT e.system_id AS sid,
+               uc.emulator_unique_id AS uid,
+               MAX(uc.updated_at) AS upd
+        FROM user_emulator_config uc
+        JOIN app_emulators e ON e.unique_identifier = uc.emulator_unique_id
+        WHERE uc.is_user_default = 1
+        GROUP BY e.system_id
+      ''');
+
+      db.execute('''
+        UPDATE user_emulator_config
+        SET is_user_default = 0
+        WHERE is_user_default = 1
+          AND emulator_unique_id IN (SELECT unique_identifier FROM app_emulators)
+          AND emulator_unique_id NOT IN (SELECT uid FROM _emu_default_keepers)
+      ''');
+
+      final cleared = db.updatedRows;
+      db.execute('DROP TABLE IF EXISTS temp._emu_default_keepers');
+
+      _log.i('Migration v105 completed (cleared $cleared stale default(s))');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v105: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 104;
+  static const int _databaseVersion = 105;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -1241,6 +1241,7 @@ class SqliteService {
         tableNames.contains('app_emulators')) {
       try {
         await _fixEmulatorDefaults(db);
+        await logEmulatorDefaultAnomalies(db);
       } catch (e) {
         _log.e('Minor fix for defaults failed (expected in first run): $e');
       }
@@ -3420,6 +3421,85 @@ class SqliteService {
     });
   }
 
+  /// Makes [uniqueIdentifier] the one and only default emulator for [systemId],
+  /// clearing every competing marker first.
+  ///
+  /// The system default is expressed across two tables — `app_emulators.is_default`
+  /// (cores) and `user_emulator_config.is_user_default` (the user's explicit pick,
+  /// core or standalone) — and [getUserDefaultEmulatorForSystem] reads the latter
+  /// with a `LIMIT 1`. Anything that leaves a second `is_user_default = 1` row on
+  /// the system therefore makes the resolved default non-deterministic, and in
+  /// practice the *oldest* selection wins: pick a core, then a standalone, and the
+  /// core still launches. Both setters funnel through here so that can't happen.
+  ///
+  /// The `is_user_default` clear is deliberately system-wide rather than
+  /// system+OS: `user_emulator_config`'s primary key is `emulator_unique_id`
+  /// alone, so a single row is shared across operating systems and anything
+  /// narrower cannot make the invariant hold.
+  static Future<void> _applySystemDefaultEmulator(
+    TransactionAdapter txn,
+    String systemId,
+    String uniqueIdentifier,
+    int osId, {
+    required bool isStandalone,
+  }) async {
+    // 1. Clear the core default across the whole system+OS — standalone rows
+    //    included, in case a seed ever flagged one.
+    await txn.rawUpdate(
+      'UPDATE app_emulators SET is_default = 0 WHERE system_id = ? AND os_id = ?',
+      [systemId, osId],
+    );
+
+    // 2. Clear every explicit user default belonging to this system.
+    await txn.rawUpdate(
+      'UPDATE user_emulator_config SET is_user_default = 0 '
+      'WHERE emulator_unique_id IN '
+      '(SELECT unique_identifier FROM app_emulators WHERE system_id = ?)',
+      [systemId],
+    );
+
+    // 3. Cores additionally carry the app-level default flag.
+    if (!isStandalone) {
+      await txn.update(
+        'app_emulators',
+        {'is_default': 1},
+        where: 'os_id = ? AND unique_identifier = ?',
+        whereArgs: [osId, uniqueIdentifier],
+      );
+    }
+
+    _log.i(
+      '[EmuSel] set system default: system=$systemId emulator=$uniqueIdentifier '
+      'osId=$osId standalone=$isStandalone',
+    );
+
+    // 4. Record the user's pick so emulator auto-detection cannot override it
+    //    on subsequent startups.
+    final now = DateTime.now().toIso8601String();
+    final existing = await txn.query(
+      'user_emulator_config',
+      columns: ['emulator_unique_id'],
+      where: 'emulator_unique_id = ?',
+      whereArgs: [uniqueIdentifier],
+    );
+    if (existing.isNotEmpty) {
+      await txn.update(
+        'user_emulator_config',
+        {'is_user_default': 1, 'updated_at': now},
+        where: 'emulator_unique_id = ?',
+        whereArgs: [uniqueIdentifier],
+      );
+    } else {
+      await txn.insert('user_emulator_config', {
+        'emulator_unique_id': uniqueIdentifier,
+        'emulator_path': '', // Path resolution is handled during launch.
+        'is_user_default': 1,
+        'created_at': now,
+        'updated_at': now,
+      });
+    }
+  }
+
   /// Sets the primary emulator core for a given system.
   static Future<void> setDefaultCore(
     String systemId,
@@ -3429,54 +3509,13 @@ class SqliteService {
     final db = await instance.database;
 
     await db.transaction((txn) async {
-      // Reset defaults for all cores within the target system and OS.
-      await txn.rawUpdate(
-        'UPDATE app_emulators SET is_default = 0 WHERE system_id = ? AND os_id = ? AND is_standalone = 0',
-        [systemId, osId],
+      await _applySystemDefaultEmulator(
+        txn,
+        systemId,
+        uniqueIdentifier,
+        osId,
+        isStandalone: false,
       );
-
-      // Mutually exclusive: Disable standalone defaults when a core is selected.
-      await txn.rawUpdate(
-        'UPDATE user_emulator_config SET is_user_default = 0 '
-        'WHERE emulator_unique_id IN (SELECT unique_identifier FROM app_emulators WHERE system_id = ? AND os_id = ? AND is_standalone = 1)',
-        [systemId, osId],
-      );
-
-      // Assign the new default core.
-      await txn.update(
-        'app_emulators',
-        {'is_default': 1},
-        where: 'os_id = ? AND unique_identifier = ?',
-        whereArgs: [osId, uniqueIdentifier],
-      );
-
-      // Track user selection in user_emulator_config so RA auto-detection
-      // does not override it on subsequent startups.
-      final existing = await txn.query(
-        'user_emulator_config',
-        columns: ['emulator_unique_id'],
-        where: 'emulator_unique_id = ?',
-        whereArgs: [uniqueIdentifier],
-      );
-      if (existing.isNotEmpty) {
-        await txn.update(
-          'user_emulator_config',
-          {
-            'is_user_default': 1,
-            'updated_at': DateTime.now().toIso8601String(),
-          },
-          where: 'emulator_unique_id = ?',
-          whereArgs: [uniqueIdentifier],
-        );
-      } else {
-        await txn.insert('user_emulator_config', {
-          'emulator_unique_id': uniqueIdentifier,
-          'emulator_path': '',
-          'is_user_default': 1,
-          'created_at': DateTime.now().toIso8601String(),
-          'updated_at': DateTime.now().toIso8601String(),
-        });
-      }
     });
 
     // Enforce disk persistence via WAL checkpoint.
@@ -3523,56 +3562,25 @@ class SqliteService {
   ) async {
     final db = await instance.database;
 
-    final emulators = await getStandaloneEmulatorsBySystemId(systemId);
+    final osRow = await db.rawQuery('SELECT id FROM app_os WHERE name = ?', [
+      getCurrentOs(),
+    ]);
+    final osId = osRow.isEmpty
+        ? null
+        : int.tryParse(osRow.first['id']?.toString() ?? '');
+    if (osId == null) {
+      _log.e('Cannot set standalone default: OS context unresolved');
+      return;
+    }
 
     await db.transaction((txn) async {
-      // 1. Unset user defaults for all standalone emulators belonging to this system.
-      for (final emu in emulators) {
-        final uniqueId = emu['unique_identifier']?.toString();
-        if (uniqueId != null) {
-          await txn.rawUpdate(
-            'UPDATE user_emulator_config SET is_user_default = 0 WHERE emulator_unique_id = ?',
-            [uniqueId],
-          );
-        }
-      }
-
-      // 2. Unset core defaults for the system (exclusive relationship).
-      final currentOs = getCurrentOs();
-      await txn.rawUpdate(
-        'UPDATE app_emulators SET is_default = 0 '
-        'WHERE system_id = ? AND os_id = (SELECT id FROM app_os WHERE name = ?) AND is_standalone = 0',
-        [systemId, currentOs],
+      await _applySystemDefaultEmulator(
+        txn,
+        systemId,
+        emulatorUniqueId,
+        osId,
+        isStandalone: true,
       );
-
-      // 3. Assign and persist the new standalone default.
-      final existing = await txn.query(
-        'user_emulator_config',
-        columns: ['emulator_unique_id'],
-        where: 'emulator_unique_id = ?',
-        whereArgs: [emulatorUniqueId],
-      );
-
-      if (existing.isNotEmpty) {
-        await txn.update(
-          'user_emulator_config',
-          {
-            'is_user_default': 1,
-            'updated_at': DateTime.now().toIso8601String(),
-          },
-          where: 'emulator_unique_id = ?',
-          whereArgs: [emulatorUniqueId],
-          conflictAlgorithm: ConflictAlgorithm.ignore,
-        );
-      } else {
-        await txn.insert('user_emulator_config', {
-          'emulator_unique_id': emulatorUniqueId,
-          'emulator_path': '', // Path resolution is handled during launch.
-          'is_user_default': 1,
-          'created_at': DateTime.now().toIso8601String(),
-          'updated_at': DateTime.now().toIso8601String(),
-        });
-      }
     });
 
     try {
@@ -3600,90 +3608,172 @@ class SqliteService {
     return results.map((row) => CoreEmulatorModel.fromMap(row)).toList();
   }
 
-  /// Heuristic logic to fix inconsistencies in default emulator assignments.
+  /// Seeds a sane app-level default emulator for any system that lacks one, and
+  /// removes app/user default contradictions. Runs on every launch.
+  ///
+  /// Two hard rules, both learned from bugs this routine used to cause:
+  ///
+  /// 1. **It never writes `user_emulator_config.is_user_default`.** That column
+  ///    means "the user picked this", and [_resolveDefaultInstalledEmulator]
+  ///    honors it outright — installed or not — precisely because it is a
+  ///    deliberate choice. Auto-seeding it made a guess indistinguishable from a
+  ///    choice, and the old PS1 branch went further and *cleared* a real user
+  ///    choice on every single launch, silently reverting anyone who picked a
+  ///    standalone for PS1. Seeding belongs in `app_emulators.is_default`, which
+  ///    [getDefaultEmulatorForSystem] already falls back to and which resolves
+  ///    standalones just as well as cores.
+  /// 2. **Every statement is scoped to the current OS.** The old writes cleared
+  ///    `is_default` for a system across *all* operating systems, corrupting the
+  ///    other platforms' state in a synced database.
+  ///
+  /// Ordering is explicit throughout so the seeded pick is reproducible rather
+  /// than whatever the storage engine happened to return first.
+  @visibleForTesting
+  static Future<void> normalizeEmulatorDefaultsForTesting(
+    DatabaseExecutorAdapter db,
+  ) => instance._fixEmulatorDefaults(db);
+
+  /// Logs any system whose default-emulator state is self-contradictory.
+  ///
+  /// The invariant is "at most one `is_user_default` per system, and no app
+  /// default contradicting it". Violations are what made a chosen emulator
+  /// launch a different one, so surface them at startup rather than waiting for
+  /// a user to notice the wrong emulator booting. Silent when everything is
+  /// consistent, which is the normal case.
+  static Future<void> logEmulatorDefaultAnomalies(
+    DatabaseExecutorAdapter db,
+  ) async {
+    try {
+      // NB: messages here deliberately avoid a word ending in "y" immediately
+      // before a colon — `y` is a redacted query parameter, so "ANOMALY: system
+      // ds" gets scrubbed to "ANOMALY: <redacted> ds" by the log redactor.
+      final dupes = await db.rawQuery('''
+        SELECT e.system_id AS sid,
+               COUNT(*) AS n,
+               GROUP_CONCAT(uc.emulator_unique_id) AS uids
+        FROM user_emulator_config uc
+        JOIN app_emulators e ON e.unique_identifier = uc.emulator_unique_id
+        WHERE uc.is_user_default = 1
+        GROUP BY e.system_id
+        HAVING COUNT(*) > 1
+      ''');
+
+      for (final row in dupes) {
+        _log.w(
+          '[EmuSel] anomaly - system=${row['sid']} has ${row['n']} user '
+          'defaults (${row['uids']})',
+        );
+      }
+
+      // Scoped to the current OS: `is_default` is per (system, os), so an
+      // unscoped check reports another platform's perfectly valid default as a
+      // contradiction on this one.
+      final contradictions = await db.rawQuery(
+        '''
+        SELECT DISTINCT e.system_id AS sid
+        FROM app_emulators e
+        WHERE e.is_default = 1
+          AND e.os_id = (SELECT id FROM app_os WHERE name = ?)
+          AND EXISTS (
+            SELECT 1 FROM user_emulator_config uc
+            JOIN app_emulators e2
+              ON e2.unique_identifier = uc.emulator_unique_id
+            WHERE uc.is_user_default = 1
+              AND e2.system_id = e.system_id
+              AND e2.os_id = e.os_id
+              AND e2.unique_identifier != e.unique_identifier
+          )
+        ''',
+        [getCurrentOs()],
+      );
+
+      for (final row in contradictions) {
+        _log.w(
+          '[EmuSel] anomaly - system=${row['sid']} has an app default that '
+          'contradicts the user-selected default',
+        );
+      }
+
+      if (dupes.isEmpty && contradictions.isEmpty) {
+        _log.i('[EmuSel] default-emulator state consistent across all systems');
+      }
+    } catch (e) {
+      _log.w('[EmuSel] Could not scan for default-emulator anomalies: $e');
+    }
+  }
+
   Future<void> _fixEmulatorDefaults(DatabaseExecutorAdapter db) async {
     try {
-      final systems = await db.query(
-        'app_systems',
-        columns: ['id', 'folder_name'],
-      );
+      final systems = await db.query('app_systems', columns: ['id']);
       final currentOs = getCurrentOs();
+
+      final osRow = await db.rawQuery('SELECT id FROM app_os WHERE name = ?', [
+        currentOs,
+      ]);
+      if (osRow.isEmpty) {
+        _log.w(
+          'Skipping emulator default normalization: unknown OS $currentOs',
+        );
+        return;
+      }
+      final osId = int.tryParse(osRow.first['id']?.toString() ?? '');
+      if (osId == null) return;
 
       for (final system in systems) {
         final systemId = system['id'].toString();
-        final folderName = system['folder_name'].toString();
 
         final cores = await db.rawQuery(
-          'SELECT * FROM app_emulators WHERE system_id = ? AND is_standalone = 0 AND os_id = (SELECT id FROM app_os WHERE name = ?)',
-          [systemId, currentOs],
+          'SELECT * FROM app_emulators '
+          'WHERE system_id = ? AND is_standalone = 0 AND os_id = ? '
+          'ORDER BY name ASC',
+          [systemId, osId],
         );
         final standalones = await db.rawQuery(
           '''
-          SELECT e.*, uc.is_user_default 
-          FROM app_emulators e 
-          LEFT JOIN user_emulator_config uc ON e.unique_identifier = uc.emulator_unique_id 
-          WHERE e.system_id = ? AND e.is_standalone = 1 AND e.os_id = (SELECT id FROM app_os WHERE name = ?)
+          SELECT e.*, uc.is_user_default
+          FROM app_emulators e
+          LEFT JOIN user_emulator_config uc ON e.unique_identifier = uc.emulator_unique_id
+          WHERE e.system_id = ? AND e.is_standalone = 1 AND e.os_id = ?
+          ORDER BY e.name ASC
           ''',
-          [systemId, currentOs],
+          [systemId, osId],
         );
 
-        final coreDefault = cores.firstWhere(
-          (c) => c['is_default'] == 1,
-          orElse: () => {},
-        );
-        final standaloneDefault = standalones.firstWhere(
+        final hasCoreDefault = cores.any((c) => c['is_default'] == 1);
+        final hasUserDefault = standalones.any(
           (s) => s['is_user_default'] == 1,
-          orElse: () => {},
         );
 
-        bool hasCoreDefault = coreDefault.isNotEmpty;
-        bool hasStandaloneDefault = standaloneDefault.isNotEmpty;
+        if (hasUserDefault) {
+          // The user made a choice. It outranks any app-level default, so drop
+          // the contradicting `is_default` rather than the choice.
+          if (hasCoreDefault) {
+            await db.rawUpdate(
+              'UPDATE app_emulators SET is_default = 0 '
+              'WHERE system_id = ? AND os_id = ?',
+              [systemId, osId],
+            );
+          }
+          continue;
+        }
 
-        // RULE: PS1/PSX systems should prioritize cores unless overridden.
-        if (folderName == 'ps1' ||
-            folderName == 'psx' ||
-            folderName == 'sony-psx' ||
-            folderName == 'playstation') {
-          if (hasCoreDefault && hasStandaloneDefault) {
-            await db.rawUpdate(
-              'UPDATE user_emulator_config SET is_user_default = 0 '
-              'WHERE emulator_unique_id IN (SELECT unique_identifier FROM app_emulators WHERE system_id = ? AND is_standalone = 1)',
-              [systemId],
-            );
-          }
-        }
-        // GENERAL RULE: Prioritize user-selected standalone if both defaults are set.
-        else if (hasCoreDefault && hasStandaloneDefault) {
+        if (hasCoreDefault) continue;
+
+        // Nothing designated at all — seed the app-level default. Preference:
+        // the core the systems JSON marks as canonical, then any standalone
+        // (more likely to work out of the box than an unverifiable core), then
+        // any core.
+        final seed =
+            cores.where((c) => c['is_default_core'] == 1).firstOrNull ??
+            standalones.firstOrNull ??
+            cores.firstOrNull;
+
+        if (seed != null) {
           await db.rawUpdate(
-            'UPDATE app_emulators SET is_default = 0 WHERE system_id = ? AND is_standalone = 0',
-            [systemId],
+            'UPDATE app_emulators SET is_default = 1 '
+            'WHERE unique_identifier = ? AND os_id = ?',
+            [seed['unique_identifier'], osId],
           );
-        }
-        // FALLBACK: Assign the first available default_core, then standalone, then any core.
-        else if (!hasCoreDefault && !hasStandaloneDefault) {
-          // Prefer the core marked as default_core in JSON
-          final defaultCore = cores.firstWhere(
-            (c) => c['is_default_core'] == 1,
-            orElse: () => {},
-          );
-          if (defaultCore.isNotEmpty) {
-            await db.rawUpdate(
-              'UPDATE app_emulators SET is_default = 1 WHERE unique_identifier = ? AND os_id = ?',
-              [defaultCore['unique_identifier'], defaultCore['os_id']],
-            );
-          } else if (standalones.isNotEmpty) {
-            // Fall back to the first standalone
-            await db.rawUpdate(
-              'UPDATE user_emulator_config SET is_user_default = 1 WHERE emulator_unique_id = ?',
-              [standalones.first['unique_identifier']],
-            );
-          } else if (cores.isNotEmpty) {
-            // Absolute fallback: any core
-            await db.rawUpdate(
-              'UPDATE app_emulators SET is_default = 1 WHERE unique_identifier = ? AND os_id = ?',
-              [cores.first['unique_identifier'], cores.first['os_id']],
-            );
-          }
         }
       }
     } catch (e) {
@@ -3730,6 +3820,7 @@ class SqliteService {
       JOIN app_os os ON e.os_id = os.id
       JOIN user_emulator_config uc ON e.unique_identifier = uc.emulator_unique_id
       WHERE e.system_id = ? AND os.name = ? AND uc.is_user_default = 1
+      ORDER BY uc.updated_at DESC
       LIMIT 1
       ''',
       [systemId, currentOs],

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -3328,6 +3328,13 @@ class SqliteService {
       getAllSystems();
 
   /// Retrieves all emulator cores available for a specific system and operating system.
+  ///
+  /// The `isInstalled` on the returned models is a *package-level* check: on
+  /// Android it means the emulator app is present, which for a RetroArch entry
+  /// says nothing about whether the libretro core itself is there; on desktop it
+  /// is unconditionally true. `loadEmulatorsForSystem` is the enumerator that
+  /// verifies cores as well — prefer it unless you specifically want the cheaper
+  /// package-only answer.
   static Future<List<CoreEmulatorModel>> getCoresBySystemId(
     String systemId,
   ) async {
@@ -4186,6 +4193,12 @@ class SqliteService {
   }
 
   /// Retrieves all emulators available for a system on the current operating system.
+  ///
+  /// The returned models carry `isInstalled = false`: a database row cannot say
+  /// whether an emulator is actually present. Callers that need install state
+  /// must use `loadEmulatorsForSystem`, which verifies packages and core files.
+  /// `hasConfiguredPath` is the only install-adjacent signal available here, and
+  /// it is desktop-only.
   static Future<List<CoreEmulatorModel>> getEmulatorsForSystemCurrentOs(
     String systemId,
   ) async {
@@ -4197,7 +4210,7 @@ class SqliteService {
         CASE
           WHEN uc.emulator_path IS NOT NULL AND uc.emulator_path != '' THEN 1
           ELSE 0
-        END as is_installed
+        END as has_configured_path
       FROM app_emulators e
       JOIN app_os os ON e.os_id = os.id
       LEFT JOIN user_emulator_config uc ON uc.emulator_unique_id = e.unique_identifier

--- a/lib/models/core_emulator_model.dart
+++ b/lib/models/core_emulator_model.dart
@@ -30,8 +30,22 @@ class CoreEmulatorModel {
   /// Android package name for intent-based launching (e.g., 'com.retroarch'), if applicable.
   final String? androidPackageName;
 
-  /// Runtime flag indicating if the emulator is currently installed on the device.
+  /// Whether the emulator is actually present and usable on this device.
+  ///
+  /// Only a verifying enumerator sets this: `loadEmulatorsForSystem` checks the
+  /// Android package *and* the libretro core file, or probes the desktop cores
+  /// directory. A model built straight from a database row leaves it `false` —
+  /// the row alone cannot answer the question. If you need a trustworthy
+  /// answer, go through `loadEmulatorsForSystem`, not a raw query.
   final bool isInstalled;
+
+  /// Whether a desktop executable path is configured for this emulator.
+  ///
+  /// Desktop-only signal, read from `user_emulator_config.emulator_path`.
+  /// Nothing populates that column on Android, so it is always `false` there —
+  /// it is *not* an install check, and was previously aliased as one
+  /// (`is_installed`), which made every Android emulator look uninstalled.
+  final bool hasConfiguredPath;
 
   /// Whether this emulator is a RetroArch variant (e.g. `com.retroarch`,
   /// `com.retroarch.aarch64`). RetroArch variants all share the same launch
@@ -57,6 +71,7 @@ class CoreEmulatorModel {
     required this.isretroAchievementsCompatible,
     this.androidPackageName,
     this.isInstalled = false,
+    this.hasConfiguredPath = false,
   });
 
   /// Creates a [CoreEmulatorModel] from a database row map.
@@ -76,6 +91,9 @@ class CoreEmulatorModel {
           (int.tryParse(map['is_ra_compatible']?.toString() ?? '0') ?? 0) == 1,
       androidPackageName: map['android_package_name']?.toString(),
       isInstalled: (map['is_installed'] == 1 || map['is_installed'] == true),
+      hasConfiguredPath:
+          (map['has_configured_path'] == 1 ||
+          map['has_configured_path'] == true),
     );
   }
 
@@ -108,6 +126,7 @@ class CoreEmulatorModel {
     bool? isretroAchievementsCompatible,
     String? androidPackageName,
     bool? isInstalled,
+    bool? hasConfiguredPath,
   }) {
     return CoreEmulatorModel(
       uniqueId: uniqueId ?? this.uniqueId,
@@ -122,6 +141,7 @@ class CoreEmulatorModel {
           isretroAchievementsCompatible ?? this.isretroAchievementsCompatible,
       androidPackageName: androidPackageName ?? this.androidPackageName,
       isInstalled: isInstalled ?? this.isInstalled,
+      hasConfiguredPath: hasConfiguredPath ?? this.hasConfiguredPath,
     );
   }
 
@@ -167,6 +187,8 @@ class CoreEmulatorModel {
         return androidPackageName;
       case 'is_installed':
         return isInstalled;
+      case 'has_configured_path':
+        return hasConfiguredPath;
       default:
         return null;
     }

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -905,20 +905,25 @@ class GameLaunchService {
     );
 
     if (emulator != null) {
-      final coreFilename = emulator['core_filename'].toString();
+      // `?.` matters: a SQL NULL arrives as Dart null, and `null.toString()`
+      // launders it into the string "null", which passes every null check
+      // downstream and reaches RetroArch as LIBRETRO="null" — a blank screen
+      // with nothing in the log to explain it. Emulators that supply no core of
+      // their own (a standalone, a malformed config entry) can hold the system
+      // default, so this is a reachable state, not a defensive one.
+      final coreFilename = emulator['core_filename']?.toString();
 
-      if (Platform.isAndroid) {
-        return coreFilename;
-      } else {
-        String coreName = coreFilename;
-        if (coreName.endsWith('.dll')) {
-          coreName = coreName.substring(0, coreName.length - 4);
-        } else if (coreName.endsWith('.so')) {
-          coreName = coreName.substring(0, coreName.length - 3);
-        }
-
-        return coreName;
+      if (coreFilename == null || coreFilename.isEmpty) {
+        _log.e(
+          'Default emulator "${emulator['unique_identifier']}" for system '
+          '${system.folderName} has no core filename',
+        );
+        return null;
       }
+
+      return Platform.isAndroid
+          ? coreFilename
+          : _stripLibraryExtension(coreFilename);
     }
 
     _log.e('No default emulator found for system ${system.folderName}');

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -106,16 +106,46 @@ class GameLaunchService {
         configFileName,
       );
 
-      if (configLoaded) {
-        String? preferredPlayerId = game.emulatorName;
+      // Resolved once and threaded through every fallback below. `isExplicit`
+      // distinguishes a choice the user actually made (a per-game override, or a
+      // system default they set) from one we guessed for them — only the former
+      // is worth failing the launch over.
+      String? preferredPlayerId = game.emulatorName;
+      bool isExplicitChoice = preferredPlayerId != null;
+      String source = isExplicitChoice ? 'per-game override' : 'none';
 
-        if (preferredPlayerId == null) {
+      if (preferredPlayerId == null && system.id != null) {
+        final userDefault =
+            await EmulatorRepository.getUserDefaultEmulatorForSystem(
+              system.id!,
+            );
+        if (userDefault != null) {
+          preferredPlayerId = userDefault.uniqueId;
+          isExplicitChoice = true;
+          source = 'system default (user-selected)';
+        } else {
           final defaultEmu = await _resolveDefaultInstalledEmulator(system);
           if (defaultEmu != null) {
             preferredPlayerId = defaultEmu.uniqueId;
+            source = 'auto-resolved default';
           }
         }
+      }
 
+      // Emulator selection has been the source of repeated, hard-to-reproduce
+      // reports ("I picked melonDS, RetroArch launched"). One tagged line per
+      // launch makes the decision auditable from a user's logcat without any
+      // debug build or flag.
+      _log.i(
+        '[EmuSel] ${system.folderName}/${game.romname}: '
+        'emulator=${preferredPlayerId ?? "<none>"} source=$source '
+        'explicit=$isExplicitChoice configLoaded=$configLoaded',
+      );
+      if (system.id != null) {
+        await _logSystemEmulatorState(system);
+      }
+
+      if (configLoaded) {
         final launchCmd = LauncherService.instance.getLaunchCommand(
           system,
           game,
@@ -222,10 +252,23 @@ class GameLaunchService {
         }
       }
 
-      final standaloneEmulator = await _getStandaloneEmulatorForSystem(system);
+      _log.i(
+        '[EmuSel] JSON launch path did not handle '
+        '${preferredPlayerId ?? "<none>"}; trying standalone fallback',
+      );
+
+      final standaloneEmulator = await _getStandaloneEmulatorForSystem(
+        system,
+        preferredUniqueId: preferredPlayerId,
+      );
       if (!context.mounted) return GameLaunchResult.failure('', '');
 
       if (standaloneEmulator != null) {
+        _log.i(
+          '[EmuSel] route=standalone '
+          'emulator=${standaloneEmulator['unique_identifier']} '
+          '(${standaloneEmulator['name']})',
+        );
         if (Platform.isAndroid) {
           return await _launchStandaloneAndroid(
             context,
@@ -248,13 +291,42 @@ class GameLaunchService {
         }
       }
 
-      final coreName = await _getCoreForSystem(system);
+      final coreName = await _getCoreForSystem(
+        system,
+        preferredUniqueId: preferredPlayerId,
+      );
       if (!context.mounted) return GameLaunchResult.failure('', '');
 
       if (coreName == null) {
         return GameLaunchResult.failure(
           AppLocale.coreNotConfigured.getString(context),
           'No core found for system ${system.folderName}',
+        );
+      }
+
+      // Every route above declined to launch the emulator the user actually
+      // picked, and the only thing left is a core we chose for them. Launching
+      // it would silently substitute a *different* emulator — the exact failure
+      // that made a deliberate melonDS/standalone selection boot a RetroArch
+      // core. Surface the misconfiguration by name instead.
+      _log.i('[EmuSel] route=core core=$coreName');
+
+      final bool substitutesUserChoice =
+          isExplicitChoice &&
+          preferredPlayerId != null &&
+          !await _emulatorProvidesCore(system, preferredPlayerId, coreName);
+      if (!context.mounted) return GameLaunchResult.failure('', '');
+
+      if (substitutesUserChoice) {
+        _log.e(
+          'Refusing to substitute a fallback core for the user-selected '
+          'emulator "$preferredPlayerId" on ${system.folderName}',
+        );
+        return GameLaunchResult.failure(
+          AppLocale.emulatorNotConfigured.getString(context),
+          'The selected emulator "$preferredPlayerId" could not be launched '
+          'for ${system.folderName}. Re-select it in the system or per-game '
+          'emulator settings, or check that it is installed.',
         );
       }
 
@@ -722,8 +794,112 @@ class GameLaunchService {
     return configured;
   }
 
+  /// Logs the raw default-emulator state for [system] under the `[EmuSel]` tag.
+  ///
+  /// The bugs in this area were all *state* bugs — two emulators flagged as the
+  /// system default, or an app default contradicting the user's pick — and they
+  /// are invisible in a launch trace that only reports the winner. This prints
+  /// the underlying rows so a log alone is enough to diagnose a report.
+  static Future<void> _logSystemEmulatorState(SystemModel system) async {
+    try {
+      // Deliberately `loadEmulatorsForSystem`, the same probe the resolver uses,
+      // NOT getEmulatorsForSystemCurrentOs: the latter's `is_installed` is
+      // derived from a configured desktop executable path, so it reports 0 for
+      // every emulator on Android and would make this dump actively misleading.
+      final all = await loadEmulatorsForSystem(system);
+      final userDefault =
+          await EmulatorRepository.getUserDefaultEmulatorForSystem(system.id!);
+      final appDefaults = all.where((e) => e.isDefault).toList();
+
+      _log.i(
+        '[EmuSel]   available=${all.length} '
+        'userDefault=${userDefault?.uniqueId ?? "<none>"} '
+        'appDefaults=${appDefaults.map((e) => e.uniqueId).join(",")}',
+      );
+      if (appDefaults.length > 1) {
+        _log.w(
+          '[EmuSel]   anomaly - ${appDefaults.length} app defaults flagged for '
+          '${system.folderName}',
+        );
+      }
+      for (final e in all) {
+        _log.i(
+          '[EmuSel]     - ${e.uniqueId} name="${e.name}" '
+          'standalone=${e.isStandalone} installed=${e.isInstalled} '
+          'isDefault=${e.isDefault} core=${e.coreFilename ?? "-"} '
+          'pkg=${e.androidPackageName ?? "-"}',
+        );
+      }
+    } catch (e) {
+      _log.w('[EmuSel] Could not dump emulator state: $e');
+    }
+  }
+
+  /// Whether [uniqueId] is the emulator that supplies [coreName] for [system].
+  ///
+  /// Used to tell "we fell back to a core, but it happens to be the very core
+  /// the user picked" (fine) from "we fell back to somebody else's core" (a
+  /// silent substitution of the user's choice).
+  static Future<bool> _emulatorProvidesCore(
+    SystemModel system,
+    String uniqueId,
+    String coreName,
+  ) async {
+    if (system.id == null) return false;
+    try {
+      final all = await EmulatorRepository.getEmulatorsForSystemCurrentOs(
+        system.id!,
+      );
+      for (final e in all) {
+        if (e.uniqueId != uniqueId) continue;
+        final file = e.coreFilename;
+        if (file == null || file.isEmpty) return false;
+        return file == coreName || _stripLibraryExtension(file) == coreName;
+      }
+    } catch (e) {
+      // Enumeration failed — don't block a launch on a diagnostic check.
+      _log.w('Could not verify emulator/core correspondence: $e');
+      return true;
+    }
+    return false;
+  }
+
+  /// Strips a platform dynamic-library extension from a core filename.
+  static String _stripLibraryExtension(String coreFilename) {
+    if (coreFilename.endsWith('.dll')) {
+      return coreFilename.substring(0, coreFilename.length - 4);
+    }
+    if (coreFilename.endsWith('.so')) {
+      return coreFilename.substring(0, coreFilename.length - 3);
+    }
+    return coreFilename;
+  }
+
   /// Resolves the identifier for the core assigned to the given system.
-  static Future<String?> _getCoreForSystem(SystemModel system) async {
+  ///
+  /// When [preferredUniqueId] names an emulator that is itself a core, that core
+  /// wins: the caller already resolved the user's choice and re-deriving the
+  /// system default here would discard it.
+  static Future<String?> _getCoreForSystem(
+    SystemModel system, {
+    String? preferredUniqueId,
+  }) async {
+    if (preferredUniqueId != null && system.id != null) {
+      try {
+        final all = await EmulatorRepository.getEmulatorsForSystemCurrentOs(
+          system.id!,
+        );
+        for (final e in all) {
+          if (e.uniqueId != preferredUniqueId) continue;
+          final file = e.coreFilename;
+          if (file == null || file.isEmpty) break;
+          return Platform.isAndroid ? file : _stripLibraryExtension(file);
+        }
+      } catch (e) {
+        _log.w('Could not resolve preferred core "$preferredUniqueId": $e');
+      }
+    }
+
     final emulator = await EmulatorRepository.getDefaultEmulatorForSystem(
       system.id!,
     );
@@ -750,9 +926,16 @@ class GameLaunchService {
   }
 
   /// Retrieves the user-assigned standalone emulator for a system if applicable.
+  ///
+  /// [preferredUniqueId] is the emulator the caller already resolved for this
+  /// launch (a per-game override or the system default). If it names one of this
+  /// system's standalones, it wins outright — re-deriving the default here is
+  /// what used to drop the user's choice on the floor when the JSON launch path
+  /// declined to handle it.
   static Future<Map<String, dynamic>?> _getStandaloneEmulatorForSystem(
-    SystemModel system,
-  ) async {
+    SystemModel system, {
+    String? preferredUniqueId,
+  }) async {
     if (system.id == null) return null;
 
     try {
@@ -764,10 +947,22 @@ class GameLaunchService {
       }
 
       Map<String, dynamic>? userDefault;
-      for (final standalone in standalones) {
-        if (standalone['is_user_default'] == 1) {
-          userDefault = standalone;
-          break;
+      if (preferredUniqueId != null) {
+        for (final standalone in standalones) {
+          if (standalone['unique_identifier']?.toString() ==
+              preferredUniqueId) {
+            userDefault = standalone;
+            break;
+          }
+        }
+      }
+
+      if (userDefault == null) {
+        for (final standalone in standalones) {
+          if (standalone['is_user_default'] == 1) {
+            userDefault = standalone;
+            break;
+          }
         }
       }
 

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -803,9 +803,9 @@ class GameLaunchService {
   static Future<void> _logSystemEmulatorState(SystemModel system) async {
     try {
       // Deliberately `loadEmulatorsForSystem`, the same probe the resolver uses,
-      // NOT getEmulatorsForSystemCurrentOs: the latter's `is_installed` is
-      // derived from a configured desktop executable path, so it reports 0 for
-      // every emulator on Android and would make this dump actively misleading.
+      // NOT getEmulatorsForSystemCurrentOs: the latter cannot answer the install
+      // question from a database row at all and leaves `isInstalled` false,
+      // which would make this dump actively misleading.
       final all = await loadEmulatorsForSystem(system);
       final userDefault =
           await EmulatorRepository.getUserDefaultEmulatorForSystem(system.id!);

--- a/lib/utils/emulator_loader.dart
+++ b/lib/utils/emulator_loader.dart
@@ -70,6 +70,15 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
       // genuinely-installed core.
       final retroArchPath =
           await EmulatorRepository.getRetroArchExecutablePath();
+
+      // Baseline: on desktop a configured executable path is the only evidence
+      // the database holds, so it stands in as the install verdict for anything
+      // the core probe below does not refine. Without this, emulators would be
+      // reported uninstalled whenever RetroArch itself is unconfigured.
+      emulators = emulators
+          .map((e) => e.copyWith(isInstalled: e.hasConfiguredPath))
+          .toList();
+
       if (retroArchPath != null && retroArchPath.isNotEmpty) {
         final coresDir =
             '${File(retroArchPath).parent.path}'
@@ -82,7 +91,7 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
               uid.contains('.ra.') ||
               uid.contains('.ra32.') ||
               uid.contains('.ra64.');
-          if (isRaCore && !e.isInstalled) {
+          if (isRaCore && !e.hasConfiguredPath) {
             var installed = true; // fail-open default
             if (coresDirReadable &&
                 e.coreFilename != null &&
@@ -91,7 +100,7 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
             }
             updated.add(e.copyWith(isInstalled: installed));
           } else {
-            updated.add(e);
+            updated.add(e); // keeps the baseline set above
           }
         }
         emulators = updated;

--- a/test/core_emulator_model_test.dart
+++ b/test/core_emulator_model_test.dart
@@ -50,4 +50,48 @@ void main() {
       },
     );
   });
+
+  group('CoreEmulatorModel install state', () {
+    test('a database row alone never claims the emulator is installed', () {
+      // The trap this guards: `getEmulatorsForSystemCurrentOs` used to alias a
+      // desktop-only "has a configured executable path" column as
+      // `is_installed`, so every Android emulator read as uninstalled while the
+      // field's name promised a real answer. A row cannot answer it — only
+      // `loadEmulatorsForSystem`, which probes packages and core files, can.
+      final row = CoreEmulatorModel.fromMap({
+        'unique_identifier': 'ds.ra64.melondsds',
+        'os_id': 2,
+        'system_id': 'ds',
+        'name': 'RetroArch64 MelonDSDS',
+        'is_standalone': 0,
+        'is_default': 1,
+        'is_ra_compatible': 1,
+        'has_configured_path': 1,
+      });
+
+      expect(row.isInstalled, isFalse);
+      expect(row.hasConfiguredPath, isTrue);
+    });
+
+    test('hasConfiguredPath is false when no path is configured', () {
+      final row = CoreEmulatorModel.fromMap({
+        'unique_identifier': 'ds.ra64.melondsds',
+        'os_id': 2,
+        'system_id': 'ds',
+        'name': 'RetroArch64 MelonDSDS',
+        'is_standalone': 0,
+        'is_default': 1,
+        'is_ra_compatible': 1,
+        'has_configured_path': 0,
+      });
+
+      expect(row.hasConfiguredPath, isFalse);
+    });
+
+    test('the two flags survive copyWith independently', () {
+      final verified = emu().copyWith(isInstalled: true);
+      expect(verified.isInstalled, isTrue);
+      expect(verified.hasConfiguredPath, isFalse);
+    });
+  });
 }

--- a/test/emulator_system_default_test.dart
+++ b/test/emulator_system_default_test.dart
@@ -1,0 +1,328 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+
+import 'database_test_helper.dart';
+
+/// Regression guard for the "system default emulator" invariant: at most ONE
+/// emulator per system may carry `user_emulator_config.is_user_default = 1`.
+///
+/// `getUserDefaultEmulatorForSystem` reads that flag with a `LIMIT 1`, so a
+/// second flagged row makes the resolved default non-deterministic — and in
+/// practice the *oldest* selection wins. That is what made a deliberately
+/// chosen standalone (melonDS) boot a RetroArch core, and a SNES system
+/// switched from Beetle to bsnes keep launching Beetle.
+void main() {
+  group('migration v105 collapses duplicate system defaults', () {
+    late Database db;
+
+    setUp(() {
+      db = sqlite3.openInMemory();
+      db.execute('''
+        CREATE TABLE app_emulators (
+          unique_identifier TEXT NOT NULL,
+          os_id INTEGER NOT NULL,
+          system_id TEXT NOT NULL,
+          name TEXT,
+          is_standalone INTEGER NOT NULL DEFAULT 0,
+          is_default INTEGER NOT NULL DEFAULT 0
+        )
+      ''');
+      db.execute('''
+        CREATE TABLE user_emulator_config (
+          emulator_unique_id TEXT PRIMARY KEY,
+          emulator_path TEXT,
+          is_user_default INTEGER,
+          updated_at TEXT
+        )
+      ''');
+      db.execute('''
+        INSERT INTO app_emulators
+          (unique_identifier, os_id, system_id, name, is_standalone, is_default)
+        VALUES
+          ('ds.ra.melonds', 2, 'ds', 'RetroArch MelonDS', 0, 1),
+          ('ds.standalone.melondual', 2, 'ds', 'melonDS Dual', 1, 0),
+          ('snes.ra.beetle', 2, 'snes', 'Beetle SNES', 0, 1),
+          ('snes.ra.bsnes', 2, 'snes', 'bsnes HD Beta', 0, 0)
+      ''');
+    });
+
+    tearDown(() => db.close());
+
+    List<String> defaultsFor(String systemId) {
+      final rows = db.select(
+        '''
+        SELECT uc.emulator_unique_id AS uid
+        FROM user_emulator_config uc
+        JOIN app_emulators e ON e.unique_identifier = uc.emulator_unique_id
+        WHERE uc.is_user_default = 1 AND e.system_id = ?
+        ''',
+        [systemId],
+      );
+      return rows.map((r) => r['uid'].toString()).toList();
+    }
+
+    Future<void> runV105() => SqliteMigrations.migrateToVersion(db, 105);
+
+    test(
+      'keeps the most recent pick when a core and a standalone conflict',
+      () async {
+        // The NDS report: a core was chosen first, then a standalone. Both rows
+        // stayed flagged because setDefaultCore never cleared its own marker.
+        db.execute('''
+        INSERT INTO user_emulator_config VALUES
+          ('ds.ra.melonds', '', 1, '2026-01-01T00:00:00.000'),
+          ('ds.standalone.melondual', '', 1, '2026-02-01T00:00:00.000')
+      ''');
+
+        await runV105();
+
+        expect(defaultsFor('ds'), ['ds.standalone.melondual']);
+      },
+    );
+
+    test('keeps the most recent pick when two cores conflict', () async {
+      // The SNES report: Beetle first, then bsnes HD Beta.
+      db.execute('''
+        INSERT INTO user_emulator_config VALUES
+          ('snes.ra.beetle', '', 1, '2026-01-01T00:00:00.000'),
+          ('snes.ra.bsnes', '', 1, '2026-03-01T00:00:00.000')
+      ''');
+
+      await runV105();
+
+      expect(defaultsFor('snes'), ['snes.ra.bsnes']);
+    });
+
+    test('collapses each system independently', () async {
+      db.execute('''
+        INSERT INTO user_emulator_config VALUES
+          ('ds.ra.melonds', '', 1, '2026-01-01T00:00:00.000'),
+          ('ds.standalone.melondual', '', 1, '2026-02-01T00:00:00.000'),
+          ('snes.ra.beetle', '', 1, '2026-01-01T00:00:00.000'),
+          ('snes.ra.bsnes', '', 1, '2026-03-01T00:00:00.000')
+      ''');
+
+      await runV105();
+
+      expect(defaultsFor('ds'), ['ds.standalone.melondual']);
+      expect(defaultsFor('snes'), ['snes.ra.bsnes']);
+    });
+
+    test('leaves a healthy single default untouched', () async {
+      db.execute('''
+        INSERT INTO user_emulator_config VALUES
+          ('ds.standalone.melondual', '', 1, '2026-02-01T00:00:00.000')
+      ''');
+
+      await runV105();
+
+      expect(defaultsFor('ds'), ['ds.standalone.melondual']);
+    });
+
+    test('leaves orphaned config rows alone', () async {
+      // No app_emulators row, so it belongs to no system and cannot be part of
+      // a per-system conflict. Clearing it would be collateral damage.
+      db.execute('''
+        INSERT INTO user_emulator_config VALUES
+          ('ra', '/usr/bin/retroarch', 1, '2026-01-01T00:00:00.000')
+      ''');
+
+      await runV105();
+
+      final row = db.select(
+        "SELECT is_user_default FROM user_emulator_config WHERE emulator_unique_id = 'ra'",
+      );
+      expect(row.first['is_user_default'], 1);
+    });
+  });
+
+  group('setters keep the system default single-valued', () {
+    final dbHelper = DatabaseTestHelper();
+    late dynamic db;
+    late int osId;
+
+    setUp(() async {
+      db = await dbHelper.setUp();
+      await db.execute(
+        "INSERT OR IGNORE INTO app_os (id, name) VALUES (1, 'windows'), (2, 'android'), (3, 'linux'), (4, 'macos')",
+      );
+      final osRow = await db.rawQuery('SELECT id FROM app_os WHERE name = ?', [
+        SqliteService.getCurrentOs(),
+      ]);
+      osId = int.parse(osRow.first['id'].toString());
+
+      await db.execute(
+        "INSERT INTO app_systems (id, real_name, folder_name) VALUES ('ds', 'Nintendo DS', 'ds')",
+      );
+      await db.execute(
+        'INSERT INTO app_emulators (system_id, os_id, name, unique_identifier, is_standalone, core_filename, is_default) VALUES '
+        "('ds', $osId, 'RetroArch MelonDS', 'ds.ra.melonds', 0, 'melonds_libretro.so', 1), "
+        "('ds', $osId, 'RetroArch DeSmuME', 'ds.ra.desmume', 0, 'desmume_libretro.so', 0), "
+        "('ds', $osId, 'melonDS Dual', 'ds.standalone.melondual', 1, NULL, 0)",
+      );
+    });
+
+    tearDown(() async {
+      await dbHelper.tearDown();
+    });
+
+    Future<List<String>> flaggedDefaults() async {
+      final rows = await db.rawQuery('''
+        SELECT uc.emulator_unique_id AS uid
+        FROM user_emulator_config uc
+        JOIN app_emulators e ON e.unique_identifier = uc.emulator_unique_id
+        WHERE uc.is_user_default = 1 AND e.system_id = 'ds'
+      ''');
+      return rows.map<String>((r) => r['uid'].toString()).toList();
+    }
+
+    test('core then standalone leaves only the standalone flagged', () async {
+      await SqliteService.setDefaultCore('ds', 'ds.ra.melonds', osId);
+      await SqliteService.setDefaultStandaloneEmulator(
+        'ds',
+        'ds.standalone.melondual',
+      );
+
+      expect(await flaggedDefaults(), ['ds.standalone.melondual']);
+
+      final resolved = await SqliteService.getUserDefaultEmulatorForSystem(
+        'ds',
+      );
+      expect(resolved?.uniqueId, 'ds.standalone.melondual');
+    });
+
+    test('standalone then core leaves only the core flagged', () async {
+      await SqliteService.setDefaultStandaloneEmulator(
+        'ds',
+        'ds.standalone.melondual',
+      );
+      await SqliteService.setDefaultCore('ds', 'ds.ra.melonds', osId);
+
+      expect(await flaggedDefaults(), ['ds.ra.melonds']);
+
+      final resolved = await SqliteService.getUserDefaultEmulatorForSystem(
+        'ds',
+      );
+      expect(resolved?.uniqueId, 'ds.ra.melonds');
+    });
+
+    test('core then a different core leaves only the newest flagged', () async {
+      await SqliteService.setDefaultCore('ds', 'ds.ra.melonds', osId);
+      await SqliteService.setDefaultCore('ds', 'ds.ra.desmume', osId);
+
+      expect(await flaggedDefaults(), ['ds.ra.desmume']);
+
+      final resolved = await SqliteService.getUserDefaultEmulatorForSystem(
+        'ds',
+      );
+      expect(resolved?.uniqueId, 'ds.ra.desmume');
+    });
+
+    test('choosing a standalone clears the core is_default flag', () async {
+      await SqliteService.setDefaultStandaloneEmulator(
+        'ds',
+        'ds.standalone.melondual',
+      );
+
+      final rows = await db.rawQuery(
+        "SELECT unique_identifier FROM app_emulators WHERE system_id = 'ds' AND is_default = 1",
+      );
+      expect(rows, isEmpty);
+    });
+
+    group('launch-time normalization', () {
+      Future<void> normalize() =>
+          SqliteService.normalizeEmulatorDefaultsForTesting(db);
+
+      Future<List<String>> appDefaults() async {
+        final rows = await db.rawQuery(
+          "SELECT unique_identifier AS uid FROM app_emulators WHERE system_id = 'ds' AND is_default = 1",
+        );
+        return rows.map<String>((r) => r['uid'].toString()).toList();
+      }
+
+      test('never invents a user default', () async {
+        // The normalizer used to write is_user_default itself, making a guess
+        // indistinguishable from a deliberate choice — and the choice is what
+        // wins outright at launch.
+        await db.execute(
+          "UPDATE app_emulators SET is_default = 0 WHERE system_id = 'ds'",
+        );
+
+        await normalize();
+
+        expect(await flaggedDefaults(), isEmpty);
+      });
+
+      test('preserves a user-selected standalone across launches', () async {
+        // Regression: the old PS1 branch cleared exactly this on every launch.
+        await SqliteService.setDefaultStandaloneEmulator(
+          'ds',
+          'ds.standalone.melondual',
+        );
+
+        await normalize();
+        await normalize();
+
+        expect(await flaggedDefaults(), ['ds.standalone.melondual']);
+        final resolved = await SqliteService.getUserDefaultEmulatorForSystem(
+          'ds',
+        );
+        expect(resolved?.uniqueId, 'ds.standalone.melondual');
+      });
+
+      test('drops an app default that contradicts the user choice', () async {
+        await db.execute(
+          "UPDATE app_emulators SET is_default = 1 WHERE unique_identifier = 'ds.ra.melonds'",
+        );
+        await db.execute(
+          "INSERT INTO user_emulator_config (emulator_unique_id, emulator_path, is_user_default) "
+          "VALUES ('ds.standalone.melondual', '', 1)",
+        );
+
+        await normalize();
+
+        expect(await appDefaults(), isEmpty);
+        expect(await flaggedDefaults(), ['ds.standalone.melondual']);
+      });
+
+      test('leaves an existing app default alone', () async {
+        await normalize();
+
+        expect(await appDefaults(), ['ds.ra.melonds']);
+      });
+
+      test('seeds an app default when the system has none', () async {
+        await db.execute(
+          "UPDATE app_emulators SET is_default = 0 WHERE system_id = 'ds'",
+        );
+
+        await normalize();
+
+        expect(await appDefaults(), hasLength(1));
+      });
+
+      test('does not touch other operating systems', () async {
+        final otherOs = osId == 2 ? 1 : 2;
+        await db.execute(
+          'INSERT INTO app_emulators (system_id, os_id, name, unique_identifier, is_standalone, is_default) '
+          "VALUES ('ds', $otherOs, 'Other OS core', 'ds.other.core', 0, 1)",
+        );
+        // A user choice on the current OS previously triggered a cross-OS wipe.
+        await SqliteService.setDefaultStandaloneEmulator(
+          'ds',
+          'ds.standalone.melondual',
+        );
+
+        await normalize();
+
+        final rows = await db.rawQuery(
+          "SELECT is_default FROM app_emulators WHERE unique_identifier = 'ds.other.core'",
+        );
+        expect(rows.first['is_default'], 1);
+      });
+    });
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code).

# Description

Two user reports that look unrelated turned out to share one root cause:

> **(NDS)** "If you select another standalone emulator like melonDS Dual it will launch a RetroArch core instead. The short fix is to select the emulator you want in the per-game settings."

> **(SNES)** "The emulator of the SNES system is *Beetle SNES*. If the emulator of the SNES system is changed to *bsnes HD Beta*, the emulator of *Live A Live* is still designated *Beetle SNES*."

**The "system default emulator" was not single-valued, and the read that resolved it was non-deterministic.** Every selection wrote `is_user_default = 1` and nothing ever cleared the previous one, so `... WHERE is_user_default = 1 LIMIT 1` with no `ORDER BY` returned whichever row SQLite scanned first — in practice the *oldest* pick. Setting the emulator per-game appeared to fix it only because that path reads `game.emulatorName` directly and never consults the broken function; that is the workaround both reporters found.

The SNES report reads as per-game staleness, but the stale state is on the *system*, not the game.

### What changed

1. **Single-valued system default.** Both setters route through one helper (`_applySystemDefaultEmulator`) that clears `is_default` across the system+OS *and* `is_user_default` across the system, then sets the chosen one. The `is_user_default` clear is system-wide rather than system+OS on purpose: `user_emulator_config` is keyed on `emulator_unique_id` alone with no `os_id`, so one row is shared across operating systems and anything narrower cannot hold the invariant.
2. **Migration v105** repairs installs already in the broken state — keep the most recently updated `is_user_default`, zero the rest. Affected users have this persisted on disk, so a code-only fix would never reach them.
3. **Ordered read** (`ORDER BY uc.updated_at DESC`) as a guard if a future path reintroduces duplicates.
4. **The launch fall-through no longer discards the user's choice.** When routing could not build a launch command, control fell through to `_getStandaloneEmulatorForSystem` and `_getCoreForSystem`, *neither of which took the resolved emulator* — both re-derived from scratch and the last in the chain landed on a RetroArch core. Both now accept the preferred `unique_id`, and when the choice was explicit and the last-resort core is not the chosen one, the launch **fails naming the emulator** instead of silently substituting.
5. **`_fixEmulatorDefaults` rewritten.** It ran at every startup and (a) wrote `is_user_default` itself, turning a guess into something indistinguishable from a deliberate choice, (b) cleared real user-selected standalones on PS1 — anyone who picked DuckStation was reverted on every launch, forever, and (c) had no `os_id` filter, wiping other platforms' defaults in a synced database.
6. **`[EmuSel]` diagnostics**, always on: startup anomaly scan, the resolution decision with its source, the per-system emulator dump, and every selection write. These are state bugs — a trace that only reports the winner cannot tell them apart.

### Adjacent fixes found while verifying this

Both were found *by* the work above and are small, so they are included here rather than split out.

- **A NULL `core_filename` became the string `"null"`.** `.toString()` on the raw column laundered SQL NULL into `"null"`, which passes every null check downstream and reaches RetroArch as `LIBRETRO="null"` — a blank screen with nothing in the log. Reachable whenever an emulator supplying no core of its own becomes the system default. This was caught by the guard in (4), which is how it surfaced at all.
- **`isInstalled` meant three different things.** One field was written by three enumerators: "a desktop exe path is configured" (always false on Android — the diagnostics above hit this immediately), "the Android package exists" (core unverified; unconditionally true on desktop), and the real probe. `isInstalled` now means only the verified answer; the desktop-only signal became `hasConfiguredPath`, and a model built from a database row leaves `isInstalled` false because a row cannot answer the question. `getCoresBySystemId` keeps its cheaper package-level check and is documented as such — verifying cores there would change the settings dialog's "Ready" state, which is #192 territory and deliberately out of scope here.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

### Testing

`flutter analyze` clean, 362 tests pass — 15 in `test/emulator_system_default_test.dart` (migration, both setter orderings, the normalizer's three defects) and 3 in `test/core_emulator_model_test.dart` pinning the install-state split.

Device testing on an AYN Thor (Android 13), dev flavor:

| test | result |
| --- | --- |
| system: core → standalone | pass — resolved the standalone, `performLaunchActivity me.magnum.melonds` |
| system: core → core | pass — resolved the second |
| system: core → standalone → standalone | pass — took the most recent; on-disk check showed exactly one `is_user_default = 1` with the superseded picks cleared |
| per-game override beats system default | pass |
| duplicate-default repair (injected) | pass — anomaly scan flagged it, ordered read returned the newest pick |
| refuse-to-substitute guard | pass — `Refusing to substitute …`, no emulator launched |
| install detection after the `isInstalled` split | pass — dump unchanged vs the pre-refactor baseline |

The refuse-to-substitute guard needed a purpose-built config fixture to reach, because a stale `unique_id` cannot survive to a launch — the systems seeder prunes it at startup. That fixture was a temporary local edit and is not part of this PR.

## Screenshots (if applicable)

n/a — no visual change.
