### PR TITLE
feat(ui): reorder the legend's default buttons and centre it in its gutter

### DIFF
--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -1112,7 +1112,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
           duration: const Duration(milliseconds: 250),
           curve: Curves.easeOutCubic,
           top: 12.r,
-          left: GameLegendVisibility.hidden.value ? -60.r : 12.r,
+          left: GameLegendVisibility.hidden.value ? -60.r : 10.r,
           child: AnimatedOpacity(
             duration: const Duration(milliseconds: 250),
             opacity: GameLegendVisibility.hidden.value ? 0.0 : 1.0,

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -1216,7 +1216,7 @@ class _GamesGridState extends State<GamesGrid> {
           duration: const Duration(milliseconds: 250),
           curve: Curves.easeOutCubic,
           top: 12.r,
-          left: GameLegendVisibility.hidden.value ? -60.r : 12.r,
+          left: GameLegendVisibility.hidden.value ? -60.r : 10.r,
           child: AnimatedOpacity(
             duration: const Duration(milliseconds: 250),
             opacity: GameLegendVisibility.hidden.value ? 0.0 : 1.0,

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1172,13 +1172,15 @@ class _SystemGamesListState extends State<SystemGamesList> {
         ),
 
         // Floating action buttons on the left side of the game list. Select + B
-        // slides this legend off the left edge (in sync with the sidebar margin).
+        // slides this legend off the left edge (in sync with the sidebar
+        // margin). The column is 40.r wide, so a 10.r inset centres it in the
+        // 60.r gutter — equal air either side of it.
         if (!isMusic)
           AnimatedPositioned(
             duration: const Duration(milliseconds: 250),
             curve: Curves.easeOutCubic,
             top: 12.r,
-            left: GameLegendVisibility.hidden.value ? -60.r : 12.r,
+            left: GameLegendVisibility.hidden.value ? -60.r : 10.r,
             child: AnimatedOpacity(
               duration: const Duration(milliseconds: 250),
               opacity: GameLegendVisibility.hidden.value ? 0.0 : 1.0,

--- a/lib/widgets/game_action_buttons.dart
+++ b/lib/widgets/game_action_buttons.dart
@@ -14,8 +14,8 @@ import 'neo_sync_status_icon.dart';
 
 /// Vertical action button column shared by the game list, grid, and carousel.
 ///
-/// Normally renders back, favorite, view-mode, an optional NeoSync status icon,
-/// and the game-settings shortcut. While Select (View) is held it swaps to the
+/// Normally renders back, view-mode, favorite, the game-settings shortcut and
+/// an optional NeoSync status icon. While Select (View) is held it swaps to the
 /// chord shortcuts it unlocks — A scrapes and Y picks a random game.
 class GameActionButtons extends StatelessWidget {
   final SystemModel system;
@@ -134,21 +134,21 @@ class GameActionButtons extends StatelessWidget {
       ),
       SizedBox(height: 6.r),
       GameActionButton(
-        iconPath: 'assets/images/gamepad/Xbox_Y_button.png',
-        symbol: Symbols.favorite_rounded,
-        color: scheme.tertiaryFixed,
-        foregroundColor: scheme.onTertiaryFixed,
-        sound: GameActionButtonSound.nav,
-        onTap: selectedGame != null ? onFavorite : null,
-      ),
-      SizedBox(height: 6.r),
-      GameActionButton(
         iconPath: 'assets/images/gamepad/Xbox_X_button.png',
         symbol: Symbols.grid_view_rounded,
         color: scheme.tertiaryFixed,
         foregroundColor: scheme.onTertiaryFixed,
         sound: GameActionButtonSound.nav,
         onTap: onViewMode,
+      ),
+      SizedBox(height: 6.r),
+      GameActionButton(
+        iconPath: 'assets/images/gamepad/Xbox_Y_button.png',
+        symbol: Symbols.favorite_rounded,
+        color: scheme.tertiaryFixed,
+        foregroundColor: scheme.onTertiaryFixed,
+        sound: GameActionButtonSound.nav,
+        onTap: selectedGame != null ? onFavorite : null,
       ),
       SizedBox(height: 6.r),
       // Game settings — second-to-last option.


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code).

# Description

Two small adjustments to the vertical action-button legend shared by the game list, grid and carousel.

**Button order.** X (view mode) moves one position up in `_buildDefaultButtons`, swapping with Y (favorite), so the default layer reads B / X / Y / Menu / NeoSync. The class doc is updated to match — it also listed the settings shortcut and the NeoSync icon in the wrong order.

**Gutter centring.** The column is 40.r wide (1.r border + 6.r padding + 26.r button, doubled) and was pinned at `left: 12.r` inside the shared 60.r content gutter, so it had 12.r of air on its left but only 8.r between it and the list panel — 36px vs 24px measured on an AYN Thor. A 10.r inset centres it in that gutter instead, equal air either side, without reflowing any content or changing the gutter itself. Applied to all three views that host the legend.

The Select-held chord layer is untouched, as is the horizontal footer legend.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

Device-tested on an AYN Thor (dev flavour, release build): both the new order and the symmetric gutters confirmed by screenshot, and the gutters measured at 30px either side of the column (was 36 / 24).

## Screenshots (if applicable)

No visual regression beyond the intended change; the column reads B / X / Y / Menu top-to-bottom and now sits centred between the screen edge and the list panel.
