### PR TITLE
fix(wizard): download the art pack on A, keep the dock hidden during setup

### DIFF
--- a/lib/models/secondary_display_state.dart
+++ b/lib/models/secondary_display_state.dart
@@ -204,6 +204,15 @@ class SecondaryDisplayStateData {
   /// while the app is still loading.
   final bool appReady;
 
+  /// Whether the first-run setup wizard is on screen on the main display.
+  /// Pushed by the main engine while the wizard runs and cleared once setup
+  /// completes. The secondary display keeps the app dock and its all-apps
+  /// launcher parked off-screen while this is true — [appReady] latches at the
+  /// main engine's first frame, which happens *behind* the wizard, so without
+  /// this the dock slides up and offers app shortcuts before the user has even
+  /// picked a ROM folder.
+  final bool setupWizardActive;
+
   SecondaryDisplayStateData({
     required this.systemName,
     this.gameFanart,
@@ -267,6 +276,7 @@ class SecondaryDisplayStateData {
     this.dockEnabled = true,
     this.dockSlotCount = 3,
     this.appReady = false,
+    this.setupWizardActive = false,
   });
 
   /// Returns a new instance with the specified properties updated.
@@ -344,6 +354,7 @@ class SecondaryDisplayStateData {
     bool? dockEnabled,
     int? dockSlotCount,
     bool? appReady,
+    bool? setupWizardActive,
   }) {
     return SecondaryDisplayStateData(
       systemName: systemName ?? this.systemName,
@@ -422,6 +433,7 @@ class SecondaryDisplayStateData {
       dockEnabled: dockEnabled ?? this.dockEnabled,
       dockSlotCount: dockSlotCount ?? this.dockSlotCount,
       appReady: appReady ?? this.appReady,
+      setupWizardActive: setupWizardActive ?? this.setupWizardActive,
     );
   }
 
@@ -502,6 +514,7 @@ class SecondaryDisplayStateData {
       dockEnabled: json['dockEnabled'] as bool? ?? true,
       dockSlotCount: (json['dockSlotCount'] as num?)?.toInt() ?? 3,
       appReady: json['appReady'] as bool? ?? false,
+      setupWizardActive: json['setupWizardActive'] as bool? ?? false,
     );
   }
 
@@ -565,6 +578,7 @@ class SecondaryDisplayStateData {
       'dockEnabled': dockEnabled,
       'dockSlotCount': dockSlotCount,
       'appReady': appReady,
+      'setupWizardActive': setupWizardActive,
     };
   }
 }
@@ -678,6 +692,7 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
     bool? dockEnabled,
     int? dockSlotCount,
     bool? appReady,
+    bool? setupWizardActive,
   }) async {
     if (!Platform.isAndroid) return;
 
@@ -760,6 +775,7 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
           dockEnabled: dockEnabled,
           dockSlotCount: dockSlotCount,
           appReady: appReady,
+          setupWizardActive: setupWizardActive,
         ),
       );
     } catch (e) {

--- a/lib/providers/sqlite_config_provider/secondary_display.dart
+++ b/lib/providers/sqlite_config_provider/secondary_display.dart
@@ -145,6 +145,28 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
     }());
   }
 
+  /// Tells the secondary display whether the first-run setup wizard is on
+  /// screen, so it can keep the app dock and all-apps launcher parked while the
+  /// user is still setting up. [markAppReady] latches at the main engine's
+  /// first frame, which happens behind the wizard, so the dock would otherwise
+  /// slide up before there's an app to dock into.
+  ///
+  /// Pushes through [SecondaryDisplayState.instance] with the same
+  /// cached-construction guard as [markAppReady] — the wizard runs before the
+  /// provider has finished its async init, so `_secondaryDisplayState` may
+  /// still be null here.
+  void setSetupWizardActive(bool active) {
+    if (!Platform.isAndroid) return;
+    final state = _secondaryDisplayState ?? SecondaryDisplayState.instance;
+    unawaited(() async {
+      // See markAppReady: a bare await on an unassigned late final throws.
+      if (state.value == null) {
+        await state.initialSync;
+      }
+      await state.updateState(setupWizardActive: active);
+    }());
+  }
+
   void _onSecondaryStateChanged() {
     final state = _secondaryDisplayState?.value;
     if (state != null) {

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -52,9 +52,9 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   /// the animation has finished.
   static const Duration _dockRevealDuration = Duration(milliseconds: 550);
 
-  /// The last `dockEnabled` this engine observed, so [_onStateChanged] can spot
-  /// the user toggling the dock off. Null until the first state push.
-  bool? _dockEnabledSeen;
+  /// The last [_dockShown] this engine observed, so [_onStateChanged] can spot
+  /// the dock going away. Null until the first state push.
+  bool? _dockShownSeen;
 
   /// Keeps the dock overlay mounted while it slides out after being disabled.
   /// The setting flips instantly, so without this the subtree would be dropped
@@ -211,8 +211,10 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
 
     // Warm the app list + dock icons exactly once, only after the dock has
     // revealed. Gating on `appReady` keeps this heavy work off the cold-boot
-    // reveal path so it can't perturb the cross-engine dock-reveal race.
-    if (state.appReady && !_dockPrefetchStarted) {
+    // reveal path so it can't perturb the cross-engine dock-reveal race — and
+    // on the wizard flag so it doesn't compete with first-run setup for a
+    // dock nobody can see yet.
+    if (state.appReady && !state.setupWizardActive && !_dockPrefetchStarted) {
       _dockPrefetchStarted = true;
       unawaited(_prefetchDockData());
     }
@@ -266,18 +268,27 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     }
   }
 
+  /// Whether the app dock (and its all-apps launcher) belongs on screen: the
+  /// user has it enabled *and* the main display isn't running the first-run
+  /// setup wizard. The wizard owns the whole first-run experience, so the
+  /// bottom screen shouldn't be offering app shortcuts underneath it.
+  bool _dockShown(SecondaryDisplayStateData state) =>
+      state.dockEnabled && !state.setupWizardActive;
+
   /// Keeps the dock overlay mounted long enough to animate out when the user
   /// turns the dock off in settings. Enabling is symmetrical and needs no
   /// bookkeeping: the overlay mounts on the next build and the reveal tween
-  /// eases it up from its parked position, exactly as it does at boot.
+  /// eases it up from its parked position, exactly as it does at boot — which
+  /// is also how the dock arrives when the wizard finishes.
   void _syncDockMount(SecondaryDisplayStateData state) {
-    final was = _dockEnabledSeen;
-    _dockEnabledSeen = state.dockEnabled;
-    if (was == null || was == state.dockEnabled) return;
+    final was = _dockShownSeen;
+    final shown = _dockShown(state);
+    _dockShownSeen = shown;
+    if (was == null || was == shown) return;
 
     _dockSlideOutTimer?.cancel();
     _dockSlideOutTimer = null;
-    if (state.dockEnabled) {
+    if (shown) {
       // Re-enabled, possibly mid-slide-out — the tween picks up from wherever
       // the dock currently sits and carries it back into place.
       if (_dockSlidingOut) setState(() => _dockSlidingOut = false);
@@ -947,7 +958,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                             // Stays mounted for one animation after being
                             // disabled so it can slide back out (see
                             // [_syncDockMount]).
-                            if (value.dockEnabled || _dockSlidingOut)
+                            if (_dockShown(value) || _dockSlidingOut)
                               _buildDockOverlay(value),
 
                             // Scraping Overlay
@@ -1158,7 +1169,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
           child: TweenAnimationBuilder<double>(
             tween: Tween(
               begin: 1.0,
-              end: _dockRevealed && value.dockEnabled ? 0.0 : 1.0,
+              end: _dockRevealed && _dockShown(value) ? 0.0 : 1.0,
             ),
             duration: _dockRevealDuration,
             curve: Curves.easeOutCubic,

--- a/lib/widgets/permission_check_wrapper.dart
+++ b/lib/widgets/permission_check_wrapper.dart
@@ -41,6 +41,7 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
       // early-launcher boot races. If set, skip the wizard unconditionally.
       final prefs = await SharedPreferences.getInstance();
       if (prefs.getBool(PermissionCheckWrapper.setupCompletedKey) == true) {
+        _pushWizardActive(false);
         setState(() {
           _needsSetup = false;
           _isChecking = false;
@@ -64,11 +65,13 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
       if (hasRomFolder || setupCompleted) {
         // Backfill the SharedPreferences flag for existing users upgrading.
         await prefs.setBool(PermissionCheckWrapper.setupCompletedKey, true);
+        _pushWizardActive(false);
         setState(() {
           _needsSetup = false;
           _isChecking = false;
         });
       } else {
+        _pushWizardActive(true);
         setState(() {
           _needsSetup = true;
           _isChecking = false;
@@ -76,11 +79,24 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
       }
     } catch (e) {
       _log.e('Error checking initial setup: $e');
+      _pushWizardActive(false);
       setState(() {
         _needsSetup = false;
         _isChecking = false;
       });
     }
+  }
+
+  /// Mirrors "the wizard is on screen" to the secondary display, which parks
+  /// its app dock and launcher while setup runs. Pushed from here — the single
+  /// place that decides whether the wizard shows — so a normal boot also clears
+  /// a flag left behind by a run that was killed mid-wizard.
+  void _pushWizardActive(bool active) {
+    if (!mounted) return;
+    Provider.of<SqliteConfigProvider>(
+      context,
+      listen: false,
+    ).setSetupWizardActive(active);
   }
 
   void _completeSetup() async {
@@ -89,6 +105,9 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
       listen: false,
     );
     await configProvider.completeSetup();
+
+    // Setup is done — let the secondary display bring in the dock/launcher.
+    configProvider.setSetupWizardActive(false);
 
     // Persist flag to SharedPreferences so the wizard is never shown again
     // even if the SQLite DB is temporarily inaccessible (e.g. SD card not ready).

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -147,7 +147,18 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
       onSelectItem: () {
         if (_isSelectingFolder || _isSelectingUserDataFolder) return;
 
-        if (_isImportingEsde) return;
+        if (_isImportingEsde || _isDownloadingArt) return;
+        // Mirror the on-screen button's disabled state on the final step: while
+        // the theme manifest is still in flight we can't tell whether a pack is
+        // available, and letting A through would finish setup with no art.
+        if (_isLastStep) {
+          final neoAssets = context.read<NeoAssetsProvider>();
+          if (neoAssets.loading &&
+              !neoAssets.hasActiveTheme &&
+              neoAssets.themes.isEmpty) {
+            return;
+          }
+        }
         if (_currentStep == _stepScanning) {
           // A advances to the ES-DE step once the scan is done.
           final provider = Provider.of<SqliteConfigProvider>(
@@ -155,10 +166,11 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
             listen: false,
           );
           if (provider.scanCompleted) _handleMainAction();
-        } else if (_isLastStep) {
-          // Final (art-pack) step: A finishes setup.
-          _finishSetup();
         } else {
+          // Every step — including the final art-pack one — goes through the
+          // same primary action as the on-screen button. Shortcutting the last
+          // step to _finishSetup() here meant an A press completed setup
+          // without ever downloading/applying the art pack.
           _handleMainAction();
         }
       },

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -70,6 +70,10 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
   /// or it doesn't apply on this device.
   bool get _accessibilityDone => !_needsAccessibility || _accessibilityGranted;
 
+  /// True once setup is being finalised, so the per-frame secondary-display
+  /// push stops re-asserting `setupWizardActive` and the dock can come in.
+  bool _finishing = false;
+
   static final _log = LoggerService.instance;
 
   GamepadNavigation? _gamepadNav;
@@ -194,6 +198,11 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
   void _updateSecondaryScreen(int bgColor, bool isOled) {
     if (_secondaryDisplayState == null) return;
     _secondaryDisplayState!.updateState(
+      // Re-asserted on every push: the shared state is written by both engines
+      // and the secondary's own pushes copyWith from a snapshot that may
+      // predate the flag, so a single push can be echoed away (same hazard as
+      // `appReady`). Stops once we're finishing so it can't undo the clear.
+      setupWizardActive: !_finishing,
       systemName: AppLocale.welcomeNeoStation.getString(context),
       useFluidShader: true,
       backgroundColor: bgColor,
@@ -1923,6 +1932,11 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
   }
 
   Future<void> _finishSetup() async {
+    // Stop pinning the secondary display's dock/launcher off-screen. Set before
+    // any await so a rebuild racing the save can't re-assert the flag; the
+    // wrapper pushes the clear once completeSetup() lands.
+    _finishing = true;
+
     // Verificar que la configuración está guardada
     final configProvider = Provider.of<SqliteConfigProvider>(
       context,

--- a/test/secondary_display_state_test.dart
+++ b/test/secondary_display_state_test.dart
@@ -86,6 +86,11 @@ void main() {
       dockEditTrigger: 3,
       dockEnabled: false,
       dockSlotCount: 4,
+      // Both non-default so a field dropped from toJson/fromJson actually fails
+      // the round-trip — at their `false` defaults a missing key restores to the
+      // same value and the comparison passes regardless.
+      appReady: true,
+      setupWizardActive: true,
     );
 
     test('round-trips every field through toJson/fromJson', () {
@@ -135,6 +140,11 @@ void main() {
       expect(restored.dockEnabled, isTrue);
       expect(restored.dockSlotCount, 3);
       expect(restored.dockApps, const ['', '', '', '', '']);
+      // Both latches start off: the main engine hasn't painted, and the dock is
+      // only withheld once the wizard says so. A payload predating either field
+      // must not read as "wizard running" — that would park the dock forever.
+      expect(restored.appReady, isFalse);
+      expect(restored.setupWizardActive, isFalse);
     });
 
     test('coerces numeric fields delivered as doubles', () {
@@ -204,6 +214,37 @@ void main() {
       expect(launched.isGameLaunching, isTrue);
       expect(launched.nowPlayingActive, isTrue);
       expect(launched.gameTitle, 'Silent Hill');
+    });
+
+    test('a partial update that omits setupWizardActive preserves it', () {
+      // The wizard parks the secondary display's dock and launcher by holding
+      // this flag true. Both engines write the shared state, so any push that
+      // doesn't mention the flag — a mute toggle, an isSecondaryActive update —
+      // must not clear it, or the dock slides up mid-setup.
+      final inWizard = SecondaryDisplayStateData(
+        systemName: 'WELCOME',
+        setupWizardActive: true,
+        appReady: true,
+      );
+
+      final next = inWizard.copyWith(isSecondaryActive: true, isOled: true);
+
+      expect(next.setupWizardActive, isTrue);
+      expect(next.appReady, isTrue);
+    });
+
+    test('an explicit setupWizardActive: false clears it (setup complete)', () {
+      // How the dock is released: the wrapper pushes the clear once setup
+      // completes, and the reveal tween brings the dock in.
+      final inWizard = SecondaryDisplayStateData(
+        systemName: 'WELCOME',
+        setupWizardActive: true,
+      );
+
+      expect(
+        inWizard.copyWith(setupWizardActive: false).setupWizardActive,
+        isFalse,
+      );
     });
   });
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was developed with [Claude Code](https://claude.com/claude-code).

# Description

Two first-run setup wizard bugs, both only visible on a handheld. Fixes # (issue)

## 1. The A button on the final step never downloaded the art pack

**Symptom:** on the art-pack step, pressing **A** completed the wizard with no art pack installed. Tapping the same on-screen button worked — so on a device where A is the only realistic input, the feature was effectively dead.

**Cause:** the gamepad `onSelectItem` handler special-cased the last step and called `_finishSetup()` directly, bypassing `_handleMainAction()` — the only path that reaches `_downloadWizardArtPack()`. The shortcut is a leftover from #184, which moved "last step" off the scanning step onto the new art-pack step; that PR also made `_downloadWizardArtPack()` finish setup itself, which left the branch redundant as well as wrong.

**Fix:**

- A now routes through `_handleMainAction()` on every step, exactly like the on-screen button.
- `_isDownloadingArt` added to the re-entry guard so repeat presses can't stack downloads.
- A on the final step now honours the same "manifest still loading" gate that disables the on-screen button — otherwise a fast press finishes setup before `themes` populates, reaching the same silent failure by another route.

## 2. The app dock and launcher appeared on the bottom screen during setup

**Symptom:** the secondary display slid its app dock and all-apps launcher up while the user was still on the wizard's early steps — offering app shortcuts before there was a configured app to shortcut to.

**Cause:** `markAppReady()` latches at the main engine's first frame, which happens *behind* the wizard, and the secondary display treats that latch as "main UI is up, bring the dock in".

**Fix** — a `setupWizardActive` flag on the shared secondary-display state:

- `PermissionCheckWrapper` owns it. It's the one place that decides whether the wizard shows, so a normal boot also clears a flag left behind by a run killed mid-wizard, and completing setup clears it.
- The wizard re-asserts it on every secondary push. The shared state is written by both engines and a lone push can be echoed away — the same hazard the `appReady` latch already works around. It stops re-asserting the moment setup starts finalising, so it can't undo the clear.
- The secondary screen gates the dock overlay on `dockEnabled && !setupWizardActive` via `_dockShown`, used by the mount condition, the reveal tween and the slide-out bookkeeping — so the dock eases up with its normal animation when setup completes instead of popping in. Gating the overlay covers the launcher button too, since it lives inside it.
- Dock icon/app-list prefetch waits for the wizard as well, keeping that work off the first-run path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Testing

Verified on an **AYN Thor** from a true first-run state — app data cleared, external `user-data/` wiped including the theme cache, and `MANAGE_EXTERNAL_STORAGE` revoked at both the package and uid level — then walking the full six-step wizard with a controller.

| Check | Result |
| --- | --- |
| Dock + launcher during all six steps | Stayed off the bottom screen |
| Dock after setup completed | Slid up with the normal reveal animation |
| A on the art-pack step | Downloaded and applied the pack, then finished |

Log from the art-pack step, showing the download running *before* the wizard exits:

```
20:05:36.499  A press → release
20:05:36.597  buildThemeDownloadPlan[NeoStation]: localVersion=null remoteVersion=0.6.0 covered=121/121 missing=121
20:05:42.001  GamepadNavigationManager: Pushing layer: app_screen   ← wizard exits, 5.4s later
```

On disk afterwards, in a directory that was empty before the run: 121 backgrounds (34 MB) plus `theme.json` v0.6.0, and the DB has `active_theme='NeoStation'`, `setup_completed=1`. Pre-fix, the A press went straight to `app_screen` with the themes directory still empty.

`setupWizardActive` is also pinned by unit tests on the shared-state bridge — round-trip, defaults, and the `copyWith` merge contract — since those are the paths that would drop it silently.

`flutter analyze` clean, 383 tests pass, `dart format` clean.
