### PR TITLE
fix(dock): slide the dock out when it's disabled instead of blinking it away

### DIFF
--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -47,6 +47,23 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   /// still slides in shortly after the screen appears. See [_buildDockOverlay].
   Timer? _dockRevealFallback;
 
+  /// How long the dock takes to slide in — and, in reverse, back out. Shared by
+  /// the reveal tween and [_dockSlideOutTimer] so the unmount can't fire before
+  /// the animation has finished.
+  static const Duration _dockRevealDuration = Duration(milliseconds: 550);
+
+  /// The last `dockEnabled` this engine observed, so [_onStateChanged] can spot
+  /// the user toggling the dock off. Null until the first state push.
+  bool? _dockEnabledSeen;
+
+  /// Keeps the dock overlay mounted while it slides out after being disabled.
+  /// The setting flips instantly, so without this the subtree would be dropped
+  /// mid-frame and the dock would blink out instead of leaving the way it came.
+  bool _dockSlidingOut = false;
+
+  /// Unmounts the dock overlay once [_dockSlidingOut] has run its course.
+  Timer? _dockSlideOutTimer;
+
   /// A BuildContext captured from *under* this screen's MaterialApp (and its
   /// Localizations). The _buildXxx helpers below run as methods on this State,
   /// so a bare `context` resolves to `this.context` — which sits ABOVE the
@@ -216,6 +233,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     _maybeResetInGamePage(state);
     _applySessionPower(state);
     _maybeStartCelebration(state);
+    _syncDockMount(state);
 
     if (state.isGameLaunching) {
       _stopVideo();
@@ -246,6 +264,30 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
         _videoController!.setVolume(state.isVideoMuted ? 0.0 : 1.0);
       }
     }
+  }
+
+  /// Keeps the dock overlay mounted long enough to animate out when the user
+  /// turns the dock off in settings. Enabling is symmetrical and needs no
+  /// bookkeeping: the overlay mounts on the next build and the reveal tween
+  /// eases it up from its parked position, exactly as it does at boot.
+  void _syncDockMount(SecondaryDisplayStateData state) {
+    final was = _dockEnabledSeen;
+    _dockEnabledSeen = state.dockEnabled;
+    if (was == null || was == state.dockEnabled) return;
+
+    _dockSlideOutTimer?.cancel();
+    _dockSlideOutTimer = null;
+    if (state.dockEnabled) {
+      // Re-enabled, possibly mid-slide-out — the tween picks up from wherever
+      // the dock currently sits and carries it back into place.
+      if (_dockSlidingOut) setState(() => _dockSlidingOut = false);
+      return;
+    }
+    setState(() => _dockSlidingOut = true);
+    _dockSlideOutTimer = Timer(_dockRevealDuration, () {
+      if (!mounted) return;
+      setState(() => _dockSlidingOut = false);
+    });
   }
 
   /// Triggers (or refreshes) the celebration banner when a new set of
@@ -555,6 +597,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     _playTimeTicker?.cancel();
     _dimTimer?.cancel();
     _dockRevealFallback?.cancel();
+    _dockSlideOutTimer?.cancel();
     _stopVideo();
     super.dispose();
   }
@@ -901,7 +944,11 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                             // stays visible while browsing systems and on the
                             // Now Playing page — hidden on the achievement pages
                             // and dimmed together with the panel's idle scrim.
-                            if (value.dockEnabled) _buildDockOverlay(value),
+                            // Stays mounted for one animation after being
+                            // disabled so it can slide back out (see
+                            // [_syncDockMount]).
+                            if (value.dockEnabled || _dockSlidingOut)
+                              _buildDockOverlay(value),
 
                             // Scraping Overlay
                             _buildScrapingOverlay(value),
@@ -1104,9 +1151,16 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
           // reports its first frame via `appReady`, then eases into place. This
           // syncs the dock's arrival with the app becoming usable instead of
           // firing on the secondary display's own (earlier) first paint.
+          //
+          // Turning the dock off in settings drives the same tween back to t=1,
+          // so it leaves the way it arrived; [_syncDockMount] holds the subtree
+          // mounted until it lands.
           child: TweenAnimationBuilder<double>(
-            tween: Tween(begin: 1.0, end: _dockRevealed ? 0.0 : 1.0),
-            duration: const Duration(milliseconds: 550),
+            tween: Tween(
+              begin: 1.0,
+              end: _dockRevealed && value.dockEnabled ? 0.0 : 1.0,
+            ),
+            duration: _dockRevealDuration,
             curve: Curves.easeOutCubic,
             builder: (context, t, child) =>
                 Transform.translate(offset: Offset(0, t * 140.r), child: child),

--- a/lib/screens/secondary_screen/widgets/app_dock.dart
+++ b/lib/screens/secondary_screen/widgets/app_dock.dart
@@ -13,7 +13,9 @@ import '../now_playing_helpers.dart';
 ///
 /// Pure, input-driven subtree — the owning [SecondaryScreen] passes the current
 /// state snapshot plus the three slot callbacks, so the dock re-reads no
-/// provider state of its own.
+/// provider state of its own. Mounting is the owner's call: it keeps the dock
+/// alive through its slide-out after `dockEnabled` flips false, so this widget
+/// deliberately does not blank itself on that flag.
 class AppDock extends StatelessWidget {
   const AppDock({
     super.key,
@@ -42,7 +44,6 @@ class AppDock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (!value.dockEnabled) return const SizedBox.shrink();
     final apps = ConfigModel.normalizeDock(value.dockApps);
     final scheme = panelScheme(value);
     // Screen Return off → guard filled slots (see [onOpenAccessibilitySettings]).


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code).

# Description

**The dock's arrival and its departure didn't match.** Enabling it eases the whole overlay up from below the bottom edge over 550ms (`easeOutCubic`), keyed to main-UI readiness. Turning it off in Secondary settings just dropped the subtree: `_buildDockOverlay` sat behind `if (value.dockEnabled)`, so the moment the setting flipped, the dock and its launcher button blinked out of existence.

The reveal tween now targets `t=1` (parked off-screen) when `dockEnabled` goes false, and `_syncDockMount` — driven from `_onStateChanged`, which sees every state push — keeps the overlay mounted for exactly one animation before unmounting it. Re-enabling mid-flight cancels that timer and the tween carries the dock back up from wherever it currently sits, so a fast toggle never snaps.

Two details worth calling out:

* The 550ms duration is now a `_dockRevealDuration` constant shared by the tween and the unmount timer, so the two can't drift apart and unmount the dock mid-slide.
* `AppDock` no longer returns `SizedBox.shrink()` on `!dockEnabled`. That early return would have blanked the slot row while the launcher button slid out alone. Mounting is documented as the owner's call now, which is consistent with the widget already being a pure, input-driven subtree.

The overlay is still fully unmounted once it lands, rather than parked off-screen forever — worth preserving deliberately, since a permanently-mounted `Positioned.fill` over the secondary display's video PlatformView is the shape of an earlier raster-stall bug.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

**Not yet device-verified.** The build is installed on an AYN Thor and `flutter analyze` is clean, but the animation lives on the secondary display and needs the Secondary settings toggle flipped by hand to observe. Please exercise the dock on/off toggle before merging.

## Screenshots (if applicable)

None — the change is a transition on the secondary display; the static states are unchanged.
