### PR TITLE
Add SFX feedback to game action buttons

### DIFF
--- a/lib/services/esde_import_service.dart
+++ b/lib/services/esde_import_service.dart
@@ -136,10 +136,8 @@ class EsdeImportService {
         // within the system too rather than freezing the bar on its name.
         onGameProgress: onProgress == null
             ? null
-            : (fraction) => onProgress(
-                (i + fraction) / systemDirs.length,
-                esdeDirName,
-              ),
+            : (fraction) =>
+                  onProgress((i + fraction) / systemDirs.length, esdeDirName),
       );
 
       // Only wire up the read-time media fallback for systems that actually
@@ -211,7 +209,11 @@ class EsdeImportService {
       );
       if (system == null) continue;
 
-      await _recordEsdeMediaDir(esdeRoot, esdeDirName, system['app_system_id']!);
+      await _recordEsdeMediaDir(
+        esdeRoot,
+        esdeDirName,
+        system['app_system_id']!,
+      );
       _log.i(
         'ES-DE import: linked art-only system "$esdeDirName" '
         '(no gamelist.xml) to ${system['app_system_id']}',

--- a/lib/widgets/game_action_button.dart
+++ b/lib/widgets/game_action_button.dart
@@ -1,7 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
+import '../services/sfx_service.dart';
 import '../themes/corner_radii.dart';
+
+/// Sound effect played when a [GameActionButton] is tapped.
+enum GameActionButtonSound {
+  /// Confirm / primary action (A button, play, scrape).
+  enter,
+
+  /// Back / cancel action (B button).
+  back,
+
+  /// Generic navigation action (X, Y, Menu, View, random).
+  nav,
+}
 
 /// A tall vertical action button used in the game list / grid / carousel.
 ///
@@ -16,6 +29,10 @@ class GameActionButton extends StatelessWidget {
   final VoidCallback? onTap;
   final bool isLoading;
 
+  /// Optional SFX to play when the button is tapped. Disabled buttons and
+  /// buttons with no callback never play a sound.
+  final GameActionButtonSound? sound;
+
   const GameActionButton({
     super.key,
     this.buttonKey,
@@ -25,6 +42,7 @@ class GameActionButton extends StatelessWidget {
     this.foregroundColor,
     this.onTap,
     this.isLoading = false,
+    this.sound,
   });
 
   @override
@@ -48,14 +66,14 @@ class GameActionButton extends StatelessWidget {
         hoverColor: Colors.transparent,
         highlightColor: Colors.transparent,
         key: buttonKey,
-        onTap: isLoading ? null : onTap,
+        onTap: isLoading || onTap == null ? null : _onTap,
         borderRadius: cornerRadius,
         child: Container(
           margin: EdgeInsets.only(bottom: 2.r),
           width: buttonWidth.r,
           height: buttonHeight.r,
           decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.primary,
+            color: color,
             borderRadius: cornerRadius,
             border: Border.all(
               color: color,
@@ -79,7 +97,7 @@ class GameActionButton extends StatelessWidget {
                     height: 16.r,
                     child: CircularProgressIndicator(
                       strokeWidth: 2.r,
-                      color: Theme.of(context).colorScheme.onPrimary,
+                      color: foregroundColor,
                     ),
                   ),
                 )
@@ -92,14 +110,14 @@ class GameActionButton extends StatelessWidget {
                       height: badgeHeight.r,
                       width: double.infinity,
                       decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surface,
+                        color: color,
                         borderRadius: badgeRadius,
                       ),
                       child: Center(
                         child: Icon(
                           symbol,
                           size: mainIconSize.r,
-                          color: Theme.of(context).colorScheme.onSurface,
+                          color: foregroundColor,
                         ),
                       ),
                     ),
@@ -110,7 +128,7 @@ class GameActionButton extends StatelessWidget {
                           iconPath,
                           width: 14.r,
                           height: 14.r,
-                          color: Theme.of(context).colorScheme.onPrimary,
+                          color: foregroundColor,
                           colorBlendMode: BlendMode.srcIn,
                         ),
                       ),
@@ -120,5 +138,19 @@ class GameActionButton extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  void _onTap() {
+    switch (sound) {
+      case GameActionButtonSound.enter:
+        SfxService().playEnterSound();
+      case GameActionButtonSound.back:
+        SfxService().playBackSound();
+      case GameActionButtonSound.nav:
+        SfxService().playNavSound();
+      case null:
+        break;
+    }
+    onTap?.call();
   }
 }

--- a/lib/widgets/game_action_buttons.dart
+++ b/lib/widgets/game_action_buttons.dart
@@ -101,8 +101,9 @@ class GameActionButtons extends StatelessWidget {
     return GameActionButton(
       iconPath: 'assets/images/gamepad/Xbox_View_button.png',
       symbol: active ? Symbols.close_rounded : Symbols.more_horiz_rounded,
-      color: active ? scheme.secondary : scheme.primary,
-      foregroundColor: active ? scheme.onSecondary : scheme.onPrimary,
+      color: active ? scheme.primary : scheme.tertiaryFixed,
+      foregroundColor: active ? scheme.onPrimary : scheme.onTertiaryFixed,
+      sound: GameActionButtonSound.nav,
       onTap: () => GamepadNavigation.selectHeldNotifier.value = !active,
     );
   }
@@ -126,24 +127,27 @@ class GameActionButtons extends StatelessWidget {
       GameActionButton(
         iconPath: 'assets/images/gamepad/Xbox_B_button.png',
         symbol: Symbols.arrow_back_rounded,
-        color: scheme.primary,
-        foregroundColor: scheme.onPrimary,
+        color: scheme.tertiaryFixed,
+        foregroundColor: scheme.onTertiaryFixed,
+        sound: GameActionButtonSound.back,
         onTap: onBack,
       ),
       SizedBox(height: 6.r),
       GameActionButton(
         iconPath: 'assets/images/gamepad/Xbox_Y_button.png',
         symbol: Symbols.favorite_rounded,
-        color: scheme.primary,
-        foregroundColor: scheme.onPrimary,
+        color: scheme.tertiaryFixed,
+        foregroundColor: scheme.onTertiaryFixed,
+        sound: GameActionButtonSound.nav,
         onTap: selectedGame != null ? onFavorite : null,
       ),
       SizedBox(height: 6.r),
       GameActionButton(
         iconPath: 'assets/images/gamepad/Xbox_X_button.png',
         symbol: Symbols.grid_view_rounded,
-        color: scheme.primary,
-        foregroundColor: scheme.onPrimary,
+        color: scheme.tertiaryFixed,
+        foregroundColor: scheme.onTertiaryFixed,
+        sound: GameActionButtonSound.nav,
         onTap: onViewMode,
       ),
       SizedBox(height: 6.r),
@@ -151,8 +155,9 @@ class GameActionButtons extends StatelessWidget {
       GameActionButton(
         iconPath: 'assets/images/gamepad/Xbox_Menu_button.png',
         symbol: Symbols.settings_rounded,
-        color: scheme.primary,
-        foregroundColor: scheme.onPrimary,
+        color: scheme.tertiaryFixed,
+        foregroundColor: scheme.onTertiaryFixed,
+        sound: GameActionButtonSound.nav,
         onTap: selectedGame != null ? onSettings : null,
       ),
       // Compact NeoSync status indicator — always the last option.
@@ -180,8 +185,9 @@ class GameActionButtons extends StatelessWidget {
       GameActionButton(
         iconPath: 'assets/images/gamepad/Xbox_A_button.png',
         symbol: Symbols.cloud_download_rounded,
-        color: scheme.secondary,
-        foregroundColor: scheme.onSecondary,
+        color: scheme.tertiaryFixed,
+        foregroundColor: scheme.onTertiaryFixed,
+        sound: GameActionButtonSound.enter,
         onTap: selectedGame != null ? _withRevert(onScrape) : null,
       ),
       SizedBox(height: 6.r),
@@ -189,8 +195,9 @@ class GameActionButtons extends StatelessWidget {
       GameActionButton(
         iconPath: 'assets/images/gamepad/Xbox_Y_button.png',
         symbol: Symbols.casino_rounded,
-        color: scheme.secondary,
-        foregroundColor: scheme.onSecondary,
+        color: scheme.tertiaryFixed,
+        foregroundColor: scheme.onTertiaryFixed,
+        sound: GameActionButtonSound.nav,
         onTap: _withRevert(onRandom),
       ),
     ];

--- a/test/esde_import_service_test.dart
+++ b/test/esde_import_service_test.dart
@@ -327,7 +327,9 @@ void main() {
         await db.execute(
           "INSERT INTO app_systems (id, real_name, folder_name, screenscraper_id) VALUES ('nes', 'NES', 'nes', 3)",
         );
-        Directory('${tempRoot.path}/gamelists/snes').createSync(recursive: true);
+        Directory(
+          '${tempRoot.path}/gamelists/snes',
+        ).createSync(recursive: true);
         File(
           '${tempRoot.path}/gamelists/snes/gamelist.xml',
         ).writeAsStringSync('<gameList></gameList>');
@@ -340,10 +342,7 @@ void main() {
         final rows = await db.rawQuery(
           "SELECT app_system_id, esde_media_dir FROM user_system_settings WHERE esde_media_dir IS NOT NULL ORDER BY app_system_id",
         );
-        expect(rows.map((r) => r['app_system_id']).toList(), [
-          'nes',
-          'snes',
-        ]);
+        expect(rows.map((r) => r['app_system_id']).toList(), ['nes', 'snes']);
         expect(rows.first['esde_media_dir'], 'nes');
       },
     );

--- a/test/file_provider_test.dart
+++ b/test/file_provider_test.dart
@@ -71,24 +71,27 @@ void main() {
       ]);
     });
 
-    test('falls back to the category root after the recorded subfolder', () async {
-      await db.execute(
-        "INSERT INTO user_screenscraper_metadata (app_system_id, filename, esde_media_subdir) VALUES ('snes', 'sonic.smc', 'Hacks')",
-      );
-      await provider.refreshEsde();
+    test(
+      'falls back to the category root after the recorded subfolder',
+      () async {
+        await db.execute(
+          "INSERT INTO user_screenscraper_metadata (app_system_id, filename, esde_media_subdir) VALUES ('snes', 'sonic.smc', 'Hacks')",
+        );
+        await provider.refreshEsde();
 
-      final candidates = provider.getEsdeMediaCandidates(
-        'snes',
-        'wheels',
-        'sonic.smc',
-      );
-      expect(candidates, [
-        '/esde/downloaded_media/snes/marquees/Hacks/sonic.png',
-        '/esde/downloaded_media/snes/marquees/Hacks/sonic.jpg',
-        '/esde/downloaded_media/snes/marquees/sonic.png',
-        '/esde/downloaded_media/snes/marquees/sonic.jpg',
-      ]);
-    });
+        final candidates = provider.getEsdeMediaCandidates(
+          'snes',
+          'wheels',
+          'sonic.smc',
+        );
+        expect(candidates, [
+          '/esde/downloaded_media/snes/marquees/Hacks/sonic.png',
+          '/esde/downloaded_media/snes/marquees/Hacks/sonic.jpg',
+          '/esde/downloaded_media/snes/marquees/sonic.png',
+          '/esde/downloaded_media/snes/marquees/sonic.jpg',
+        ]);
+      },
+    );
 
     test('returns nothing for a system with no recorded ES-DE media dir', () {
       expect(


### PR DESCRIPTION
## Summary
Adds sound-effect feedback to the on-screen game action buttons so touchscreen users get the same audio response as gamepad/keyboard navigation.

## Changes
- Introduces  enum (, , ) in .
- Adds an optional  parameter to ; disabled or callback-less buttons remain silent.
- Maps each action in  to its matching SFX:
  - Back → back
  - Scrape (A) → enter
  - Favorite, view-mode, settings, View toggle, random → nav
- Formats touched files with .

## Notes
-  passes on the modified widget files.