### PR TITLE
fix(scraper): refresh artwork immediately

### DIFF
--- a/lib/providers/scraping_provider.dart
+++ b/lib/providers/scraping_provider.dart
@@ -131,6 +131,9 @@ class ScrapingProvider extends ChangeNotifier {
   /// Fixed list of worker threads available for the session.
   List<ThreadProgress> _threads = [];
 
+  /// Increments after a completed scrape writes new artwork to disk.
+  int _artworkRevision = 0;
+
   bool get isScraping => _isScraping;
   int get totalRequests => _totalRequests;
   int get maxDailyRequests => _maxDailyRequests;
@@ -141,6 +144,12 @@ class ScrapingProvider extends ChangeNotifier {
   int get maxThreads => _maxThreads;
   List<ThreadProgress> get threads => _threads;
   Duration? get estimatedTimeRemaining => _estimatedTimeRemaining;
+  int get artworkRevision => _artworkRevision;
+
+  void markArtworkUpdated() {
+    _artworkRevision++;
+    notifyListeners();
+  }
 
   /// Initializes and starts a new scraping session.
   ///

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -42,11 +42,18 @@ class GamesCarousel extends StatefulWidget {
   final VoidCallback? onScrape;
   final Set<String> scrapingGameRomnames;
   final Map<String, double> scrapeProgress;
+  final int artworkVersion;
 
-  /// No-op stub retained for API compatibility with the current scraping tab.
-  /// This pre-#188 carousel keeps no static artwork caches; the Flutter image
-  /// cache is evicted separately by the caller.
-  static void evictArtworkCaches(Iterable<String> paths) {}
+  /// Clears artwork dimension caches after files are added or overwritten.
+  static void evictArtworkCaches(Iterable<String> paths) {
+    if (paths.isEmpty) {
+      _GamesCarouselState._imgSizeCache.clear();
+      return;
+    }
+    for (final path in paths) {
+      _GamesCarouselState._imgSizeCache.remove(path);
+    }
+  }
 
   const GamesCarousel({
     super.key,
@@ -63,6 +70,7 @@ class GamesCarousel extends StatefulWidget {
     this.onScrape,
     this.scrapingGameRomnames = const {},
     this.scrapeProgress = const {},
+    this.artworkVersion = 0,
   });
 
   @override
@@ -262,6 +270,11 @@ class _GamesCarouselState extends State<GamesCarousel> {
       if (_currentIndex >= widget.games.length) {
         _currentIndex = 0;
       }
+    }
+    if (widget.artworkVersion != oldWidget.artworkVersion) {
+      _fileExistsCache.clear();
+      _lastBgIndex = -1;
+      WidgetsBinding.instance.addPostFrameCallback((_) => _updateBackground());
     }
   }
 

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -42,11 +42,20 @@ class GamesGrid extends StatefulWidget {
   final VoidCallback? onScrape;
   final Set<String> scrapingGameRomnames;
   final Map<String, double> scrapeProgress;
+  final int artworkVersion;
 
-  /// No-op stub retained for API compatibility with the current scraping tab.
-  /// This pre-#188 grid keeps no static artwork caches; the Flutter image
-  /// cache is evicted separately by the caller.
-  static void evictArtworkCaches(Iterable<String> paths) {}
+  /// Clears path-derived caches after artwork is added or overwritten.
+  static void evictArtworkCaches(Iterable<String> paths) {
+    if (paths.isEmpty) {
+      _GamesGridState._imageSizeCache.clear();
+      _GameCardImageState._existsCache.clear();
+      return;
+    }
+    for (final path in paths) {
+      _GamesGridState._imageSizeCache.remove(path);
+      _GameCardImageState._existsCache.remove(path);
+    }
+  }
 
   const GamesGrid({
     super.key,
@@ -63,6 +72,7 @@ class GamesGrid extends StatefulWidget {
     this.onScrape,
     this.scrapingGameRomnames = const {},
     this.scrapeProgress = const {},
+    this.artworkVersion = 0,
   });
 
   @override
@@ -615,6 +625,7 @@ class _GamesGridState extends State<GamesGrid> {
     // them (a changed game set / cols also invalidates via _layoutGen, but the
     // scrape props do not touch layout — clear explicitly).
     if (widget.games != oldWidget.games ||
+        widget.artworkVersion != oldWidget.artworkVersion ||
         widget.scrapingGameRomnames != oldWidget.scrapingGameRomnames ||
         widget.scrapeProgress != oldWidget.scrapeProgress) {
       _rowCache.clear();
@@ -1324,7 +1335,7 @@ class _GamesGridState extends State<GamesGrid> {
               ),
               clipBehavior: Clip.antiAlias,
               child: _GameCardImage(
-                key: ValueKey('img_${game.romname}'),
+                key: ValueKey('img_${game.romname}_${widget.artworkVersion}'),
                 box2dPath: box2dPath,
                 game: game,
                 targetWidth: targetWidth,

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -28,6 +28,7 @@ import '../../utils/letter_jump.dart';
 import '../../providers/file_provider.dart';
 import '../../providers/sqlite_config_provider.dart';
 import '../../providers/sqlite_database_provider.dart';
+import '../../providers/scraping_provider.dart';
 import '../../models/system_model.dart';
 import '../../models/game_model.dart';
 import 'game_details_card/game_details_card_list.dart';
@@ -185,6 +186,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
   // Memoized providers for lifecycle management.
   late SqliteConfigProvider _configProvider;
   late SqliteDatabaseProvider _databaseProvider;
+  late ScrapingProvider _scrapingProvider;
+  int _lastArtworkRevision = 0;
 
   @override
   void initState() {
@@ -200,6 +203,12 @@ class _SystemGamesListState extends State<SystemGamesList> {
 
     _configProvider = context.read<SqliteConfigProvider>();
     _configProvider.addListener(_onConfigChanged);
+
+    _scrapingProvider = context.read<ScrapingProvider>();
+    _lastArtworkRevision = _scrapingProvider.artworkRevision;
+    _scrapingProvider.addListener(_onScrapingUpdated);
+    _artworkVersion = _lastArtworkRevision;
+    _invalidateArtworkCaches();
 
     GameLegendVisibility.hidden.addListener(_onLegendVisibilityChanged);
 
@@ -230,6 +239,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
     // Detach listeners before disposal.
     _configProvider.removeListener(_onConfigChanged);
     _databaseProvider.removeListener(_onDatabaseUpdated);
+    _scrapingProvider.removeListener(_onScrapingUpdated);
     MusicPlayerService().removeListener(_onMusicPlayerStateChanged);
     GameLegendVisibility.hidden.removeListener(_onLegendVisibilityChanged);
 
@@ -240,6 +250,24 @@ class _SystemGamesListState extends State<SystemGamesList> {
     _cleanupResources();
     _backButtonFocusNode.dispose();
     super.dispose();
+  }
+
+  void _onScrapingUpdated() {
+    final revision = _scrapingProvider.artworkRevision;
+    if (!mounted || revision == _lastArtworkRevision) return;
+    _lastArtworkRevision = revision;
+
+    // Bulk scraping happens outside this route. Reload its metadata and force
+    // image widgets to check the artwork files again.
+    _invalidateArtworkCaches();
+    setState(() => _artworkVersion++);
+    _loadGames();
+  }
+
+  void _invalidateArtworkCaches() {
+    GamesGrid.evictArtworkCaches(const []);
+    GamesCarousel.evictArtworkCaches(const []);
+    PaintingBinding.instance.imageCache.clear();
   }
 
   /// Synchronizes UI state with global configuration changes.
@@ -1058,6 +1086,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
       onScrape: _scrapeSelectedGame,
       scrapingGameRomnames: _scrapingGameRomnames,
       scrapeProgress: _scrapeProgress,
+      artworkVersion: _artworkVersion,
     );
   }
 
@@ -1083,6 +1112,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
       onScrape: _scrapeSelectedGame,
       scrapingGameRomnames: _scrapingGameRomnames,
       scrapeProgress: _scrapeProgress,
+      artworkVersion: _artworkVersion,
     );
   }
 
@@ -1531,6 +1561,15 @@ class _SystemGamesListState extends State<SystemGamesList> {
       );
 
       if (updatedGame != null) {
+        final artworkFolder =
+            updatedGame.systemFolderName ?? widget.system.primaryFolderName;
+        final artworkPaths = [
+          updatedGame.getScreenshotPath(artworkFolder, _fileProvider),
+          updatedGame.getImagePath(artworkFolder, 'box2d', _fileProvider),
+          updatedGame.getImagePath(artworkFolder, 'fanarts', _fileProvider),
+        ];
+        GamesGrid.evictArtworkCaches(artworkPaths);
+        GamesCarousel.evictArtworkCaches(artworkPaths);
         setState(() {
           _selectedGame = updatedGame;
           _artworkVersion++;

--- a/lib/screens/scraper_screen/scraper_contents/scraping_content.dart
+++ b/lib/screens/scraper_screen/scraper_contents/scraping_content.dart
@@ -78,6 +78,9 @@ class ScrapingContentState extends State<ScrapingContent> {
       );
 
       if (scrapingSuccess) {
+        if (scrapingProvider.successfulGames > 0) {
+          scrapingProvider.markArtworkUpdated();
+        }
         if (mounted) {
           final message = scrapingProvider.totalGames == 0
               ? AppLocale.allGamesUpToDate.getString(context)


### PR DESCRIPTION
## Summary

Refresh scraped artwork immediately in open game views.

- Clear grid and carousel artwork path caches after individual scrapes.
- Recreate grid image widgets when the artwork version changes, so a previously missing file is checked again.
- Publish a bulk-scrape artwork revision; active game screens clear decoded image/path caches and reload their metadata.

## Root cause

The previous fix rebuilt the game list, but the grid retained a process-wide cache saying an artwork path did not exist. A file created by scraping therefore remained invisible until process restart. Bulk scraping also had no signal to refresh an open game list.

## Validation

- `flutter analyze` on the five changed files
- Built and installed the debug APK on an AYN Thor
- Verified the refresh behavior on-device