### PR TITLE
fix(emulator): stop launches being addressed to a RetroArch variant that is not installed

### DIFF
--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -4539,29 +4539,31 @@ class SqliteService {
         .toList();
   }
 
+  /// The systems the user has explicitly chosen an emulator for.
+  ///
+  /// Used to exclude those systems from automatic default management. Both
+  /// RetroArch alignment routines below previously answered "has the user
+  /// chosen anything, anywhere?" with a global `COUNT(*)` and skipped
+  /// wholesale if so. That made one deliberate pick on one system freeze
+  /// variant alignment for *every* system: a user on a non-aarch64 build hits a
+  /// launch failure, sets an emulator by hand to work around it, and thereby
+  /// disables the very repair that would have fixed the rest of their library.
+  /// Scoping the guard per system respects the same intent without the
+  /// collateral damage.
+  static const String _systemsWithUserDefaultSql =
+      'SELECT e.system_id FROM user_emulator_config uc '
+      'JOIN app_emulators e ON e.unique_identifier = uc.emulator_unique_id '
+      'WHERE uc.is_user_default = 1 AND e.system_id IS NOT NULL';
+
   /// Updates [is_default] so that [preferredPackage] is the active RetroArch
-  /// variant on Android. Skips entirely if the user has made any custom
-  /// emulator selections (tracked in [user_emulator_config]). Sets only the
-  /// entries marked as [is_default_core] for the preferred package, and
-  /// clears conflicting standalone defaults.
+  /// variant on Android. Systems the user has explicitly configured are left
+  /// untouched (see [_systemsWithUserDefaultSql]). Sets only the entries marked
+  /// as [is_default_core] for the preferred package, and clears conflicting
+  /// standalone defaults.
   static Future<void> fixRetroArchDefaultForAndroid(
     String preferredPackage,
   ) async {
     final db = await instance.database;
-
-    // If user has made any emulator selections, respect them and skip
-    final userChoices = await db.rawQuery(
-      'SELECT COUNT(*) as count FROM user_emulator_config WHERE is_user_default = 1',
-    );
-    final userChoiceCount = userChoices.isNotEmpty
-        ? (int.tryParse(userChoices.first['count']?.toString() ?? '0') ?? 0)
-        : 0;
-    if (userChoiceCount > 0) {
-      _log.i(
-        'Android: User has custom emulator choices ($userChoiceCount), skipping RA defaults',
-      );
-      return;
-    }
 
     final osResult = await db.query(
       'app_os',
@@ -4575,14 +4577,16 @@ class SqliteService {
       // Clear all RetroArch core defaults
       await txn.rawUpdate(
         'UPDATE app_emulators SET is_default = 0 '
-        'WHERE os_id = ? AND android_package_name LIKE ?',
+        'WHERE os_id = ? AND android_package_name LIKE ? '
+        'AND system_id NOT IN ($_systemsWithUserDefaultSql)',
         [osId, 'com.retroarch%'],
       );
 
       // Set default only for entries with default_core marker
       await txn.rawUpdate(
         'UPDATE app_emulators SET is_default = 1 '
-        'WHERE os_id = ? AND android_package_name = ? AND is_default_core = 1',
+        'WHERE os_id = ? AND android_package_name = ? AND is_default_core = 1 '
+        'AND system_id NOT IN ($_systemsWithUserDefaultSql)',
         [osId, preferredPackage],
       );
 
@@ -4592,7 +4596,7 @@ class SqliteService {
         'WHERE os_id = ? AND is_standalone = 1 AND system_id IN ('
         'SELECT DISTINCT system_id FROM app_emulators '
         'WHERE os_id = ? AND android_package_name = ? AND is_default_core = 1 AND is_default = 1'
-        ')',
+        ') AND system_id NOT IN ($_systemsWithUserDefaultSql)',
         [osId, osId, preferredPackage],
       );
     });
@@ -4608,25 +4612,11 @@ class SqliteService {
   }
 
   /// Clears all RetroArch core defaults on Android when no RetroArch variant
-  /// is installed. Skips entirely if the user has made custom selections.
-  /// For systems that lose their default, falls back to the first available
-  /// standalone emulator.
+  /// is installed. Systems the user has explicitly configured are left
+  /// untouched (see [_systemsWithUserDefaultSql]). For systems that lose their
+  /// default, falls back to the first available standalone emulator.
   static Future<void> clearRetroArchDefaultsForAndroid() async {
     final db = await instance.database;
-
-    // If user has made any emulator selections, respect them and skip
-    final userChoices = await db.rawQuery(
-      'SELECT COUNT(*) as count FROM user_emulator_config WHERE is_user_default = 1',
-    );
-    final userChoiceCount = userChoices.isNotEmpty
-        ? (int.tryParse(userChoices.first['count']?.toString() ?? '0') ?? 0)
-        : 0;
-    if (userChoiceCount > 0) {
-      _log.i(
-        'Android: User has custom emulator choices ($userChoiceCount), skipping RA default clear',
-      );
-      return;
-    }
 
     final osResult = await db.query(
       'app_os',
@@ -4640,7 +4630,8 @@ class SqliteService {
       // Reset all RetroArch core defaults
       await txn.rawUpdate(
         'UPDATE app_emulators SET is_default = 0 '
-        'WHERE os_id = ? AND android_package_name LIKE ?',
+        'WHERE os_id = ? AND android_package_name LIKE ? '
+        'AND system_id NOT IN ($_systemsWithUserDefaultSql)',
         [osId, 'com.retroarch%'],
       );
 
@@ -4654,7 +4645,7 @@ class SqliteService {
         ') AND NOT EXISTS ('
         'SELECT 1 FROM app_emulators e2 '
         'WHERE e2.system_id = app_emulators.system_id AND e2.os_id = ? AND e2.is_default = 1'
-        ')',
+        ') AND system_id NOT IN ($_systemsWithUserDefaultSql)',
         [osId, osId, 'com.retroarch%', osId],
       );
     });

--- a/lib/models/core_emulator_model.dart
+++ b/lib/models/core_emulator_model.dart
@@ -59,6 +59,18 @@ class CoreEmulatorModel {
   /// Package prefix shared by every RetroArch variant.
   static const String retroArchPackagePrefix = 'com.retroarch';
 
+  /// Every RetroArch variant, best first.
+  ///
+  /// "Best" means most capable on the widest range of current devices, so an
+  /// arm64 build outranks the legacy universal one, which outranks the 32-bit
+  /// build. Callers that must choose between several *installed* variants
+  /// should follow this order rather than whatever order the database returns.
+  static const List<String> retroArchPackagePriority = [
+    'com.retroarch.aarch64',
+    'com.retroarch',
+    'com.retroarch.ra32',
+  ];
+
   const CoreEmulatorModel({
     required this.uniqueId,
     required this.osId,

--- a/lib/repositories/emulator_repository.dart
+++ b/lib/repositories/emulator_repository.dart
@@ -1,6 +1,7 @@
 import '../models/core_emulator_model.dart';
 import '../models/emulator_model.dart';
 import '../data/datasources/sqlite_service.dart';
+import '../services/android_service.dart';
 
 /// Repository for emulator configuration data access.
 class EmulatorRepository {
@@ -84,8 +85,47 @@ class EmulatorRepository {
     String systemId,
   ) => SqliteService.getUserDefaultEmulatorForSystem(systemId);
 
+  /// Every RetroArch package the database knows about, installed or not.
+  ///
+  /// Prefer [getInstalledAndroidRetroArchPackages] anywhere the result is used
+  /// to actually launch something: this list is seeded data, and picking from
+  /// it directly is how an intent ends up addressed to a variant the user does
+  /// not have.
   static Future<List<String>> getAndroidRetroArchPackages() =>
       SqliteService.getAndroidRetroArchPackages();
+
+  /// The RetroArch variants that are genuinely installed, best first.
+  ///
+  /// Ordered by [CoreEmulatorModel.retroArchPackagePriority] rather than by
+  /// database order, so `.first` is always a safe thing to launch. Returns an
+  /// empty list when no variant is installed — which is a real answer, not a
+  /// reason to guess.
+  static Future<List<String>> getInstalledAndroidRetroArchPackages() async {
+    final known = (await SqliteService.getAndroidRetroArchPackages()).toSet();
+    final installed = <String>[];
+    for (final pkg in CoreEmulatorModel.retroArchPackagePriority) {
+      if (known.contains(pkg) && await AndroidService.isPackageInstalled(pkg)) {
+        installed.add(pkg);
+      }
+    }
+    // Any variant the priority list does not name yet (a future package) still
+    // counts if it is installed; it just sorts after the known ones.
+    for (final pkg in known) {
+      if (!CoreEmulatorModel.retroArchPackagePriority.contains(pkg) &&
+          await AndroidService.isPackageInstalled(pkg)) {
+        installed.add(pkg);
+      }
+    }
+    return installed;
+  }
+
+  /// Whether [packageName] is an installed RetroArch variant.
+  static Future<bool> isRetroArchVariantInstalled(String packageName) async {
+    if (!packageName.startsWith(CoreEmulatorModel.retroArchPackagePrefix)) {
+      return false;
+    }
+    return AndroidService.isPackageInstalled(packageName);
+  }
 
   static Future<void> fixRetroArchDefaultForAndroid(String preferredPackage) =>
       SqliteService.fixRetroArchDefaultForAndroid(preferredPackage);

--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -16,7 +16,6 @@ import 'neo_sync_screen/login_screen/neo_sync_content.dart';
 import 'neo_sync_screen/neo_sync_tab.dart';
 import '../widgets/scraper_content.dart';
 import 'package:neostation/services/game_service.dart';
-import 'package:neostation/services/android_service.dart';
 import 'package:neostation/providers/theme_provider.dart';
 import 'package:neostation/repositories/emulator_repository.dart';
 import 'dart:async';
@@ -213,32 +212,14 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
     if (!Platform.isAndroid) return;
 
     try {
-      final packages = await EmulatorRepository.getAndroidRetroArchPackages();
-      if (packages.isEmpty) {
-        await EmulatorRepository.clearRetroArchDefaultsForAndroid();
-        _log.i('Android: No RetroArch found, cleared RetroArch defaults');
-        return;
-      }
+      // Already filtered to installed variants and ordered best-first, so the
+      // first entry is the one to promote. Only promote a variant that is
+      // actually installed: falling back to an uninstalled package would
+      // silently replace working standalone defaults with a broken core one.
+      final installed =
+          await EmulatorRepository.getInstalledAndroidRetroArchPackages();
 
-      const priorityOrder = [
-        'com.retroarch.aarch64',
-        'com.retroarch',
-        'com.retroarch.ra32',
-      ];
-
-      String? chosenPackage;
-      for (final pkg in priorityOrder) {
-        if (packages.contains(pkg) &&
-            await AndroidService.isPackageInstalled(pkg)) {
-          chosenPackage = pkg;
-          break;
-        }
-      }
-
-      // Only promote a RetroArch variant to default if it is actually
-      // installed. Falling back to an uninstalled package would silently
-      // replace working standalone defaults with a broken core default.
-      if (chosenPackage == null) {
+      if (installed.isEmpty) {
         await EmulatorRepository.clearRetroArchDefaultsForAndroid();
         _log.i(
           'Android: No RetroArch variant installed; cleared RA defaults so standalone defaults remain active',
@@ -246,6 +227,7 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
         return;
       }
 
+      final chosenPackage = installed.first;
       await EmulatorRepository.fixRetroArchDefaultForAndroid(chosenPackage);
       _log.i('Android: Set RetroArch default package to $chosenPackage');
     } catch (e) {

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -364,20 +364,35 @@ class GameLaunchService {
     String coreName,
   ) async {
     try {
-      final packages = await EmulatorRepository.getAndroidRetroArchPackages();
+      // Installed variants only. The database lists every RetroArch package
+      // that exists (com.retroarch, .ra32, .aarch64), so taking `.first` of the
+      // raw list addressed the intent to whichever one the seed happened to
+      // return — routinely one the user does not have, which fails with no
+      // explanation the user can act on.
+      final packages =
+          await EmulatorRepository.getInstalledAndroidRetroArchPackages();
 
       if (packages.isNotEmpty) {
         try {
           final defaultEmu =
               await EmulatorRepository.getDefaultEmulatorForSystem(system.id!);
-          if (defaultEmu != null &&
-              defaultEmu.androidPackageName != null &&
-              defaultEmu.androidPackageName!.isNotEmpty) {
-            final specificPackage = defaultEmu.androidPackageName!;
-            _log.i(
-              'Android: User selected specific RetroArch package: $specificPackage',
-            );
-            packages.insert(0, specificPackage);
+          final specificPackage = defaultEmu?.androidPackageName;
+          if (specificPackage != null && specificPackage.isNotEmpty) {
+            // Promote the configured variant only if it is really present.
+            // `is_default` is stale whenever variant alignment has been skipped,
+            // and an absent package must never outrank an installed one.
+            if (packages.contains(specificPackage)) {
+              _log.i(
+                'Android: Using configured RetroArch package: $specificPackage',
+              );
+              packages.remove(specificPackage);
+              packages.insert(0, specificPackage);
+            } else {
+              _log.w(
+                'Android: Configured RetroArch package "$specificPackage" is '
+                'not installed; falling back to ${packages.first}',
+              );
+            }
           }
         } catch (e) {
           _log.e('Error getting default emulator package: $e');
@@ -1187,7 +1202,19 @@ class GameLaunchService {
         system.id!,
       );
       if (defaultEmu != null && defaultEmu.isRetroArch) {
-        resolved = defaultEmu.androidPackageName!;
+        final candidate = defaultEmu.androidPackageName!;
+        // Substitute only a variant that is actually installed. `is_default`
+        // records which variant was *configured*, not which one exists, and
+        // trusting it blindly is how a launch gets addressed to a RetroArch
+        // build the user never had.
+        if (await EmulatorRepository.isRetroArchVariantInstalled(candidate)) {
+          resolved = candidate;
+        } else {
+          _log.w(
+            'Android: Configured RetroArch variant "$candidate" is not '
+            'installed; keeping "$package"',
+          );
+        }
       }
     } catch (e) {
       _log.e('Error resolving RetroArch package variant: $e');

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -141,6 +141,7 @@ class DatabaseTestHelper {
         android_package_name TEXT,
         android_activity_name TEXT,
         is_default INTEGER,
+        is_default_core INTEGER,
         is_ra_compatible INTEGER
       )
     ''');

--- a/test/retroarch_variant_alignment_test.dart
+++ b/test/retroarch_variant_alignment_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+
+import 'database_test_helper.dart';
+
+/// Regression guard for RetroArch variant alignment on Android.
+///
+/// `app_emulators.is_default` decides which RetroArch package receives the
+/// launch intent, and these two routines are the only thing keeping it pointed
+/// at the variant the user actually installed. They used to skip wholesale
+/// whenever *any* `is_user_default` row existed anywhere, so one deliberate
+/// pick on one system froze alignment for the entire library — and the natural
+/// workaround for a failing launch (choosing an emulator by hand) was itself
+/// what made the breakage permanent.
+void main() {
+  late DatabaseTestHelper helper;
+  late DatabaseAdapter db;
+
+  const androidOsId = 2;
+
+  setUp(() async {
+    helper = DatabaseTestHelper();
+    db = await helper.setUp();
+    await db.execute(
+      "INSERT INTO app_os (id, name) VALUES ($androidOsId, 'android')",
+    );
+
+    // Two systems, each offered by both RetroArch variants plus a standalone.
+    await db.execute('''
+      INSERT INTO app_emulators
+        (system_id, os_id, name, unique_identifier, is_standalone,
+         android_package_name, is_default, is_default_core)
+      VALUES
+        ('snes', $androidOsId, 'RA64 bsnes', 'snes.ra64.bsnes', 0, 'com.retroarch.aarch64', 0, 1),
+        ('snes', $androidOsId, 'RA32 bsnes', 'snes.ra32.bsnes', 0, 'com.retroarch.ra32',    1, 1),
+        ('snes', $androidOsId, 'Snes9x EX', 'snes.standalone.snes9x', 1, 'com.explusalpha.Snes9xPlus', 0, 0),
+        ('nes',  $androidOsId, 'RA64 mesen', 'nes.ra64.mesen', 0, 'com.retroarch.aarch64', 0, 1),
+        ('nes',  $androidOsId, 'RA32 mesen', 'nes.ra32.mesen', 0, 'com.retroarch.ra32',    1, 1),
+        ('nes',  $androidOsId, 'Nesoid',    'nes.standalone.nesoid', 1, 'com.androidemu.nes', 0, 0)
+    ''');
+  });
+
+  tearDown(() async => helper.tearDown());
+
+  Future<List<String>> defaultsFor(String systemId) async {
+    final rows = await db.rawQuery(
+      'SELECT unique_identifier FROM app_emulators '
+      'WHERE system_id = ? AND is_default = 1 ORDER BY unique_identifier',
+      [systemId],
+    );
+    return rows.map((r) => r['unique_identifier'].toString()).toList();
+  }
+
+  Future<void> setUserDefault(String uid) => db.rawInsert(
+    'INSERT INTO user_emulator_config (emulator_unique_id, emulator_path, is_user_default) '
+    'VALUES (?, ?, 1)',
+    [uid, ''],
+  );
+
+  group('fixRetroArchDefaultForAndroid', () {
+    test('points systems at the installed variant', () async {
+      await SqliteService.fixRetroArchDefaultForAndroid(
+        'com.retroarch.aarch64',
+      );
+
+      expect(await defaultsFor('snes'), ['snes.ra64.bsnes']);
+      expect(await defaultsFor('nes'), ['nes.ra64.mesen']);
+    });
+
+    test('leaves a system the user configured alone', () async {
+      await setUserDefault('snes.standalone.snes9x');
+
+      await SqliteService.fixRetroArchDefaultForAndroid(
+        'com.retroarch.aarch64',
+      );
+
+      // Untouched: the user's choice governs this system.
+      expect(await defaultsFor('snes'), ['snes.ra32.bsnes']);
+    });
+
+    test(
+      'still repairs every other system when one is user-configured',
+      () async {
+        // The regression: this single row used to abort alignment globally,
+        // leaving 'nes' pointed at a variant that may not be installed.
+        await setUserDefault('snes.standalone.snes9x');
+
+        await SqliteService.fixRetroArchDefaultForAndroid(
+          'com.retroarch.aarch64',
+        );
+
+        expect(await defaultsFor('nes'), ['nes.ra64.mesen']);
+      },
+    );
+
+    test(
+      'clears a standalone default that a core default supersedes',
+      () async {
+        await db.rawUpdate(
+          "UPDATE app_emulators SET is_default = 1 "
+          "WHERE unique_identifier = 'nes.standalone.nesoid'",
+        );
+
+        await SqliteService.fixRetroArchDefaultForAndroid(
+          'com.retroarch.aarch64',
+        );
+
+        expect(await defaultsFor('nes'), ['nes.ra64.mesen']);
+      },
+    );
+  });
+
+  group('clearRetroArchDefaultsForAndroid', () {
+    test('falls back to standalone when no RetroArch is installed', () async {
+      await SqliteService.clearRetroArchDefaultsForAndroid();
+
+      expect(await defaultsFor('snes'), ['snes.standalone.snes9x']);
+      expect(await defaultsFor('nes'), ['nes.standalone.nesoid']);
+    });
+
+    test('leaves a user-configured system alone but clears the rest', () async {
+      await setUserDefault('snes.ra32.bsnes');
+
+      await SqliteService.clearRetroArchDefaultsForAndroid();
+
+      // snes keeps the user's RetroArch pick; nes still gets repaired.
+      expect(await defaultsFor('snes'), ['snes.ra32.bsnes']);
+      expect(await defaultsFor('nes'), ['nes.standalone.nesoid']);
+    });
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code).

# Description

Follow-up to #238, found while device-testing it. Rebased onto the merged #238; this PR is one commit.

**`app_emulators.is_default` decides which RetroArch package receives the launch intent, and nothing on the launch path checked whether that package exists.**

`getAndroidRetroArchPackages` returns every RetroArch package the seed knows about — `com.retroarch`, `.ra32`, `.aarch64` — filtered by nothing but the name. `_launchGameAndroid` then took `packages.first`, so the intent went to whichever variant the query happened to return first. On a device with only `.aarch64` installed that is plain `com.retroarch`, and the hardcoded fallback it overrides (`.aarch64`) was the correct answer all along. `_resolveRetroArchVariant` had the same hole: it substituted the configured variant verbatim, install state unexamined.

The only thing holding this together was `fixRetroArchDefaultForAndroid` keeping `is_default` aligned with the installed variant — and that routine, plus its clear- counterpart, **skipped entirely whenever any `is_user_default` row existed anywhere**. One deliberate pick on one system froze alignment across the whole library, so a user on a non-aarch64 build who hit a launch failure and set an emulator by hand to work around it thereby disabled the repair for every other system they owned.

### What changed

1. **`getInstalledAndroidRetroArchPackages`** returns only installed variants, best first, per `CoreEmulatorModel.retroArchPackagePriority`. `.first` is now always safe to launch, whatever the database says.
2. **`_launchGameAndroid` and `_resolveRetroArchVariant`** promote a configured variant only when it is actually installed, and log when they decline.
3. **Both alignment routines scope their "user has chosen" guard per system** instead of globally, so a pick on one system no longer speaks for the rest.

`app_screen.dart` drops its duplicate priority list and install probe in favour of the shared helper.

No schema change — this PR adds no migration.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

### Testing

`flutter analyze` clean, 381 tests pass — 6 new in `test/retroarch_variant_alignment_test.dart` covering the installed-variant filter, the per-system guard (including "one system is user-configured, every other system still repairs"), the standalone-superseded clear, and the standalone fall-back when no RetroArch is installed.

Device testing on an AYN Thor (Android 13), dev flavor, evidenced by `[EmuSel]` lines in `app.log` plus `ActivityTaskManager: START` in logcat:

| check | result |
| --- | --- |
| intent targets an **installed** variant | pass — GBC and Genesis both launched `com.retroarch.aarch64`; every `com.retroarch` / `com.retroarch.ra32` candidate correctly `installed=false`. Pre-fix, `packages.first` would have addressed these to plain `com.retroarch`. |
| per-system guard, real data not fixtures | pass — a user default set on `ps1` (DuckStation) did not stop a subsequent Genesis launch resolving and aligning normally (`userDefault=<none>` for `md`). Pre-fix that single pick would have made `fixRetroArchDefaultForAndroid` skip for every system in the library. |

**Not reachable from the UI, by design:** the "configured variant is not installed, decline and fall back" branch. The picker will not let you select a 32-bit core, so the configured variant cannot disagree with install state through user action. That branch guards against seed data on non-aarch64 devices and against install-state changes, and it is covered by the unit tests; provoking it on hardware would need RetroArch uninstalled or a hand-edited `is_default` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
