### PR TITLE
fix(search): filter menu placement, d-pad shortcuts, and a hideable Search tab

### DIFF
--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -186,6 +186,10 @@ class SqliteConfigService {
             (int.tryParse(userConfig?['hide_tab_scraper']?.toString() ?? '0') ??
                 0) ==
             1,
+        hideTabSearch:
+            (int.tryParse(userConfig?['hide_tab_search']?.toString() ?? '0') ??
+                0) ==
+            1,
         activeSyncProvider:
             userConfig?['active_sync_provider']?.toString() ?? 'neosync',
         autoUpdateApp:
@@ -268,6 +272,7 @@ class SqliteConfigService {
         hideTabSync: config.hideTabSync ? 1 : 0,
         hideTabAchievements: config.hideTabAchievements ? 1 : 0,
         hideTabScraper: config.hideTabScraper ? 1 : 0,
+        hideTabSearch: config.hideTabSearch ? 1 : 0,
         activeSyncProvider: config.activeSyncProvider,
         autoUpdateApp: config.autoUpdateApp ? 1 : 0,
         autoUpdateSystems: config.autoUpdateSystems ? 1 : 0,

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -324,6 +324,9 @@ class SqliteMigrations {
       case 106:
         await _migrateToVersion106(db);
         break;
+      case 107:
+        await _migrateToVersion107(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -5093,6 +5096,34 @@ class SqliteMigrations {
       _log.i('Migration v106 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v106: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v107: Adds the Search tab's visibility flag.
+  ///
+  /// Search shipped after the v106 flags, so it gets its own column on the same
+  /// hidden-defaults-to-`0` terms — upgrading users keep the tab they already
+  /// have and can hide it from General settings.
+  static Future<void> _migrateToVersion107(Database db) async {
+    _log.i('Migration v107: Adding hide_tab_search to user_config');
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_config)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+
+      if (!columns.contains('hide_tab_search')) {
+        db.execute(
+          'ALTER TABLE user_config ADD COLUMN hide_tab_search INTEGER DEFAULT 0',
+        );
+        _log.i('Column hide_tab_search added via v107');
+      } else {
+        _log.i('Column hide_tab_search already exists');
+      }
+
+      _log.i('Migration v107 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v107: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 106;
+  static const int _databaseVersion = 107;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -1679,6 +1679,7 @@ class SqliteService {
         hide_tab_sync INTEGER DEFAULT 0,
         hide_tab_achievements INTEGER DEFAULT 0,
         hide_tab_scraper INTEGER DEFAULT 0,
+        hide_tab_search INTEGER DEFAULT 0,
         active_sync_provider TEXT DEFAULT 'neosync',
         systems_version TEXT DEFAULT '',
         neostation_app_version TEXT DEFAULT '',
@@ -2449,6 +2450,7 @@ class SqliteService {
     int? hideTabSync,
     int? hideTabAchievements,
     int? hideTabScraper,
+    int? hideTabSearch,
     String? activeSyncProvider,
     String? systemsVersion,
     String? neostationAppVersion,
@@ -2535,6 +2537,9 @@ class SqliteService {
     }
     if (hideTabScraper != null) {
       newConfig['hide_tab_scraper'] = hideTabScraper;
+    }
+    if (hideTabSearch != null) {
+      newConfig['hide_tab_search'] = hideTabSearch;
     }
     if (activeSyncProvider != null) {
       newConfig['active_sync_provider'] = activeSyncProvider;

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -184,6 +184,8 @@ mixin AppLocale {
       'show_achievements_tab_subtitle';
   static const String showScraperTab = 'show_scraper_tab';
   static const String showScraperTabSubtitle = 'show_scraper_tab_subtitle';
+  static const String showSearchTab = 'show_search_tab';
+  static const String showSearchTabSubtitle = 'show_search_tab_subtitle';
 
   // ---------------------------------------------------------------------------
   // Directories

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -180,6 +180,9 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.showScraperTab: 'Scraper-Tab anzeigen',
   AppLocale.showScraperTabSubtitle:
       'Zeigt den Scraping-Tab in der Navigationsleiste an',
+  AppLocale.showSearchTab: 'Suche-Tab anzeigen',
+  AppLocale.showSearchTabSubtitle:
+      'Zeigt den Suche-Tab in der Navigationsleiste an',
 
   AppLocale.configureDirectories: 'Verzeichnisse konfigurieren',
   AppLocale.configureRomsFolder: 'ROM-Ordner konfigurieren',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -175,6 +175,9 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.showScraperTab: 'Show Scraper tab',
   AppLocale.showScraperTabSubtitle:
       'Display the Scraping tab in the navigation bar',
+  AppLocale.showSearchTab: 'Show Search tab',
+  AppLocale.showSearchTabSubtitle:
+      'Display the Search tab in the navigation bar',
 
   AppLocale.configureDirectories: 'Directories',
   AppLocale.configureRomsFolder: 'Configure ROMs folder',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -182,6 +182,9 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.showScraperTab: 'Mostrar pestaña Scraper',
   AppLocale.showScraperTabSubtitle:
       'Muestra la pestaña de scraping en la barra de navegación',
+  AppLocale.showSearchTab: 'Mostrar pestaña Buscar',
+  AppLocale.showSearchTabSubtitle:
+      'Muestra la pestaña de búsqueda en la barra de navegación',
 
   AppLocale.configureDirectories: 'Directorios',
   AppLocale.configureRomsFolder: 'Configurar carpeta de ROMs',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -185,6 +185,9 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.showScraperTab: 'Afficher l’onglet Scraper',
   AppLocale.showScraperTabSubtitle:
       'Affiche l’onglet de scraping dans la barre de navigation',
+  AppLocale.showSearchTab: 'Afficher l’onglet Rechercher',
+  AppLocale.showSearchTabSubtitle:
+      'Affiche l’onglet de recherche dans la barre de navigation',
 
   AppLocale.configureDirectories: 'Configurer les Répertoires',
   AppLocale.configureRomsFolder: 'Configurer le Dossier des ROMs',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -176,6 +176,9 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.showScraperTab: 'Tampilkan tab Scraper',
   AppLocale.showScraperTabSubtitle:
       'Menampilkan tab scraping di bilah navigasi',
+  AppLocale.showSearchTab: 'Tampilkan tab Cari',
+  AppLocale.showSearchTabSubtitle:
+      'Menampilkan tab pencarian di bilah navigasi',
 
   AppLocale.configureDirectories: 'Konfigurasi Direktori',
   AppLocale.configureRomsFolder: 'Konfigurasi Folder ROM',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -179,6 +179,9 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.showScraperTab: 'Mostra scheda Scraper',
   AppLocale.showScraperTabSubtitle:
       'Mostra la scheda di scraping nella barra di navigazione',
+  AppLocale.showSearchTab: 'Mostra scheda Cerca',
+  AppLocale.showSearchTabSubtitle:
+      'Mostra la scheda di ricerca nella barra di navigazione',
 
   AppLocale.configureDirectories: 'Configura Directory',
   AppLocale.configureRomsFolder: 'Configura Cartella ROM',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -150,6 +150,8 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.showAchievementsTabSubtitle: 'ナビゲーションバーにRetroAchievementsタブを表示します',
   AppLocale.showScraperTab: 'スクレイパータブを表示',
   AppLocale.showScraperTabSubtitle: 'ナビゲーションバーにスクレイピングタブを表示します',
+  AppLocale.showSearchTab: '検索タブを表示',
+  AppLocale.showSearchTabSubtitle: 'ナビゲーションバーに検索タブを表示します',
 
   AppLocale.configureDirectories: 'ディレクトリの設定',
   AppLocale.configureRomsFolder: 'ROMフォルダの設定',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -149,6 +149,8 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.showAchievementsTabSubtitle: '내비게이션 바에 RetroAchievements 탭을 표시합니다',
   AppLocale.showScraperTab: '스크레이퍼 탭 표시',
   AppLocale.showScraperTabSubtitle: '내비게이션 바에 스크래핑 탭을 표시합니다',
+  AppLocale.showSearchTab: '검색 탭 표시',
+  AppLocale.showSearchTabSubtitle: '내비게이션 바에 검색 탭을 표시합니다',
 
   AppLocale.configureDirectories: '폴더',
   AppLocale.configureRomsFolder: 'ROM 폴더 설정',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -180,6 +180,9 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.showScraperTab: 'Mostrar aba Scraper',
   AppLocale.showScraperTabSubtitle:
       'Exibe a aba de scraping na barra de navegação',
+  AppLocale.showSearchTab: 'Mostrar aba Pesquisar',
+  AppLocale.showSearchTabSubtitle:
+      'Exibe a aba de pesquisa na barra de navegação',
 
   AppLocale.configureDirectories: 'Configurar Diretórios',
   AppLocale.configureRomsFolder: 'Configurar Pasta de ROMs',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -180,6 +180,9 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.showScraperTab: 'Показывать вкладку скрапера',
   AppLocale.showScraperTabSubtitle:
       'Отображает вкладку скрапинга на панели навигации',
+  AppLocale.showSearchTab: 'Показывать вкладку поиска',
+  AppLocale.showSearchTabSubtitle:
+      'Отображает вкладку поиска на панели навигации',
 
   AppLocale.configureDirectories: 'Директории',
   AppLocale.configureRomsFolder: 'Настроить папку ROM',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -148,6 +148,8 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.showAchievementsTabSubtitle: '在导航栏中显示 RetroAchievements 选项卡',
   AppLocale.showScraperTab: '显示刮削选项卡',
   AppLocale.showScraperTabSubtitle: '在导航栏中显示刮削选项卡',
+  AppLocale.showSearchTab: '显示搜索选项卡',
+  AppLocale.showSearchTabSubtitle: '在导航栏中显示搜索选项卡',
 
   AppLocale.configureDirectories: '目录设置',
   AppLocale.configureRomsFolder: '配置 ROM 文件夹',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -148,6 +148,8 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.showAchievementsTabSubtitle: '在導覽列中顯示 RetroAchievements 分頁',
   AppLocale.showScraperTab: '顯示刮削分頁',
   AppLocale.showScraperTabSubtitle: '在導覽列中顯示刮削分頁',
+  AppLocale.showSearchTab: '顯示搜尋分頁',
+  AppLocale.showSearchTabSubtitle: '在導覽列中顯示搜尋分頁',
 
   AppLocale.configureDirectories: '目錄設定',
   AppLocale.configureRomsFolder: '設定 ROM 資料夾',

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -117,6 +117,9 @@ class ConfigModel {
   /// Whether the Scraper navigation tab is hidden. See [hideTabSync].
   final bool hideTabScraper;
 
+  /// Whether the Search navigation tab is hidden. See [hideTabSync].
+  final bool hideTabSearch;
+
   /// Seconds of inactivity before the secondary "Now Playing" panel dims, or `0`
   /// to never dim. Only meaningful when a secondary display is active.
   final int nowPlayingDimDelay;
@@ -190,6 +193,7 @@ class ConfigModel {
     this.hideTabSync = false,
     this.hideTabAchievements = false,
     this.hideTabScraper = false,
+    this.hideTabSearch = false,
     this.activeSyncProvider = 'neosync',
     this.autoUpdateApp = true,
     this.autoUpdateSystems = true,
@@ -312,6 +316,10 @@ class ConfigModel {
                   .toString() ==
               '1' ||
           (json['hideTabScraper'] ?? false).toString().toLowerCase() == 'true',
+      hideTabSearch:
+          (json['hideTabSearch'] ?? json['hide_tab_search'] ?? 0).toString() ==
+              '1' ||
+          (json['hideTabSearch'] ?? false).toString().toLowerCase() == 'true',
       activeSyncProvider:
           (json['activeSyncProvider'] ??
                   json['active_sync_provider'] ??
@@ -405,6 +413,7 @@ class ConfigModel {
       'hideTabSync': hideTabSync,
       'hideTabAchievements': hideTabAchievements,
       'hideTabScraper': hideTabScraper,
+      'hideTabSearch': hideTabSearch,
       'activeSyncProvider': activeSyncProvider,
       'autoUpdateApp': autoUpdateApp,
       'autoUpdateSystems': autoUpdateSystems,
@@ -448,6 +457,7 @@ class ConfigModel {
     bool? hideTabSync,
     bool? hideTabAchievements,
     bool? hideTabScraper,
+    bool? hideTabSearch,
     String? activeSyncProvider,
     bool? autoUpdateApp,
     bool? autoUpdateSystems,
@@ -488,6 +498,7 @@ class ConfigModel {
       hideTabSync: hideTabSync ?? this.hideTabSync,
       hideTabAchievements: hideTabAchievements ?? this.hideTabAchievements,
       hideTabScraper: hideTabScraper ?? this.hideTabScraper,
+      hideTabSearch: hideTabSearch ?? this.hideTabSearch,
       activeSyncProvider: activeSyncProvider ?? this.activeSyncProvider,
       autoUpdateApp: autoUpdateApp ?? this.autoUpdateApp,
       autoUpdateSystems: autoUpdateSystems ?? this.autoUpdateSystems,

--- a/lib/screens/search_screen/search_screen.dart
+++ b/lib/screens/search_screen/search_screen.dart
@@ -1197,9 +1197,9 @@ class _SearchScreenState extends State<SearchScreen> {
   /// most of a 1080p handheld's screen, which pushed a long list (platforms,
   /// years) to full height and slid its title under the global tab strip. The
   /// overlay covers the whole tab area — which starts behind the header — so the
-  /// menu keeps the same 64.r header clearance the tab content does, applied as
-  /// a *height cap* rather than as top padding: padding centred the menu in the
-  /// space left below the header, which read as sitting too low on screen.
+  /// menu keeps clear of that header via [_FilterMenuLayout] rather than top
+  /// padding: padding centred the menu in the space left below the header,
+  /// which read as sitting too low on screen.
   Widget _buildFilterMenu(ThemeData theme, String key) {
     final scheme = theme.colorScheme;
     final labels = _menuLabels(key);
@@ -1210,70 +1210,61 @@ class _SearchScreenState extends State<SearchScreen> {
         onTap: _cancelFilterMenu,
         child: ColoredBox(
           color: Colors.black.withValues(alpha: 0.6),
-          child: LayoutBuilder(
-            builder: (context, viewport) {
-              // Budgeting twice the header clearance leaves a centred menu
-              // unable to reach it at any height, so the tallest lists stop
-              // clear of the tab strip while short ones stay optically centred.
-              final topInset = 64.r + 12.r;
-              final maxHeight = math.max(
-                0.0,
-                math.min(
-                  viewport.maxHeight * 0.6,
-                  viewport.maxHeight - topInset * 2,
-                ),
-              );
-              return Center(
-                child: GestureDetector(
-                  onTap: () {},
-                  child: Container(
-                    width: 320.r,
-                    constraints: BoxConstraints(maxHeight: maxHeight),
-                    padding: EdgeInsets.all(12.r),
-                    decoration: BoxDecoration(
-                      color: scheme.surface,
-                      borderRadius: BorderRadius.circular(16.r),
-                      border: Border.all(
-                        color: scheme.primary.withValues(alpha: 0.4),
-                        width: 1.r,
-                      ),
-                    ),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Padding(
-                          padding: EdgeInsets.only(left: 4.r, bottom: 8.r),
-                          child: Text(
-                            _filterLabel(key),
-                            style: TextStyle(
-                              fontSize: 15.r,
-                              fontWeight: FontWeight.w700,
-                              color: scheme.onSurface,
-                            ),
-                          ),
-                        ),
-                        Flexible(
-                          child: ListView.builder(
-                            controller: _menuScroll,
-                            shrinkWrap: true,
-                            itemExtent: _menuExtent.r,
-                            itemCount: labels.length,
-                            itemBuilder: (context, i) => _buildMenuOption(
-                              theme,
-                              key,
-                              labels[i],
-                              i,
-                              selected,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+          child: CustomSingleChildLayout(
+            delegate: _FilterMenuLayout(
+              // The header's own 46.r (see header.dart) plus a 12.r gap — not
+              // the 64.r top spacer the tab *content* starts after, which
+              // reserved space the header never occupied.
+              topInset: 46.r + 12.r,
+              bottomInset: 12.r,
+            ),
+            child: GestureDetector(
+              onTap: () {},
+              child: Container(
+                width: 320.r,
+                padding: EdgeInsets.all(12.r),
+                decoration: BoxDecoration(
+                  color: scheme.surface,
+                  borderRadius: BorderRadius.circular(16.r),
+                  border: Border.all(
+                    color: scheme.primary.withValues(alpha: 0.4),
+                    width: 1.r,
                   ),
                 ),
-              );
-            },
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.only(left: 4.r, bottom: 8.r),
+                      child: Text(
+                        _filterLabel(key),
+                        style: TextStyle(
+                          fontSize: 15.r,
+                          fontWeight: FontWeight.w700,
+                          color: scheme.onSurface,
+                        ),
+                      ),
+                    ),
+                    Flexible(
+                      child: ListView.builder(
+                        controller: _menuScroll,
+                        shrinkWrap: true,
+                        itemExtent: _menuExtent.r,
+                        itemCount: labels.length,
+                        itemBuilder: (context, i) => _buildMenuOption(
+                          theme,
+                          key,
+                          labels[i],
+                          i,
+                          selected,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
           ),
         ),
       ),
@@ -1532,4 +1523,45 @@ class _SearchScreenState extends State<SearchScreen> {
             ),
     );
   }
+}
+
+/// Lays out a filter menu that is centred while it fits, then grows downward.
+///
+/// Centring alone forces a symmetric budget: to keep its top edge below the
+/// header a centred box must leave the same room underneath, which costs a long
+/// list rows to empty space at the bottom of the screen. So the menu is centred
+/// only until centring would push it under the header; past that it stays
+/// pinned at [topInset] and takes the whole run down to [bottomInset]. Short
+/// lists still sit optically centred, long ones use the screen.
+class _FilterMenuLayout extends SingleChildLayoutDelegate {
+  const _FilterMenuLayout({required this.topInset, required this.bottomInset});
+
+  /// Space kept clear at the top, for the global header the overlay covers.
+  final double topInset;
+
+  /// Space kept clear at the bottom, so the menu never meets the screen edge.
+  final double bottomInset;
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) =>
+      constraints.loosen().copyWith(
+        maxHeight: math.max(
+          0.0,
+          constraints.maxHeight - topInset - bottomInset,
+        ),
+      );
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    final centred = (size.height - childSize.height) / 2;
+    return Offset(
+      (size.width - childSize.width) / 2,
+      math.max(centred, topInset),
+    );
+  }
+
+  @override
+  bool shouldRelayout(_FilterMenuLayout oldDelegate) =>
+      oldDelegate.topInset != topInset ||
+      oldDelegate.bottomInset != bottomInset;
 }

--- a/lib/screens/search_screen/search_screen.dart
+++ b/lib/screens/search_screen/search_screen.dart
@@ -315,6 +315,8 @@ class _SearchScreenState extends State<SearchScreen> {
       );
       _scrollChipIntoView();
       SfxService().playNavSound();
+    } else if (_region == _FocusRegion.results) {
+      _jumpToSearchItem('field');
     }
   }
 
@@ -328,7 +330,25 @@ class _SearchScreenState extends State<SearchScreen> {
       setState(() => _barIndex = (_barIndex + 1) % _barItems.length);
       _scrollChipIntoView();
       SfxService().playNavSound();
+    } else if (_region == _FocusRegion.results) {
+      _jumpToSearchItem('filters');
     }
+  }
+
+  /// Jumps focus out of the results list straight onto a search-band item.
+  ///
+  /// The list has no horizontal axis of its own, so Left/Right are free to act
+  /// as shortcuts back to the top band: Up only steps one result at a time, and
+  /// climbing out of a few hundred matches one row at a time is not navigation.
+  /// Left lands on the query field, Right on the Filters toggle.
+  void _jumpToSearchItem(String item) {
+    final index = _searchItems.indexOf(item);
+    if (index < 0) return;
+    setState(() {
+      _region = _FocusRegion.search;
+      _searchIndex = index;
+    });
+    SfxService().playNavSound();
   }
 
   void _navigateUp() {
@@ -1176,8 +1196,10 @@ class _SearchScreenState extends State<SearchScreen> {
   /// Sized against the real viewport rather than a fixed `.r` height: 360.r is
   /// most of a 1080p handheld's screen, which pushed a long list (platforms,
   /// years) to full height and slid its title under the global tab strip. The
-  /// overlay covers the whole tab area — which starts behind the header — so it
-  /// carries the same 64.r header clearance the tab content does.
+  /// overlay covers the whole tab area — which starts behind the header — so the
+  /// menu keeps the same 64.r header clearance the tab content does, applied as
+  /// a *height cap* rather than as top padding: padding centred the menu in the
+  /// space left below the header, which read as sitting too low on screen.
   Widget _buildFilterMenu(ThemeData theme, String key) {
     final scheme = theme.colorScheme;
     final labels = _menuLabels(key);
@@ -1190,62 +1212,63 @@ class _SearchScreenState extends State<SearchScreen> {
           color: Colors.black.withValues(alpha: 0.6),
           child: LayoutBuilder(
             builder: (context, viewport) {
+              // Budgeting twice the header clearance leaves a centred menu
+              // unable to reach it at any height, so the tallest lists stop
+              // clear of the tab strip while short ones stay optically centred.
               final topInset = 64.r + 12.r;
-              final available = viewport.maxHeight - topInset - 12.r;
-              return Padding(
-                padding: EdgeInsets.only(top: topInset, bottom: 12.r),
-                child: Center(
-                  child: GestureDetector(
-                    onTap: () {},
-                    child: Container(
-                      width: 320.r,
-                      constraints: BoxConstraints(
-                        maxHeight: math.max(
-                          0,
-                          math.min(available, viewport.maxHeight * 0.6),
-                        ),
+              final maxHeight = math.max(
+                0.0,
+                math.min(
+                  viewport.maxHeight * 0.6,
+                  viewport.maxHeight - topInset * 2,
+                ),
+              );
+              return Center(
+                child: GestureDetector(
+                  onTap: () {},
+                  child: Container(
+                    width: 320.r,
+                    constraints: BoxConstraints(maxHeight: maxHeight),
+                    padding: EdgeInsets.all(12.r),
+                    decoration: BoxDecoration(
+                      color: scheme.surface,
+                      borderRadius: BorderRadius.circular(16.r),
+                      border: Border.all(
+                        color: scheme.primary.withValues(alpha: 0.4),
+                        width: 1.r,
                       ),
-                      padding: EdgeInsets.all(12.r),
-                      decoration: BoxDecoration(
-                        color: scheme.surface,
-                        borderRadius: BorderRadius.circular(16.r),
-                        border: Border.all(
-                          color: scheme.primary.withValues(alpha: 0.4),
-                          width: 1.r,
-                        ),
-                      ),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          Padding(
-                            padding: EdgeInsets.only(left: 4.r, bottom: 8.r),
-                            child: Text(
-                              _filterLabel(key),
-                              style: TextStyle(
-                                fontSize: 15.r,
-                                fontWeight: FontWeight.w700,
-                                color: scheme.onSurface,
-                              ),
+                    ),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Padding(
+                          padding: EdgeInsets.only(left: 4.r, bottom: 8.r),
+                          child: Text(
+                            _filterLabel(key),
+                            style: TextStyle(
+                              fontSize: 15.r,
+                              fontWeight: FontWeight.w700,
+                              color: scheme.onSurface,
                             ),
                           ),
-                          Flexible(
-                            child: ListView.builder(
-                              controller: _menuScroll,
-                              shrinkWrap: true,
-                              itemExtent: _menuExtent.r,
-                              itemCount: labels.length,
-                              itemBuilder: (context, i) => _buildMenuOption(
-                                theme,
-                                key,
-                                labels[i],
-                                i,
-                                selected,
-                              ),
+                        ),
+                        Flexible(
+                          child: ListView.builder(
+                            controller: _menuScroll,
+                            shrinkWrap: true,
+                            itemExtent: _menuExtent.r,
+                            itemCount: labels.length,
+                            itemBuilder: (context, i) => _buildMenuOption(
+                              theme,
+                              key,
+                              labels[i],
+                              i,
+                              selected,
                             ),
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
                   ),
                 ),

--- a/lib/utils/nav_tabs.dart
+++ b/lib/utils/nav_tabs.dart
@@ -70,6 +70,10 @@ const Map<NavTab, NavTabSpec> navTabSpecs = {
     icon: '',
     labelKey: AppLocale.searchTitle,
     iconData: Symbols.search_rounded,
+    hidden: _hideTabSearch,
+    withHidden: _withHideTabSearch,
+    settingsTitleKey: AppLocale.showSearchTab,
+    settingsSubtitleKey: AppLocale.showSearchTabSubtitle,
   ),
   NavTab.sync: NavTabSpec(
     icon: 'assets/images/icons/cloud-add.webp',
@@ -105,6 +109,7 @@ const Map<NavTab, NavTabSpec> navTabSpecs = {
 bool _hideTabSync(ConfigModel c) => c.hideTabSync;
 bool _hideTabAchievements(ConfigModel c) => c.hideTabAchievements;
 bool _hideTabScraper(ConfigModel c) => c.hideTabScraper;
+bool _hideTabSearch(ConfigModel c) => c.hideTabSearch;
 
 ConfigModel _withHideTabSync(ConfigModel c, bool hidden) =>
     c.copyWith(hideTabSync: hidden);
@@ -112,6 +117,8 @@ ConfigModel _withHideTabAchievements(ConfigModel c, bool hidden) =>
     c.copyWith(hideTabAchievements: hidden);
 ConfigModel _withHideTabScraper(ConfigModel c, bool hidden) =>
     c.copyWith(hideTabScraper: hidden);
+ConfigModel _withHideTabSearch(ConfigModel c, bool hidden) =>
+    c.copyWith(hideTabSearch: hidden);
 
 /// Description of [tab], never null — see [_fallbackSpec].
 NavTabSpec navTabSpec(NavTab tab) => navTabSpecs[tab] ?? _fallbackSpec;


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Three changes to the Search tab, plus the visibility toggle it was missing.

**Filter menus sit and size properly.** The value picker applied its header clearance as top padding, so `Center` centred it in the space *below* the header rather than on the screen — about 95px too low at 1080p. The clearance is now a layout constraint instead, and the menu no longer pays for symmetry: `_FilterMenuLayout` (a `SingleChildLayoutDelegate`) keeps the menu centred while it fits, and once centring would slide it under the header it pins just below the header and runs down to 12.r off the bottom. Short lists (Platform) still read as centred; the Genre list goes from ~624px of 1080 to ~870 — 3½ visible rows to 6.

**D-pad shortcuts out of the results list.** The results list has no horizontal axis of its own, so Left/Right were inert there while Up stepped one result at a time — climbing out of a few hundred matches was not navigation. Left now jumps to the query field, Right to the Filters toggle.

**The Search tab can be hidden.** Search shipped without a visibility toggle, unlike Sync, Achievements and Scraper. It slots into the existing `NavTabSpec` framework: a `hideTabSearch` flag on `ConfigModel`, a `hide_tab_search` column, and the spec entry wiring the predicate, the mutator and the settings copy. The General settings row and its gamepad index both come from `hidableNavTabs()`, so there is no per-tab plumbing. Locale keys added for all 13 languages.

The column lands in **migration v107 (DB version 106 → 107)** on the same hidden-defaults-to-`0` terms as v106, so upgrading users keep the tab they already have. Worth flagging for anyone testing: a device on this branch cannot then run a v106 branch without `_onDowngrade` recreating the database.

Fixes # (issue) _(N/A — no linked issue)_

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. _(N/A — layout/geometry change, verified on-device)_
- [ ] I have updated the corresponding documentation. _(N/A — no docs cover the Search tab)_
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. _(N/A — no new assets)_
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

Verified on an AYN Thor (dev flavor, 1080p): filter-menu placement and height across a short list (Platform, 3 entries) and a long one (Genre), and migration v107 applying cleanly in the logs (`Column hide_tab_search added via v107`) with existing data intact. The menu-centring and d-pad work was measured on the same device when it landed.

## Screenshots (if applicable)

Genre menu at 1080p. "Before" is measured from device screenshots; "after" is
the layout budget the delegate now allows (`viewport − 58.r − 12.r`), on a build
running on the device:

| | before | after |
|---|---|---|
| menu height | ~624 px | **~870 px** |
| top edge | y≈228 | y≈174 (tab strip ends ≈118) |
