### PR TITLE
feat(game-details): restructure detail tabs and extract dedicated media tabs

### DIFF
--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -27,6 +27,8 @@ import '../../../models/secondary_display_state.dart';
 import 'widgets/game_details_footer.dart';
 import 'widgets/game_details_tabs_header.dart';
 import 'tabs/game_details_general_tab.dart';
+import 'tabs/game_details_box2d_tab.dart';
+import 'tabs/game_details_screenshot_video_tab.dart';
 import 'tabs/game_details_game_info_tab.dart';
 import 'tabs/game_details_achievements_tab.dart';
 
@@ -184,7 +186,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
   String _scrapeStatus = '';
 
   // View state: Current active tab and scrolling context.
-  DetailTab _currentTab = DetailTab.general;
+  DetailTab _currentTab = DetailTab.wheel;
   final ScrollController _achievementsScrollController = ScrollController();
   int _imageVersion =
       0; // Cache-busting version for images after metadata refreshes.
@@ -196,11 +198,10 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
   final GlobalKey<GameDetailsAchievementsTabState> _achievementsTabKey =
       GlobalKey<GameDetailsAchievementsTabState>();
 
-  /// Determines if the detailed game info tab should be suppressed in favor of secondary display output.
+  /// Determines if the screenshot/video tab should be suppressed when secondary display is active.
   bool get _isGameInfoHidden {
     if (!widget.isSecondaryScreenActive) return false;
     final config = context.read<SqliteConfigProvider>().config;
-    // If secondary display is active and not explicitly hidden in config, suppress primary UI info.
     return !config.hideBottomScreen;
   }
 
@@ -247,7 +248,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
     _favoriteButtonFocusNode = FocusNode();
     _scrapeButtonFocusNode = FocusNode();
 
-    _currentTab = DetailTab.general;
+    _currentTab = DetailTab.wheel;
 
     // Reset primary UI 'Game Info' overlay to ensure clean state transitions.
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -284,7 +285,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
     widget.onShowAchievements?.call(() {
       _setTab(
         _currentTab == DetailTab.achievements
-            ? DetailTab.general
+            ? DetailTab.wheel
             : DetailTab.achievements,
       );
     });
@@ -293,9 +294,8 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
 
     widget.onToggleVideoMute?.call(_toggleVideoMute);
 
-    // Info toggle: Triggers metadata scraping if information is missing.
     widget.onToggleInfo?.call(() {
-      if (_currentTab == DetailTab.gameInfo && _isScrapingGame == false) {
+      if (_currentTab == DetailTab.screenshotVideo && _isScrapingGame == false) {
         if (_game.getDescriptionForLanguage('en').isEmpty ||
             _game.getDescriptionForLanguage('en') ==
                 'No description available.') {
@@ -307,19 +307,19 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
         refreshAchievements();
       } else {
         _setTab(
-          _currentTab == DetailTab.gameInfo
-              ? DetailTab.general
-              : DetailTab.gameInfo,
+          _currentTab == DetailTab.screenshotVideo
+              ? DetailTab.wheel
+              : DetailTab.screenshotVideo,
         );
       }
     });
 
     widget.onRegisterOverlayState?.call(
-      () => _currentTab != DetailTab.general,
+      () => _currentTab != DetailTab.wheel,
       () => _currentTab == DetailTab.achievements,
     );
     widget.onRegisterCloseOverlays?.call(() {
-      _setTab(DetailTab.general);
+      _setTab(DetailTab.wheel);
     });
     widget.onRegisterTabNavigation?.call(_handleTabNavigation);
     widget.onRegisterSelectButton?.call(_handleSelectAction);
@@ -426,17 +426,16 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
       _applyVideoMuteState();
     }
 
-    // Dynamic UI constraints: exit tabs if their requirements are no longer met.
-    if ((_isGameInfoHidden && _currentTab == DetailTab.gameInfo) ||
+    if ((_isGameInfoHidden && _currentTab == DetailTab.screenshotVideo) ||
         (!_hasRetroAchievements && _currentTab == DetailTab.achievements)) {
-      _currentTab = DetailTab.general;
+      _currentTab = DetailTab.wheel;
     }
 
     widget.onToggleInfo?.call(() {
       _setTab(
-        _currentTab == DetailTab.gameInfo
-            ? DetailTab.general
-            : DetailTab.gameInfo,
+        _currentTab == DetailTab.screenshotVideo
+            ? DetailTab.wheel
+            : DetailTab.screenshotVideo,
       );
     });
   }
@@ -486,18 +485,6 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
         }
       }
     });
-  }
-
-  /// Gracefully terminates video preview playback and cancels pending transition timers.
-  void _cancelVideoDelay() {
-    _videoDelayTimer?.cancel();
-    _videoDelayTimer = null;
-    setState(() {
-      _isVideoDelayActive = false;
-    });
-    if (widget.videoController?.value.isPlaying == true) {
-      widget.videoController?.pause();
-    }
   }
 
   /// Loads RetroAchievements data for the current game, including MD5 hash generation.
@@ -615,7 +602,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
             right: 0.r,
             top: 0.r,
             child: GameDetailsTabsHeader(
-              isGameInfoHidden: _isGameInfoHidden,
+              isScreenshotVideoHidden: _isGameInfoHidden,
               hasRetroAchievements: _hasRetroAchievements,
               currentTab: _currentTab,
               onTabChanged: (tab) => _setTab(tab),
@@ -639,13 +626,26 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
             currentGameInfo: _currentGameInfo,
           ),
 
-          // Dynamic Content Layer: Selected Tab View.
-          if (_currentTab == DetailTab.general)
+          if (_currentTab == DetailTab.wheel)
             GameDetailsGeneralTab(
               system: _effectiveSystem,
               game: _game,
               fileProvider: widget.fileProvider,
               androidAppIconFuture: _androidAppIconFuture,
+            ),
+          if (_currentTab == DetailTab.box2d)
+            GameDetailsBox2dTab(
+              system: _effectiveSystem,
+              game: _game,
+              fileProvider: widget.fileProvider,
+            ),
+          if (_currentTab == DetailTab.screenshotVideo)
+            GameDetailsScreenshotVideoTab(
+              screenshotPath: screenshotPath,
+              isVideoDelayActive: _isVideoDelayActive,
+              videoController: widget.videoController,
+              imageVersion: _imageVersion,
+              onToggleVideoMute: _toggleVideoMute,
             ),
           if (_currentTab == DetailTab.gameInfo)
             GameDetailsGameInfoTab(
@@ -657,15 +657,10 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
                   (_game.getDescriptionForLanguage('en').isEmpty
                       ? AppLocale.noDescription.getString(context)
                       : _game.getDescriptionForLanguage('en')),
-              screenshotPath: screenshotPath,
               isScrapingGame: _isScrapingGame || widget.isExternallyScraping,
               scrapeProgress: _scrapeProgress,
               scrapeStatus: _scrapeStatus,
               isSecondaryScreenActive: widget.isSecondaryScreenActive,
-              isVideoDelayActive: _isVideoDelayActive,
-              videoController: widget.videoController,
-              imageVersion: _imageVersion,
-              onToggleVideoMute: _toggleVideoMute,
               onScrapeGame: _onScrapeGameCompact,
             ),
           if (_currentTab == DetailTab.achievements)
@@ -694,17 +689,14 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
         description.trim().isEmpty;
 
     if (!widget.isSecondaryScreenActive) {
-      _setTab(DetailTab.gameInfo);
+      _setTab(DetailTab.screenshotVideo);
     }
-    // Force metadata overwrite if a valid description is already present.
     _startSingleGameScrape(forceOverwrite: !isDescriptionMissing);
   }
 
   /// Renders the background fanart with smooth cross-fades and scale animations.
 
-  /// Directs primary gamepad inputs (A Button) based on the currently active tab.
   void _handleTriggerAction() {
-    // Achievements Tab: Triggers a data refresh.
     if (_currentTab == DetailTab.achievements) {
       if (_scrapeButtonFocusNode.hasFocus) {
         refreshAchievements();
@@ -712,8 +704,8 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
       return;
     }
 
-    // Metadata Tab: Initiates scraping if the dedicated button is focused.
-    if (_currentTab == DetailTab.gameInfo) {
+    if (_currentTab == DetailTab.gameInfo ||
+        _currentTab == DetailTab.screenshotVideo) {
       if (_scrapeButtonFocusNode.hasFocus) {
         _startSingleGameScrape();
       }
@@ -723,9 +715,8 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
   /// Handles secondary hardware actions (typically mapped to X or RB).
   void _handleSecondaryAction() {
     if (!_isGameInfoHidden) {
-      _setTab(DetailTab.gameInfo);
+      _setTab(DetailTab.screenshotVideo);
     } else {
-      // If primary UI is hidden (OLED secondary screen optimization), skip navigation.
       return;
     }
 
@@ -738,9 +729,8 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
   bool _handleTabNavigation(bool isRight) {
     if (!mounted) return false;
 
-    // Resolve which tabs are logically available for the current context.
     final availableTabs = DetailTab.values.where((tab) {
-      if (tab == DetailTab.gameInfo && _isGameInfoHidden) return false;
+      if (tab == DetailTab.screenshotVideo && _isGameInfoHidden) return false;
       if (tab == DetailTab.achievements && !_hasRetroAchievements) return false;
       return true;
     }).toList();
@@ -756,17 +746,25 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
     return true; // Input consumed.
   }
 
-  /// Updates the active tab and synchronizes required global state (e.g., video mute during info browsing).
   void _setTab(DetailTab tab) {
     if (_currentTab == tab) return;
 
-    final wasGameInfo = _currentTab == DetailTab.gameInfo;
+    final wasScreenshotVideo = _currentTab == DetailTab.screenshotVideo;
+
+    if (wasScreenshotVideo && tab != DetailTab.screenshotVideo) {
+      _videoDelayTimer?.cancel();
+      _videoDelayTimer = null;
+      _isVideoDelayActive = false;
+      if (widget.videoController?.value.isPlaying == true) {
+        widget.videoController?.pause();
+      }
+    }
 
     setState(() {
       _currentTab = tab;
 
       final config = context.read<SqliteConfigProvider>();
-      if (tab == DetailTab.gameInfo) {
+      if (tab == DetailTab.screenshotVideo) {
         config.updateShowGameInfo(true);
         widget.videoController?.setVolume(0);
         _startVideoDelay();
@@ -774,10 +772,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
         if (config.config.showGameInfo) {
           config.updateShowGameInfo(false);
         }
-        if (wasGameInfo) {
-          _cancelVideoDelay();
-        }
-        if (tab == DetailTab.general &&
+        if (tab == DetailTab.wheel &&
             widget.videoController != null &&
             widget.showVideo) {
           _applyVideoMuteState();
@@ -786,9 +781,8 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
     });
   }
 
-  /// Closes all open metadata/achievement overlays, returning to the general view.
   void _closeAllOverlays() {
-    _setTab(DetailTab.general);
+    _setTab(DetailTab.wheel);
   }
 
   /// Orchestrates a metadata acquisition process via ScreenScraperService.

--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -487,6 +487,17 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
     });
   }
 
+  void _cancelVideoDelay() {
+    _videoDelayTimer?.cancel();
+    _videoDelayTimer = null;
+    setState(() {
+      _isVideoDelayActive = false;
+    });
+    if (widget.videoController?.value.isPlaying == true) {
+      widget.videoController?.pause();
+    }
+  }
+
   /// Loads RetroAchievements data for the current game, including MD5 hash generation.
   Future<void> _loadAchievementsForGame({bool forceRefresh = false}) async {
     final gameTarget = widget.game;
@@ -639,14 +650,20 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
               game: _game,
               fileProvider: widget.fileProvider,
             ),
-          if (_currentTab == DetailTab.screenshotVideo)
-            GameDetailsScreenshotVideoTab(
+          Visibility(
+            visible: _currentTab == DetailTab.screenshotVideo,
+            maintainState: true,
+            maintainSize: true,
+            maintainAnimation: true,
+            maintainInteractivity: true,
+            child: GameDetailsScreenshotVideoTab(
               screenshotPath: screenshotPath,
               isVideoDelayActive: _isVideoDelayActive,
               videoController: widget.videoController,
               imageVersion: _imageVersion,
               onToggleVideoMute: _toggleVideoMute,
             ),
+          ),
           if (_currentTab == DetailTab.gameInfo)
             GameDetailsGameInfoTab(
               system: _effectiveSystem,
@@ -751,15 +768,6 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
 
     final wasScreenshotVideo = _currentTab == DetailTab.screenshotVideo;
 
-    if (wasScreenshotVideo && tab != DetailTab.screenshotVideo) {
-      _videoDelayTimer?.cancel();
-      _videoDelayTimer = null;
-      _isVideoDelayActive = false;
-      if (widget.videoController?.value.isPlaying == true) {
-        widget.videoController?.pause();
-      }
-    }
-
     setState(() {
       _currentTab = tab;
 
@@ -771,6 +779,9 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
       } else {
         if (config.config.showGameInfo) {
           config.updateShowGameInfo(false);
+        }
+        if (wasScreenshotVideo) {
+          _cancelVideoDelay();
         }
         if (tab == DetailTab.wheel &&
             widget.videoController != null &&

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_box2d_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_box2d_tab.dart
@@ -6,7 +6,7 @@ import '../../../../models/game_model.dart';
 import '../../../../providers/file_provider.dart';
 import '../../../../themes/corner_radii.dart';
 
-class GameDetailsBox2dTab extends StatelessWidget {
+class GameDetailsBox2dTab extends StatefulWidget {
   final SystemModel system;
   final GameModel game;
   final FileProvider fileProvider;
@@ -19,14 +19,81 @@ class GameDetailsBox2dTab extends StatelessWidget {
   });
 
   @override
+  State<GameDetailsBox2dTab> createState() => _GameDetailsBox2dTabState();
+}
+
+class _GameDetailsBox2dTabState extends State<GameDetailsBox2dTab> {
+  double _imageAspectRatio = 3 / 4;
+
+  ImageStream? _currentImageStream;
+  ImageStreamListener? _currentImageListener;
+
+  void _loadImageAspectRatio(String path) {
+    if (path.isEmpty) return;
+
+    final File file = File(path);
+    if (!file.existsSync()) return;
+
+    _removeImageListener();
+
+    final Image image = Image.file(file);
+    final ImageStream stream = image.image.resolve(const ImageConfiguration());
+
+    final listener = ImageStreamListener((
+      ImageInfo info,
+      bool synchronousCall,
+    ) {
+      if (!mounted) return;
+      final double aspectRatio = info.image.width / info.image.height;
+      if (aspectRatio <= 0) return;
+
+      void update() {
+        setState(() {
+          _imageAspectRatio = aspectRatio;
+        });
+      }
+
+      if (synchronousCall) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) update();
+        });
+      } else {
+        update();
+      }
+    });
+
+    stream.addListener(listener);
+    _currentImageStream = stream;
+    _currentImageListener = listener;
+  }
+
+  void _removeImageListener() {
+    if (_currentImageStream != null && _currentImageListener != null) {
+      _currentImageStream!.removeListener(_currentImageListener!);
+      _currentImageStream = null;
+      _currentImageListener = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _removeImageListener();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final imageSystemFolder = system.primaryFolderName;
-    final box2dPath = game.getImagePath(
+    final imageSystemFolder = widget.system.primaryFolderName;
+    final box2dPath = widget.game.getImagePath(
       imageSystemFolder,
       'box2d',
-      fileProvider,
+      widget.fileProvider,
     );
     final box2dExists = File(box2dPath).existsSync();
+
+    if (box2dExists) {
+      _loadImageAspectRatio(box2dPath);
+    }
 
     return Positioned(
       left: 12.r,
@@ -57,12 +124,12 @@ class GameDetailsBox2dTab extends StatelessWidget {
                 BorderRadius.circular(14.r),
             clipBehavior: Clip.antiAlias,
             child: AspectRatio(
-              aspectRatio: 3 / 4,
+              aspectRatio: _imageAspectRatio,
               child: box2dExists
                   ? Image.file(
                       File(box2dPath),
                       key: ValueKey(
-                        'box2d_${game.romPath ?? game.romname}',
+                        'box2d_${widget.game.romPath ?? widget.game.romname}',
                       ),
                       fit: BoxFit.contain,
                       cacheWidth: 640,

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_box2d_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_box2d_tab.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../../../../models/system_model.dart';
+import '../../../../models/game_model.dart';
+import '../../../../providers/file_provider.dart';
+import '../../../../themes/corner_radii.dart';
+
+class GameDetailsBox2dTab extends StatelessWidget {
+  final SystemModel system;
+  final GameModel game;
+  final FileProvider fileProvider;
+
+  const GameDetailsBox2dTab({
+    super.key,
+    required this.system,
+    required this.game,
+    required this.fileProvider,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final imageSystemFolder = system.primaryFolderName;
+    final box2dPath = game.getImagePath(
+      imageSystemFolder,
+      'box2d',
+      fileProvider,
+    );
+    final box2dExists = File(box2dPath).existsSync();
+
+    return Positioned(
+      left: 12.r,
+      right: 12.r,
+      top: 55.r,
+      bottom: 110.r,
+      child: Center(
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius:
+                Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
+                BorderRadius.circular(14.r),
+            boxShadow: [
+              BoxShadow(
+                color: Theme.of(context)
+                    .colorScheme
+                    .shadow
+                    .withValues(alpha: 0.3),
+                blurRadius: 3.r,
+                offset: Offset(3.0.r, 3.0.r),
+              ),
+            ],
+            color: Colors.transparent,
+          ),
+          child: ClipRRect(
+            borderRadius:
+                Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
+                BorderRadius.circular(14.r),
+            clipBehavior: Clip.antiAlias,
+            child: AspectRatio(
+              aspectRatio: 3 / 4,
+              child: box2dExists
+                  ? Image.file(
+                      File(box2dPath),
+                      key: ValueKey(
+                        'box2d_${game.romPath ?? game.romname}',
+                      ),
+                      fit: BoxFit.contain,
+                      cacheWidth: 640,
+                    )
+                  : Center(
+                      child: Icon(
+                        Icons.inventory_2_outlined,
+                        size: 48.r,
+                        color: Colors.white24,
+                      ),
+                    ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_game_info_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_game_info_tab.dart
@@ -1,39 +1,25 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/l10n/app_locale.dart';
-import 'package:provider/provider.dart';
-import 'package:video_player/video_player.dart';
 import '../../../../models/system_model.dart';
 import '../../../../models/game_model.dart';
 import '../../../../providers/file_provider.dart';
-import '../../../../providers/sqlite_config_provider.dart';
 import '../../../../services/screenscraper_service.dart';
-import '../../../../services/sfx_service.dart';
 import '../../../../themes/corner_radii.dart';
 import '../../../../utils/game_utils.dart';
 import '../widgets/scrolling_description_text.dart';
 
-/// A tab component that renders comprehensive game metadata, descriptions, and media previews.
-///
-/// Handles media arbitration (prioritizing video over screenshots), dynamic aspect ratio
-/// calculation for non-standard artwork, and real-time scraping progress visualization.
 class GameDetailsGameInfoTab extends StatefulWidget {
   final SystemModel system;
   final GameModel game;
   final FileProvider fileProvider;
   final String description;
-  final String screenshotPath;
   final bool isScrapingGame;
   final double scrapeProgress;
   final String scrapeStatus;
   final bool isSecondaryScreenActive;
-  final bool isVideoDelayActive;
-  final VideoPlayerController? videoController;
-  final int imageVersion;
-  final VoidCallback onToggleVideoMute;
   final VoidCallback onScrapeGame;
 
   const GameDetailsGameInfoTab({
@@ -42,15 +28,10 @@ class GameDetailsGameInfoTab extends StatefulWidget {
     required this.game,
     required this.fileProvider,
     required this.description,
-    required this.screenshotPath,
     required this.isScrapingGame,
     required this.scrapeProgress,
     required this.scrapeStatus,
     required this.isSecondaryScreenActive,
-    required this.isVideoDelayActive,
-    this.videoController,
-    required this.imageVersion,
-    required this.onToggleVideoMute,
     required this.onScrapeGame,
   });
 
@@ -59,77 +40,46 @@ class GameDetailsGameInfoTab extends StatefulWidget {
 }
 
 class _GameDetailsGameInfoTabState extends State<GameDetailsGameInfoTab> {
-  /// Local cache for resolved image aspect ratios to prevent jitter during layout.
-  final Map<String, double> _imageAspectRatios = {};
+  static const List<String> _languageLabels = [
+    'en', 'es', 'fr', 'de', 'it', 'pt', 'jp', 'ko', 'ru', 'zh', 'nl', 'sv', 'da', 'fi', 'no', 'pl', 'hu', 'cs', 'ro',
+  ];
 
-  ImageStream? _currentImageStream;
-  ImageStreamListener? _currentImageListener;
+  static const Map<String, String> _languageNames = {
+    'en': 'English',
+    'es': 'Espanol',
+    'fr': 'Francais',
+    'de': 'Deutsch',
+    'it': 'Italiano',
+    'pt': 'Portugues',
+    'jp': 'Japanese',
+    'ko': 'Korean',
+    'zh': 'Chinese',
+    'nl': 'Nederlands',
+    'sv': 'Svenska',
+    'da': 'Dansk',
+    'fi': 'Suomi',
+    'no': 'Norsk',
+    'pl': 'Polski',
+    'hu': 'Magyar',
+    'cs': 'Cesky',
+    'ro': 'Romanian',
+  };
 
-  /// Asynchronously resolves the intrinsic aspect ratio of a local image file.
-  void _loadImageAspectRatio(String path) {
-    if (_imageAspectRatios.containsKey(path) || path.isEmpty) return;
+  String _selectedLanguage = 'en';
 
-    final File file = File(path);
-    if (!file.existsSync()) return;
-
-    // Remove any pending listener from a previous path to avoid leaks.
-    _removeImageListener();
-
-    final Image image = Image.file(file);
-    final ImageStream stream = image.image.resolve(const ImageConfiguration());
-
-    final listener = ImageStreamListener((
-      ImageInfo info,
-      bool synchronousCall,
-    ) {
-      if (!mounted) return;
-      final double aspectRatio = info.image.width / info.image.height;
-      if (aspectRatio <= 0 || (_imageAspectRatios[path] == aspectRatio)) {
-        return;
-      }
-
-      void update() {
-        setState(() {
-          _imageAspectRatios[path] = aspectRatio;
-        });
-      }
-
-      // If the image is already cached, the listener fires synchronously during
-      // build. Defer setState to the next frame to avoid the framework exception.
-      if (synchronousCall) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) update();
-        });
-      } else {
-        update();
-      }
-    });
-
-    stream.addListener(listener);
-    _currentImageStream = stream;
-    _currentImageListener = listener;
-  }
-
-  void _removeImageListener() {
-    if (_currentImageStream != null && _currentImageListener != null) {
-      _currentImageStream!.removeListener(_currentImageListener!);
-      _currentImageStream = null;
-      _currentImageListener = null;
-    }
-  }
-
-  @override
-  void dispose() {
-    _removeImageListener();
-    super.dispose();
+  List<String> _availableLanguages() {
+    final descriptions = widget.game.descriptions;
+    if (descriptions == null || descriptions.isEmpty) return [];
+    return _languageLabels.where(
+      (lang) =>
+          descriptions[lang] != null && descriptions[lang]!.isNotEmpty,
+    ).toList();
   }
 
   @override
   Widget build(BuildContext context) {
     final description = widget.description;
-    final screenshotPath = widget.screenshotPath;
 
-    // Check if the metadata is functionally empty to determine the initial view state.
     final bool showScrapeView =
         description.isEmpty ||
         description == AppLocale.noDescription.getString(context) ||
@@ -163,7 +113,6 @@ class _GameDetailsGameInfoTabState extends State<GameDetailsGameInfoTab> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Header Section: Title and metadata summary pills.
             Padding(
               padding: EdgeInsets.fromLTRB(8.r, 8.r, 8.r, 0.r),
               child: Column(
@@ -172,7 +121,7 @@ class _GameDetailsGameInfoTabState extends State<GameDetailsGameInfoTab> {
                   Row(
                     children: [
                       Icon(
-                        Symbols.info_rounded,
+                        Symbols.description_rounded,
                         color: Theme.of(context).colorScheme.onSurface,
                         size: 13.r,
                       ),
@@ -226,7 +175,6 @@ class _GameDetailsGameInfoTabState extends State<GameDetailsGameInfoTab> {
               ),
             ),
 
-            // Content Section: Dynamic switching between scraping, missing, and resolved states.
             Expanded(
               child: Padding(
                 padding: EdgeInsets.all(8.r),
@@ -239,7 +187,7 @@ class _GameDetailsGameInfoTabState extends State<GameDetailsGameInfoTab> {
 
                     return showScrapeView
                         ? _buildNonScrapedView()
-                        : _buildScrapedView(description, screenshotPath);
+                        : _buildScrapedView();
                   },
                 ),
               ),
@@ -250,7 +198,6 @@ class _GameDetailsGameInfoTabState extends State<GameDetailsGameInfoTab> {
     );
   }
 
-  /// Renders a deterministic progress visualization for active scraping operations.
   Widget _buildScrapingProgressView() {
     return Center(
       child: Column(
@@ -311,7 +258,6 @@ class _GameDetailsGameInfoTabState extends State<GameDetailsGameInfoTab> {
     );
   }
 
-  /// Renders a placeholder view for games missing local metadata assets.
   Widget _buildNonScrapedView() {
     return Center(
       child: Column(
@@ -370,200 +316,99 @@ class _GameDetailsGameInfoTabState extends State<GameDetailsGameInfoTab> {
     );
   }
 
-  /// Main metadata view containing descriptions and media previews.
-  Widget _buildScrapedView(String description, String screenshotPath) {
+  Widget _buildScrapedView() {
+    final availableLanguages = _availableLanguages();
+
+    if (availableLanguages.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: EdgeInsets.all(12.r),
+          child: ScrollingDescriptionText(
+            text: GameUtils.cleanupDescription(widget.description),
+            style: TextStyle(
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurface.withValues(alpha: 0.8),
+              fontSize: 11.r,
+              height: 1.6,
+            ),
+          ),
+        ),
+      );
+    }
+
+    final activeDesc = widget.game.getDescriptionForLanguage(_selectedLanguage);
+
     return Column(
       children: [
         Expanded(
           child: Padding(
             padding: EdgeInsets.symmetric(horizontal: 12.r),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Expanded(
-                  flex: 2,
-                  child: ScrollingDescriptionText(
-                    text: GameUtils.cleanupDescription(description),
-                    style: TextStyle(
-                      color: Theme.of(
-                        context,
-                      ).colorScheme.onSurface.withValues(alpha: 0.8),
-                      fontSize: 11.r,
-                      height: 1.6,
-                    ),
-                  ),
-                ),
-                SizedBox(width: 16.r),
-                Expanded(flex: 3, child: _buildMediaPreview(screenshotPath)),
-              ],
+            child: ScrollingDescriptionText(
+              text: GameUtils.cleanupDescription(
+                activeDesc.isNotEmpty ? activeDesc : widget.description,
+              ),
+              style: TextStyle(
+                color: Theme.of(
+                  context,
+                ).colorScheme.onSurface.withValues(alpha: 0.8),
+                fontSize: 11.r,
+                height: 1.6,
+              ),
             ),
           ),
         ),
-        SizedBox(height: 8.r),
-      ],
-    );
-  }
-
-  /// Manages media arbitration and rendering for screenshots or video previews.
-  Widget _buildMediaPreview(String screenshotPath) {
-    final bool hasVideo =
-        widget.videoController != null &&
-        widget.videoController!.value.isInitialized;
-
-    if (screenshotPath.isNotEmpty) {
-      _loadImageAspectRatio(screenshotPath);
-    }
-
-    double mediaAspectRatio = 16 / 9;
-
-    // Prioritize video aspect ratio if active; fall back to resolved image ratio.
-    if (!widget.isVideoDelayActive && hasVideo) {
-      mediaAspectRatio = widget.videoController!.value.aspectRatio;
-    } else if (_imageAspectRatios.containsKey(screenshotPath)) {
-      mediaAspectRatio = _imageAspectRatios[screenshotPath]!;
-    }
-
-    // Defensive check to avoid layout breaks.
-    if (mediaAspectRatio <= 0 || mediaAspectRatio.isNaN) {
-      mediaAspectRatio = 16 / 9;
-    }
-
-    return Center(
-      child: Container(
-        decoration: BoxDecoration(
-          borderRadius:
-              Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
-              BorderRadius.circular(14.r),
-          border: Border.all(
-            color: Theme.of(context).colorScheme.outline,
-            width: 1.r,
-          ),
-          boxShadow: [
-            BoxShadow(
-              color: Theme.of(
-                context,
-              ).colorScheme.shadow.withValues(alpha: 0.25),
-              blurRadius: 2.r,
-              offset: Offset(2.0.r, 2.0.r),
-            ),
-          ],
-          color: Colors.transparent,
-        ),
-        child: ClipRRect(
-          borderRadius:
-              Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
-              BorderRadius.circular(14.r),
-          clipBehavior: Clip.antiAlias,
-          child: AspectRatio(
-            aspectRatio: mediaAspectRatio,
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                // Render Video Layer.
-                if (!widget.isVideoDelayActive &&
-                    hasVideo &&
-                    widget.videoController!.value.isInitialized &&
-                    widget.videoController!.value.size.width > 0 &&
-                    widget.videoController!.value.size.height > 0) ...[
-                  Consumer<SqliteConfigProvider>(
-                    builder: (context, config, child) {
-                      return VideoPlayer(widget.videoController!);
+        if (availableLanguages.length > 1)
+          Container(
+            height: 28.r,
+            margin: EdgeInsets.only(bottom: 4.r),
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: EdgeInsets.symmetric(horizontal: 8.r),
+              itemCount: availableLanguages.length,
+              separatorBuilder: (_, _) => SizedBox(width: 4.r),
+              itemBuilder: (context, index) {
+                final lang = availableLanguages[index];
+                final isSelected = lang == _selectedLanguage;
+                return Material(
+                  color: isSelected
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(context).colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(6.r),
+                  child: InkWell(
+                    onTap: () {
+                      setState(() {
+                        _selectedLanguage = lang;
+                      });
                     },
-                  ),
-                ] else if (File(screenshotPath).existsSync()) ...[
-                  // Fallback: Render Screenshot Layer.
-                  Image.file(
-                    File(screenshotPath),
-                    height: double.infinity,
-                    cacheHeight: 640,
-                    key: ValueKey(
-                      '${screenshotPath}_fg_${widget.imageVersion}',
-                    ),
-                    fit: BoxFit.cover,
-                    errorBuilder: (_, _, _) => const SizedBox.shrink(),
-                  ),
-                ] else
-                  Center(
-                    child: Icon(
-                      Symbols.videogame_asset_rounded,
-                      size: 48.r,
-                      color: Colors.white24,
-                    ),
-                  ),
-
-                // Audio Status Indicator (Floating Overlay).
-                if (!widget.isVideoDelayActive && hasVideo)
-                  Positioned(
-                    bottom: 8.r,
-                    right: 8.r,
-                    child: ExcludeFocus(
-                      child: Material(
-                        color: Colors.black54,
-                        borderRadius:
-                            Theme.of(
-                              context,
-                            ).extension<CornerRadii>()?.radiusExternal ??
-                            BorderRadius.circular(14.r),
-                        child: InkWell(
-                          onTap: () {
-                            SfxService().playNavSound();
-                            widget.onToggleVideoMute();
-                          },
-                          canRequestFocus: false,
-                          focusColor: Colors.transparent,
-                          hoverColor: Colors.transparent,
-                          highlightColor: Colors.transparent,
-                          splashColor: Colors.transparent,
-                          borderRadius:
-                              Theme.of(
-                                context,
-                              ).extension<CornerRadii>()?.radiusInternal ??
-                              BorderRadius.circular(14.r),
-                          child: Padding(
-                            padding: EdgeInsets.symmetric(
-                              horizontal: 8.r,
-                              vertical: 4.r,
-                            ),
-                            child: Consumer<SqliteConfigProvider>(
-                              builder: (context, configProvider, child) {
-                                final isMuted =
-                                    !configProvider.config.videoSound;
-                                return Row(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    Image.asset(
-                                      'assets/images/gamepad/Xbox_View_button.png',
-                                      width: 14.r,
-                                      height: 14.r,
-                                      color: Colors.white,
-                                    ),
-                                    SizedBox(width: 4.r),
-                                    Icon(
-                                      isMuted
-                                          ? Symbols.volume_off_rounded
-                                          : Symbols.volume_up_rounded,
-                                      size: 12.r,
-                                      color: Colors.white,
-                                    ),
-                                  ],
-                                );
-                              },
-                            ),
-                          ),
+                    borderRadius: BorderRadius.circular(6.r),
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 8.r,
+                        vertical: 4.r,
+                      ),
+                      child: Text(
+                        _languageNames[lang] ?? lang.toUpperCase(),
+                        style: TextStyle(
+                          color: isSelected
+                              ? Theme.of(context).colorScheme.onPrimary
+                              : Theme.of(context).colorScheme.onSurface,
+                          fontSize: 9.r,
+                          fontWeight:
+                              isSelected ? FontWeight.bold : FontWeight.normal,
                         ),
                       ),
                     ),
                   ),
-              ],
+                );
+              },
             ),
           ),
-        ),
-      ),
+      ],
     );
   }
 }
 
-/// A compact metadata indicator styled as a pill badge.
 class _InfoPill extends StatelessWidget {
   final IconData icon;
   final String text;

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_screenshot_video_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_screenshot_video_tab.dart
@@ -115,11 +115,8 @@ class _GameDetailsScreenshotVideoTabState
       mediaAspectRatio = 16 / 9;
     }
 
-    return Positioned(
-      left: 12.r,
-      right: 12.r,
-      top: 55.r,
-      bottom: 110.r,
+    return Padding(
+      padding: EdgeInsets.fromLTRB(12.r, 55.r, 12.r, 110.r),
       child: Center(
         child: Container(
           decoration: BoxDecoration(

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_screenshot_video_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_screenshot_video_tab.dart
@@ -1,0 +1,250 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:provider/provider.dart';
+import 'package:video_player/video_player.dart';
+import '../../../../providers/sqlite_config_provider.dart';
+import '../../../../services/sfx_service.dart';
+import '../../../../themes/corner_radii.dart';
+
+class GameDetailsScreenshotVideoTab extends StatefulWidget {
+  final String screenshotPath;
+  final bool isVideoDelayActive;
+  final VideoPlayerController? videoController;
+  final int imageVersion;
+  final VoidCallback onToggleVideoMute;
+
+  const GameDetailsScreenshotVideoTab({
+    super.key,
+    required this.screenshotPath,
+    required this.isVideoDelayActive,
+    this.videoController,
+    required this.imageVersion,
+    required this.onToggleVideoMute,
+  });
+
+  @override
+  State<GameDetailsScreenshotVideoTab> createState() =>
+      _GameDetailsScreenshotVideoTabState();
+}
+
+class _GameDetailsScreenshotVideoTabState
+    extends State<GameDetailsScreenshotVideoTab> {
+  final Map<String, double> _imageAspectRatios = {};
+
+  ImageStream? _currentImageStream;
+  ImageStreamListener? _currentImageListener;
+
+  void _loadImageAspectRatio(String path) {
+    if (_imageAspectRatios.containsKey(path) || path.isEmpty) return;
+
+    final File file = File(path);
+    if (!file.existsSync()) return;
+
+    _removeImageListener();
+
+    final Image image = Image.file(file);
+    final ImageStream stream = image.image.resolve(const ImageConfiguration());
+
+    final listener = ImageStreamListener((
+      ImageInfo info,
+      bool synchronousCall,
+    ) {
+      if (!mounted) return;
+      final double aspectRatio = info.image.width / info.image.height;
+      if (aspectRatio <= 0 || (_imageAspectRatios[path] == aspectRatio)) {
+        return;
+      }
+
+      void update() {
+        setState(() {
+          _imageAspectRatios[path] = aspectRatio;
+        });
+      }
+
+      if (synchronousCall) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) update();
+        });
+      } else {
+        update();
+      }
+    });
+
+    stream.addListener(listener);
+    _currentImageStream = stream;
+    _currentImageListener = listener;
+  }
+
+  void _removeImageListener() {
+    if (_currentImageStream != null && _currentImageListener != null) {
+      _currentImageStream!.removeListener(_currentImageListener!);
+      _currentImageStream = null;
+      _currentImageListener = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _removeImageListener();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenshotPath = widget.screenshotPath;
+
+    final bool hasVideo =
+        widget.videoController != null &&
+        widget.videoController!.value.isInitialized;
+
+    if (screenshotPath.isNotEmpty) {
+      _loadImageAspectRatio(screenshotPath);
+    }
+
+    double mediaAspectRatio = 16 / 9;
+
+    if (!widget.isVideoDelayActive && hasVideo) {
+      mediaAspectRatio = widget.videoController!.value.aspectRatio;
+    } else if (_imageAspectRatios.containsKey(screenshotPath)) {
+      mediaAspectRatio = _imageAspectRatios[screenshotPath]!;
+    }
+
+    if (mediaAspectRatio <= 0 || mediaAspectRatio.isNaN) {
+      mediaAspectRatio = 16 / 9;
+    }
+
+    return Positioned(
+      left: 12.r,
+      right: 12.r,
+      top: 55.r,
+      bottom: 110.r,
+      child: Center(
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius:
+                Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
+                BorderRadius.circular(14.r),
+            boxShadow: [
+              BoxShadow(
+                color: Theme.of(
+                  context,
+                ).colorScheme.shadow.withValues(alpha: 0.3),
+                blurRadius: 3.r,
+                offset: Offset(3.0.r, 3.0.r),
+              ),
+            ],
+            color: Colors.transparent,
+          ),
+          child: ClipRRect(
+            borderRadius:
+                Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
+                BorderRadius.circular(14.r),
+            clipBehavior: Clip.antiAlias,
+            child: AspectRatio(
+              aspectRatio: mediaAspectRatio,
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  if (!widget.isVideoDelayActive &&
+                      hasVideo &&
+                      widget.videoController!.value.isInitialized &&
+                      widget.videoController!.value.size.width > 0 &&
+                      widget.videoController!.value.size.height > 0) ...[
+                    Consumer<SqliteConfigProvider>(
+                      builder: (context, config, child) {
+                        return VideoPlayer(widget.videoController!);
+                      },
+                    ),
+                  ] else if (File(screenshotPath).existsSync()) ...[
+                    Image.file(
+                      File(screenshotPath),
+                      height: double.infinity,
+                      cacheHeight: 640,
+                      key: ValueKey(
+                        '${screenshotPath}_fg_${widget.imageVersion}',
+                      ),
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                    ),
+                  ] else
+                    Center(
+                      child: Icon(
+                        Symbols.videogame_asset_rounded,
+                        size: 48.r,
+                        color: Colors.white24,
+                      ),
+                    ),
+
+                  if (!widget.isVideoDelayActive && hasVideo)
+                    Positioned(
+                      bottom: 8.r,
+                      right: 8.r,
+                      child: ExcludeFocus(
+                        child: Material(
+                          color: Colors.black54,
+                          borderRadius:
+                              Theme.of(
+                                context,
+                              ).extension<CornerRadii>()?.radiusExternal ??
+                              BorderRadius.circular(14.r),
+                          child: InkWell(
+                            onTap: () {
+                              SfxService().playNavSound();
+                              widget.onToggleVideoMute();
+                            },
+                            canRequestFocus: false,
+                            focusColor: Colors.transparent,
+                            hoverColor: Colors.transparent,
+                            highlightColor: Colors.transparent,
+                            splashColor: Colors.transparent,
+                            borderRadius:
+                                Theme.of(
+                                  context,
+                                ).extension<CornerRadii>()?.radiusInternal ??
+                                BorderRadius.circular(14.r),
+                            child: Padding(
+                              padding: EdgeInsets.symmetric(
+                                horizontal: 8.r,
+                                vertical: 4.r,
+                              ),
+                              child: Consumer<SqliteConfigProvider>(
+                                builder: (context, configProvider, child) {
+                                  final isMuted =
+                                      !configProvider.config.videoSound;
+                                  return Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Image.asset(
+                                        'assets/images/gamepad/Xbox_View_button.png',
+                                        width: 14.r,
+                                        height: 14.r,
+                                        color: Colors.white,
+                                      ),
+                                      SizedBox(width: 4.r),
+                                      Icon(
+                                        isMuted
+                                            ? Symbols.volume_off_rounded
+                                            : Symbols.volume_up_rounded,
+                                        size: 12.r,
+                                        color: Colors.white,
+                                      ),
+                                    ],
+                                  );
+                                },
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/game_screen/game_details_card/widgets/game_details_tabs_header.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_tabs_header.dart
@@ -6,7 +6,7 @@ import 'package:neostation/services/sfx_service.dart';
 import '../../../../themes/corner_radii.dart';
 
 /// Defines the navigable sections within the game details card.
-enum DetailTab { general, gameInfo, achievements }
+enum DetailTab { wheel, box2d, screenshotVideo, gameInfo, achievements }
 
 /// A navigation header component that manages tab switching and global card actions.
 ///
@@ -14,36 +14,43 @@ enum DetailTab { general, gameInfo, achievements }
 /// navigation and uses fluid animations for tab transitions. Dynamically adjusts
 /// its layout based on the availability of metadata and system features.
 class GameDetailsTabsHeader extends StatelessWidget {
-  final bool isGameInfoHidden;
+  final bool isScreenshotVideoHidden;
   final bool hasRetroAchievements;
   final DetailTab currentTab;
   final ValueChanged<DetailTab> onTabChanged;
 
   const GameDetailsTabsHeader({
     super.key,
-    required this.isGameInfoHidden,
+    required this.isScreenshotVideoHidden,
     required this.hasRetroAchievements,
     required this.currentTab,
     required this.onTabChanged,
   });
 
+  /// Ordered list of always-visible tab enums.
+  static const List<DetailTab> _baseTabs = [
+    DetailTab.wheel,
+    DetailTab.box2d,
+    DetailTab.screenshotVideo,
+    DetailTab.gameInfo,
+  ];
+
   @override
   Widget build(BuildContext context) {
     // Dynamically calculate the active tab count for layout arbitration.
-    int numTabs = 1; // General is always present.
-    if (!isGameInfoHidden) numTabs++;
-    if (hasRetroAchievements) numTabs++;
+    final List<DetailTab> visibleTabs = [
+      ..._baseTabs.where(
+        (t) => t != DetailTab.screenshotVideo || !isScreenshotVideoHidden,
+      ),
+      if (hasRetroAchievements) DetailTab.achievements,
+    ];
 
+    final int numTabs = visibleTabs.length;
     final double tabWidth = 36.r;
     final double totalTabsWidth = numTabs * tabWidth;
 
     // Resolve the visual index for the cursor animation, accounting for hidden tabs.
-    int visualIndex = 0;
-    if (currentTab == DetailTab.gameInfo) {
-      visualIndex = 1;
-    } else if (currentTab == DetailTab.achievements) {
-      visualIndex = isGameInfoHidden ? 1 : 2;
-    }
+    final int visualIndex = visibleTabs.indexOf(currentTab).clamp(0, numTabs - 1);
 
     final theme = Theme.of(context);
 
@@ -117,28 +124,12 @@ class GameDetailsTabsHeader extends StatelessWidget {
                           ),
                           Row(
                             children: [
-                              _TabItem(
-                                icon: Symbols.gamepad_rounded,
-                                tab: DetailTab.general,
-                                width: tabWidth,
-                                isSelected: currentTab == DetailTab.general,
-                                onTap: onTabChanged,
-                              ),
-                              if (!isGameInfoHidden)
+                              for (final tab in visibleTabs)
                                 _TabItem(
-                                  icon: Symbols.image_rounded,
-                                  tab: DetailTab.gameInfo,
+                                  icon: _iconForTab(tab),
+                                  tab: tab,
                                   width: tabWidth,
-                                  isSelected: currentTab == DetailTab.gameInfo,
-                                  onTap: onTabChanged,
-                                ),
-                              if (hasRetroAchievements)
-                                _TabItem(
-                                  icon: Symbols.emoji_events_rounded,
-                                  tab: DetailTab.achievements,
-                                  width: tabWidth,
-                                  isSelected:
-                                      currentTab == DetailTab.achievements,
+                                  isSelected: currentTab == tab,
                                   onTap: onTabChanged,
                                 ),
                             ],
@@ -161,6 +152,16 @@ class GameDetailsTabsHeader extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  static IconData _iconForTab(DetailTab tab) {
+    return switch (tab) {
+      DetailTab.wheel => Symbols.gamepad_rounded,
+      DetailTab.box2d => Symbols.widgets_rounded,
+      DetailTab.screenshotVideo => Symbols.image_rounded,
+      DetailTab.gameInfo => Symbols.description_rounded,
+      DetailTab.achievements => Symbols.emoji_events_rounded,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

Restructure the game details card from 3 tabs (general/wheel, game info, retroachievements) to 5 focused tabs: **Wheel**, **Box2D**, **Screenshot/Video**, **Game Info**, and **RetroAchievements**.

## Changes

### Tab Restructure
- **DetailTab enum**: \{ general, gameInfo, achievements }\ → \{ wheel, box2d, screenshotVideo, gameInfo, achievements }\
- **GameDetailsTabsHeader**: Dynamically builds tab list from base tabs + optional achievements. Visual cursor index computed from visible tabs. Icons: wheel (gamepad), box2d (widgets), screenshot/video (image), game info (description), achievements (trophy).
- All tab-switching handlers (\_setTab\, \_handleTabNavigation\, \_handleTriggerAction\, \_handleSecondaryAction\, \onToggleInfo\) updated to reference the new tab structure.

### New Tabs
- **Box2D tab** (\game_details_box2d_tab.dart\): Displays box art with rounded corners and shadow matching the screenshot/video tab styling. Dynamically loads the real image aspect ratio via \ImageStreamListener\ so the shadow matches the actual box art proportions (not a hardcoded 3/4 ratio). Shows placeholder icon when no image exists.
- **Screenshot/Video tab** (\game_details_screenshot_video_tab.dart\): Extracted from the old game-info tab. Full-width media player with 3-second video delay, dynamic aspect ratio detection (video or screenshot), and mute toggle. No background fill (transparent). Uses \Visibility(maintainState: true)\ to keep the video player alive across tab switches, preventing fvp's \MdkVideoPlayer\ stream controller disposal crash.

### Refactored Tabs
- **Wheel tab** (renamed from general tab): Unchanged behavior — shows wheel/logo or Android app icon with shadow effect.
- **Game Info tab**: Removed screenshot/video/media rendering — now shows only metadata (developer, players, year) and descriptions. Added **language selector chips** at the bottom for all available description languages from scraped metadata (\game.descriptions\ map). Supports fallback hierarchy when switching languages.

### Video Lifecycle Fix
The fvp package's \MdkVideoPlayer\ subscribes to native player streams that call \streamCtl.add()\ after \dispose()\ closes the controller. The ScreenshotVideoTab uses \Visibility(maintainState: true)\ (with \Padding\ instead of \Positioned\ to respect the Stack widget hierarchy) so the video player stays alive across tab switches instead of being destroyed and recreated.