### PR TITLE
fix(carousel): stop the systems carousel hiding its outer cards

### DIFF
--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -791,6 +791,20 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
                           itemCount: allSystems.length,
                           initialIndex: _currentIndex,
                           footerHeight: 60.r,
+                          // System cards are height-bound (square art + footer)
+                          // so ~3.6 of them fit across the screen. With the
+                          // default envelope the 4th card is already down to
+                          // 44% scale / 10% opacity by the time it reaches the
+                          // edge, leaving a ~16px sliver. Floor the scale, lift
+                          // the fade, and pull the outer pair back toward the
+                          // pack so the row visibly continues past both edges.
+                          depth: const CarouselDepth(
+                            minScale: 0.7,
+                            opacityBase: 0.75,
+                            opacityFalloff: 0.55,
+                            minOpacity: 0.3,
+                            edgePull: 0.15,
+                          ),
                           itemBuilder: (context, index) {
                             final system = allSystems[index];
                             final isSelected = index == _currentIndex;

--- a/lib/widgets/native_carousel.dart
+++ b/lib/widgets/native_carousel.dart
@@ -2,6 +2,46 @@ import 'package:flutter/material.dart';
 
 enum CarouselPageChangeReason { manual, controller }
 
+/// How off-centre pages shrink and fade with distance from the centred card.
+///
+/// The defaults suit a carousel that fits ~2 pages across the viewport (the
+/// games carousel): the neighbours are already half off-screen, so a steep
+/// falloff reads as depth. A carousel that fits more pages — the systems
+/// carousel gets ~3.6 — needs the floors raised, otherwise everything past the
+/// immediate neighbours has collapsed to a dim sliver before it reaches the
+/// screen edge.
+class CarouselDepth {
+  const CarouselDepth({
+    this.scaleFalloff = 0.4,
+    this.minScale = 0.25,
+    this.opacityBase = 0.6,
+    this.opacityFalloff = 1.0,
+    this.minOpacity = 0.1,
+    this.edgePull = 0.0,
+  });
+
+  /// Scale lost per page of distance, and the size distant cards settle at.
+  final double scaleFalloff;
+  final double minScale;
+
+  /// Opacity at the centre, lost per page of distance, and the floor.
+  final double opacityBase;
+  final double opacityFalloff;
+  final double minOpacity;
+
+  /// How far the outer cards are drawn back toward the centre, as a fraction
+  /// of the page pitch.
+  ///
+  /// The pitch is the card width, so a shrunk card leaves a gap proportional
+  /// to how much it shrank — the outermost cards drift away from the pack
+  /// exactly where they can least afford the room. This pulls them back
+  /// (purely visual; scroll positions and snapping are untouched). It ramps in
+  /// past the immediate neighbours and caps one page later, so the centre and
+  /// its two neighbours keep their spacing and the cards beyond the edge stay
+  /// off-screen instead of piling up.
+  final double edgePull;
+}
+
 class NativeCarousel extends StatefulWidget {
   final int itemCount;
   final Widget Function(BuildContext context, int index) itemBuilder;
@@ -16,6 +56,9 @@ class NativeCarousel extends StatefulWidget {
   /// the grid, where the footer is rendered under the artwork.
   final double? footerHeight;
 
+  /// Shrink/fade envelope applied to off-centre pages.
+  final CarouselDepth depth;
+
   const NativeCarousel({
     super.key,
     required this.itemCount,
@@ -24,6 +67,7 @@ class NativeCarousel extends StatefulWidget {
     this.onPageScrolled,
     this.initialIndex = 0,
     this.footerHeight,
+    this.depth = const CarouselDepth(),
   });
 
   @override
@@ -190,15 +234,32 @@ class NativeCarouselState extends State<NativeCarousel> {
                   child: card,
                   builder: (context, page, child) {
                     final distance = (index - page).abs() - 0.6;
-                    final scale = (1.0 - distance * 0.4).clamp(0.25, 1.0);
-                    final opacity = (0.6 - distance * 1).clamp(0.1, 1.0);
+                    final depth = widget.depth;
+                    final scale = (1.0 - distance * depth.scaleFalloff).clamp(
+                      depth.minScale,
+                      1.0,
+                    );
+                    final opacity =
+                        (depth.opacityBase - distance * depth.opacityFalloff)
+                            .clamp(depth.minOpacity, 1.0);
+                    // Ramps in from the neighbours (distance 0.4 at rest) and
+                    // caps a page later, then signed toward the centre.
+                    final pull = depth.edgePull == 0.0
+                        ? 0.0
+                        : (distance - 0.4).clamp(0.0, 1.0) *
+                              depth.edgePull *
+                              pageWidth *
+                              (page - index).sign;
 
                     return Opacity(
                       opacity: opacity,
-                      child: Transform.scale(
-                        scale: scale,
-                        alignment: Alignment.center,
-                        child: child,
+                      child: Transform.translate(
+                        offset: Offset(pull, 0),
+                        child: Transform.scale(
+                          scale: scale,
+                          alignment: Alignment.center,
+                          child: child,
+                        ),
                       ),
                     );
                   },


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). Reviewed and tested on hardware by me before opening.

# Description

The systems carousel showed three cards and a ~16px sliver at each edge, so the row read as "three systems and some noise" rather than as a row that continues.

Its pages are sized from the height available (square art plus footer), so **~3.6 pages fit across a 1080p screen**. The shrink/fade envelope, however, is tuned for the games carousel, which fits ~2 — there the neighbours are already half off-screen, so a steep falloff reads as depth. Applied to 3.6 pages it winds the fourth card down to **44% scale and 10% opacity** before it reaches the edge. Measured off a device screenshot: centred artwork RGB ~(155,172,119), the neighbours ~(36,48,58).

The pitch compounds it. Page pitch *is* the card width, so shrinking a card also pushes it away from its neighbours — the outermost cards drift away from the pack exactly where they can least afford the room. The outer pair sat 133px clear of the neighbours with almost nothing left to show.

This makes the envelope a `CarouselDepth` parameter whose defaults are the constants it replaces, so **the games carousel is unchanged by construction**, and gives the systems carousel raised floors plus an `edgePull` that draws the outer cards back toward the centre:

- `edgePull` ramps in *past* the immediate neighbours, so the centred card and its two neighbours keep their exact current spacing
- it caps a page later, so the cards beyond the edge stay off-screen instead of piling up
- it is a paint-time `Transform.translate` only — scroll positions, snapping, physics and hit-testing are untouched

Result: the outer cards show ~165px instead of ~16px, sitting about as far off the neighbours as the neighbours sit off the centred card, so the spacing rhythm is uniform across all five.

Fixes # (no issue — visual defect noticed on device)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. — the change is a presentation envelope evaluated inside the `itemBuilder` closure with no branching logic; unit-testing it would mean extracting the scale/opacity/pull maths purely for the test, and the repo has no existing carousel tests. Verified on hardware instead (below). Happy to add it if you'd rather have the seam.
- [ ] I have updated the corresponding documentation. — no docs cover carousel geometry.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. — no new assets.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable). — D-pad navigation through the carousel is unaffected; the change never touches scroll position or focus.

### Verification

- `flutter analyze` — no issues, whole project
- `flutter test` — 434/434 passing
- AYN Thor @ 1920×1080 — the fix as described, confirmed by screenshot and by sampling pixel values before/after
- Games carousel exercised on-device after the change — unaffected, as expected from the defaults
- **RG DS-class 640×480 4:3 panel** (the tuning was done at 1080p, so this needed checking): only ~2.2 pages fit there, so the ±2 cards are off-screen entirely and `edgePull` never engages — the change correctly degrades to a no-op on small panels

## Screenshots (if applicable)

Before: three cards, then a ~16px sliver at each edge, separated from the pack by a 133px gap.
After: five cards in a uniform rhythm, the outer pair showing ~165px.

*(Device screenshots to be attached.)*
