### PR TITLE
Add EmuCoreX PS2 emulator support and PCFX retroachievements ID

### DIFF
--- a/assets/systems/pcfx.json
+++ b/assets/systems/pcfx.json
@@ -12,7 +12,7 @@
     },
     "ids": {
       "screenscraper": 72,
-      "retroachievements": null
+      "retroachievements": 49
     },
     "folders": [
       "pcfx",

--- a/assets/systems/ps2.json
+++ b/assets/systems/ps2.json
@@ -272,6 +272,17 @@
       }
     },
     {
+      "name": "EmuCoreX",
+      "unique_id": "ps2.com.sbro.emucorex",
+      "description": "Supported extensions: iso, chd, bin.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.sbro.emucorex/.MainActivity -a com.sbro.emucorex.action.LAUNCH_GAME --es com.sbro.emucorex.extra.GAME_PATH \"{file.uri}\" --activity-clear-task --activity-clear-top"
+        }
+      }
+    },
+    {
       "name": "Standalone PCSX2",
       "unique_id": "ps2.net.pcsx2.android",
       "description": "Supported extensions: iso, chd, gz, mdf, bin, ciso, img.",


### PR DESCRIPTION
- Add EmuCoreX standalone Android emulator for PS2 (package com.sbro.emucorex)\n- Fix retroachievements console ID for PC-FX (49)