### PR TITLE
Add Xendroid and X360 Mobile emulators for Xbox 360

### DIFF
--- a/assets/systems/xbox360.json
+++ b/assets/systems/xbox360.json
@@ -53,6 +53,28 @@
       }
     },
     {
+      "name": "Xendroid",
+      "unique_id": "xbox360.xendroid.composee",
+      "description": "Supported extensions: iso.",
+      "is_retroachievements_compatible": false,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n xendroid.compose/.EmulatorHostActivity --es game_uri \"{file.uri}\""
+        }
+      }
+    },
+    {
+      "name": "X360 Mobile",
+      "unique_id": "xbox360.emu.x360.mobile",
+      "description": "Supported extensions: iso, xex.",
+      "is_retroachievements_compatible": false,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n emu.x360.mobile/.X360MobileGameLaunchActivity -d \"{file.uri}\""
+        }
+      }
+    },
+    {
       "name": "Xenia",
       "unique_id": "xbox360.xenia",
       "description": "Supported extensions: iso.",


### PR DESCRIPTION
- Add Xendroid (xendroid.compose) with game_uri extra\n- Add X360 Mobile (emu.x360.mobile) with intent data URI\n- Both support .iso extension; X360 Mobile also supports .xex