### PR TITLE
fix(scraper): force re-download in 'all content' mode and notify on daily quota exceeded

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -833,6 +833,7 @@ mixin AppLocale {
   static const String scrapeUnexpectedError = 'scrape_unexpected_error';
   static const String scrapeSuccessful = 'scrape_successful';
   static const String scrapeErrorGame = 'scrape_error_game';
+  static const String scrapeQuotaExceeded = 'scrape_quota_exceeded';
 
   // ---------------------------------------------------------------------------
   // User data location

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -445,6 +445,8 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.stoppingScraping: 'Scraping-Prozess wird gestoppt...',
   AppLocale.syncError: 'Fehler beim Synchronisieren der System-IDs',
   AppLocale.metadataError: 'Fehler während des Scraping-Prozesses',
+  AppLocale.scrapeQuotaExceeded:
+      'ScreenScraper Tages-Scraping-Kontingent überschritten',
   AppLocale.start: 'Start',
   AppLocale.systemsSub: 'Wähle die Systeme zum Scrapen',
   AppLocale.disableAll: 'Alle deaktivieren',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -427,6 +427,8 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.stoppingScraping: 'Stopping scraping process...',
   AppLocale.syncError: 'Error synchronizing system IDs',
   AppLocale.metadataError: 'Error during metadata scraping',
+  AppLocale.scrapeQuotaExceeded:
+      'ScreenScraper daily scraping quota exceeded',
   AppLocale.start: 'Start',
   AppLocale.systemsSub: 'Select which systems to scrape',
   AppLocale.disableAll: 'Disable All',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -442,6 +442,8 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.stoppingScraping: 'Deteniendo el proceso de scraping...',
   AppLocale.syncError: 'Error al sincronizar IDs de sistemas',
   AppLocale.metadataError: 'Error durante el scraping de metadatos',
+  AppLocale.scrapeQuotaExceeded:
+      'Has superado la cuota diaria de scraping de ScreenScraper',
   AppLocale.start: 'Iniciar',
   AppLocale.systemsSub: 'Selecciona qué sistemas escanear',
   AppLocale.disableAll: 'Desactivar Todos',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -451,6 +451,8 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.stoppingScraping: 'Arrêt du processus de scraping...',
   AppLocale.syncError: 'Erreur lors de la synchronisation des IDs système',
   AppLocale.metadataError: 'Erreur lors du processus de scraping',
+  AppLocale.scrapeQuotaExceeded:
+      'Quota de scraping quotidien ScreenScraper dépassé',
   AppLocale.start: 'Démarrer',
   AppLocale.systemsSub: 'Sélectionner les systèmes à rechercher',
   AppLocale.disableAll: 'Tout Désactiver',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -427,6 +427,8 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.stoppingScraping: 'Menghentikan proses scraping...',
   AppLocale.syncError: 'Kesalahan saat menyinkronkan ID sistem',
   AppLocale.metadataError: 'Kesalahan selama proses scraping',
+  AppLocale.scrapeQuotaExceeded:
+      'Kuota harian scraping ScreenScraper terlampaui',
   AppLocale.start: 'Mulai',
   AppLocale.systemsSub: 'Pilih sistem yang akan di-scrape',
   AppLocale.disableAll: 'Nonaktifkan Semua',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -439,6 +439,8 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.stoppingScraping: 'Arresto processo scraping...',
   AppLocale.syncError: 'Errore durante la sincronizzazione degli ID di sistema',
   AppLocale.metadataError: 'Errore durante il processo di scraping',
+  AppLocale.scrapeQuotaExceeded:
+      'Quota giornaliera di scraping di ScreenScraper superata',
   AppLocale.start: 'Inizia',
   AppLocale.systemsSub: 'Seleziona i sistemi da cercare',
   AppLocale.disableAll: 'Disabilita Tutti',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -380,6 +380,8 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.stoppingScraping: 'スクレイピングプロセスを停止中...',
   AppLocale.syncError: 'システムIDの同期中にエラーが発生しました',
   AppLocale.metadataError: 'スクレイピングプロセス中にエラーが発生しました',
+  AppLocale.scrapeQuotaExceeded:
+      'ScreenScraperの1日のスクレイピングクォータを超えました',
   AppLocale.start: '開始',
   AppLocale.systemsSub: 'スクレイピングするシステムを選択',
   AppLocale.disableAll: 'すべて無効',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -387,6 +387,8 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.stoppingScraping: '게임 정보 가져오기를 중지하는 중...',
   AppLocale.syncError: '시스템 ID를 동기화하는 중 오류가 발생했습니다',
   AppLocale.metadataError: '게임 정보 가져오기 오류',
+  AppLocale.scrapeQuotaExceeded:
+      'ScreenScraper 일일 스크래핑 할당량 초과',
   AppLocale.start: '시작',
   AppLocale.systemsSub: '게임 정보를 가져올 시스템을 선택합니다',
   AppLocale.disableAll: '모두 비활성화',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -436,6 +436,8 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.stoppingScraping: 'Parando processo de scraping...',
   AppLocale.syncError: 'Erro ao sincronizar IDs do sistema',
   AppLocale.metadataError: 'Erro durante o processo de scraping',
+  AppLocale.scrapeQuotaExceeded:
+      'Cota diária de scraping do ScreenScraper excedida',
   AppLocale.start: 'Iniciar',
   AppLocale.systemsSub: 'Selecionar sistemas para buscar',
   AppLocale.disableAll: 'Desativar Todos',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -436,6 +436,8 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.stoppingScraping: 'Остановка процесса скрапинга...',
   AppLocale.syncError: 'Ошибка синхронизации ID систем',
   AppLocale.metadataError: 'Ошибка при скрапинге метаданных',
+  AppLocale.scrapeQuotaExceeded:
+      'Превышена дневная квота скрейпинга ScreenScraper',
   AppLocale.start: 'Старт',
   AppLocale.systemsSub: 'Выберите системы для скрапинга',
   AppLocale.disableAll: 'Отключить все',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -377,6 +377,8 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.stoppingScraping: '正在停止抓取过程...',
   AppLocale.syncError: '同步系统 ID 时出错',
   AppLocale.metadataError: '元数据抓取过程中出错',
+  AppLocale.scrapeQuotaExceeded:
+      'ScreenScraper 每日刮削配额已超出',
   AppLocale.start: '开始',
   AppLocale.systemsSub: '选择要抓取的系统',
   AppLocale.disableAll: '全部禁用',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -377,6 +377,8 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.stoppingScraping: '正在停止抓取程序...',
   AppLocale.syncError: '同步系統 ID 時發生錯誤',
   AppLocale.metadataError: '中繼資料抓取過程中發生錯誤',
+  AppLocale.scrapeQuotaExceeded:
+      'ScreenScraper 每日刮削配額已超出',
   AppLocale.start: '開始',
   AppLocale.systemsSub: '選擇要抓取的系統',
   AppLocale.disableAll: '全部停用',

--- a/lib/screens/game_screen/game_settings_dialog/game_settings_scrapping_tab.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_scrapping_tab.dart
@@ -315,11 +315,12 @@ class GameSettingsScrappingTabState extends State<GameSettingsScrappingTab> {
       GamesCarousel.evictArtworkCaches(_artworkPaths());
 
       if (mounted) {
+        final message = result['success'] == true
+            ? 'Scraping completed'
+            : 'Scraping failed: ${result['message'].toString().getString(context)}';
         AppNotification.showNotification(
           context,
-          result['success'] == true
-              ? 'Scraping completed'
-              : 'Scraping failed: ${result['message']}',
+          message,
           type: result['success'] == true
               ? NotificationType.success
               : NotificationType.error,

--- a/lib/screens/scraper_screen/scraper_contents/scraping_content.dart
+++ b/lib/screens/scraper_screen/scraper_contents/scraping_content.dart
@@ -6,6 +6,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:neostation/providers/scraping_provider.dart';
 import 'package:neostation/services/screenscraper_service.dart';
+import 'package:neostation/services/screenscraper/screenscraper_exceptions.dart';
 import 'package:neostation/widgets/custom_notification.dart';
 import 'package:neostation/services/logger_service.dart';
 import '../../settings_screen/new_settings_options/settings_title.dart';
@@ -105,6 +106,14 @@ class ScrapingContentState extends State<ScrapingContent> {
             type: NotificationType.error,
           );
         }
+      }
+    } on ScreenscraperQuotaExceededException {
+      if (mounted) {
+        AppNotification.showNotification(
+          context,
+          AppLocale.scrapeQuotaExceeded.getString(context),
+          type: NotificationType.error,
+        );
       }
     } catch (e) {
       if (mounted) {

--- a/lib/services/screenscraper/screenscraper_client.dart
+++ b/lib/services/screenscraper/screenscraper_client.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:neostation/services/logger_service.dart';
+import 'screenscraper_exceptions.dart';
 import '../../utils/semaphore.dart';
 
 /// HTTP transport, rate limiting, and request identity for ScreenScraper.
@@ -117,6 +118,10 @@ class ScreenscraperClient {
         if (response.statusCode == 200 || response.statusCode == 403) {
           _dailyRequestsCount++;
           return response;
+        } else if (response.statusCode == 430) {
+          throw ScreenscraperQuotaExceededException(
+            'Daily scraping quota exceeded (HTTP 430)',
+          );
         } else if (response.statusCode >= 500) {
           if (attempt < maxRetries - 1) {
             final delay = Duration(milliseconds: 500 * (attempt + 1));

--- a/lib/services/screenscraper/screenscraper_exceptions.dart
+++ b/lib/services/screenscraper/screenscraper_exceptions.dart
@@ -1,0 +1,10 @@
+/// Exceptions thrown by the ScreenScraper service layer.
+class ScreenscraperQuotaExceededException implements Exception {
+  final String message;
+
+  ScreenscraperQuotaExceededException([this.message = '']);
+
+  @override
+  String toString() =>
+      'ScreenscraperQuotaExceededException: ${message.isEmpty ? 'Daily scraping quota exceeded' : message}';
+}

--- a/lib/services/screenscraper_service.dart
+++ b/lib/services/screenscraper_service.dart
@@ -10,6 +10,7 @@ import 'screenscraper/rom_hasher.dart';
 import 'screenscraper/media_resolver.dart';
 import 'screenscraper/screenscraper_client.dart';
 import 'screenscraper/media_downloader.dart';
+import 'screenscraper/screenscraper_exceptions.dart';
 import '../providers/scraping_provider.dart';
 import '../l10n/app_locale.dart';
 import '../widgets/scraping_summary_dialog.dart';
@@ -386,6 +387,8 @@ class ScreenScraperService {
         _log.e('HTTP Error ${response.statusCode}: ${response.body}');
         return null;
       }
+    } on ScreenscraperQuotaExceededException {
+      rethrow;
     } catch (e) {
       _log.e('Error getting game information: $e');
       return null;
@@ -661,6 +664,8 @@ class ScreenScraperService {
             ? AppLocale.scrapeSuccessful
             : AppLocale.scrapeMediaDownloadsFailed,
       };
+    } on ScreenscraperQuotaExceededException {
+      return {'success': false, 'message': AppLocale.scrapeQuotaExceeded};
     } catch (e) {
       _log.e('Error scraping single game: $e');
       return {'success': false, 'message': AppLocale.scrapeUnexpectedError};
@@ -827,6 +832,10 @@ class ScreenScraperService {
 
       scrapingProvider.stopScraping();
       return true;
+    } on ScreenscraperQuotaExceededException {
+      _log.e('Daily scraping quota exceeded; stopping scraping session.');
+      scrapingProvider.stopScraping();
+      rethrow;
     } catch (e) {
       _log.e('Error during scraping process: $e');
       scrapingProvider.stopScraping();
@@ -951,6 +960,7 @@ class ScreenScraperService {
             shouldCancel: shouldCancel,
             allowedMediaTypes: allowedTypes,
             maxDailyRequests: maxDailyRequests,
+            forceOverwrite: scraperConfig['scrape_mode'].toString() == 'all',
           );
           if (res['cancelled'] == true) {
             return {
@@ -976,6 +986,8 @@ class ScreenScraperService {
         return {'success': true, 'cancelled': false, 'requests': requestsMade};
       }
       return {'success': false, 'cancelled': false, 'requests': requestsMade};
+    } on ScreenscraperQuotaExceededException {
+      rethrow;
     } catch (e) {
       return {'success': false, 'cancelled': false, 'requests': 0};
     }


### PR DESCRIPTION
## Summary

This PR fixes two scraper issues:

1. **'All content' mode now re-downloads everything**
   - Media downloads receive  when , so existing images/videos are re-downloaded and replaced.
   - Metadata already used , so it is overwritten as expected.

2. **Notify when ScreenScraper daily quota is exceeded**
   - Detects HTTP 430 from the ScreenScraper API ().
   - Bulk scraping stops immediately and shows a localized .
   - Single-game scraping returns the localized quota message so all callers (grid, carousel, settings dialog) display the correct error.
   - Added  localization key for all supported languages.