### PR TITLE
fix(nav): stop a config write clearing the Select chord layer in grid/carousel

### DIFF
--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -130,6 +130,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
     milliseconds: 1500,
   ); // Debounce for video playback.
   bool _lastShowInfo = false; // Memoizes 'showGameInfo' config state.
+  String? _lastGameViewMode; // Memoizes 'gameViewMode' config state.
   bool _isGameLaunching =
       false; // Critical flag to suppress media tasks during transitions.
 
@@ -248,13 +249,23 @@ class _SystemGamesListState extends State<SystemGamesList> {
     final newShowInfo = configProvider.config.showGameInfo;
     final gameViewMode = configProvider.config.gameViewMode;
 
-    try {
-      if (gameViewMode == 'grid' || gameViewMode == 'carousel') {
-        _gamepadNav.deactivate();
-      } else {
-        _gamepadNav.activate();
-      }
-    } catch (_) {}
+    // Hand input to whichever layer owns the new view mode — but ONLY on an
+    // actual mode change. Re-asserting this on every config write is not free:
+    // deactivate() resets the shared Select chord-modifier state, so any
+    // setting written while Select is held (the legend toggle persists
+    // `legend_hidden`, for one) would drop the legend back to its default layer
+    // mid-hold, and `SelectTap.reset()` means it can't recover until Select is
+    // released and pressed again.
+    if (gameViewMode != _lastGameViewMode) {
+      _lastGameViewMode = gameViewMode;
+      try {
+        if (gameViewMode == 'grid' || gameViewMode == 'carousel') {
+          _gamepadNav.deactivate();
+        } else {
+          _gamepadNav.activate();
+        }
+      } catch (_) {}
+    }
 
     if (newShowInfo != _lastShowInfo) {
       _lastShowInfo = newShowInfo;


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code).

# Description

**Select + B reshowed the vertical legend on its default layer in the grid and carousel views, even with Select still held.** The list view behaved correctly — the legend slid back in showing the chord layer (A scrape / Y random) and only reverted once Select was released.

The chord layer isn't per-view state; it's the shared `GamepadNavigation.selectHeldNotifier`. What differs is what each view mode does to it on a config write:

1. The legend flag is durable, so `GameLegendVisibility.toggle()` calls its persistence sink, `updateLegendHidden`, which ends in `_notify()`.
2. `SystemGamesList` still hosts the grid and carousel and listens to the config provider, so `_onConfigChanged` runs on every legend toggle.
3. It re-asserted layer ownership unconditionally: in grid/carousel mode `_gamepadNav.deactivate()`, whose `_resetSelectModifier()` clears `selectHeldNotifier`. List mode took the `activate()` branch, which deliberately leaves select-tap state alone — hence the asymmetry.

`SelectTap.reset()` also drops the press timestamp, so this wasn't just a flicker during the slide-in: no new press edge arrives while the button is already down, so the chord layer stayed gone for the remainder of that hold.

The fix gates the activate/deactivate on an actual `gameViewMode` change, mirroring the `_lastShowInfo` guard already used a few lines below in the same method. The block is a safety net either way — `GamepadNavigationManager.pushLayer` already deactivates the previous layer when the grid or carousel mounts, which is what genuinely hands over input.

Note the general form of the bug: *any* config write while Select was held would clear the chord layer in grid/carousel, not just the legend toggle.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

Device-tested on an AYN Thor (dev flavour, release build): holding Select and pressing B twice now returns the legend on the chord layer in both grid and carousel, matching the list view. Reaching both views exercises the view-mode switching path the new guard governs.

## Screenshots (if applicable)

None — the change is to gamepad state handling; the legend's two layers render as before.
