### PR TITLE
feat(nav): let users hide navigation tabs from Settings

### DIFF
--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -171,6 +171,21 @@ class SqliteConfigService {
             (int.tryParse(userConfig?['legend_hidden']?.toString() ?? '0') ??
                 0) ==
             1,
+        // Missing column/row => '0' => tab visible (see migration v106).
+        hideTabSync:
+            (int.tryParse(userConfig?['hide_tab_sync']?.toString() ?? '0') ??
+                0) ==
+            1,
+        hideTabAchievements:
+            (int.tryParse(
+                  userConfig?['hide_tab_achievements']?.toString() ?? '0',
+                ) ??
+                0) ==
+            1,
+        hideTabScraper:
+            (int.tryParse(userConfig?['hide_tab_scraper']?.toString() ?? '0') ??
+                0) ==
+            1,
         activeSyncProvider:
             userConfig?['active_sync_provider']?.toString() ?? 'neosync',
         autoUpdateApp:
@@ -250,6 +265,9 @@ class SqliteConfigService {
         themeName: config.themeName,
         hideRecentCard: config.hideRecentCard ? 1 : 0,
         legendHidden: config.legendHidden ? 1 : 0,
+        hideTabSync: config.hideTabSync ? 1 : 0,
+        hideTabAchievements: config.hideTabAchievements ? 1 : 0,
+        hideTabScraper: config.hideTabScraper ? 1 : 0,
         activeSyncProvider: config.activeSyncProvider,
         autoUpdateApp: config.autoUpdateApp ? 1 : 0,
         autoUpdateSystems: config.autoUpdateSystems ? 1 : 0,

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -321,6 +321,9 @@ class SqliteMigrations {
       case 105:
         await _migrateToVersion105(db);
         break;
+      case 106:
+        await _migrateToVersion106(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -5052,6 +5055,44 @@ class SqliteMigrations {
       _log.i('Migration v105 completed (cleared $cleared stale default(s))');
     } catch (e, stackTrace) {
       _log.e('Error in migration v105: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v106: Persist per-tab visibility for the main navigation strip.
+  ///
+  /// Each column stores *hidden*, not *shown*, and defaults to `0`. SQLite
+  /// backfills existing rows with that default on ALTER, so upgrading users keep
+  /// every tab they already had — and a tab introduced in a future version, added
+  /// here as another `DEFAULT 0` column, shows up rather than silently staying
+  /// hidden.
+  static Future<void> _migrateToVersion106(Database db) async {
+    _log.i('Migration v106: Adding nav tab visibility flags to user_config');
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_config)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+
+      const newColumns = [
+        'hide_tab_sync',
+        'hide_tab_achievements',
+        'hide_tab_scraper',
+      ];
+
+      for (final column in newColumns) {
+        if (!columns.contains(column)) {
+          db.execute(
+            'ALTER TABLE user_config ADD COLUMN $column INTEGER DEFAULT 0',
+          );
+          _log.i('Column $column added via v106');
+        } else {
+          _log.i('Column $column already exists');
+        }
+      }
+
+      _log.i('Migration v106 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v106: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 105;
+  static const int _databaseVersion = 106;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -1676,6 +1676,9 @@ class SqliteService {
         active_theme TEXT DEFAULT '',
         hide_recent_card INTEGER DEFAULT 0,
         legend_hidden INTEGER DEFAULT 0,
+        hide_tab_sync INTEGER DEFAULT 0,
+        hide_tab_achievements INTEGER DEFAULT 0,
+        hide_tab_scraper INTEGER DEFAULT 0,
         active_sync_provider TEXT DEFAULT 'neosync',
         systems_version TEXT DEFAULT '',
         neostation_app_version TEXT DEFAULT '',
@@ -2443,6 +2446,9 @@ class SqliteService {
     String? activeTheme,
     int? hideRecentCard,
     int? legendHidden,
+    int? hideTabSync,
+    int? hideTabAchievements,
+    int? hideTabScraper,
     String? activeSyncProvider,
     String? systemsVersion,
     String? neostationAppVersion,
@@ -2520,6 +2526,15 @@ class SqliteService {
     }
     if (legendHidden != null) {
       newConfig['legend_hidden'] = legendHidden;
+    }
+    if (hideTabSync != null) {
+      newConfig['hide_tab_sync'] = hideTabSync;
+    }
+    if (hideTabAchievements != null) {
+      newConfig['hide_tab_achievements'] = hideTabAchievements;
+    }
+    if (hideTabScraper != null) {
+      newConfig['hide_tab_scraper'] = hideTabScraper;
     }
     if (activeSyncProvider != null) {
       newConfig['active_sync_provider'] = activeSyncProvider;

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -177,6 +177,13 @@ mixin AppLocale {
       'disable_secondary_screen_sub';
   static const String bartopShutdown = 'bartop_shutdown';
   static const String bartopShutdownSubtitle = 'bartop_shutdown_subtitle';
+  static const String showSyncTab = 'show_sync_tab';
+  static const String showSyncTabSubtitle = 'show_sync_tab_subtitle';
+  static const String showAchievementsTab = 'show_achievements_tab';
+  static const String showAchievementsTabSubtitle =
+      'show_achievements_tab_subtitle';
+  static const String showScraperTab = 'show_scraper_tab';
+  static const String showScraperTabSubtitle = 'show_scraper_tab_subtitle';
 
   // ---------------------------------------------------------------------------
   // Directories

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -171,6 +171,16 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.bartopShutdownSubtitle:
       'Schaltet den Computer beim Schließen der App aus',
 
+  AppLocale.showSyncTab: 'Sync-Tab anzeigen',
+  AppLocale.showSyncTabSubtitle:
+      'Zeigt den Cloud-Sync-Tab in der Navigationsleiste an',
+  AppLocale.showAchievementsTab: 'Erfolge-Tab anzeigen',
+  AppLocale.showAchievementsTabSubtitle:
+      'Zeigt den RetroAchievements-Tab in der Navigationsleiste an',
+  AppLocale.showScraperTab: 'Scraper-Tab anzeigen',
+  AppLocale.showScraperTabSubtitle:
+      'Zeigt den Scraping-Tab in der Navigationsleiste an',
+
   AppLocale.configureDirectories: 'Verzeichnisse konfigurieren',
   AppLocale.configureRomsFolder: 'ROM-Ordner konfigurieren',
   AppLocale.cannotAccessFolder: 'Zugriff auf den Ordner nicht möglich',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -166,6 +166,16 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.bartopShutdownSubtitle:
       'Shut down the computer when exiting the application',
 
+  AppLocale.showSyncTab: 'Show Sync tab',
+  AppLocale.showSyncTabSubtitle:
+      'Display the Cloud Sync tab in the navigation bar',
+  AppLocale.showAchievementsTab: 'Show Achievements tab',
+  AppLocale.showAchievementsTabSubtitle:
+      'Display the RetroAchievements tab in the navigation bar',
+  AppLocale.showScraperTab: 'Show Scraper tab',
+  AppLocale.showScraperTabSubtitle:
+      'Display the Scraping tab in the navigation bar',
+
   AppLocale.configureDirectories: 'Directories',
   AppLocale.configureRomsFolder: 'Configure ROMs folder',
   AppLocale.cannotAccessFolder: 'Cannot Access Folder',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -173,6 +173,16 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.bartopShutdownSubtitle:
       'Apagar el equipo al salir de la aplicación',
 
+  AppLocale.showSyncTab: 'Mostrar pestaña Sincronización',
+  AppLocale.showSyncTabSubtitle:
+      'Muestra la pestaña de sincronización en la nube en la barra de navegación',
+  AppLocale.showAchievementsTab: 'Mostrar pestaña Logros',
+  AppLocale.showAchievementsTabSubtitle:
+      'Muestra la pestaña de RetroAchievements en la barra de navegación',
+  AppLocale.showScraperTab: 'Mostrar pestaña Scraper',
+  AppLocale.showScraperTabSubtitle:
+      'Muestra la pestaña de scraping en la barra de navegación',
+
   AppLocale.configureDirectories: 'Directorios',
   AppLocale.configureRomsFolder: 'Configurar carpeta de ROMs',
   AppLocale.cannotAccessFolder: 'No se puede acceder a la carpeta',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -176,6 +176,16 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.bartopShutdownSubtitle:
       'Éteint l’ordinateur à la fermeture de l’application',
 
+  AppLocale.showSyncTab: 'Afficher l’onglet Synchronisation',
+  AppLocale.showSyncTabSubtitle:
+      'Affiche l’onglet de synchronisation cloud dans la barre de navigation',
+  AppLocale.showAchievementsTab: 'Afficher l’onglet Succès',
+  AppLocale.showAchievementsTabSubtitle:
+      'Affiche l’onglet RetroAchievements dans la barre de navigation',
+  AppLocale.showScraperTab: 'Afficher l’onglet Scraper',
+  AppLocale.showScraperTabSubtitle:
+      'Affiche l’onglet de scraping dans la barre de navigation',
+
   AppLocale.configureDirectories: 'Configurer les Répertoires',
   AppLocale.configureRomsFolder: 'Configurer le Dossier des ROMs',
   AppLocale.cannotAccessFolder: 'Impossible d’accéder au dossier',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -167,6 +167,16 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.bartopShutdown: 'Matikan BarTOP saat keluar',
   AppLocale.bartopShutdownSubtitle: 'Mematikan komputer saat menutup aplikasi',
 
+  AppLocale.showSyncTab: 'Tampilkan tab Sinkronisasi',
+  AppLocale.showSyncTabSubtitle:
+      'Menampilkan tab sinkronisasi cloud di bilah navigasi',
+  AppLocale.showAchievementsTab: 'Tampilkan tab Pencapaian',
+  AppLocale.showAchievementsTabSubtitle:
+      'Menampilkan tab RetroAchievements di bilah navigasi',
+  AppLocale.showScraperTab: 'Tampilkan tab Scraper',
+  AppLocale.showScraperTabSubtitle:
+      'Menampilkan tab scraping di bilah navigasi',
+
   AppLocale.configureDirectories: 'Konfigurasi Direktori',
   AppLocale.configureRomsFolder: 'Konfigurasi Folder ROM',
   AppLocale.cannotAccessFolder: 'Tidak dapat mengakses folder',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -170,6 +170,16 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.bartopShutdown: 'Spegni BarTOP all’uscita',
   AppLocale.bartopShutdownSubtitle: 'Spegne il computer alla chiusura dell’app',
 
+  AppLocale.showSyncTab: 'Mostra scheda Sincronizzazione',
+  AppLocale.showSyncTabSubtitle:
+      'Mostra la scheda di sincronizzazione cloud nella barra di navigazione',
+  AppLocale.showAchievementsTab: 'Mostra scheda Obiettivi',
+  AppLocale.showAchievementsTabSubtitle:
+      'Mostra la scheda RetroAchievements nella barra di navigazione',
+  AppLocale.showScraperTab: 'Mostra scheda Scraper',
+  AppLocale.showScraperTabSubtitle:
+      'Mostra la scheda di scraping nella barra di navigazione',
+
   AppLocale.configureDirectories: 'Configura Directory',
   AppLocale.configureRomsFolder: 'Configura Cartella ROM',
   AppLocale.cannotAccessFolder: 'Impossibile accedere alla cartella',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -144,6 +144,13 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.bartopShutdown: '終了時にBarTOPをシャットダウン',
   AppLocale.bartopShutdownSubtitle: 'アプリ終了時にコンピュータをシャットダウン',
 
+  AppLocale.showSyncTab: '同期タブを表示',
+  AppLocale.showSyncTabSubtitle: 'ナビゲーションバーにクラウド同期タブを表示します',
+  AppLocale.showAchievementsTab: '実績タブを表示',
+  AppLocale.showAchievementsTabSubtitle: 'ナビゲーションバーにRetroAchievementsタブを表示します',
+  AppLocale.showScraperTab: 'スクレイパータブを表示',
+  AppLocale.showScraperTabSubtitle: 'ナビゲーションバーにスクレイピングタブを表示します',
+
   AppLocale.configureDirectories: 'ディレクトリの設定',
   AppLocale.configureRomsFolder: 'ROMフォルダの設定',
   AppLocale.cannotAccessFolder: 'フォルダにアクセスできません',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -143,6 +143,13 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.bartopShutdown: '종료할 때 BarTOP 전원 끄기',
   AppLocale.bartopShutdownSubtitle: '앱을 종료할 때 컴퓨터도 함께 종료합니다',
 
+  AppLocale.showSyncTab: '동기화 탭 표시',
+  AppLocale.showSyncTabSubtitle: '내비게이션 바에 클라우드 동기화 탭을 표시합니다',
+  AppLocale.showAchievementsTab: '업적 탭 표시',
+  AppLocale.showAchievementsTabSubtitle: '내비게이션 바에 RetroAchievements 탭을 표시합니다',
+  AppLocale.showScraperTab: '스크레이퍼 탭 표시',
+  AppLocale.showScraperTabSubtitle: '내비게이션 바에 스크래핑 탭을 표시합니다',
+
   AppLocale.configureDirectories: '폴더',
   AppLocale.configureRomsFolder: 'ROM 폴더 설정',
   AppLocale.cannotAccessFolder: '폴더에 접근할 수 없습니다',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -171,6 +171,16 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.bartopShutdownSubtitle:
       'Desliga o computador ao fechar o aplicativo',
 
+  AppLocale.showSyncTab: 'Mostrar aba Sincronização',
+  AppLocale.showSyncTabSubtitle:
+      'Exibe a aba de sincronização na nuvem na barra de navegação',
+  AppLocale.showAchievementsTab: 'Mostrar aba Conquistas',
+  AppLocale.showAchievementsTabSubtitle:
+      'Exibe a aba do RetroAchievements na barra de navegação',
+  AppLocale.showScraperTab: 'Mostrar aba Scraper',
+  AppLocale.showScraperTabSubtitle:
+      'Exibe a aba de scraping na barra de navegação',
+
   AppLocale.configureDirectories: 'Configurar Diretórios',
   AppLocale.configureRomsFolder: 'Configurar Pasta de ROMs',
   AppLocale.cannotAccessFolder: 'Não foi possível acessar a pasta',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -171,6 +171,16 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.bartopShutdownSubtitle:
       'Выключать компьютер при выходе из приложения',
 
+  AppLocale.showSyncTab: 'Показывать вкладку синхронизации',
+  AppLocale.showSyncTabSubtitle:
+      'Отображает вкладку облачной синхронизации на панели навигации',
+  AppLocale.showAchievementsTab: 'Показывать вкладку достижений',
+  AppLocale.showAchievementsTabSubtitle:
+      'Отображает вкладку RetroAchievements на панели навигации',
+  AppLocale.showScraperTab: 'Показывать вкладку скрапера',
+  AppLocale.showScraperTabSubtitle:
+      'Отображает вкладку скрапинга на панели навигации',
+
   AppLocale.configureDirectories: 'Директории',
   AppLocale.configureRomsFolder: 'Настроить папку ROM',
   AppLocale.cannotAccessFolder: 'Нет доступа к папке',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -142,6 +142,13 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.bartopShutdown: '退出时关闭 BarTOP',
   AppLocale.bartopShutdownSubtitle: '退出应用时关闭计算机',
 
+  AppLocale.showSyncTab: '显示同步选项卡',
+  AppLocale.showSyncTabSubtitle: '在导航栏中显示云同步选项卡',
+  AppLocale.showAchievementsTab: '显示成就选项卡',
+  AppLocale.showAchievementsTabSubtitle: '在导航栏中显示 RetroAchievements 选项卡',
+  AppLocale.showScraperTab: '显示刮削选项卡',
+  AppLocale.showScraperTabSubtitle: '在导航栏中显示刮削选项卡',
+
   AppLocale.configureDirectories: '目录设置',
   AppLocale.configureRomsFolder: '配置 ROM 文件夹',
   AppLocale.cannotAccessFolder: '无法访问文件夹',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -142,6 +142,13 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.bartopShutdown: '離開時關閉 BarTOP',
   AppLocale.bartopShutdownSubtitle: '離開應用程式時關閉電腦',
 
+  AppLocale.showSyncTab: '顯示同步分頁',
+  AppLocale.showSyncTabSubtitle: '在導覽列中顯示雲端同步分頁',
+  AppLocale.showAchievementsTab: '顯示成就分頁',
+  AppLocale.showAchievementsTabSubtitle: '在導覽列中顯示 RetroAchievements 分頁',
+  AppLocale.showScraperTab: '顯示刮削分頁',
+  AppLocale.showScraperTabSubtitle: '在導覽列中顯示刮削分頁',
+
   AppLocale.configureDirectories: '目錄設定',
   AppLocale.configureRomsFolder: '設定 ROM 資料夾',
   AppLocale.cannotAccessFolder: '無法存取資料夾',

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -103,6 +103,20 @@ class ConfigModel {
   /// (list, grid, carousel). Toggled by the Select + B chord.
   final bool legendHidden;
 
+  /// Whether the Sync navigation tab is hidden from the header strip and the
+  /// L1/R1 tab cycle.
+  ///
+  /// Stored as "hidden" rather than "shown" so the default (`false`) is
+  /// visible: a tab added in a future version appears for upgrading users
+  /// instead of silently staying hidden. See `NavTab` in utils/nav_tabs.dart.
+  final bool hideTabSync;
+
+  /// Whether the Achievements navigation tab is hidden. See [hideTabSync].
+  final bool hideTabAchievements;
+
+  /// Whether the Scraper navigation tab is hidden. See [hideTabSync].
+  final bool hideTabScraper;
+
   /// Seconds of inactivity before the secondary "Now Playing" panel dims, or `0`
   /// to never dim. Only meaningful when a secondary display is active.
   final int nowPlayingDimDelay;
@@ -173,6 +187,9 @@ class ConfigModel {
     this.appLanguage = 'es',
     this.hideRecentCard = false,
     this.legendHidden = false,
+    this.hideTabSync = false,
+    this.hideTabAchievements = false,
+    this.hideTabScraper = false,
     this.activeSyncProvider = 'neosync',
     this.autoUpdateApp = true,
     this.autoUpdateSystems = true,
@@ -278,6 +295,23 @@ class ConfigModel {
           (json['legendHidden'] ?? json['legend_hidden'] ?? 0).toString() ==
               '1' ||
           (json['legendHidden'] ?? false).toString().toLowerCase() == 'true',
+      // Absent key => false => tab visible. Keeps a config written by an older
+      // build (or restored from cloud sync) from hiding tabs it never knew about.
+      hideTabSync:
+          (json['hideTabSync'] ?? json['hide_tab_sync'] ?? 0).toString() ==
+              '1' ||
+          (json['hideTabSync'] ?? false).toString().toLowerCase() == 'true',
+      hideTabAchievements:
+          (json['hideTabAchievements'] ?? json['hide_tab_achievements'] ?? 0)
+                  .toString() ==
+              '1' ||
+          (json['hideTabAchievements'] ?? false).toString().toLowerCase() ==
+              'true',
+      hideTabScraper:
+          (json['hideTabScraper'] ?? json['hide_tab_scraper'] ?? 0)
+                  .toString() ==
+              '1' ||
+          (json['hideTabScraper'] ?? false).toString().toLowerCase() == 'true',
       activeSyncProvider:
           (json['activeSyncProvider'] ??
                   json['active_sync_provider'] ??
@@ -368,6 +402,9 @@ class ConfigModel {
       'appLanguage': appLanguage,
       'hideRecentCard': hideRecentCard,
       'legendHidden': legendHidden,
+      'hideTabSync': hideTabSync,
+      'hideTabAchievements': hideTabAchievements,
+      'hideTabScraper': hideTabScraper,
       'activeSyncProvider': activeSyncProvider,
       'autoUpdateApp': autoUpdateApp,
       'autoUpdateSystems': autoUpdateSystems,
@@ -408,6 +445,9 @@ class ConfigModel {
     String? appLanguage,
     bool? hideRecentCard,
     bool? legendHidden,
+    bool? hideTabSync,
+    bool? hideTabAchievements,
+    bool? hideTabScraper,
     String? activeSyncProvider,
     bool? autoUpdateApp,
     bool? autoUpdateSystems,
@@ -445,6 +485,9 @@ class ConfigModel {
       appLanguage: appLanguage ?? this.appLanguage,
       hideRecentCard: hideRecentCard ?? this.hideRecentCard,
       legendHidden: legendHidden ?? this.legendHidden,
+      hideTabSync: hideTabSync ?? this.hideTabSync,
+      hideTabAchievements: hideTabAchievements ?? this.hideTabAchievements,
+      hideTabScraper: hideTabScraper ?? this.hideTabScraper,
       activeSyncProvider: activeSyncProvider ?? this.activeSyncProvider,
       autoUpdateApp: autoUpdateApp ?? this.autoUpdateApp,
       autoUpdateSystems: autoUpdateSystems ?? this.autoUpdateSystems,

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -24,6 +24,7 @@ import 'package:flutter/services.dart';
 import '../widgets/tv_directory_picker.dart';
 import '../constants/system_folder_names.dart';
 import '../services/game_session_persistence.dart';
+import '../utils/nav_tabs.dart';
 
 part 'sqlite_config_provider/mutators.dart';
 part 'sqlite_config_provider/scanning.dart';

--- a/lib/providers/sqlite_config_provider/mutators.dart
+++ b/lib/providers/sqlite_config_provider/mutators.dart
@@ -91,6 +91,20 @@ extension SqliteConfigMutators on SqliteConfigProvider {
     _notify();
   }
 
+  /// Shows or hides [tab] in the header strip and the L1/R1 tab cycle.
+  ///
+  /// Routed through the tab's [NavTabSpec] so a future tab needs only a spec
+  /// entry, not another mutator. A tab with no `withHidden` (Systems, Settings)
+  /// can't be hidden and is ignored.
+  Future<void> updateNavTabHidden(NavTab tab, bool hidden) async {
+    final applyHidden = navTabSpec(tab).withHidden;
+    if (applyHidden == null) return;
+
+    _config = applyHidden(_config, hidden);
+    await SqliteConfigService.saveConfig(_config);
+    _notify();
+  }
+
   Future<void> updateActiveSyncProvider(String providerId) async {
     _config = _config.copyWith(activeSyncProvider: providerId);
     await SqliteConfigService.saveConfig(_config);

--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/utils/nav_tabs.dart';
+import 'package:neostation/models/config_model.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/services/update_service.dart';
 import 'package:neostation/services/systems_update_service.dart';
@@ -12,7 +14,6 @@ import 'systems_screen/system_content.dart';
 import 'retro_achievements_screen/ra_content.dart';
 import 'settings_screen/new_settings_screen.dart';
 import 'scraper_screen/new_scraper_options_screen.dart';
-import 'neo_sync_screen/login_screen/neo_sync_content.dart';
 import 'neo_sync_screen/neo_sync_tab.dart';
 import '../widgets/scraper_content.dart';
 import 'package:neostation/services/game_service.dart';
@@ -70,9 +71,6 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
   /// Input orchestration layer for gamepad and keyboard support.
   late GamepadNavigation _gamepadNav;
 
-  /// Cached list of primary content widgets for each navigation tab.
-  late final List<Widget> _tabContents;
-
   /// Static reference to the currently active instance for global access.
   static AppScreenState? _currentInstance;
 
@@ -99,14 +97,6 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
     super.initState();
     _currentInstance = this;
     WidgetsBinding.instance.addObserver(this);
-
-    _tabContents = [
-      SystemContent(), // Tab 0: Game Systems
-      NeoSyncContent(), // Tab 1: Cloud Persistence (NeoSync)
-      RAContent(), // Tab 2: RetroAchievements
-      ScraperContent(), // Tab 3: Metadata Scraper
-      NewSettingsScreen(), // Tab 4: Global Settings
-    ];
 
     // Initialize the navigation bridge with core application callbacks.
     _gamepadNav = GamepadNavigation(
@@ -519,21 +509,51 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
     }
   }
 
-  void _navigateToNextTab() {
-    final nextIndex = (_selectedTabIndex + 1) % _tabContents.length;
-    _onTabSelected(nextIndex);
+  /// Tabs the user hasn't hidden, in canonical order. Never empty — Systems and
+  /// Settings can't be hidden.
+  List<NavTab> get _visibleTabs => visibleNavTabs(
+    Provider.of<SqliteConfigProvider>(context, listen: false).config,
+  );
+
+  /// Steps [step] places through the visible tabs, wrapping at both ends, so a
+  /// hidden tab is skipped rather than selected and immediately bounced.
+  void _cycleTab(int step) {
+    final visible = _visibleTabs;
+    if (visible.isEmpty) return;
+
+    final current = NavTab.values[_selectedTabIndex];
+    final position = visible.indexOf(current);
+    // Currently on a hidden tab (config changed underneath us): step from the
+    // start of the strip rather than off the end of the list.
+    final from = position == -1 ? 0 : position;
+    final next = (from + step + visible.length) % visible.length;
+    _onTabSelected(visible[next].index);
   }
 
-  void _navigateToPreviousTab() {
-    final previousIndex =
-        (_selectedTabIndex - 1 + _tabContents.length) % _tabContents.length;
-    _onTabSelected(previousIndex);
+  void _navigateToNextTab() => _cycleTab(1);
+
+  void _navigateToPreviousTab() => _cycleTab(-1);
+
+  /// Falls back to Systems if the selected tab is no longer visible.
+  ///
+  /// Unreachable in normal use (the toggles live on Settings, which can't be
+  /// hidden), but it keeps an imported or cloud-restored config from stranding
+  /// the user on a tab that has no entry in the strip.
+  void _ensureSelectedTabVisible(ConfigModel config) {
+    if (visibleNavTabs(config).contains(NavTab.values[_selectedTabIndex])) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _onTabSelected(NavTab.systems.index);
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return Consumer2<SqliteConfigProvider, ThemeProvider>(
       builder: (context, configProvider, themeProvider, child) {
+        _ensureSelectedTabVisible(configProvider.config);
+
         return PopScope(
           canPop: false, // Intercept hardware back button to maintain app flow.
           child: Scaffold(

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -11,6 +11,7 @@ import 'package:window_manager/window_manager.dart';
 import 'package:fullscreen_window/fullscreen_window.dart';
 import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/utils/adaptive_scroll.dart';
+import 'package:neostation/utils/nav_tabs.dart';
 import '../../../providers/sqlite_config_provider.dart';
 import '../../../widgets/custom_toggle_switch.dart';
 import 'settings_title.dart';
@@ -60,8 +61,9 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
     _loadFullscreenState();
     _checkDefaultLauncher();
 
-    // Pre-allocate keys for maximum theoretical setting items.
-    for (int i = 0; i < 14; i++) {
+    // Pre-allocate keys for maximum theoretical setting items (the fixed rows
+    // plus one per navigation tab that can be toggled).
+    for (int i = 0; i < 14 + NavTab.values.length; i++) {
       _itemKeys.add(GlobalKey());
     }
   }
@@ -174,6 +176,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
     count++; // Auto-update Systems
     count++; // SFX Sounds
     count++; // 12-Hour Clock
+    count += hidableNavTabs().length; // Navigation tab visibility
     count++; // Language
     if (!kIsWeb &&
         (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
@@ -243,6 +246,18 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
       return;
     }
     currentItemIndex++;
+
+    // Protocol: Navigation Tab Visibility (one entry per hidable tab, in the
+    // same order the rows are built below).
+    for (final tab in hidableNavTabs()) {
+      if (index == currentItemIndex) {
+        final hidden =
+            navTabSpec(tab).hidden?.call(configProvider.config) ?? false;
+        configProvider.updateNavTabHidden(tab, !hidden);
+        return;
+      }
+      currentItemIndex++;
+    }
 
     // Protocol: Localization Selection.
     if (index == currentItemIndex) {
@@ -475,6 +490,37 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     ),
                   );
                 }(),
+
+                // Setting: Navigation Tab Visibility — one row per hidable tab,
+                // so a future tab gets its toggle from its NavTabSpec alone.
+                for (final tab in hidableNavTabs()) ...[
+                  SizedBox(height: 12.r),
+                  () {
+                    final index = currentItemIdx++;
+                    final spec = navTabSpec(tab);
+                    final titleKey = spec.settingsTitleKey;
+                    final hidden = spec.hidden?.call(config) ?? false;
+                    return SettingRow(
+                      key: _itemKeys[index],
+                      focused:
+                          widget.isContentFocused &&
+                          widget.selectedContentIndex == index,
+                      title: (titleKey ?? spec.labelKey).getString(context),
+                      subtitle:
+                          spec.settingsSubtitleKey?.getString(context) ?? '',
+                      // The switch reads as "shown"; the config stores "hidden".
+                      trailing: CustomToggleSwitch(
+                        value: !hidden,
+                        onChanged: (value) {
+                          context
+                              .read<SqliteConfigProvider>()
+                              .updateNavTabHidden(tab, !value);
+                        },
+                        activeColor: theme.colorScheme.primary,
+                      ),
+                    );
+                  }(),
+                ],
 
                 // Setting: Localization & Language.
                 SizedBox(height: 12.r),

--- a/lib/utils/nav_tabs.dart
+++ b/lib/utils/nav_tabs.dart
@@ -1,0 +1,120 @@
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/models/config_model.dart';
+
+/// Identity of a top-level navigation tab (the L1/R1 strip in the header).
+///
+/// The ordinal **is** the canonical tab index used by `AppScreenState`
+/// (`_selectedTabIndex`, `_buildCurrentTabContent`, the secondary-display tab
+/// names). Append new tabs at the end — inserting one renumbers every existing
+/// tab and silently repoints all of that dispatch.
+enum NavTab { systems, sync, achievements, scraper, settings }
+
+/// Static description of one navigation tab: how it is drawn, whether the user
+/// may hide it, and how that preference is read and written.
+class NavTabSpec {
+  const NavTabSpec({
+    required this.icon,
+    required this.labelKey,
+    this.hidden,
+    this.withHidden,
+    this.settingsTitleKey,
+    this.settingsSubtitleKey,
+  });
+
+  /// Asset drawn in the header strip.
+  final String icon;
+
+  /// [AppLocale] key for the tab's display name.
+  final String labelKey;
+
+  /// Reads this tab's "hidden" preference. `null` means the tab can never be
+  /// hidden — that is the default for any tab not wired up here.
+  final bool Function(ConfigModel config)? hidden;
+
+  /// Returns a copy of [config] with this tab's "hidden" preference set.
+  final ConfigModel Function(ConfigModel config, bool hidden)? withHidden;
+
+  /// [AppLocale] keys for this tab's row in General settings.
+  final String? settingsTitleKey;
+  final String? settingsSubtitleKey;
+
+  /// Whether the user can toggle this tab's visibility.
+  bool get isHidable => hidden != null && withHidden != null;
+}
+
+/// Fallback for a [NavTab] with no entry in [navTabSpecs].
+///
+/// It has no [NavTabSpec.hidden] predicate, so an unregistered tab renders and
+/// stays permanently visible rather than disappearing — the safe failure for a
+/// tab added in a future version before its toggle is wired up.
+const NavTabSpec _fallbackSpec = NavTabSpec(
+  icon: 'assets/images/icons/grids.webp',
+  labelKey: AppLocale.systems,
+);
+
+/// Systems and Settings are deliberately absent a [NavTabSpec.hidden]
+/// predicate: Systems is the home tab, and Settings must stay reachable or a
+/// user who hid everything else could never turn it back on.
+const Map<NavTab, NavTabSpec> navTabSpecs = {
+  NavTab.systems: NavTabSpec(
+    icon: 'assets/images/icons/grids.webp',
+    labelKey: AppLocale.systems,
+  ),
+  NavTab.sync: NavTabSpec(
+    icon: 'assets/images/icons/cloud-add.webp',
+    labelKey: AppLocale.cloudSync,
+    hidden: _hideTabSync,
+    withHidden: _withHideTabSync,
+    settingsTitleKey: AppLocale.showSyncTab,
+    settingsSubtitleKey: AppLocale.showSyncTabSubtitle,
+  ),
+  NavTab.achievements: NavTabSpec(
+    icon: 'assets/images/icons/enhance-prize.webp',
+    labelKey: AppLocale.achievements,
+    hidden: _hideTabAchievements,
+    withHidden: _withHideTabAchievements,
+    settingsTitleKey: AppLocale.showAchievementsTab,
+    settingsSubtitleKey: AppLocale.showAchievementsTabSubtitle,
+  ),
+  NavTab.scraper: NavTabSpec(
+    icon: 'assets/images/icons/box-search.webp',
+    labelKey: AppLocale.scraping,
+    hidden: _hideTabScraper,
+    withHidden: _withHideTabScraper,
+    settingsTitleKey: AppLocale.showScraperTab,
+    settingsSubtitleKey: AppLocale.showScraperTabSubtitle,
+  ),
+  NavTab.settings: NavTabSpec(
+    icon: 'assets/images/icons/setting.webp',
+    labelKey: AppLocale.settings,
+  ),
+};
+
+// Torn out as top-level functions so [navTabSpecs] can stay `const`.
+bool _hideTabSync(ConfigModel c) => c.hideTabSync;
+bool _hideTabAchievements(ConfigModel c) => c.hideTabAchievements;
+bool _hideTabScraper(ConfigModel c) => c.hideTabScraper;
+
+ConfigModel _withHideTabSync(ConfigModel c, bool hidden) =>
+    c.copyWith(hideTabSync: hidden);
+ConfigModel _withHideTabAchievements(ConfigModel c, bool hidden) =>
+    c.copyWith(hideTabAchievements: hidden);
+ConfigModel _withHideTabScraper(ConfigModel c, bool hidden) =>
+    c.copyWith(hideTabScraper: hidden);
+
+/// Description of [tab], never null — see [_fallbackSpec].
+NavTabSpec navTabSpec(NavTab tab) => navTabSpecs[tab] ?? _fallbackSpec;
+
+/// Tabs the user should see, in canonical order.
+///
+/// A tab is visible unless it has a registered hide-predicate that says
+/// otherwise, so an unregistered (i.e. newly added) tab is visible by default.
+List<NavTab> visibleNavTabs(ConfigModel config) => NavTab.values
+    .where((tab) => !(navTabSpec(tab).hidden?.call(config) ?? false))
+    .toList(growable: false);
+
+/// Tabs the user can toggle, in canonical order. Drives the General settings
+/// rows, so wiring a future tab's spec is all it takes to give it a toggle.
+List<NavTab> hidableNavTabs() => NavTab.values
+    .where((tab) => navTabSpec(tab).isHidable)
+    .toList(growable: false);

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -12,7 +12,7 @@ import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/services/permission_service.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/widgets/header_sort_dropdown.dart';
-import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/utils/nav_tabs.dart';
 import 'package:neostation/utils/time_format.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 
@@ -45,7 +45,12 @@ class HeaderState extends State<Header> {
   @override
   void initState() {
     super.initState();
-    _tabFocusNodes = List.generate(5, (_) => FocusNode(skipTraversal: true));
+    // One per canonical tab (indexed by NavTab.index), not per *visible* tab, so
+    // hiding a tab can't shift a node onto a different button.
+    _tabFocusNodes = List.generate(
+      NavTab.values.length,
+      (_) => FocusNode(skipTraversal: true),
+    );
     _getBatteryLevel();
     _listenToBatteryState();
     _updateTime();
@@ -220,94 +225,73 @@ class HeaderState extends State<Header> {
                       ),
                     ],
                   ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      // LB button (left)
-                      _buildShoulderButton('LB', true),
-                      // Tabs Section
-                      Stack(
+                  child: Builder(
+                    builder: (context) {
+                      final visibleTabs = visibleNavTabs(configProvider.config);
+                      // The indicator tracks the tab's slot in the *rendered*
+                      // strip, not its canonical index — otherwise hiding a tab
+                      // parks it past the end of a shortened strip.
+                      final selectedSlot = visibleTabs.indexOf(
+                        NavTab.values[widget.selectedTabIndex],
+                      );
+
+                      return Row(
+                        mainAxisSize: MainAxisSize.min,
                         children: [
-                          // Moving indicator
-                          AnimatedPositioned(
-                            left: widget.selectedTabIndex * 32.r,
-                            top: 4.r,
-                            bottom: 4.r,
-                            width: 32.r,
-                            duration: const Duration(milliseconds: 160),
-                            curve: Curves.easeInOut,
-                            child: Container(
-                              decoration: BoxDecoration(
-                                color: Theme.of(context).colorScheme.primary,
-                                borderRadius:
-                                    Theme.of(context)
-                                        .extension<CornerRadii>()
-                                        ?.radiusInternal ??
-                                    BorderRadius.circular(4.r),
-                              ),
-                            ),
-                          ),
-                          // Tab buttons
-                          Row(
-                            mainAxisSize: MainAxisSize.min,
+                          // LB button (left)
+                          _buildShoulderButton('LB', true),
+                          // Tabs Section
+                          Stack(
                             children: [
-                              SizedBox(
+                              // Moving indicator
+                              AnimatedPositioned(
+                                left:
+                                    (selectedSlot < 0 ? 0 : selectedSlot) *
+                                    32.r,
+                                top: 4.r,
+                                bottom: 4.r,
                                 width: 32.r,
-                                height: 32.r,
-                                child: _buildTabButton(
-                                  context,
-                                  0,
-                                  "assets/images/icons/grids.webp",
-                                  AppLocale.systems.getString(context),
+                                duration: const Duration(milliseconds: 160),
+                                curve: Curves.easeInOut,
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.primary,
+                                    borderRadius:
+                                        Theme.of(context)
+                                            .extension<CornerRadii>()
+                                            ?.radiusInternal ??
+                                        BorderRadius.circular(4.r),
+                                  ),
                                 ),
                               ),
-                              SizedBox(
-                                width: 32.r,
-                                height: 32.r,
-                                child: _buildTabButton(
-                                  context,
-                                  1,
-                                  "assets/images/icons/cloud-add.webp",
-                                  'Sync',
-                                ),
-                              ),
-                              SizedBox(
-                                width: 32.r,
-                                height: 32.r,
-                                child: _buildTabButton(
-                                  context,
-                                  2,
-                                  "assets/images/icons/enhance-prize.webp",
-                                  AppLocale.achievements.getString(context),
-                                ),
-                              ),
-                              SizedBox(
-                                width: 32.r,
-                                height: 32.r,
-                                child: _buildTabButton(
-                                  context,
-                                  3,
-                                  "assets/images/icons/box-search.webp",
-                                  AppLocale.scraping.getString(context),
-                                ),
-                              ),
-                              SizedBox(
-                                width: 32.r,
-                                height: 32.r,
-                                child: _buildTabButton(
-                                  context,
-                                  4,
-                                  "assets/images/icons/setting.webp",
-                                  AppLocale.settings.getString(context),
-                                ),
+                              // Tab buttons
+                              Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  for (final tab in visibleTabs)
+                                    SizedBox(
+                                      width: 32.r,
+                                      height: 32.r,
+                                      child: _buildTabButton(
+                                        context,
+                                        tab.index,
+                                        navTabSpec(tab).icon,
+                                        navTabSpec(
+                                          tab,
+                                        ).labelKey.getString(context),
+                                      ),
+                                    ),
+                                ],
                               ),
                             ],
                           ),
+                          // RB button (right)
+                          _buildShoulderButton('RB', false),
                         ],
-                      ),
-                      // RB button (right)
-                      _buildShoulderButton('RB', false),
-                    ],
+                      );
+                    },
                   ),
                 ),
               ),


### PR DESCRIPTION
> [!NOTE]
> This PR was developed with [Claude Code](https://claude.com/claude-code).

# Description

Adds per-tab visibility toggles for the main L1/R1 navigation strip, in **Settings → General** (below *12-hour clock*, above *Language*):

- Show Sync tab
- Show Achievements tab
- Show Scraper tab

Systems and Settings are deliberately not hidable, per the issue: Systems is the home tab, and hiding Settings would leave the user with no way to turn anything back on.

**New tabs stay visible on upgrade.** Visibility is stored as *hidden* (`INTEGER DEFAULT 0`), not *shown*, so both a fresh install and an ALTER'd existing DB default to every tab visible — and a tab added in a future version appears for existing users rather than silently staying hidden.

**Tab identity is centralised.** `lib/utils/nav_tabs.dart` introduces a `NavTab` enum whose ordinal *is* the canonical tab index, plus a `NavTabSpec` registry holding each tab's icon, label key, hide-predicate, config applier and settings-row keys. Because the indices don't move, `AppScreen`'s existing index-based content and secondary-display dispatch is untouched; visibility is applied only where tabs are walked or drawn. A `NavTab` with no registered hide-predicate is treated as visible, so adding a tab and forgetting to wire its toggle fails open. The settings rows, `getItemCount()` and `selectItem()` are all generated from the same registry, so a future tab needs only a spec entry.

Other notes:

- `header.dart`: the sliding indicator now tracks the tab's slot in the **rendered** strip rather than its canonical index — otherwise hiding a tab parks it past the end of a shortened strip. Focus nodes are sized from `NavTab.values.length`.
- `app_screen.dart`: L1/R1 cycles the visible tabs only, and falls back to Systems if the selected tab is somehow not visible (unreachable in normal use, but it keeps an imported/cloud-restored config from stranding the user).
- Removed the unused `_tabContents` list — only its `.length` was ever read, while it eagerly constructed five never-mounted widgets.
- `user_config` gains `hide_tab_sync` / `hide_tab_achievements` / `hide_tab_scraper` via **migration v106** (versioned migration, not the on-launch `_ensure*Columns` pattern).
- Localisation: 6 new keys, translated across all 12 locale files.

Closes #245

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. — no new tests; the existing suite (381 tests, incl. the locale key-coverage test) passes
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. — no new assets; reuses the existing tab icons
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

### Verification

Deployed to an AYN Thor (dev channel):

- **Upgrade path** — migration v106 ran on an existing v105 DB, all three columns added.
- **Fresh-install path** — wiped `data.sqlite`, relaunched: `user_version = 106`, `user_config` carries all three columns defaulted to `0` (every tab visible), 121 systems seeded.
- Toggles confirmed working on-device.

## Screenshots (if applicable)

<img width="1905" height="1060" alt="image" src="https://github.com/user-attachments/assets/6a5de04f-1429-4b92-9a46-be947ac70009" />

