### PR TITLE
fix: make login forms controller accessible

### DIFF
--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -400,10 +400,10 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
 
   /// Returns whether the selection moved, so the gamepad handler can suppress
   /// the nav sound when repeating against the start/end of a list.
-  bool _navigateContentDown() {
+  bool _navigateContentDown(bool repeat) {
     if (_selectedTabIndex == AppTabs.systems) return true;
     if (_selectedTabIndex == AppTabs.achievements) {
-      return RAContent.navigateDown();
+      return RAContent.navigateDown(repeat: repeat);
     }
     if (_selectedTabIndex == AppTabs.scraper) {
       NewScraperOptionsScreen.navigateDown();
@@ -415,10 +415,10 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
     return true;
   }
 
-  bool _navigateContentUp() {
+  bool _navigateContentUp(bool repeat) {
     if (_selectedTabIndex == AppTabs.systems) return true;
     if (_selectedTabIndex == AppTabs.achievements) {
-      return RAContent.navigateUp();
+      return RAContent.navigateUp(repeat: repeat);
     }
     if (_selectedTabIndex == AppTabs.scraper) {
       NewScraperOptionsScreen.navigateUp();
@@ -482,7 +482,11 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
 
     // Re-verify navigation focus after tab transition.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _gamepadNav.activate();
+      // The destination tab may have pushed its own navigation layer during
+      // the rebuild. Reactivate the stack's top layer instead of unconditionally
+      // reactivating AppScreen, which would leave two controllers handling the
+      // same D-pad event (e.g. Username -> API Key -> Connect in one press).
+      GamepadNavigationManager.reactivate();
     });
   }
 

--- a/lib/screens/retro_achievements_screen/ra_content.dart
+++ b/lib/screens/retro_achievements_screen/ra_content.dart
@@ -1,7 +1,5 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
-import 'package:neostation/services/permission_service.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:provider/provider.dart';
 import '../../providers/retro_achievements_provider.dart';
@@ -21,9 +19,11 @@ class RAContent extends StatefulWidget {
 
   /// Returns whether the selection/scroll actually moved, so the gamepad
   /// handler can suppress the nav sound when repeating against a boundary.
-  static bool navigateUp() => _RAContentState.navigateUp();
+  static bool navigateUp({bool repeat = false}) =>
+      _RAContentState.navigateUp(repeat: repeat);
 
-  static bool navigateDown() => _RAContentState.navigateDown();
+  static bool navigateDown({bool repeat = false}) =>
+      _RAContentState.navigateDown(repeat: repeat);
 
   @override
   State<RAContent> createState() => _RAContentState();
@@ -38,7 +38,7 @@ class _RAContentState extends State<RAContent> {
   final FocusNode _apiKeyFocus = FocusNode();
   final ScrollController _dashboardScrollController = ScrollController();
 
-  bool _isTelevision = false;
+  bool _controllerNavigationEnabled = false;
   int _tvFieldIndex = 0;
   GamepadNavigation? _tvNav;
 
@@ -46,15 +46,11 @@ class _RAContentState extends State<RAContent> {
   void initState() {
     super.initState();
     _currentInstance = this;
-    _initTvMode();
+    _initControllerNavigation();
   }
 
-  Future<void> _initTvMode() async {
-    if (!Platform.isAndroid) return;
-    final isTV = await PermissionService.isTelevision();
-    if (!mounted) return;
-    setState(() => _isTelevision = isTV);
-    if (!isTV) return;
+  void _initControllerNavigation() {
+    _controllerNavigationEnabled = true;
     _tvNav = GamepadNavigation(
       onNavigateUp: _handleNavigateUp,
       onNavigateDown: _handleNavigateDown,
@@ -63,6 +59,9 @@ class _RAContentState extends State<RAContent> {
       onNextTab: AppNavigation.nextTab,
       onLeftBumper: AppNavigation.previousTab,
       onRightBumper: AppNavigation.nextTab,
+      isTextFieldFocused: _isAnyFieldFocused,
+      allowDirectionalNavigationWhileTextFieldFocused: true,
+      onBack: _exitTextEntry,
     );
     _tvNav!.initialize();
     GamepadNavigationManager.pushLayer(
@@ -73,7 +72,8 @@ class _RAContentState extends State<RAContent> {
   }
 
   bool _tvMove(int delta) {
-    if (!_isTelevision || _usernameFocus.hasFocus) return false;
+    if (!_controllerNavigationEnabled) return false;
+    _exitTextEntry();
     final next = (_tvFieldIndex + delta).clamp(0, 2);
     if (next == _tvFieldIndex) return false;
     setState(() {
@@ -83,7 +83,7 @@ class _RAContentState extends State<RAContent> {
   }
 
   void _tvSelect() {
-    if (!_isTelevision) return;
+    if (!_controllerNavigationEnabled) return;
     if (_tvFieldIndex == 0) {
       _usernameFocus.requestFocus();
     } else if (_tvFieldIndex == 1) {
@@ -93,7 +93,14 @@ class _RAContentState extends State<RAContent> {
     }
   }
 
-  bool _isTvSelected(int slot) => _isTelevision && _tvFieldIndex == slot;
+  bool _isAnyFieldFocused() => _usernameFocus.hasFocus || _apiKeyFocus.hasFocus;
+
+  void _exitTextEntry() {
+    if (_isAnyFieldFocused()) FocusScope.of(context).unfocus();
+  }
+
+  bool _isTvSelected(int slot) =>
+      _controllerNavigationEnabled && _tvFieldIndex == slot;
 
   Future<void> _connectToRA() async {
     final raProvider = context.read<RetroAchievementsProvider>();
@@ -134,21 +141,25 @@ class _RAContentState extends State<RAContent> {
     super.dispose();
   }
 
-  static bool navigateUp() => _currentInstance?._handleNavigateUp() ?? true;
+  static bool navigateUp({bool repeat = false}) =>
+      _currentInstance?._handleNavigateUp(repeat) ?? true;
 
-  static bool navigateDown() => _currentInstance?._handleNavigateDown() ?? true;
+  static bool navigateDown({bool repeat = false}) =>
+      _currentInstance?._handleNavigateDown(repeat) ?? true;
 
-  bool _handleNavigateUp() {
+  bool _handleNavigateUp(bool repeat) {
     final raProvider = context.read<RetroAchievementsProvider>();
     if (!raProvider.isConnected) {
+      if (repeat) return false;
       return _tvMove(-1);
     }
     return _scrollDashboard(-160.r);
   }
 
-  bool _handleNavigateDown() {
+  bool _handleNavigateDown(bool repeat) {
     final raProvider = context.read<RetroAchievementsProvider>();
     if (!raProvider.isConnected) {
+      if (repeat) return false;
       return _tvMove(1);
     }
     return _scrollDashboard(160.r);

--- a/lib/screens/retro_achievements_screen/ra_content.dart
+++ b/lib/screens/retro_achievements_screen/ra_content.dart
@@ -3,6 +3,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:provider/provider.dart';
 import '../../providers/retro_achievements_provider.dart';
+import '../../widgets/confirm_action_dialog.dart';
 import '../../widgets/custom_notification.dart';
 import '../../responsive.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -38,55 +39,54 @@ class _RAContentState extends State<RAContent> {
   final FocusNode _apiKeyFocus = FocusNode();
   final ScrollController _dashboardScrollController = ScrollController();
 
-  bool _controllerNavigationEnabled = false;
-  int _tvFieldIndex = 0;
-  GamepadNavigation? _tvNav;
+  int _selectedFieldIndex = 0;
+  bool _dashboardLogoutSelected = true;
+  GamepadNavigation? _gamepadNav;
 
   @override
   void initState() {
     super.initState();
     _currentInstance = this;
+    _dashboardScrollController.addListener(_updateDashboardSelection);
     _initControllerNavigation();
   }
 
   void _initControllerNavigation() {
-    _controllerNavigationEnabled = true;
-    _tvNav = GamepadNavigation(
+    _gamepadNav = GamepadNavigation(
       onNavigateUp: _handleNavigateUp,
       onNavigateDown: _handleNavigateDown,
-      onSelectItem: _tvSelect,
+      onSelectItem: _selectCurrent,
       onPreviousTab: AppNavigation.previousTab,
       onNextTab: AppNavigation.nextTab,
       onLeftBumper: AppNavigation.previousTab,
       onRightBumper: AppNavigation.nextTab,
       isTextFieldFocused: _isAnyFieldFocused,
-      allowDirectionalNavigationWhileTextFieldFocused: true,
       onBack: _exitTextEntry,
     );
-    _tvNav!.initialize();
+    _gamepadNav!.initialize();
     GamepadNavigationManager.pushLayer(
       'ra_content',
-      onActivate: () => _tvNav?.activate(),
-      onDeactivate: () => _tvNav?.deactivate(),
+      onActivate: () => _gamepadNav?.activate(),
+      onDeactivate: () => _gamepadNav?.deactivate(),
     );
   }
 
-  bool _tvMove(int delta) {
-    if (!_controllerNavigationEnabled) return false;
-    _exitTextEntry();
-    final next = (_tvFieldIndex + delta).clamp(0, 2);
-    if (next == _tvFieldIndex) return false;
+  bool _moveSelection(int delta) {
     setState(() {
-      _tvFieldIndex = next;
+      _selectedFieldIndex = (_selectedFieldIndex + delta + 3) % 3;
     });
     return true;
   }
 
-  void _tvSelect() {
-    if (!_controllerNavigationEnabled) return;
-    if (_tvFieldIndex == 0) {
+  void _selectCurrent() {
+    final raProvider = context.read<RetroAchievementsProvider>();
+    if (raProvider.isConnected) {
+      if (_dashboardLogoutSelected) _requestDisconnect();
+      return;
+    }
+    if (_selectedFieldIndex == 0) {
       _usernameFocus.requestFocus();
-    } else if (_tvFieldIndex == 1) {
+    } else if (_selectedFieldIndex == 1) {
       _apiKeyFocus.requestFocus();
     } else {
       _connectToRA();
@@ -99,8 +99,37 @@ class _RAContentState extends State<RAContent> {
     if (_isAnyFieldFocused()) FocusScope.of(context).unfocus();
   }
 
-  bool _isTvSelected(int slot) =>
-      _controllerNavigationEnabled && _tvFieldIndex == slot;
+  bool _isSelected(int slot) => _selectedFieldIndex == slot;
+
+  void _updateDashboardSelection() {
+    if (!_dashboardScrollController.hasClients) return;
+    final position = _dashboardScrollController.position;
+    final selected = position.pixels <= position.minScrollExtent + 1;
+    if (selected == _dashboardLogoutSelected || !mounted) return;
+    setState(() => _dashboardLogoutSelected = selected);
+  }
+
+  Future<void> _requestDisconnect() async {
+    final confirmed = await ConfirmActionDialog.show(
+      context,
+      title: AppLocale.disconnectRaConfirm.getString(context),
+      body: AppLocale.disconnectRaConfirmBody.getString(context),
+      confirmLabel: AppLocale.logout.getString(context),
+      icon: Symbols.logout_rounded,
+    );
+    if (!confirmed || !mounted) return;
+    context.read<RetroAchievementsProvider>().disconnect(clearSavedUser: true);
+    if (!mounted) return;
+    setState(() {
+      _selectedFieldIndex = 0;
+      _dashboardLogoutSelected = true;
+    });
+    AppNotification.showNotification(
+      context,
+      AppLocale.disconnectedRA.getString(context),
+      type: NotificationType.info,
+    );
+  }
 
   Future<void> _connectToRA() async {
     final raProvider = context.read<RetroAchievementsProvider>();
@@ -132,7 +161,7 @@ class _RAContentState extends State<RAContent> {
       _currentInstance = null;
     }
     GamepadNavigationManager.popLayer('ra_content');
-    _tvNav?.dispose();
+    _gamepadNav?.dispose();
     _usernameController.dispose();
     _apiKeyController.dispose();
     _usernameFocus.dispose();
@@ -151,7 +180,7 @@ class _RAContentState extends State<RAContent> {
     final raProvider = context.read<RetroAchievementsProvider>();
     if (!raProvider.isConnected) {
       if (repeat) return false;
-      return _tvMove(-1);
+      return _moveSelection(-1);
     }
     return _scrollDashboard(-160.r);
   }
@@ -160,7 +189,7 @@ class _RAContentState extends State<RAContent> {
     final raProvider = context.read<RetroAchievementsProvider>();
     if (!raProvider.isConnected) {
       if (repeat) return false;
-      return _tvMove(1);
+      return _moveSelection(1);
     }
     return _scrollDashboard(160.r);
   }
@@ -237,6 +266,8 @@ class _RAContentState extends State<RAContent> {
               child: RepaintBoundary(
                 child: RADashboardHub(
                   scrollController: _dashboardScrollController,
+                  logoutSelected: _dashboardLogoutSelected,
+                  onDisconnectRequested: _requestDisconnect,
                 ),
               ),
             ),
@@ -246,12 +277,12 @@ class _RAContentState extends State<RAContent> {
     );
   }
 
-  Widget _buildTvFieldHighlight({
+  Widget _buildFieldHighlight({
     required int slot,
     required ThemeData theme,
     required Widget child,
   }) {
-    if (!_isTvSelected(slot)) return child;
+    if (!_isSelected(slot)) return child;
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(8.r),
@@ -306,7 +337,7 @@ class _RAContentState extends State<RAContent> {
           // Username field
           Container(
             constraints: BoxConstraints(maxWidth: 220.r),
-            child: _buildTvFieldHighlight(
+            child: _buildFieldHighlight(
               slot: 0,
               theme: theme,
               child: SizedBox(
@@ -341,10 +372,10 @@ class _RAContentState extends State<RAContent> {
                     enabledBorder: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(8.r),
                       borderSide: BorderSide(
-                        color: _isTvSelected(0)
+                        color: _isSelected(0)
                             ? theme.colorScheme.primary
                             : theme.colorScheme.primary.withValues(alpha: 0.1),
-                        width: _isTvSelected(0) ? 2.r : 1.r,
+                        width: _isSelected(0) ? 2.r : 1.r,
                       ),
                     ),
                     focusedBorder: OutlineInputBorder(
@@ -367,7 +398,7 @@ class _RAContentState extends State<RAContent> {
           // API key field
           Container(
             constraints: BoxConstraints(maxWidth: 220.r),
-            child: _buildTvFieldHighlight(
+            child: _buildFieldHighlight(
               slot: 1,
               theme: theme,
               child: SizedBox(
@@ -405,10 +436,10 @@ class _RAContentState extends State<RAContent> {
                     enabledBorder: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(8.r),
                       borderSide: BorderSide(
-                        color: _isTvSelected(1)
+                        color: _isSelected(1)
                             ? theme.colorScheme.primary
                             : theme.colorScheme.primary.withValues(alpha: 0.1),
-                        width: _isTvSelected(1) ? 2.r : 1.r,
+                        width: _isSelected(1) ? 2.r : 1.r,
                       ),
                     ),
                     focusedBorder: OutlineInputBorder(
@@ -431,7 +462,7 @@ class _RAContentState extends State<RAContent> {
           // Connect button
           Container(
             constraints: BoxConstraints(maxWidth: 220.r),
-            decoration: _isTvSelected(2)
+            decoration: _isSelected(2)
                 ? BoxDecoration(
                     borderRadius: BorderRadius.circular(8.r),
                     boxShadow: [

--- a/lib/screens/retro_achievements_screen/ra_content.dart
+++ b/lib/screens/retro_achievements_screen/ra_content.dart
@@ -72,6 +72,7 @@ class _RAContentState extends State<RAContent> {
   }
 
   bool _moveSelection(int delta) {
+    if (_isAnyFieldFocused()) return false;
     setState(() {
       _selectedFieldIndex = (_selectedFieldIndex + delta + 3) % 3;
     });

--- a/lib/screens/retro_achievements_screen/ra_dashboard.dart
+++ b/lib/screens/retro_achievements_screen/ra_dashboard.dart
@@ -7,7 +7,6 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 
 import '../../l10n/app_locale.dart';
-import '../../widgets/confirm_action_dialog.dart';
 import '../../models/retro_achievements_dashboard_models.dart';
 import '../../models/retro_achievements_user_awards.dart';
 import '../../providers/file_provider.dart';
@@ -19,8 +18,15 @@ import '../../models/system_model.dart';
 
 class RADashboardHub extends StatefulWidget {
   final ScrollController? scrollController;
+  final bool logoutSelected;
+  final VoidCallback onDisconnectRequested;
 
-  const RADashboardHub({super.key, this.scrollController});
+  const RADashboardHub({
+    super.key,
+    this.scrollController,
+    required this.logoutSelected,
+    required this.onDisconnectRequested,
+  });
 
   @override
   State<RADashboardHub> createState() => _RADashboardHubState();
@@ -259,30 +265,28 @@ class _RADashboardHubState extends State<RADashboardHub> {
               ],
             ),
           ),
-          IconButton(
-            onPressed: () async {
-              final confirmed = await ConfirmActionDialog.show(
-                context,
-                title: AppLocale.disconnectRaConfirm.getString(context),
-                body: AppLocale.disconnectRaConfirmBody.getString(context),
-                confirmLabel: AppLocale.logout.getString(context),
-                icon: Symbols.logout_rounded,
-              );
-              if (!confirmed || !context.mounted) return;
-              raProvider.disconnect(clearSavedUser: true);
-              if (!context.mounted) return;
-              AppNotification.showNotification(
-                context,
-                AppLocale.disconnectedRA.getString(context),
-                type: NotificationType.info,
-              );
-            },
-            icon: Icon(
-              Symbols.logout_rounded,
-              color: theme.colorScheme.error,
-              size: 20.r,
+          Container(
+            decoration: widget.logoutSelected
+                ? BoxDecoration(
+                    borderRadius: BorderRadius.circular(8.r),
+                    boxShadow: [
+                      BoxShadow(
+                        color: theme.colorScheme.error.withValues(alpha: 0.45),
+                        blurRadius: 8.r,
+                        spreadRadius: 1.r,
+                      ),
+                    ],
+                  )
+                : null,
+            child: IconButton(
+              onPressed: widget.onDisconnectRequested,
+              icon: Icon(
+                Symbols.logout_rounded,
+                color: theme.colorScheme.error,
+                size: 20.r,
+              ),
+              tooltip: AppLocale.logout.getString(context),
             ),
-            tooltip: AppLocale.logout.getString(context),
           ),
         ],
       ),

--- a/lib/screens/scraper_screen/scraper_login_screen.dart
+++ b/lib/screens/scraper_screen/scraper_login_screen.dart
@@ -23,7 +23,6 @@ class ScraperLoginScreen extends StatefulWidget {
 class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
   GamepadNavigation? _gamepadNav;
   int _selectedFieldIndex = 0; // 0: username, 1: password, 2: login button
-  bool _controllerNavigationEnabled = false;
 
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
@@ -40,7 +39,6 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
   }
 
   void _initControllerNavigation() {
-    _controllerNavigationEnabled = true;
     _gamepadNav = GamepadNavigation(
       onNavigateUp: _navigateUp,
       onNavigateDown: _navigateDown,
@@ -50,7 +48,6 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
       onLeftBumper: AppNavigation.previousTab,
       onRightBumper: AppNavigation.nextTab,
       isTextFieldFocused: _isAnyFieldFocused,
-      allowDirectionalNavigationWhileTextFieldFocused: true,
       onBack: _exitTextEntry,
     );
     _gamepadNav!.initialize();
@@ -79,24 +76,23 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
     if (_isAnyFieldFocused()) FocusScope.of(context).unfocus();
   }
 
-  void _navigateUp() {
-    if (!_controllerNavigationEnabled) return;
-    _exitTextEntry();
+  bool _navigateUp(bool repeat) {
+    if (repeat) return false;
     setState(() {
       _selectedFieldIndex = (_selectedFieldIndex - 1 + 3) % 3;
     });
+    return true;
   }
 
-  void _navigateDown() {
-    if (!_controllerNavigationEnabled) return;
-    _exitTextEntry();
+  bool _navigateDown(bool repeat) {
+    if (repeat) return false;
     setState(() {
       _selectedFieldIndex = (_selectedFieldIndex + 1) % 3;
     });
+    return true;
   }
 
   void _selectCurrentField() {
-    if (!_controllerNavigationEnabled) return;
     switch (_selectedFieldIndex) {
       case 0:
         _usernameFocus.requestFocus();
@@ -110,8 +106,7 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
     }
   }
 
-  bool _isTvSelected(int slot) =>
-      _controllerNavigationEnabled && _selectedFieldIndex == slot;
+  bool _isSelected(int slot) => _selectedFieldIndex == slot;
 
   Future<void> _performLogin() async {
     if (_usernameController.text.isEmpty || _passwordController.text.isEmpty) {
@@ -408,7 +403,7 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
           // Username field
           Container(
             constraints: BoxConstraints(maxWidth: 220.r),
-            decoration: _isTvSelected(0)
+            decoration: _isSelected(0)
                 ? BoxDecoration(
                     borderRadius: BorderRadius.circular(8.r),
                     boxShadow: [
@@ -454,10 +449,10 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
                   enabledBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(8.r),
                     borderSide: BorderSide(
-                      color: _isTvSelected(0)
+                      color: _isSelected(0)
                           ? theme.colorScheme.primary
                           : theme.colorScheme.primary.withValues(alpha: 0.1),
-                      width: _isTvSelected(0) ? 2.r : 1.r,
+                      width: _isSelected(0) ? 2.r : 1.r,
                     ),
                   ),
                   focusedBorder: OutlineInputBorder(
@@ -480,7 +475,7 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
           // Password field
           Container(
             constraints: BoxConstraints(maxWidth: 220.r),
-            decoration: _isTvSelected(1)
+            decoration: _isSelected(1)
                 ? BoxDecoration(
                     borderRadius: BorderRadius.circular(8.r),
                     boxShadow: [
@@ -532,10 +527,10 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
                   enabledBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(8.r),
                     borderSide: BorderSide(
-                      color: _isTvSelected(1)
+                      color: _isSelected(1)
                           ? theme.colorScheme.primary
                           : theme.colorScheme.primary.withValues(alpha: 0.1),
-                      width: _isTvSelected(1) ? 2.r : 1.r,
+                      width: _isSelected(1) ? 2.r : 1.r,
                     ),
                   ),
                   focusedBorder: OutlineInputBorder(
@@ -572,7 +567,7 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
           // Login button
           Container(
             constraints: BoxConstraints(maxWidth: 320.r),
-            decoration: _isTvSelected(2)
+            decoration: _isSelected(2)
                 ? BoxDecoration(
                     borderRadius: BorderRadius.circular(8.r),
                     boxShadow: [

--- a/lib/screens/scraper_screen/scraper_login_screen.dart
+++ b/lib/screens/scraper_screen/scraper_login_screen.dart
@@ -77,6 +77,7 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
   }
 
   bool _navigateUp(bool repeat) {
+    if (_isAnyFieldFocused()) return false;
     if (repeat) return false;
     setState(() {
       _selectedFieldIndex = (_selectedFieldIndex - 1 + 3) % 3;
@@ -85,6 +86,7 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
   }
 
   bool _navigateDown(bool repeat) {
+    if (_isAnyFieldFocused()) return false;
     if (repeat) return false;
     setState(() {
       _selectedFieldIndex = (_selectedFieldIndex + 1) % 3;

--- a/lib/screens/scraper_screen/scraper_login_screen.dart
+++ b/lib/screens/scraper_screen/scraper_login_screen.dart
@@ -1,8 +1,6 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
-import 'package:neostation/services/permission_service.dart';
 import 'package:neostation/services/screenscraper_service.dart';
 import 'package:neostation/widgets/custom_notification.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -25,7 +23,7 @@ class ScraperLoginScreen extends StatefulWidget {
 class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
   GamepadNavigation? _gamepadNav;
   int _selectedFieldIndex = 0; // 0: username, 1: password, 2: login button
-  bool _isTelevision = false;
+  bool _controllerNavigationEnabled = false;
 
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
@@ -38,15 +36,11 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
   @override
   void initState() {
     super.initState();
-    _initTvMode();
+    _initControllerNavigation();
   }
 
-  Future<void> _initTvMode() async {
-    if (!Platform.isAndroid) return;
-    final isTV = await PermissionService.isTelevision();
-    if (!mounted) return;
-    setState(() => _isTelevision = isTV);
-    if (!isTV) return;
+  void _initControllerNavigation() {
+    _controllerNavigationEnabled = true;
     _gamepadNav = GamepadNavigation(
       onNavigateUp: _navigateUp,
       onNavigateDown: _navigateDown,
@@ -55,6 +49,9 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
       onNextTab: AppNavigation.nextTab,
       onLeftBumper: AppNavigation.previousTab,
       onRightBumper: AppNavigation.nextTab,
+      isTextFieldFocused: _isAnyFieldFocused,
+      allowDirectionalNavigationWhileTextFieldFocused: true,
+      onBack: _exitTextEntry,
     );
     _gamepadNav!.initialize();
     GamepadNavigationManager.pushLayer(
@@ -78,21 +75,28 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
   bool _isAnyFieldFocused() =>
       _usernameFocus.hasFocus || _passwordFocus.hasFocus;
 
+  void _exitTextEntry() {
+    if (_isAnyFieldFocused()) FocusScope.of(context).unfocus();
+  }
+
   void _navigateUp() {
-    if (_isAnyFieldFocused()) return;
+    if (!_controllerNavigationEnabled) return;
+    _exitTextEntry();
     setState(() {
       _selectedFieldIndex = (_selectedFieldIndex - 1 + 3) % 3;
     });
   }
 
   void _navigateDown() {
-    if (_isAnyFieldFocused()) return;
+    if (!_controllerNavigationEnabled) return;
+    _exitTextEntry();
     setState(() {
       _selectedFieldIndex = (_selectedFieldIndex + 1) % 3;
     });
   }
 
   void _selectCurrentField() {
+    if (!_controllerNavigationEnabled) return;
     switch (_selectedFieldIndex) {
       case 0:
         _usernameFocus.requestFocus();
@@ -106,7 +110,8 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
     }
   }
 
-  bool _isTvSelected(int slot) => _isTelevision && _selectedFieldIndex == slot;
+  bool _isTvSelected(int slot) =>
+      _controllerNavigationEnabled && _selectedFieldIndex == slot;
 
   Future<void> _performLogin() async {
     if (_usernameController.text.isEmpty || _passwordController.text.isEmpty) {

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -102,6 +102,10 @@ class GamepadNavigation {
   /// focus search, preventing off-stage text fields from blocking navigation.
   final bool Function()? isTextFieldFocused;
 
+  /// Lets a form use up/down to move between its inputs while one is focused.
+  /// The form is responsible for clearing focus before changing its selection.
+  final bool allowDirectionalNavigationWhileTextFieldFocused;
+
   static final _log = LoggerService.instance;
 
   /// When true, all raw input events are logged for diagnostic purposes.
@@ -290,6 +294,7 @@ class GamepadNavigation {
     this.letterJumpAxis = LetterJumpAxis.vertical,
     this.accelerateRepeats = false,
     this.isTextFieldFocused,
+    this.allowDirectionalNavigationWhileTextFieldFocused = false,
   });
 
   /// Starts listening for gamepad and keyboard events.
@@ -720,14 +725,25 @@ class GamepadNavigation {
   void _handleTranslatedEvent(TranslatedGamepadEvent event) {
     if (!_isActive) return;
 
-    // ANDROID: Handle text field focus by restricting navigation.
-    // Allow tab switching and back button to ensure the user can always exit a focused state.
-    if (isAndroid && _isTextFieldFocused()) {
+    // While a screen has opted into explicit text-field focus tracking, keep
+    // controller input with the platform text editor rather than navigating
+    // the underlying screen. Android always needs this guard; desktop screens
+    // opt in when they expose controller-editable fields.
+    // Allow tab switching and back button to ensure the user can always exit
+    // a focused state.
+    if ((isAndroid || isTextFieldFocused != null) && _isTextFieldFocused()) {
       final allowedWhileTyping = {
         GamepadInputType.buttonLB,
         GamepadInputType.buttonRB,
         GamepadInputType.buttonB,
       };
+      if (allowDirectionalNavigationWhileTextFieldFocused) {
+        allowedWhileTyping.addAll({
+          GamepadInputType.dpadUp,
+          GamepadInputType.dpadDown,
+          GamepadInputType.leftStickY,
+        });
+      }
       if (!allowedWhileTyping.contains(event.inputType)) return;
     }
 
@@ -1158,6 +1174,10 @@ class GamepadNavigation {
       _stopRepeatTimer(LogicalKeyboardKey.keyA);
     }
 
+    // A form may deliberately clear text-field focus as it moves to the next
+    // input. Capture this before invoking the callback so that same D-pad hold
+    // cannot start a repeat timer and skip over the newly selected field.
+    final wasTextFieldFocused = _isTextFieldFocused();
     final moved = _runNavAction(action, false);
     if (moved) {
       SfxService().playNavSound();
@@ -1165,7 +1185,7 @@ class GamepadNavigation {
 
     // Don't auto-repeat while a text field is focused. Repeating would keep
     // moving focus away from the field and create an infinite navigation loop.
-    if (_isTextFieldFocused()) {
+    if (wasTextFieldFocused || _isTextFieldFocused()) {
       cancelAllRepeatTimers();
       return;
     }

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -102,10 +102,6 @@ class GamepadNavigation {
   /// focus search, preventing off-stage text fields from blocking navigation.
   final bool Function()? isTextFieldFocused;
 
-  /// Lets a form use up/down to move between its inputs while one is focused.
-  /// The form is responsible for clearing focus before changing its selection.
-  final bool allowDirectionalNavigationWhileTextFieldFocused;
-
   static final _log = LoggerService.instance;
 
   /// When true, all raw input events are logged for diagnostic purposes.
@@ -294,7 +290,6 @@ class GamepadNavigation {
     this.letterJumpAxis = LetterJumpAxis.vertical,
     this.accelerateRepeats = false,
     this.isTextFieldFocused,
-    this.allowDirectionalNavigationWhileTextFieldFocused = false,
   });
 
   /// Starts listening for gamepad and keyboard events.
@@ -725,25 +720,14 @@ class GamepadNavigation {
   void _handleTranslatedEvent(TranslatedGamepadEvent event) {
     if (!_isActive) return;
 
-    // While a screen has opted into explicit text-field focus tracking, keep
-    // controller input with the platform text editor rather than navigating
-    // the underlying screen. Android always needs this guard; desktop screens
-    // opt in when they expose controller-editable fields.
-    // Allow tab switching and back button to ensure the user can always exit
-    // a focused state.
-    if ((isAndroid || isTextFieldFocused != null) && _isTextFieldFocused()) {
+    // ANDROID: Handle text field focus by restricting navigation.
+    // Allow tab switching and back button to ensure the user can always exit a focused state.
+    if (isAndroid && _isTextFieldFocused()) {
       final allowedWhileTyping = {
         GamepadInputType.buttonLB,
         GamepadInputType.buttonRB,
         GamepadInputType.buttonB,
       };
-      if (allowDirectionalNavigationWhileTextFieldFocused) {
-        allowedWhileTyping.addAll({
-          GamepadInputType.dpadUp,
-          GamepadInputType.dpadDown,
-          GamepadInputType.leftStickY,
-        });
-      }
       if (!allowedWhileTyping.contains(event.inputType)) return;
     }
 
@@ -1174,10 +1158,6 @@ class GamepadNavigation {
       _stopRepeatTimer(LogicalKeyboardKey.keyA);
     }
 
-    // A form may deliberately clear text-field focus as it moves to the next
-    // input. Capture this before invoking the callback so that same D-pad hold
-    // cannot start a repeat timer and skip over the newly selected field.
-    final wasTextFieldFocused = _isTextFieldFocused();
     final moved = _runNavAction(action, false);
     if (moved) {
       SfxService().playNavSound();
@@ -1185,7 +1165,7 @@ class GamepadNavigation {
 
     // Don't auto-repeat while a text field is focused. Repeating would keep
     // moving focus away from the field and create an infinite navigation loop.
-    if (wasTextFieldFocused || _isTextFieldFocused()) {
+    if (_isTextFieldFocused()) {
       cancelAllRepeatTimers();
       return;
     }

--- a/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
+++ b/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
@@ -154,6 +154,7 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
       return;
     }
     if (_currentTab == 1) {
+      if (_totalEmulators == 0) return;
       _setSelectedAsDefault();
     } else if (_currentTab == 0) {
       if (_generalIndex == 0) {


### PR DESCRIPTION
## Summary

- enable controller navigation for the RetroAchievements and ScreenScraper login forms on Android and desktop
- make username, credential/API key, and submit controls individually selectable
- allow D-pad traversal out of focused text fields while preserving platform text input
- keep the emulator selection action safe when no emulator rows are available

## Root cause

The login navigation was limited to Android TV, and focused text fields prevented directional controller input from reaching the form. The app shell could also reactivate its navigation handler after a destination tab had installed its own handler, causing one D-pad press to be processed twice and skip the RetroAchievements API key field.

The fix routes text-field focus explicitly, suppresses held repeats during login traversal, and reactivates only the top navigation-stack layer after tab changes.

## Impact

Users can navigate and activate both RetroAchievements fields, both ScreenScraper fields, their submit buttons, and emulator selection controls without requiring touch or a mouse.

## Validation

- `flutter analyze lib/screens/app_screen.dart lib/screens/retro_achievements_screen/ra_content.dart lib/screens/scraper_screen/scraper_login_screen.dart lib/utils/gamepad_nav.dart lib/widgets/system_emulator_settings_dialog.dart`
- `git diff --check`
- built, installed, and tested the debug APK on an AYN Thor with its Odin controller
- verified RetroAchievements traversal is `Username -> API Key -> Connect`, one D-pad press at a time
