### PR TITLE
fix(emulator): make the systems JSON own the app default per system and OS

### DIFF
--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -327,6 +327,9 @@ class SqliteMigrations {
       case 107:
         await _migrateToVersion107(db);
         break;
+      case 108:
+        await _migrateToVersion108(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -5124,6 +5127,81 @@ class SqliteMigrations {
       _log.i('Migration v107 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v107: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v108: Repairs databases that hold more than one app-provided
+  /// default emulator for the same (system_id, os_id).
+  ///
+  /// `app_emulators.is_default` is meant to be single-valued per system and OS:
+  /// it is the app's recommendation, and the launch path takes whichever row the
+  /// query happens to return first. Duplicates therefore turn emulator choice
+  /// into a coin flip — on Android this was observed as `xbox360` flipping
+  /// between the paid `aenu.ax360e` and the free `aenu.ax360e.free`, and
+  /// `switch` flipping between Eden and Benji-SC.
+  ///
+  /// The seed data (`assets/systems/*.json`) is the authority on which emulator
+  /// wins, and no SQL rule can reproduce its choice (it is neither "first" nor
+  /// "last" nor "lowest id"). So rather than guess a winner, this migration
+  /// demotes *every* row in an offending (system_id, os_id) group to
+  /// `is_default = 0`. The JSON sync in `SqliteService._syncEmulators` then
+  /// re-applies the single `default_core` / `default_standalone` row for that
+  /// group on the next scan, and on Android the RetroArch detection pass
+  /// re-picks the installed RetroArch variant. Groups that already satisfy the
+  /// invariant are left untouched, so this is safe to re-run.
+  static Future<void> _migrateToVersion108(Database db) async {
+    _log.i(
+      'Migration v108: Collapsing duplicate app_emulators.is_default rows',
+    );
+
+    try {
+      final tables = db.select(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'app_emulators'",
+      );
+      if (tables.isEmpty) {
+        _log.i('Migration v108: app_emulators table missing, nothing to do');
+        return;
+      }
+
+      const duplicateGroups = '''
+        SELECT system_id, os_id
+        FROM app_emulators
+        WHERE is_default = 1
+        GROUP BY system_id, os_id
+        HAVING COUNT(*) > 1
+      ''';
+
+      final offenders = db.select(duplicateGroups);
+      if (offenders.isEmpty) {
+        _log.i('Migration v108: No duplicate defaults found');
+        return;
+      }
+
+      // Collect the offending groups first and update them explicitly. Doing it
+      // as a single UPDATE with the HAVING sub-select would re-evaluate the
+      // aggregate as rows are written, so a group could stop qualifying halfway
+      // through and keep an arbitrary survivor.
+      for (final row in offenders) {
+        final systemId = row['system_id'];
+        final osId = row['os_id'];
+        _log.w(
+          'Migration v108: system $systemId os $osId had multiple is_default '
+          'rows; clearing so the seed data re-decides',
+        );
+        db.execute(
+          'UPDATE app_emulators SET is_default = 0 '
+          'WHERE system_id = ? AND os_id = ? AND is_default = 1',
+          [systemId, osId],
+        );
+      }
+
+      _log.i(
+        'Migration v108 completed (${offenders.length} group(s) reset)',
+      );
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v108: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -330,6 +330,9 @@ class SqliteMigrations {
       case 108:
         await _migrateToVersion108(db);
         break;
+      case 109:
+        await _migrateToVersion109(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -5202,6 +5205,53 @@ class SqliteMigrations {
       );
     } catch (e, stackTrace) {
       _log.e('Error in migration v108: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v109: Records which standalone emulator the systems JSON
+  /// designates, in `app_emulators.is_default_standalone`.
+  ///
+  /// `is_default_core` has always persisted the JSON's `default_core` flag, but
+  /// its `default_standalone` counterpart was only ever consumed in memory
+  /// during the sync and then thrown away. Anything that later had to pick a
+  /// standalone — [SqliteService.clearRetroArchDefaultsForAndroid] when no
+  /// RetroArch is installed, or the launch-time normalizer when a system has no
+  /// default at all — had no way to ask which one the seed meant, so it guessed
+  /// by name and could land on the wrong build entirely (the paid `aenu.ax360e`
+  /// ahead of the free `aenu.ax360e.free`).
+  ///
+  /// The column backfills to `0` and the next emulator sync writes the real
+  /// values, so both consumers degrade to the old name-ordered guess until then
+  /// rather than breaking.
+  static Future<void> _migrateToVersion109(Database db) async {
+    _log.i('Migration v109: Adding is_default_standalone to app_emulators');
+    try {
+      final tables = db.select(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'app_emulators'",
+      );
+      if (tables.isEmpty) {
+        _log.i('Migration v109: app_emulators table missing, nothing to do');
+        return;
+      }
+
+      final tableInfo = db.select('PRAGMA table_info(app_emulators)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+
+      if (!columns.contains('is_default_standalone')) {
+        db.execute(
+          'ALTER TABLE app_emulators '
+          'ADD COLUMN is_default_standalone INTEGER NOT NULL DEFAULT 0',
+        );
+        _log.i('Column is_default_standalone added via v109');
+      } else {
+        _log.i('Column is_default_standalone already exists');
+      }
+
+      _log.i('Migration v109 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v109: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 108;
+  static const int _databaseVersion = 109;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -871,6 +871,10 @@ class SqliteService {
           if (isDefaultCore) {
             updateData['is_default_core'] = 1;
           }
+          // Written on every pass, unlike is_default_core: it is what tells the
+          // RetroArch fallback which standalone the seed designates, so a JSON
+          // that moves the flag has to be able to move it back off a row.
+          updateData['is_default_standalone'] = isDefaultStandalone ? 1 : 0;
 
           await txn.update(
             'app_emulators',
@@ -901,6 +905,7 @@ class SqliteService {
             if (isDefaultCore) {
               updateData['is_default_core'] = 1;
             }
+            updateData['is_default_standalone'] = isDefaultStandalone ? 1 : 0;
 
             await txn.update(
               'app_emulators',
@@ -929,6 +934,7 @@ class SqliteService {
             if (isDefaultCore) {
               insertData['is_default_core'] = 1;
             }
+            insertData['is_default_standalone'] = isDefaultStandalone ? 1 : 0;
 
             await txn.insert('app_emulators', insertData);
             processedUniqueIds.add(emuDef.uniqueId);
@@ -1708,6 +1714,7 @@ class SqliteService {
           core_filename TEXT,
           is_default INTEGER NOT NULL DEFAULT 0,
           is_default_core INTEGER NOT NULL DEFAULT 0,
+          is_default_standalone INTEGER NOT NULL DEFAULT 0,
           is_ra_compatible INTEGER NOT NULL DEFAULT 0,
           android_package_name TEXT,
           android_activity_name TEXT,
@@ -3869,11 +3876,16 @@ class SqliteService {
         if (hasAppDefault) continue;
 
         // Nothing designated at all — seed the app-level default. Preference:
-        // the core the systems JSON marks as canonical, then any standalone
-        // (more likely to work out of the box than an unverifiable core), then
-        // any core.
+        // the core the systems JSON marks as canonical, then the standalone it
+        // marks, then any standalone (more likely to work out of the box than
+        // an unverifiable core), then any core. Falling straight to "any
+        // standalone" meant an alphabetical guess overrode a seed that had a
+        // perfectly good answer — the paid AX360e ahead of AX360e (Free).
         final seed =
             cores.where((c) => c['is_default_core'] == 1).firstOrNull ??
+            standalones
+                .where((s) => s['is_default_standalone'] == 1)
+                .firstOrNull ??
             standalones.firstOrNull ??
             cores.firstOrNull;
 
@@ -4716,7 +4728,15 @@ class SqliteService {
   /// Clears all RetroArch core defaults on Android when no RetroArch variant
   /// is installed. Systems the user has explicitly configured are left
   /// untouched (see [_systemsWithUserDefaultSql]). For systems that lose their
-  /// default, falls back to the first available standalone emulator.
+  /// default, falls back to a single standalone emulator: the one the systems
+  /// JSON designates, or the first by name if it designates none.
+  ///
+  /// The fallback used to be one set-based `UPDATE ... SET is_default = 1`
+  /// guarded by `NOT EXISTS`, with nothing limiting it to a single row — so it
+  /// promoted *every* standalone of a qualifying system at once and left the
+  /// launch target a coin flip between them, which is the same broken state
+  /// migration v108 exists to repair. Resolving one winner per system in Dart
+  /// also sidesteps the guard re-evaluating as rows are written.
   static Future<void> clearRetroArchDefaultsForAndroid() async {
     final db = await instance.database;
 
@@ -4737,19 +4757,37 @@ class SqliteService {
         [osId, 'com.retroarch%'],
       );
 
-      // For systems with no default after clearing RA, fall back to standalone
-      // Only set standalone as default if it has is_default = 0 AND the system has no other default
-      await txn.rawUpdate(
-        'UPDATE app_emulators SET is_default = 1 '
-        'WHERE os_id = ? AND is_standalone = 1 AND is_default = 0 AND system_id IN ('
-        'SELECT DISTINCT e.system_id FROM app_emulators e '
-        'WHERE e.os_id = ? AND e.android_package_name LIKE ? AND e.is_default = 0'
-        ') AND NOT EXISTS ('
-        'SELECT 1 FROM app_emulators e2 '
-        'WHERE e2.system_id = app_emulators.system_id AND e2.os_id = ? AND e2.is_default = 1'
-        ') AND system_id NOT IN ($_systemsWithUserDefaultSql)',
-        [osId, osId, 'com.retroarch%', osId],
+      // For systems left with no default after clearing RA, fall back to
+      // exactly one standalone — the seed's pick where there is one.
+      final orphaned = await txn.rawQuery(
+        'SELECT DISTINCT e.system_id AS sid FROM app_emulators e '
+        'WHERE e.os_id = ? AND e.android_package_name LIKE ? '
+        'AND e.system_id NOT IN ($_systemsWithUserDefaultSql) '
+        'AND NOT EXISTS ('
+        '  SELECT 1 FROM app_emulators d '
+        '  WHERE d.system_id = e.system_id AND d.os_id = ? AND d.is_default = 1'
+        ')',
+        [osId, 'com.retroarch%', osId],
       );
+
+      for (final row in orphaned) {
+        final systemId = row['sid']?.toString();
+        if (systemId == null) continue;
+
+        final candidates = await txn.rawQuery(
+          'SELECT unique_identifier FROM app_emulators '
+          'WHERE system_id = ? AND os_id = ? AND is_standalone = 1 '
+          'ORDER BY is_default_standalone DESC, name ASC LIMIT 1',
+          [systemId, osId],
+        );
+        if (candidates.isEmpty) continue;
+
+        await txn.rawUpdate(
+          'UPDATE app_emulators SET is_default = 1 '
+          'WHERE system_id = ? AND os_id = ? AND unique_identifier = ?',
+          [systemId, osId, candidates.first['unique_identifier']],
+        );
+      }
     });
 
     try {

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 107;
+  static const int _databaseVersion = 108;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -626,6 +626,16 @@ class SqliteService {
     return syncedSystems;
   }
 
+  /// Runs one emulator sync pass against [txn] — the seed data applied to the
+  /// database, including which row ends up carrying `is_default`.
+  @visibleForTesting
+  static Future<void> syncEmulatorsForTesting(
+    TransactionAdapter txn,
+    String systemId,
+    List<EmulatorDefinition> emulators,
+    Map<String, int> osMap,
+  ) => _syncEmulators(txn, systemId, emulators, osMap, systemId);
+
   static Future<void> _syncEmulators(
     TransactionAdapter txn,
     String systemId,
@@ -633,32 +643,41 @@ class SqliteService {
     Map<String, int> osMap,
     String systemFolderName,
   ) async {
-    // Check if any default exists for this system (Core in app_emulators)
-    final result = await txn.rawQuery(
-      'SELECT COUNT(*) as count FROM app_emulators WHERE system_id = ? AND is_default = 1',
-      [systemId],
-    );
-    final count = result.isNotEmpty
-        ? (int.tryParse(result.first['count']?.toString() ?? '') ?? 0)
-        : 0;
+    // The invariant is "at most one default per (system_id, os_id)", so every
+    // default bookkeeping below is scoped per OS. Scoping it per system would
+    // both starve secondary platforms of a default (the first OS in the JSON
+    // wins and every other OS silently gets none) and let a stale default on
+    // one OS suppress the JSON default on another.
 
-    // Also check if user has set a default standalone emulator
-    final userResult = await txn.rawQuery(
+    // Existing user-chosen defaults for this system, per OS. A user choice
+    // outranks the seed data, so these operating systems are left entirely
+    // alone below — [_fixEmulatorDefaults] already keeps `is_default` from
+    // contradicting them.
+    final userDefaultRows = await txn.rawQuery(
       '''
-      SELECT COUNT(*) as count 
-      FROM user_emulator_config uc 
-      JOIN app_emulators e ON uc.emulator_unique_id = e.unique_identifier 
+      SELECT e.os_id as os_id, COUNT(*) as count
+      FROM user_emulator_config uc
+      JOIN app_emulators e ON uc.emulator_unique_id = e.unique_identifier
       WHERE e.system_id = ? AND uc.is_user_default = 1
+      GROUP BY e.os_id
       ''',
       [systemId],
     );
-    final userCount = userResult.isNotEmpty
-        ? (int.tryParse(userResult.first['count']?.toString() ?? '') ?? 0)
-        : 0;
 
-    final hasDefaultInDB = count > 0 || userCount > 0;
+    final Set<int> osWithUserDefault = {};
+    for (final row in userDefaultRows) {
+      final rowOsId = int.tryParse(row['os_id']?.toString() ?? '');
+      final rowCount = int.tryParse(row['count']?.toString() ?? '') ?? 0;
+      if (rowOsId != null && rowCount > 0) {
+        osWithUserDefault.add(rowOsId);
+      }
+    }
 
-    bool defaultSetInLoop = false;
+    // The emulator the systems JSON designates for each OS — the first flagged
+    // entry that is actually applicable there. Recorded during the row loop and
+    // enforced once afterwards, because the flag is only meaningful relative to
+    // the other rows of the same (system_id, os_id).
+    final Map<int, String> osJsonPick = {};
 
     final Set<String> processedUniqueIds = {};
 
@@ -806,7 +825,10 @@ class SqliteService {
           }
         }
 
-        // Determine if we should apply default from JSON
+        // Record which emulator the JSON designates for this OS. Nothing writes
+        // `is_default` inside this loop: the flag only means anything relative
+        // to the rest of the (system_id, os_id) group, so one statement after
+        // the loop owns it — see the enforcement pass below.
         final bool isDefaultCore = emuDef.isDefaultCore;
         final bool isDefaultStandalone = emuDef.isDefaultStandalone;
         // On Android, skip setting is_default for RetroArch cores here;
@@ -814,14 +836,12 @@ class SqliteService {
         final bool isAndroidTarget = osName == 'android';
         final bool isRetroArchCore = isDefaultCore && !isStandalone;
         final bool skipCoreDefault = isAndroidTarget && isRetroArchCore;
-        final bool applyJsonDefault =
-            !hasDefaultInDB &&
-            !defaultSetInLoop &&
-            !skipCoreDefault &&
-            (isDefaultCore || isDefaultStandalone);
 
-        if (applyJsonDefault) {
-          defaultSetInLoop = true;
+        // First flagged entry wins the OS. Systems that flag several (the
+        // ra/ra32/ra64 core trio, on desktop where none of them is skipped)
+        // resolve by JSON array order, which is at least reproducible.
+        if (!skipCoreDefault && (isDefaultCore || isDefaultStandalone)) {
+          osJsonPick.putIfAbsent(osId, () => emuDef.uniqueId);
         }
 
         // Determine RetroAchievements compatibility
@@ -848,9 +868,6 @@ class SqliteService {
             'is_ra_compatible': retroAchievementsCompatible ? 1 : 0,
           };
 
-          if (applyJsonDefault) {
-            updateData['is_default'] = 1;
-          }
           if (isDefaultCore) {
             updateData['is_default_core'] = 1;
           }
@@ -904,7 +921,9 @@ class SqliteService {
               'core_filename': coreFilename,
               'android_package_name': packageName,
               'android_activity_name': platformData['_resolved_activity_name'],
-              'is_default': applyJsonDefault ? 1 : 0,
+              // Assigned by the enforcement pass after the loop, which is the
+              // only thing that can see the whole (system_id, os_id) group.
+              'is_default': 0,
               'is_ra_compatible': retroAchievementsCompatible ? 1 : 0,
             };
             if (isDefaultCore) {
@@ -915,6 +934,60 @@ class SqliteService {
             processedUniqueIds.add(emuDef.uniqueId);
           }
         }
+      }
+    }
+
+    // Enforce the seed's pick for every OS the JSON designates one for.
+    //
+    // Setting `is_default` on the flagged row is not enough on its own: nothing
+    // else in the sync path ever *clears* the flag, so a row that acquired it
+    // under an older systems JSON (or from a repair pass that guessed) kept it
+    // forever, and the seed's real choice could never take effect. Shipping a
+    // changed default therefore never reached an install that already had one.
+    // Writing the whole group in one statement makes the JSON authoritative and
+    // collapses any duplicates in the same pass.
+    //
+    // Two owners are deliberately not overruled:
+    //   * an OS where the user picked an emulator — their choice outranks the
+    //     seed, and re-asserting `is_default` here would recreate exactly the
+    //     app-default-contradicts-user-choice anomaly v105 exists to clear;
+    //   * RetroArch on Android, where [fixRetroArchDefaultForAndroid] owns the
+    //     flag because only it knows which variant is installed. Its cores are
+    //     already excluded by `skipCoreDefault`; this also declines to demote a
+    //     core it has designated in favour of the JSON's standalone.
+    if (osJsonPick.isNotEmpty) {
+      int? androidOsId;
+      for (final entry in osMap.entries) {
+        if (entry.key.toLowerCase() == 'android') {
+          androidOsId = entry.value;
+          break;
+        }
+      }
+
+      final coreDefaultRows = await txn.rawQuery(
+        'SELECT DISTINCT os_id FROM app_emulators '
+        'WHERE system_id = ? AND is_default = 1 AND is_standalone = 0',
+        [systemId],
+      );
+      final Set<int> osWithCoreDefault = {};
+      for (final row in coreDefaultRows) {
+        final rowOsId = int.tryParse(row['os_id']?.toString() ?? '');
+        if (rowOsId != null) osWithCoreDefault.add(rowOsId);
+      }
+
+      for (final pick in osJsonPick.entries) {
+        final pickOsId = pick.key;
+        if (osWithUserDefault.contains(pickOsId)) continue;
+        if (pickOsId == androidOsId && osWithCoreDefault.contains(pickOsId)) {
+          continue;
+        }
+
+        await txn.rawUpdate(
+          'UPDATE app_emulators '
+          'SET is_default = CASE WHEN unique_identifier = ? THEN 1 ELSE 0 END '
+          'WHERE system_id = ? AND os_id = ?',
+          [pick.value, systemId, pickOsId],
+        );
       }
     }
 
@@ -3766,7 +3839,16 @@ class SqliteService {
           [systemId, osId],
         );
 
-        final hasCoreDefault = cores.any((c) => c['is_default'] == 1);
+        // "Is anything already designated for this (system, os)?" — and a
+        // standalone counts. Asking only the cores made every all-standalone
+        // system (switch, xbox360) look undesignated on every single database
+        // open, so the seeding below ran again and flagged the alphabetically
+        // first standalone *alongside* the one the systems JSON had chosen:
+        // AX360e next to AX360e (Free), Benji-SC next to Eden. That is where
+        // the duplicate defaults v108 repairs came from.
+        final hasAppDefault =
+            cores.any((c) => c['is_default'] == 1) ||
+            standalones.any((s) => s['is_default'] == 1);
         final hasUserDefault = standalones.any(
           (s) => s['is_user_default'] == 1,
         );
@@ -3774,7 +3856,7 @@ class SqliteService {
         if (hasUserDefault) {
           // The user made a choice. It outranks any app-level default, so drop
           // the contradicting `is_default` rather than the choice.
-          if (hasCoreDefault) {
+          if (hasAppDefault) {
             await db.rawUpdate(
               'UPDATE app_emulators SET is_default = 0 '
               'WHERE system_id = ? AND os_id = ?',
@@ -3784,7 +3866,7 @@ class SqliteService {
           continue;
         }
 
-        if (hasCoreDefault) continue;
+        if (hasAppDefault) continue;
 
         // Nothing designated at all — seed the app-level default. Preference:
         // the core the systems JSON marks as canonical, then any standalone

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -142,6 +142,7 @@ class DatabaseTestHelper {
         android_activity_name TEXT,
         is_default INTEGER,
         is_default_core INTEGER,
+        is_default_standalone INTEGER NOT NULL DEFAULT 0,
         is_ra_compatible INTEGER
       )
     ''');

--- a/test/emulator_duplicate_default_migration_test.dart
+++ b/test/emulator_duplicate_default_migration_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+
+/// Tests for migration v108, which repairs databases holding more than one
+/// `app_emulators.is_default = 1` row for the same (system_id, os_id).
+///
+/// The seed data (`assets/systems/*.json`) is the authority on which emulator
+/// should win, and no SQL rule reproduces its choice, so v108 demotes the whole
+/// offending group to 0 and lets the JSON sync re-apply the single flagged
+/// emulator on the next scan.
+void main() {
+  late Database db;
+
+  setUp(() {
+    db = sqlite3.openInMemory();
+    db.execute('''
+      CREATE TABLE app_emulators (
+        unique_identifier TEXT NOT NULL,
+        os_id INTEGER NOT NULL,
+        system_id TEXT NOT NULL,
+        name TEXT,
+        is_standalone INTEGER NOT NULL DEFAULT 0,
+        is_default INTEGER NOT NULL DEFAULT 0
+      )
+    ''');
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  Future<void> runV108() => SqliteMigrations.migrateToVersion(db, 108);
+
+  void insert(
+    String uniqueId,
+    int osId,
+    String systemId, {
+    int isDefault = 0,
+    int isStandalone = 1,
+  }) {
+    db.execute(
+      'INSERT INTO app_emulators '
+      '(unique_identifier, os_id, system_id, name, is_standalone, is_default) '
+      'VALUES (?, ?, ?, ?, ?, ?)',
+      [uniqueId, osId, systemId, uniqueId, isStandalone, isDefault],
+    );
+  }
+
+  int defaultOf(String uniqueId, int osId) {
+    final rows = db.select(
+      'SELECT is_default FROM app_emulators WHERE unique_identifier = ? AND os_id = ?',
+      [uniqueId, osId],
+    );
+    return int.parse(rows.first['is_default'].toString());
+  }
+
+  test('clears both rows of a duplicated (system, os) group', () {
+    // The real xbox360 case: paid vs free AX360e both flagged default.
+    insert('xbox360.aenu.ax360e', 2, 'xbox360', isDefault: 1);
+    insert('xbox360.aenu.ax360e.free', 2, 'xbox360', isDefault: 1);
+
+    return runV108().then((_) {
+      expect(defaultOf('xbox360.aenu.ax360e', 2), 0);
+      expect(defaultOf('xbox360.aenu.ax360e.free', 2), 0);
+    });
+  });
+
+  test('clears a duplicated group with more than two members', () async {
+    insert('switch.dev.eden.eden_emulator', 2, 'switch', isDefault: 1);
+    insert('switch.org.benjisc.android', 2, 'switch', isDefault: 1);
+    insert('switch.skyline.emu', 2, 'switch', isDefault: 1);
+    insert('switch.com.miHoYo.Yuanshen', 2, 'switch');
+
+    await runV108();
+
+    final remaining = db.select(
+      "SELECT COUNT(*) as c FROM app_emulators WHERE system_id = 'switch' AND is_default = 1",
+    );
+    expect(remaining.first['c'], 0);
+  });
+
+  test('leaves a healthy single-default group untouched', () async {
+    insert('snes.ra64.snes9x', 2, 'snes', isDefault: 1, isStandalone: 0);
+    insert('snes.ra32.snes9x', 2, 'snes', isStandalone: 0);
+
+    await runV108();
+
+    expect(defaultOf('snes.ra64.snes9x', 2), 1);
+    expect(defaultOf('snes.ra32.snes9x', 2), 0);
+  });
+
+  test('does not touch other systems that share the same os', () async {
+    insert('xbox360.aenu.ax360e', 2, 'xbox360', isDefault: 1);
+    insert('xbox360.aenu.ax360e.free', 2, 'xbox360', isDefault: 1);
+    insert('psp.ppsspp', 2, 'psp', isDefault: 1);
+
+    await runV108();
+
+    expect(defaultOf('psp.ppsspp', 2), 1);
+    expect(defaultOf('xbox360.aenu.ax360e', 2), 0);
+  });
+
+  test('scopes the repair per os — a healthy os keeps its default', () async {
+    // Android is broken, Windows has a single legitimate default.
+    insert('xbox360.aenu.ax360e', 2, 'xbox360', isDefault: 1);
+    insert('xbox360.aenu.ax360e.free', 2, 'xbox360', isDefault: 1);
+    insert('xbox360.xenia', 1, 'xbox360', isDefault: 1);
+
+    await runV108();
+
+    expect(defaultOf('xbox360.xenia', 1), 1);
+    expect(defaultOf('xbox360.aenu.ax360e', 2), 0);
+    expect(defaultOf('xbox360.aenu.ax360e.free', 2), 0);
+  });
+
+  test('is idempotent — a second run changes nothing', () async {
+    insert('xbox360.aenu.ax360e', 2, 'xbox360', isDefault: 1);
+    insert('xbox360.aenu.ax360e.free', 2, 'xbox360', isDefault: 1);
+    insert('psp.ppsspp', 2, 'psp', isDefault: 1);
+
+    await runV108();
+    await runV108();
+
+    expect(defaultOf('psp.ppsspp', 2), 1);
+    expect(defaultOf('xbox360.aenu.ax360e', 2), 0);
+    expect(defaultOf('xbox360.aenu.ax360e.free', 2), 0);
+  });
+
+  test('tolerates a database without an app_emulators table', () async {
+    db.execute('DROP TABLE app_emulators');
+    await expectLater(runV108(), completes);
+  });
+}

--- a/test/emulator_seed_authority_test.dart
+++ b/test/emulator_seed_authority_test.dart
@@ -133,6 +133,30 @@ void main() {
     expect(await defaultsOn(androidOsId), ['xbox360.aenu.ax360e.free']);
   });
 
+  test('records which standalone the seed designates, and moves it', () async {
+    Future<List<String>> flaggedStandalones() async {
+      final rows = await db.rawQuery(
+        "SELECT unique_identifier AS uid FROM app_emulators "
+        "WHERE system_id = 'xbox360' AND is_default_standalone = 1 ORDER BY uid",
+      );
+      return rows.map<String>((r) => r['uid'].toString()).toList();
+    }
+
+    await sync(xbox360);
+    expect(await flaggedStandalones(), ['xbox360.aenu.ax360e.free']);
+
+    // The marker has to be cleared as well as set, or a systems update that
+    // moves `default_standalone` would leave two rows claiming to be the
+    // seed's pick — and it is what the RetroArch fallback consults.
+    await sync([
+      standalone('AX360e', 'xbox360.aenu.ax360e', isDefault: true),
+      standalone('AX360e (Free)', 'xbox360.aenu.ax360e.free'),
+      standalone('Xendroid', 'xbox360.xendroid'),
+    ]);
+
+    expect(await flaggedStandalones(), ['xbox360.aenu.ax360e']);
+  });
+
   test('designates every OS the seed lists, not just the first', () async {
     // The bookkeeping used to be one flag for the whole system, so the first OS
     // in the JSON consumed it and every other platform got no default at all.

--- a/test/emulator_seed_authority_test.dart
+++ b/test/emulator_seed_authority_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+import 'package:neostation/models/system_configuration.dart';
+
+import 'database_test_helper.dart';
+
+/// The systems JSON owns `app_emulators.is_default` for every (system, os) it
+/// designates an emulator for.
+///
+/// The sync used to only ever *set* the flag, never clear it, and only when the
+/// system had no default at all. A row that acquired the flag under an older
+/// JSON — or from a repair pass that guessed — therefore kept it forever, and
+/// the two failure modes that produced were: a changed default never reaching
+/// an install that already had one, and two rows flagged at once, which makes
+/// the launch target whichever row the query happens to return first.
+void main() {
+  final dbHelper = DatabaseTestHelper();
+  late dynamic db;
+  late Map<String, int> osMap;
+
+  const androidOsId = 2;
+  const linuxOsId = 3;
+
+  /// The xbox360 shape: standalone-only, and the seed picks the free build
+  /// rather than the paid one it sorts next to.
+  EmulatorDefinition standalone(
+    String name,
+    String uniqueId, {
+    bool isDefault = false,
+    List<String> platforms = const ['android'],
+  }) => EmulatorDefinition(
+    name: name,
+    uniqueId: uniqueId,
+    description: '',
+    isDefaultStandalone: isDefault,
+    platforms: {
+      for (final p in platforms)
+        p: p == 'android'
+            ? {'package': uniqueId, 'activity': '.MainActivity'}
+            : {'executable': '/usr/bin/$uniqueId'},
+    },
+  );
+
+  EmulatorDefinition retroArchCore(
+    String name,
+    String uniqueId, {
+    bool isDefault = false,
+  }) => EmulatorDefinition(
+    name: name,
+    uniqueId: uniqueId,
+    description: '',
+    isDefaultCore: isDefault,
+    platforms: {
+      'android': {
+        'package': 'com.retroarch.aarch64',
+        'activity': '.browser.retroactivity.RetroActivityFuture',
+        'extras': [
+          {'key': 'LIBRETRO', 'value': 'core_libretro.so'},
+        ],
+      },
+    },
+  );
+
+  setUp(() async {
+    db = await dbHelper.setUp();
+    await db.execute(
+      "INSERT OR IGNORE INTO app_os (id, name) VALUES (1, 'windows'), "
+      "($androidOsId, 'android'), ($linuxOsId, 'linux'), (4, 'macos')",
+    );
+    await db.execute(
+      "INSERT INTO app_systems (id, real_name, folder_name) VALUES ('xbox360', 'Xbox 360', 'xbox360')",
+    );
+    osMap = {'windows': 1, 'android': androidOsId, 'linux': linuxOsId};
+  });
+
+  tearDown(() async => dbHelper.tearDown());
+
+  Future<void> sync(List<EmulatorDefinition> emulators) =>
+      db.transaction((txn) async {
+        await SqliteService.syncEmulatorsForTesting(
+          txn,
+          'xbox360',
+          emulators,
+          osMap,
+        );
+      });
+
+  Future<List<String>> defaultsOn(int osId) async {
+    final rows = await db.rawQuery(
+      "SELECT unique_identifier AS uid FROM app_emulators "
+      "WHERE system_id = 'xbox360' AND os_id = ? AND is_default = 1 ORDER BY uid",
+      [osId],
+    );
+    return rows.map<String>((r) => r['uid'].toString()).toList();
+  }
+
+  final xbox360 = [
+    standalone('AX360e', 'xbox360.aenu.ax360e'),
+    standalone('AX360e (Free)', 'xbox360.aenu.ax360e.free', isDefault: true),
+    standalone('Xendroid', 'xbox360.xendroid'),
+  ];
+
+  test('applies the seed default on a fresh database', () async {
+    await sync(xbox360);
+
+    expect(await defaultsOn(androidOsId), ['xbox360.aenu.ax360e.free']);
+  });
+
+  test('re-applies the seed default over a stale one', () async {
+    // The install already designated a different emulator — an older JSON's
+    // pick, or a repair pass that guessed. The seed's choice never used to
+    // reach it, so shipping a changed default was a no-op for existing users.
+    await sync(xbox360);
+    await db.execute(
+      "UPDATE app_emulators SET is_default = CASE WHEN unique_identifier = 'xbox360.aenu.ax360e' THEN 1 ELSE 0 END "
+      "WHERE system_id = 'xbox360'",
+    );
+
+    await sync(xbox360);
+
+    expect(await defaultsOn(androidOsId), ['xbox360.aenu.ax360e.free']);
+  });
+
+  test('collapses a group that already has two defaults', () async {
+    await sync(xbox360);
+    await db.execute(
+      "UPDATE app_emulators SET is_default = 1 WHERE unique_identifier = 'xbox360.aenu.ax360e'",
+    );
+    expect(await defaultsOn(androidOsId), hasLength(2));
+
+    await sync(xbox360);
+
+    expect(await defaultsOn(androidOsId), ['xbox360.aenu.ax360e.free']);
+  });
+
+  test('designates every OS the seed lists, not just the first', () async {
+    // The bookkeeping used to be one flag for the whole system, so the first OS
+    // in the JSON consumed it and every other platform got no default at all.
+    final crossPlatform = [
+      standalone(
+        'Standalone Eden',
+        'switch.dev.eden',
+        isDefault: true,
+        platforms: ['android', 'linux'],
+      ),
+      standalone(
+        'Standalone Citron',
+        'switch.citron',
+        platforms: ['android', 'linux'],
+      ),
+    ];
+
+    await sync(crossPlatform);
+
+    expect(await defaultsOn(androidOsId), ['switch.dev.eden']);
+    expect(await defaultsOn(linuxOsId), ['switch.dev.eden']);
+  });
+
+  test('leaves an OS where the user picked an emulator alone', () async {
+    // Runs on whichever OS the suite is hosted on, because that is the one
+    // the emulator setters scope their writes to.
+    final hostOs = SqliteService.getCurrentOs();
+    final hostOsId = osMap[hostOs]!;
+    final onHostOs = [
+      standalone('AX360e', 'xbox360.aenu.ax360e', platforms: [hostOs]),
+      standalone(
+        'AX360e (Free)',
+        'xbox360.aenu.ax360e.free',
+        isDefault: true,
+        platforms: [hostOs],
+      ),
+      standalone('Xendroid', 'xbox360.xendroid', platforms: [hostOs]),
+    ];
+
+    await sync(onHostOs);
+    expect(await defaultsOn(hostOsId), ['xbox360.aenu.ax360e.free']);
+
+    await SqliteService.setDefaultStandaloneEmulator(
+      'xbox360',
+      'xbox360.xendroid',
+    );
+    expect(await defaultsOn(hostOsId), isEmpty);
+
+    await sync(onHostOs);
+
+    // Re-asserting the seed's pick here would recreate the exact
+    // app-default-contradicts-user-choice state v105 exists to clear.
+    expect(await defaultsOn(hostOsId), isEmpty);
+  });
+
+  test('does not overrule the installed RetroArch variant on Android', () async {
+    // On Android the RA core defaults belong to fixRetroArchDefaultForAndroid,
+    // which is the only thing that knows which variant is installed. The seed's
+    // standalone must not demote a core it has designated.
+    final mixed = [
+      retroArchCore('RetroArch Play!', 'xbox360.ra.play', isDefault: true),
+      ...xbox360,
+    ];
+
+    await sync(mixed);
+    await db.execute(
+      "UPDATE app_emulators SET is_default = CASE WHEN unique_identifier = 'xbox360.ra.play' THEN 1 ELSE 0 END "
+      "WHERE system_id = 'xbox360'",
+    );
+
+    await sync(mixed);
+
+    expect(await defaultsOn(androidOsId), ['xbox360.ra.play']);
+  });
+}

--- a/test/emulator_seed_default_test.dart
+++ b/test/emulator_seed_default_test.dart
@@ -1,0 +1,190 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the "at most one app default per (system_id, os_id)" invariant at its
+/// source: the bundled seed definitions in `assets/systems/*.json`.
+///
+/// `SqliteService._syncEmulators` turns these files into `app_emulators` rows
+/// and stamps `is_default = 1` on the emulator flagged `default_core` /
+/// `default_standalone`. If a system ever ships two competing flags for the
+/// same OS, which emulator receives the launch intent becomes a coin flip
+/// (this is how `xbox360` ended up flipping between the paid `aenu.ax360e` and
+/// the free `aenu.ax360e.free`). These tests fail the build on the *next*
+/// occurrence rather than waiting for it to be found on a device.
+void main() {
+  late List<_SeedSystem> systems;
+
+  setUpAll(() {
+    final dir = Directory('assets/systems');
+    expect(
+      dir.existsSync(),
+      isTrue,
+      reason: 'assets/systems must exist — it is the seed source of truth',
+    );
+
+    systems = dir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.json'))
+        .map((f) => _SeedSystem.parse(f))
+        .toList();
+
+    expect(systems, isNotEmpty);
+  });
+
+  test('every system ships at most one default_standalone emulator', () {
+    final offenders = <String>[];
+    for (final system in systems) {
+      final flagged = system.emulators
+          .where((e) => e.isDefaultStandalone)
+          .map((e) => e.uniqueId)
+          .toList();
+      if (flagged.length > 1) {
+        offenders.add('${system.name}: $flagged');
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'Two default_standalone entries in one system produce two '
+          'is_default=1 rows for the same (system_id, os_id):\n'
+          '${offenders.join('\n')}',
+    );
+  });
+
+  test(
+    'per (system, os) at most one default_standalone emulator is offered',
+    () {
+      final offenders = <String>[];
+      for (final system in systems) {
+        final byOs = <String, List<String>>{};
+        for (final emu in system.emulators) {
+          if (!emu.isDefaultStandalone) continue;
+          for (final os in emu.platforms.keys) {
+            byOs.putIfAbsent(os.toLowerCase(), () => []).add(emu.uniqueId);
+          }
+        }
+        byOs.forEach((os, ids) {
+          if (ids.length > 1) offenders.add('${system.name} [$os]: $ids');
+        });
+      }
+
+      expect(offenders, isEmpty, reason: offenders.join('\n'));
+    },
+  );
+
+  test('every default_core emulator is a RetroArch definition', () {
+    // Multiple default_core entries per system are legitimate *only* because
+    // they are the ra / ra64 / ra32 packaging variants of one RetroArch core;
+    // on Android `_syncEmulators` skips them entirely and the installed-variant
+    // detection picks exactly one. A non-RetroArch emulator flagged
+    // default_core would break that assumption.
+    final offenders = <String>[];
+    for (final system in systems) {
+      for (final emu in system.emulators) {
+        if (!emu.isDefaultCore) continue;
+        emu.platforms.forEach((os, platform) {
+          if (!jsonEncode(platform).toLowerCase().contains('retroarch')) {
+            offenders.add('${system.name}: ${emu.uniqueId} [$os]');
+          }
+        });
+      }
+    }
+
+    expect(offenders, isEmpty, reason: offenders.join('\n'));
+  });
+
+  test('all default_core entries in a system name the same libretro core', () {
+    // If the variants disagreed on the core they load, "which variant is
+    // installed" would silently change *which emulator core* runs the game.
+    final offenders = <String>[];
+    for (final system in systems) {
+      final cores = <String>{};
+      for (final emu in system.emulators) {
+        if (!emu.isDefaultCore) continue;
+        for (final platform in emu.platforms.values) {
+          final match = RegExp(
+            r'libretro\s+"?([^"\s]+)',
+            caseSensitive: false,
+          ).firstMatch(jsonEncode(platform));
+          if (match != null) cores.add(match.group(1)!);
+        }
+      }
+      if (cores.length > 1) {
+        offenders.add('${system.name}: $cores');
+      }
+    }
+
+    expect(offenders, isEmpty, reason: offenders.join('\n'));
+  });
+
+  test('the two systems fixed on this branch resolve to a single default', () {
+    // Regression pins for the pair found on the AYN Thor.
+    final switchSystem = systems.firstWhere((s) => s.name == 'switch.json');
+    final xbox360 = systems.firstWhere((s) => s.name == 'xbox360.json');
+
+    expect(
+      switchSystem.emulators
+          .where((e) => e.isDefaultStandalone)
+          .map((e) => e.uniqueId),
+      ['switch.dev.eden.eden_emulator'],
+    );
+    expect(
+      xbox360.emulators
+          .where((e) => e.isDefaultStandalone)
+          .map((e) => e.uniqueId),
+      ['xbox360.aenu.ax360e.free'],
+    );
+  });
+}
+
+class _SeedSystem {
+  _SeedSystem(this.name, this.emulators);
+
+  final String name;
+  final List<_SeedEmulator> emulators;
+
+  static _SeedSystem parse(File file) {
+    final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+    final raw = (json['emulators'] as List?) ?? const [];
+    return _SeedSystem(
+      file.uri.pathSegments.last,
+      raw
+          .cast<Map<String, dynamic>>()
+          .map(_SeedEmulator.fromJson)
+          .toList(growable: false),
+    );
+  }
+}
+
+class _SeedEmulator {
+  _SeedEmulator({
+    required this.uniqueId,
+    required this.isDefaultCore,
+    required this.isDefaultStandalone,
+    required this.platforms,
+  });
+
+  final String uniqueId;
+  final bool isDefaultCore;
+  final bool isDefaultStandalone;
+  final Map<String, dynamic> platforms;
+
+  static bool _flag(Object? value) =>
+      value.toString().toLowerCase() == 'true';
+
+  factory _SeedEmulator.fromJson(Map<String, dynamic> json) {
+    return _SeedEmulator(
+      uniqueId: (json['unique_id'] ?? json['uniqueId'] ?? '').toString(),
+      isDefaultCore: _flag(json['default_core']),
+      isDefaultStandalone: _flag(json['default_standalone']),
+      platforms: json['platforms'] is Map
+          ? Map<String, dynamic>.from(json['platforms'] as Map)
+          : <String, dynamic>{},
+    );
+  }
+}

--- a/test/emulator_system_default_test.dart
+++ b/test/emulator_system_default_test.dart
@@ -304,6 +304,62 @@ void main() {
         expect(await appDefaults(), hasLength(1));
       });
 
+      /// A system whose only emulators are standalones — switch and xbox360
+      /// are the real ones. `defaultUid` is the pick the systems JSON makes,
+      /// which is deliberately *not* the alphabetically first entry.
+      Future<void> seedAllStandaloneSystem({required String defaultUid}) async {
+        await db.execute(
+          "INSERT INTO app_systems (id, real_name, folder_name) VALUES ('xbox360', 'Xbox 360', 'xbox360')",
+        );
+        for (final emu in [
+          ('AX360e', 'xbox360.aenu.ax360e'),
+          ('AX360e (Free)', 'xbox360.aenu.ax360e.free'),
+          ('X360 Mobile', 'xbox360.x360mobile'),
+          ('Xendroid', 'xbox360.xendroid'),
+        ]) {
+          await db.execute(
+            'INSERT INTO app_emulators (system_id, os_id, name, unique_identifier, is_standalone, is_default) '
+            "VALUES ('xbox360', $osId, '${emu.$1}', '${emu.$2}', 1, "
+            '${emu.$2 == defaultUid ? 1 : 0})',
+          );
+        }
+      }
+
+      Future<List<String>> xbox360Defaults() async {
+        final rows = await db.rawQuery(
+          "SELECT unique_identifier AS uid FROM app_emulators "
+          "WHERE system_id = 'xbox360' AND is_default = 1 ORDER BY uid",
+        );
+        return rows.map<String>((r) => r['uid'].toString()).toList();
+      }
+
+      test('leaves an existing standalone app default alone', () async {
+        // Regression: the designation check only looked at cores, so a system
+        // with nothing but standalones read as undesignated and got seeded
+        // again — every launch, next to the default already there. Two winners
+        // for one (system, os) makes the launch target a coin flip, which is
+        // how xbox360 started booting the paid AX360e instead of the free
+        // build the systems JSON picks.
+        await seedAllStandaloneSystem(
+          defaultUid: 'xbox360.aenu.ax360e.free',
+        );
+
+        await normalize();
+        await normalize();
+
+        expect(await xbox360Defaults(), ['xbox360.aenu.ax360e.free']);
+      });
+
+      test('still seeds an all-standalone system that has no default', () async {
+        // The other half: with no designation at all, seeding must still fire,
+        // or the system launches nothing.
+        await seedAllStandaloneSystem(defaultUid: 'none');
+
+        await normalize();
+
+        expect(await xbox360Defaults(), hasLength(1));
+      });
+
       test('does not touch other operating systems', () async {
         final otherOs = osId == 2 ? 1 : 2;
         await db.execute(

--- a/test/retroarch_clear_fallback_test.dart
+++ b/test/retroarch_clear_fallback_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+
+import 'database_test_helper.dart';
+
+/// [SqliteService.clearRetroArchDefaultsForAndroid] runs when no RetroArch
+/// variant is installed on Android: the RA core defaults are meaningless, so
+/// they are cleared and each affected system falls back to a standalone.
+///
+/// "A standalone" has to mean exactly one. The fallback used to be a single
+/// set-based UPDATE with no `LIMIT 1`, so every standalone of a qualifying
+/// system got flagged at once — the same two-winners state that makes the
+/// launch target a coin flip.
+void main() {
+  final dbHelper = DatabaseTestHelper();
+  late dynamic db;
+
+  const androidOsId = 2;
+
+  setUp(() async {
+    db = await dbHelper.setUp();
+    await db.execute(
+      "INSERT OR IGNORE INTO app_os (id, name) VALUES (1, 'windows'), "
+      "($androidOsId, 'android'), (3, 'linux'), (4, 'macos')",
+    );
+    await db.execute(
+      "INSERT INTO app_systems (id, real_name, folder_name) VALUES ('ps2', 'PlayStation 2', 'ps2')",
+    );
+    // The real ps2 shape: a RetroArch core holding the default, and standalones
+    // whose alphabetical order disagrees with the seed's pick.
+    await db.execute('''
+      INSERT INTO app_emulators
+        (system_id, os_id, name, unique_identifier, is_standalone, is_default,
+         is_default_core, is_default_standalone, android_package_name)
+      VALUES
+        ('ps2', $androidOsId, 'RetroArch64 Play!', 'ps2.ra64.play', 0, 1, 1, 0, 'com.retroarch.aarch64'),
+        ('ps2', $androidOsId, 'EmuCoreX', 'ps2.emucorex', 1, 0, 0, 0, 'com.emucorex'),
+        ('ps2', $androidOsId, 'Standalone ARMSX2', 'ps2.armsx2', 1, 0, 0, 0, 'xyz.armsx2'),
+        ('ps2', $androidOsId, 'Standalone NetherSX2', 'ps2.nethersx2', 1, 0, 0, 1, 'xyz.aethersx2')
+    ''');
+  });
+
+  tearDown(() async => dbHelper.tearDown());
+
+  Future<List<String>> defaults() async {
+    final rows = await db.rawQuery(
+      "SELECT unique_identifier AS uid FROM app_emulators "
+      "WHERE system_id = 'ps2' AND os_id = $androidOsId AND is_default = 1 ORDER BY uid",
+    );
+    return rows.map<String>((r) => r['uid'].toString()).toList();
+  }
+
+  test('promotes exactly one standalone, the one the seed designates', () async {
+    await SqliteService.clearRetroArchDefaultsForAndroid();
+
+    // Not EmuCoreX, which merely sorts first.
+    expect(await defaults(), ['ps2.nethersx2']);
+  });
+
+  test('falls back to the first by name when the seed designates none', () async {
+    await db.execute(
+      "UPDATE app_emulators SET is_default_standalone = 0 WHERE system_id = 'ps2'",
+    );
+
+    await SqliteService.clearRetroArchDefaultsForAndroid();
+
+    expect(await defaults(), ['ps2.emucorex']);
+  });
+
+  test('leaves a system the user has configured alone', () async {
+    await db.execute(
+      "INSERT INTO user_emulator_config (emulator_unique_id, emulator_path, is_user_default) "
+      "VALUES ('ps2.armsx2', '', 1)",
+    );
+
+    await SqliteService.clearRetroArchDefaultsForAndroid();
+
+    // The RA core default is left in place rather than being cleared and
+    // second-guessed; the user's own pick outranks it at launch anyway.
+    expect(await defaults(), ['ps2.ra64.play']);
+  });
+
+  test('is idempotent', () async {
+    await SqliteService.clearRetroArchDefaultsForAndroid();
+    await SqliteService.clearRetroArchDefaultsForAndroid();
+
+    expect(await defaults(), ['ps2.nethersx2']);
+  });
+
+  test('leaves a system with no RetroArch emulator untouched', () async {
+    // xbox360 has no RA core at all, so this routine has no business
+    // designating anything for it.
+    await db.execute(
+      "INSERT INTO app_systems (id, real_name, folder_name) VALUES ('xbox360', 'Xbox 360', 'xbox360')",
+    );
+    await db.execute('''
+      INSERT INTO app_emulators
+        (system_id, os_id, name, unique_identifier, is_standalone, is_default,
+         is_default_core, is_default_standalone, android_package_name)
+      VALUES
+        ('xbox360', $androidOsId, 'AX360e', 'xbox360.ax360e', 1, 0, 0, 0, 'aenu.ax360e'),
+        ('xbox360', $androidOsId, 'AX360e (Free)', 'xbox360.ax360e.free', 1, 0, 0, 1, 'aenu.ax360e.free')
+    ''');
+
+    await SqliteService.clearRetroArchDefaultsForAndroid();
+
+    final rows = await db.rawQuery(
+      "SELECT unique_identifier AS uid FROM app_emulators "
+      "WHERE system_id = 'xbox360' AND is_default = 1",
+    );
+    expect(rows, isEmpty);
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code).

# Description

**`app_emulators.is_default` is supposed to hold one row per system and OS. On two systems it held two, and the launch path picks between them with `LIMIT 1` and no `ORDER BY`.**

Found on my Thor while device-testing something else:

```
switch   os_id=2:  switch.dev.eden.eden_emulator   is_default=1
                   switch.org.benjisc.android      is_default=1
xbox360  os_id=2:  xbox360.aenu.ax360e             is_default=1   <- paid
                   xbox360.aenu.ax360e.free        is_default=1   <- what the JSON picks
```

## What this looks like for a user

**You install the free AX360e — the one the app recommends — and pressing A does nothing.**

`xbox360.json` designates `AX360e (Free)`, so that is the build a user goes and installs. But with both rows flagged, `getDefaultEmulatorForSystem` returns whichever row the query happens to scan first, and that may well be `aenu.ax360e`: a different package, one that isn't on the device. Unlike RetroArch variants — install-checked since #240 — a standalone default is handed to the launcher as-is, so the intent goes to a package that isn't there and the user gets nothing they can act on, having installed exactly what NeoStation told them to. Same shape on Switch, where the pick flips between Eden and Benji-SC.

**Your Steam Deck launches Switch games in Citron, not Eden.** `switch.json` designates Eden on `android`, `windows` *and* `linux`, but the sync had one default flag for the whole system: Android is processed first, consumes it, and the desktop platforms get nothing from the seed. The launch-time normalizer then fills the hole with the alphabetically first standalone — `Standalone Citron`.

**We change a system's recommended emulator and nobody gets it.** The sync only ever *set* `is_default`, never cleared it, and only when the system had no default at all. Any install that already had one kept it forever, so a corrected default in `assets/systems/*.json` reached new installs only.

**You uninstall RetroArch and ps2 ends up with three defaults.** With no RA variant present, `clearRetroArchDefaultsForAndroid` clears the core defaults and falls back to a standalone — via one set-based UPDATE with nothing limiting it to a single row, so *every* standalone of the system got flagged at once.

The seed data was never wrong: `xbox360.json` has flagged the free build and `switch.json` Eden since `310603e`. Four separate defects let the database drift away from it.

### 1. A repair pass was minting the duplicates, on every launch

`_fixEmulatorDefaults` runs from `_onConfigure`, i.e. every database open. It asked only the **cores** whether the system had a default, and only `user_emulator_config` whether the user had chosen one:

```dart
final hasCoreDefault = cores.any((c) => c['is_default'] == 1);   // is_standalone = 0 only
final hasUserDefault = standalones.any((s) => s['is_user_default'] == 1);
```

A standalone carrying `is_default` is invisible to both. So switch and xbox360 — which have no cores at all — read as undesignated *every single launch* and got seeded again, flagging the alphabetically first standalone **alongside** the one already there. `AX360e` sorts before `AX360e (Free)`; `Standalone Benji-SC` before `Standalone Eden`. That is exactly the two pairs above.

### 2. One default flag served every operating system

`_syncEmulators` scoped its bookkeeping per system rather than per `(system, os)`: a single `hasDefaultInDB` query and a single `defaultSetInLoop` bool. The first OS in the JSON consumed the system's only default and every other platform silently got none — the Steam Deck case above.

### 3. The sync promoted but never demoted

A row that acquired the flag under an older systems JSON kept it forever, and because the system then looked designated, the JSON's real choice could never re-apply.

### 4. A second generator, for devices without RetroArch

`clearRetroArchDefaultsForAndroid`'s standalone fallback was one statement with no row limit:

```sql
UPDATE app_emulators SET is_default = 1
WHERE os_id = ? AND is_standalone = 1 AND is_default = 0
  AND system_id IN (...) AND NOT EXISTS (...)
```

It flagged every standalone of a qualifying system, minting the two-winners state fresh on any RetroArch-less device. It also read its own writes — the `NOT EXISTS` guard was re-evaluated as rows were updated — so which rows survived depended on scan order. Run the new tests against the old statement and all three ps2 standalones come back flagged.

## What changed

- **`_fixEmulatorDefaults`** counts a standalone's `is_default` as a designation, so it stops re-seeding systems that already have one.
- **`_syncEmulators`** is now per-OS and authoritative. It records the emulator the JSON designates for each OS during the row loop, then writes the whole group in one statement afterwards (`SET is_default = CASE WHEN unique_identifier = ? THEN 1 ELSE 0 END WHERE system_id = ? AND os_id = ?`). Nothing writes the flag inside the loop any more — it only means something relative to the rest of the group. A changed default now takes effect, and duplicates collapse in the same pass.
- **Two owners are deliberately not overruled:** an OS where the user picked an emulator (re-asserting the seed there would recreate the app-default-contradicts-user-choice state #238's v105 exists to clear), and RetroArch on Android, where `fixRetroArchDefaultForAndroid` owns the flag because only it knows which variant is installed.
- **`clearRetroArchDefaultsForAndroid`** resolves one winner per system in Dart and updates that row alone.
- **`is_default_standalone` (migration v109)** persists which standalone the seed designates. `is_default_core` has always recorded the JSON's `default_core` flag, but `default_standalone` was consumed in memory during the sync and thrown away, so everything that later had to pick a standalone guessed by name — which is what put the paid `aenu.ax360e` ahead of the free build, and would have put `EmuCoreX` ahead of NetherSX2 for ps2 after #253. The RetroArch fallback and the launch-time normalizer both consult it now. It is cleared as well as set, so a systems update can move the flag.
- **Migration v108** demotes every row of an already-duplicated group so existing installs are repaired at database-open time rather than waiting for a scan. It picks no survivor — no SQL rule reproduces the seed's intent, since Eden is lexicographically first of its pair and `ax360e.free` last of its — it clears the group and lets the now-authoritative sync re-apply the JSON's choice.
- **`syncEmulatorsForTesting`** is a new `@visibleForTesting` hook; `_syncEmulators` had no coverage at all before this.

## Verified on device

AYN Thor, dev channel: before (current `main`, v107) → after this branch → after a restart.

| | before | after | after restart |
|---|---|---|---|
| duplicate groups | `switch/2`, `xbox360/2` | none | none |
| xbox360 android | `ax360e` **and** `ax360e.free` | `ax360e.free` | `ax360e.free` |
| switch android | Eden **and** Benji-SC | Eden | Eden |
| ps2 android | `ra64.play` | `ra64.play` | `ra64.play` |

The restart column is the one that matters: that is the launch which used to re-mint the duplicate. 12 Android systems carry a seed standalone marker after the sync, with no group holding two, and ps2's is `xyz.aethersx2.android` — what the RetroArch-absent fallback would now pick instead of `EmuCoreX`. Systems with no Android default at all is unchanged at 5 (virtual collections plus `jagcd`, which has no Android emulator), and total Android default rows went 118 → 116: exactly the two duplicates removed, nothing starved.

The RetroArch-absent path itself is covered by unit tests rather than on device — the Thor has RetroArch installed, so that routine cannot fire there.

## Notes for review

- **Migration numbers.** This takes **v108** and **v109**, immediately after #259's v107. Worth re-checking against whatever merges first.
- **Not the same as v105.** #238's v105 collapses duplicate `user_emulator_config.is_user_default` (the user's pick). This is `app_emulators.is_default` (the app's seeded recommendation) — different table, different bug, and v108 is still needed for groups the sync declines to touch.
- **`ps2` was about to hit this too:** #253 added `EmuCoreX`, which sorts before `Standalone NetherSX2/AetherSX2`, so on any Android device without RetroArch installed it would have become the second flagged default.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works. (434 passing, +14 here: 6 sync-authority cases in `emulator_seed_authority_test.dart`, 2 normalizer regression cases added to the existing `emulator_system_default_test.dart`, 5 in `retroarch_clear_fallback_test.dart`, plus the v108 migration and seed-data suites)
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. (no new assets)
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Not applicable — database-level fix with no visual change.
