### PR TITLE
fix(linux): make the SoLoud audio plugin loadable outside the build machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ flatpak-builder --user --install-deps-from=flathub \
   build-dir linux/flatpak/com.neogamelab.neostation.yml
 ```
 
+### Steam Deck
+
+Download the x86_64 AppImage, then **add it to Steam and launch it from there** —
+either from Game Mode, or from the desktop with Steam running:
+
+1. Steam → *Games → Add a Non-Steam Game to My Library* → *Browse*
+2. Set the file filter to *All Files* (the picker hides `.AppImage` by default)
+3. Select the AppImage, then launch NeoStation from your library
+
+This matters for the controls. With Steam not running, the Deck's controller sits
+in **lizard mode**, where the hardware emulates a keyboard and mouse instead of a
+gamepad: the D-pad sends arrow keys, A/B send Enter/Escape, the trackpad moves the
+mouse pointer, and **the bumpers send nothing at all**. Running through Steam hands
+the app a proper virtual gamepad, and every button works.
+
+So if the shoulder buttons seem dead, or A/B behave oddly, or a mouse cursor sits on
+screen, the app isn't at fault — it's being run outside Steam.
+
 ### Build from source
 
 ```bash

--- a/build-utils/build-linux.sh
+++ b/build-utils/build-linux.sh
@@ -193,13 +193,65 @@ for audiolib in libFLAC.so.* libFLAC++.so.* libogg.so.* libvorbis.so.* libvorbis
   copy_lib_to_appdir "$audiolib" || true
 done
 
+# ...and put them where the loader will actually look. usr/lib is NOT on any
+# runtime search path: AppRun deliberately leaves LD_LIBRARY_PATH unset (see the
+# note there — setting it shadows system GL/EGL and breaks video), so the only
+# bundled directory that resolves is usr/bin/lib, via the executable's
+# RUNPATH of $ORIGIN/lib. libflutter_soloud_plugin.so is dlopen'd from there and
+# needs its FLAC/Xiph deps alongside it. Without this the plugin loads only on
+# hosts that happen to ship the same FLAC SONAME as the build machine — e.g.
+# every release so far has needed libFLAC.so.14, which SteamOS does not have,
+# so audio has never worked on the Steam Deck.
+mkdir -p "$APPDIR/usr/bin/lib"
+for audiolib in libFLAC.so.* libFLAC++.so.* libogg.so.* libvorbis.so.* libvorbisenc.so.* libvorbisfile.so.* libopus.so.*; do
+  for lib_path in "$APPDIR"/usr/lib/$audiolib; do
+    [ -f "$lib_path" ] && cp -L "$lib_path" "$APPDIR/usr/bin/lib/" 2>/dev/null || true
+  done
+done
+
 # Verify critical audio libraries were bundled. Fedora/RHEL places them under /usr/lib64,
 # while Debian/Ubuntu uses /usr/lib/x86_64-linux-gnu. If the build machine lacks the
 # -devel/-dev package, CMake may link against a versioned SONAME that we then fail to ship.
-if [ ! -f "$APPDIR/usr/lib/libFLAC.so.12" ] && [ ! -f "$APPDIR/usr/lib/libFLAC.so.14" ]; then
+# Checked in usr/bin/lib, since a copy anywhere else cannot be loaded, and matched by
+# glob rather than by SONAME so the next FLAC bump doesn't silently slip through.
+if ! ls "$APPDIR"/usr/bin/lib/libFLAC.so.* >/dev/null 2>&1; then
   echo "ERROR: libFLAC was not bundled. Ensure libflac/libflac-dev is installed and found in one of:"
   printf '  %s\n' "${LIB_SEARCH_PATHS[@]}"
   exit 1
+fi
+
+# Copying the libraries next to the plugin is necessary but NOT sufficient: the
+# plugin is dlopen'd, and its own DT_NEEDED entries are resolved using ITS RUNPATH,
+# not the executable's. CMake bakes in a RUNPATH pointing at the build machine
+# (linux/flutter/ephemeral/.plugin_symlinks/...), which exists on no user's system,
+# so resolution falls through to the system paths and finds libFLAC only on hosts
+# that happen to ship the same SONAME. Point it at its own directory instead.
+SOLOUD_PLUGIN="$APPDIR/usr/bin/lib/libflutter_soloud_plugin.so"
+if [ -f "$SOLOUD_PLUGIN" ]; then
+  if ! command -v patchelf >/dev/null 2>&1; then
+    echo "ERROR: patchelf is required to fix the SoLoud plugin's RUNPATH (see the dependency list at the top of this script)."
+    exit 1
+  fi
+  patchelf --set-rpath '$ORIGIN' "$SOLOUD_PLUGIN"
+  echo "Set RUNPATH=\$ORIGIN on libflutter_soloud_plugin.so"
+fi
+
+# Belt and braces: the plugin is dlopen'd, so a dependency it cannot find surfaces
+# only as a silent "no audio" on the user's machine. Assert every Xiph/FLAC library
+# it declares is actually sitting next to it. This reads DT_NEEDED rather than using
+# ldd on purpose — ldd resolves against the BUILD HOST's /usr/lib and would pass
+# happily while shipping an AppImage that loads nowhere else.
+if command -v objdump >/dev/null 2>&1 && [ -f "$SOLOUD_PLUGIN" ]; then
+  MISSING_AUDIO_DEPS=""
+  for dep in $(objdump -p "$SOLOUD_PLUGIN" 2>/dev/null | awk '/NEEDED/{print $2}' | grep -E '^lib(FLAC|ogg|vorbis|opus)'); do
+    [ -f "$APPDIR/usr/bin/lib/$dep" ] || MISSING_AUDIO_DEPS="$MISSING_AUDIO_DEPS $dep"
+  done
+  if [ -n "$MISSING_AUDIO_DEPS" ]; then
+    echo "ERROR: libflutter_soloud_plugin.so needs these libraries, which are not in usr/bin/lib:$MISSING_AUDIO_DEPS"
+    echo "       Only usr/bin/lib is on the runtime search path (RUNPATH \$ORIGIN/lib);"
+    echo "       a copy in usr/lib cannot be loaded."
+    exit 1
+  fi
 fi
 
 # Analyze and copy additional binary dependencies

--- a/build-utils/build-linuxarm.sh
+++ b/build-utils/build-linuxarm.sh
@@ -224,13 +224,63 @@ for audiolib in libFLAC.so.* libFLAC++.so.* libogg.so.* libvorbis.so.* libvorbis
   copy_lib_to_appdir "$audiolib" || true
 done
 
+# ...and put them where the loader will actually look. usr/lib is NOT on any
+# runtime search path: AppRun deliberately leaves LD_LIBRARY_PATH unset (see the
+# note there — setting it shadows system GL/EGL and breaks video), so the only
+# bundled directory that resolves is usr/bin/lib, via the executable's
+# RUNPATH of $ORIGIN/lib. libflutter_soloud_plugin.so is dlopen'd from there and
+# needs its FLAC/Xiph deps alongside it, or audio silently fails on any host that
+# doesn't happen to ship the same FLAC SONAME as the build machine.
+mkdir -p "$APPDIR/usr/bin/lib"
+for audiolib in libFLAC.so.* libFLAC++.so.* libogg.so.* libvorbis.so.* libvorbisenc.so.* libvorbisfile.so.* libopus.so.*; do
+  for lib_path in "$APPDIR"/usr/lib/$audiolib; do
+    [ -f "$lib_path" ] && cp -L "$lib_path" "$APPDIR/usr/bin/lib/" 2>/dev/null || true
+  done
+done
+
 # Verify critical audio libraries were bundled. Fedora/Asahi places them under /usr/lib64,
 # while Debian/Ubuntu uses /usr/lib/aarch64-linux-gnu. If the build machine lacks the
 # -devel/-dev package, CMake may link against a versioned SONAME that we then fail to ship.
-if [ ! -f "$APPDIR/usr/lib/libFLAC.so.12" ] && [ ! -f "$APPDIR/usr/lib/libFLAC.so.14" ]; then
+# Checked in usr/bin/lib, since a copy anywhere else cannot be loaded, and matched by
+# glob rather than by SONAME so the next FLAC bump doesn't silently slip through.
+if ! ls "$APPDIR"/usr/bin/lib/libFLAC.so.* >/dev/null 2>&1; then
   echo "ERROR: libFLAC was not bundled. Ensure libflac/libflac-dev is installed and found in one of:"
   printf '  %s\n' "${LIB_SEARCH_PATHS[@]}"
   exit 1
+fi
+
+# Copying the libraries next to the plugin is necessary but NOT sufficient: the
+# plugin is dlopen'd, and its own DT_NEEDED entries are resolved using ITS RUNPATH,
+# not the executable's. CMake bakes in a RUNPATH pointing at the build machine
+# (linux/flutter/ephemeral/.plugin_symlinks/...), which exists on no user's system,
+# so resolution falls through to the system paths and finds libFLAC only on hosts
+# that happen to ship the same SONAME. Point it at its own directory instead.
+SOLOUD_PLUGIN="$APPDIR/usr/bin/lib/libflutter_soloud_plugin.so"
+if [ -f "$SOLOUD_PLUGIN" ]; then
+  if ! command -v patchelf >/dev/null 2>&1; then
+    echo "ERROR: patchelf is required to fix the SoLoud plugin's RUNPATH (see the dependency list at the top of this script)."
+    exit 1
+  fi
+  patchelf --set-rpath '$ORIGIN' "$SOLOUD_PLUGIN"
+  echo "Set RUNPATH=\$ORIGIN on libflutter_soloud_plugin.so"
+fi
+
+# Belt and braces: the plugin is dlopen'd, so a dependency it cannot find surfaces
+# only as a silent "no audio" on the user's machine. Assert every Xiph/FLAC library
+# it declares is actually sitting next to it. This reads DT_NEEDED rather than using
+# ldd on purpose — ldd resolves against the BUILD HOST's /usr/lib and would pass
+# happily while shipping an AppImage that loads nowhere else.
+if command -v objdump >/dev/null 2>&1 && [ -f "$SOLOUD_PLUGIN" ]; then
+  MISSING_AUDIO_DEPS=""
+  for dep in $(objdump -p "$SOLOUD_PLUGIN" 2>/dev/null | awk '/NEEDED/{print $2}' | grep -E '^lib(FLAC|ogg|vorbis|opus)'); do
+    [ -f "$APPDIR/usr/bin/lib/$dep" ] || MISSING_AUDIO_DEPS="$MISSING_AUDIO_DEPS $dep"
+  done
+  if [ -n "$MISSING_AUDIO_DEPS" ]; then
+    echo "ERROR: libflutter_soloud_plugin.so needs these libraries, which are not in usr/bin/lib:$MISSING_AUDIO_DEPS"
+    echo "       Only usr/bin/lib is on the runtime search path (RUNPATH \$ORIGIN/lib);"
+    echo "       a copy in usr/lib cannot be loaded."
+    exit 1
+  fi
 fi
 
 # Analyze and copy additional binary dependencies


### PR DESCRIPTION
> [!NOTE]
> This pull request was prepared with [Claude Code](https://claude.com/claude-code).

# Description

Audio has never worked in the Linux AppImage on any distro that doesn't ship the
same FLAC SONAME as the CI runner — the Steam Deck among them. On every nav sound
the app logs:

```
[SfxService] Init error: Failed to load dynamic library
'libflutter_soloud_plugin.so': libFLAC.so.14: cannot open shared object file
```

I checked every published Linux x86_64 AppImage back to the first one
(`v0.7.1+86`, 2026-04-30): all of them link `libFLAC.so.14`. This is not a
regression from any release — it has never worked. SteamOS ships only
`libFLAC.so.12`.

Two distinct faults, both required for the plugin to load anywhere but the
machine that built it:

1. **The libraries were unreachable.** The FLAC/Xiph libraries were copied into
   `usr/lib`, which is on no runtime search path. `AppRun` deliberately leaves
   `LD_LIBRARY_PATH` unset (its own comment explains that setting it shadows
   system GL/EGL and breaks video rendering), so the only bundled directory that
   resolves is `usr/bin/lib`, via the executable's `RUNPATH` of `$ORIGIN/lib`.
   They are now copied there as well.

2. **That alone was not enough — this is the part that actually fixes it.** The
   plugin is `dlopen`'d, so its own `DT_NEEDED` entries resolve through *its*
   `RUNPATH`, not the executable's; `RUNPATH` is not inherited. CMake bakes in an
   absolute path into the build tree, which exists on no user's machine, so
   resolution fell through to the system paths and found libFLAC only where the
   SONAME happened to match. `patchelf --set-rpath '$ORIGIN'` repoints it at its
   own directory. `patchelf` is already in the CI dependency list, so no workflow
   change is needed.

I verified fault 1 was insufficient by deploying it to a Steam Deck on its own
and reproducing the identical failure, rather than assuming the copy was enough.

Also hardened the existing guard, which passed while shipping broken audio: it
now checks `usr/bin/lib` rather than `usr/lib`, matches libFLAC by glob instead of
naming SONAMEs 12/14 so the next bump can't slip through, and asserts every Xiph
library the plugin declares is actually present. That check reads `DT_NEEDED`
rather than running `ldd` on purpose — `ldd` resolves against the build host and
would pass happily while producing an AppImage that loads nowhere else.

The same fix is applied to `build-linuxarm.sh`, which had the identical bug.

### README note

Also documents that the Steam Deck must be launched through Steam. With Steam not
running the controller sits in **lizard mode**, emulating a keyboard and mouse:
the D-pad arrives as arrow keys, A/B as Enter/Escape, the trackpad drives the
pointer, and the bumpers emit nothing at all. The joystick device exists but stays
silent, so no app-side mapping can help. This is a docs-only addition alongside a
build fix; happy to split it out if you'd rather.

Fixes # (no issue filed)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. — packaging change; verified on hardware instead (below)
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. — no new assets
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable). — not applicable; no input code touched

## Verification

Built and deployed to a Steam Deck (SteamOS 3.x, glibc 2.41):

```
[SfxService] Initializing...
[SfxService] Ready. 5/5 sounds loaded.
```

Zero dynamic-library failures, against 82 failed init attempts on the same
hardware beforehand. The packaged plugin carries `RUNPATH $ORIGIN`, and all five
declared Xiph dependencies sit in `usr/bin/lib`.

Not verified: the ARM64 path, which received the same change but no aarch64
hardware to test on.
