### PR TITLE
feat(touch): enter systems and games with a single tap

### DIFF
--- a/lib/screens/game_screen/android_apps/android_apps_grid.dart
+++ b/lib/screens/game_screen/android_apps/android_apps_grid.dart
@@ -374,6 +374,14 @@ class _AndroidAppsGridState extends State<AndroidAppsGrid> {
                       app: _apps[index],
                       isSelected: _selectedIndex == index,
                       onTap: () {
+                        // Touch users have no A button: tapping the app that is
+                        // already selected launches it. (_launchSelectedApp
+                        // plays the enter sound itself.)
+                        if (index == _selectedIndex) {
+                          _launchSelectedApp();
+                          return;
+                        }
+                        SfxService().playNavSound();
                         setState(() {
                           _selectedIndex = index;
                           _ensureSelectedItemVisible();

--- a/lib/screens/game_screen/game_list_view.dart
+++ b/lib/screens/game_screen/game_list_view.dart
@@ -26,6 +26,10 @@ class GameListView extends StatefulWidget {
   final int selectedIndex;
   final Color systemColor;
   final Function(GameModel) onGameSelected;
+
+  /// Confirms the row that is already selected (same action as the A button).
+  /// Tapping a row selects it; tapping the selected row again fires this.
+  final VoidCallback onGameConfirmed;
   final bool isAllMode;
   final bool isNavigatingFast;
   final VoidCallback? onGamepadReactivated;
@@ -37,6 +41,7 @@ class GameListView extends StatefulWidget {
     required this.selectedIndex,
     required this.systemColor,
     required this.onGameSelected,
+    required this.onGameConfirmed,
     this.isAllMode = false,
     this.isNavigatingFast = false,
     this.onGamepadReactivated,
@@ -273,6 +278,14 @@ class GameListViewState extends State<GameListView>
 
                       return GestureDetector(
                         onTap: () {
+                          // Touch users have no A button: the first tap selects
+                          // the row (populating the details panel), a second tap
+                          // on that same row launches it.
+                          if (isSelected) {
+                            SfxService().playEnterSound();
+                            widget.onGameConfirmed();
+                            return;
+                          }
                           SfxService().playNavSound();
                           widget.onGameSelected(game);
                         },

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -1027,11 +1027,26 @@ class _GamesCarouselState extends State<GamesCarousel> {
                   initialIndex: _currentIndex.clamp(0, widget.games.length - 1),
                   itemBuilder: (context, index) {
                     final game = widget.games[index];
+                    final isCentred = index == _currentIndex;
                     return KeyedSubtree(
                       key: ValueKey(game.romname),
-                      child: isFanart
-                          ? _buildFanartCard(game, index == _currentIndex)
-                          : _buildBoxCard(game, index == _currentIndex),
+                      child: GestureDetector(
+                        // Tapping an off-centre card brings it to the middle;
+                        // tapping the centred one plays it, so touch users
+                        // never need the footer's A button.
+                        onTap: () {
+                          if (isCentred) {
+                            SfxService().playEnterSound();
+                            widget.onPlay();
+                          } else {
+                            SfxService().playNavSound();
+                            _carouselKey.currentState?.animateToPage(index);
+                          }
+                        },
+                        child: isFanart
+                            ? _buildFanartCard(game, isCentred)
+                            : _buildBoxCard(game, isCentred),
+                      ),
                     );
                   },
                   onPageChanged: _onPageChanged,

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -1310,6 +1310,14 @@ class _GamesGridState extends State<GamesGrid> {
     return GestureDetector(
       key: ValueKey('game_${game.romname}'),
       onTap: () {
+        // Second tap on the already-selected card plays it — touch users have
+        // no A button, so the footer's Play is an affordance, not a step.
+        if (index == _selectedIndex) {
+          SfxService().playEnterSound();
+          widget.onPlay();
+          return;
+        }
+
         setState(() {
           _selectedIndex = index;
           _settledIndex = index; // discrete tap: update chrome immediately
@@ -1427,6 +1435,14 @@ class _GamesGridState extends State<GamesGrid> {
     return GestureDetector(
       key: ValueKey('game_${game.romname}'),
       onTap: () {
+        // Second tap on the already-selected card plays it — touch users have
+        // no A button, so the footer's Play is an affordance, not a step.
+        if (index == _selectedIndex) {
+          SfxService().playEnterSound();
+          widget.onPlay();
+          return;
+        }
+
         setState(() {
           _selectedIndex = index;
           _settledIndex = index; // discrete tap: update chrome immediately

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1342,6 +1342,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
                   selectedIndex: _selectedGameIndex,
                   systemColor: widget.system.colorAsColor,
                   onGameSelected: _selectGame,
+                  onGameConfirmed: _selectCurrentGame,
                   isAllMode:
                       widget.system.folderName == 'all' ||
                       widget.system.folderName == SystemFolderNames.favorites,

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -816,7 +816,13 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
                               isSelected: isSelected,
                               backgroundCacheWidth: 1024,
                               onTap: () {
-                                if (!isSelected) {
+                                // Tapping an off-centre card brings it to the
+                                // middle; tapping the centred one enters it, so
+                                // touch users never need the footer's A button.
+                                // (SystemCard plays the sound.)
+                                if (isSelected) {
+                                  _selectCurrentSystem();
+                                } else {
                                   _carouselKey.currentState?.animateToPage(
                                     index,
                                   );

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -982,7 +982,14 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
                     info: card,
                     isSelected: cardIdx == widget.selectedIndex,
                     onTap: () {
-                      SfxService().playNavSound();
+                      // Touch users have no A button: tapping the card that is
+                      // already selected enters it, so reaching for the footer
+                      // is only ever optional. (SystemCard plays the sound.)
+                      if (cardIdx == widget.selectedIndex) {
+                        widget.onEnterPressed?.call();
+                        return;
+                      }
+
                       if (_gamepadNavigationActive) {
                         return;
                       }

--- a/lib/screens/systems_screen/my_systems_section/system_card.dart
+++ b/lib/screens/systems_screen/my_systems_section/system_card.dart
@@ -237,7 +237,14 @@ class _SystemCardState extends State<SystemCard> {
             child: InkWell(
               focusNode: _focusNode,
               onTap: () {
-                SfxService().playNavSound();
+                // A tap on the already-selected card confirms it rather than
+                // moving the selection (touch users have no A button), so it
+                // earns the enter sound instead of the nav sound.
+                if (widget.isSelected) {
+                  SfxService().playEnterSound();
+                } else {
+                  SfxService().playNavSound();
+                }
                 widget.onTap?.call();
               },
               canRequestFocus: false,

--- a/lib/widgets/native_carousel.dart
+++ b/lib/widgets/native_carousel.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 enum CarouselPageChangeReason { manual, controller }
@@ -42,6 +44,70 @@ class CarouselDepth {
   final double edgePull;
 }
 
+/// Page-snapping physics that lets a fling carry across many cards.
+///
+/// [PageScrollPhysics] — what [PageView] applies when `pageSnapping` is on —
+/// deliberately caps a swipe at one page, so a hard fling through a 9,000-game
+/// library still advances a single card. This instead lets the normal friction
+/// simulation run to wherever momentum would carry it, then settles on the
+/// nearest card. Requires `pageSnapping: false` so [PageScrollPhysics] is not
+/// layered back on top and re-imposes the one-page cap.
+class _FlingPageScrollPhysics extends ScrollPhysics {
+  const _FlingPageScrollPhysics({required this.viewportFraction, super.parent});
+
+  final double viewportFraction;
+
+  @override
+  _FlingPageScrollPhysics applyTo(ScrollPhysics? ancestor) =>
+      _FlingPageScrollPhysics(
+        viewportFraction: viewportFraction,
+        parent: buildParent(ancestor),
+      );
+
+  double _pageExtent(ScrollMetrics position) =>
+      math.max(1.0, position.viewportDimension * viewportFraction);
+
+  double _snapTarget(ScrollMetrics position, double pixels) {
+    final extent = _pageExtent(position);
+    final page = (pixels / extent).roundToDouble();
+    return (page * extent).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+  }
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) {
+    // Out of range (overscroll): let the parent spring it back.
+    if ((velocity <= 0.0 && position.pixels <= position.minScrollExtent) ||
+        (velocity >= 0.0 && position.pixels >= position.maxScrollExtent)) {
+      return super.createBallisticSimulation(position, velocity);
+    }
+
+    // Where unrestricted momentum would come to rest, snapped to a card.
+    final friction = super.createBallisticSimulation(position, velocity);
+    final settleAt = friction?.x(double.infinity) ?? position.pixels;
+    final target = _snapTarget(position, settleAt);
+
+    final tolerance = toleranceFor(position);
+    if ((target - position.pixels).abs() < tolerance.distance) return null;
+
+    return ScrollSpringSimulation(
+      spring,
+      position.pixels,
+      target,
+      velocity,
+      tolerance: tolerance,
+    );
+  }
+
+  @override
+  bool get allowImplicitScrolling => false;
+}
+
 class NativeCarousel extends StatefulWidget {
   final int itemCount;
   final Widget Function(BuildContext context, int index) itemBuilder;
@@ -80,6 +146,14 @@ class NativeCarouselState extends State<NativeCarousel> {
   double _lastVpFraction = 0;
   int _lastReportedIndex = 0;
   final ValueNotifier<double> _pageNotifier = ValueNotifier(0.0);
+
+  /// True while a controller-driven page animation is running. Gates pointer
+  /// input so a stray touch cannot cancel the animation mid-flight.
+  final ValueNotifier<bool> _animating = ValueNotifier(false);
+
+  /// Whether a finger is currently on the carousel. A gesture in progress
+  /// always outranks the input gate.
+  bool _pointerDown = false;
   CarouselPageChangeReason _pageChangeReason =
       CarouselPageChangeReason.controller;
 
@@ -97,7 +171,10 @@ class NativeCarouselState extends State<NativeCarousel> {
     if (widget.initialIndex != oldWidget.initialIndex &&
         widget.initialIndex != _currentIndex &&
         _pageController != null) {
-      _animateToPage(widget.initialIndex);
+      // Reconciling with the parent, not acting on a discrete user input. A
+      // fling outruns the parent's index, so this fires mid-swipe — gating
+      // input here would kill the gesture the user is still performing.
+      _animateToPage(widget.initialIndex, gateInput: false);
     }
   }
 
@@ -106,6 +183,7 @@ class NativeCarouselState extends State<NativeCarousel> {
     _pageController?.removeListener(_onPageScroll);
     _pageController?.dispose();
     _pageNotifier.dispose();
+    _animating.dispose();
     super.dispose();
   }
 
@@ -154,13 +232,23 @@ class NativeCarouselState extends State<NativeCarousel> {
     }
   }
 
-  void _animateToPage(int index) {
+  void _animateToPage(int index, {bool gateInput = true}) {
     _pageChangeReason = CarouselPageChangeReason.controller;
-    _pageController?.animateToPage(
-      index,
-      duration: const Duration(milliseconds: 260),
-      curve: Curves.easeOutQuart,
-    );
+    // Never gate while a finger is on the glass: the user is mid-gesture and
+    // owns the carousel until they lift it.
+    if (gateInput && !_pointerDown) _animating.value = true;
+    _pageController
+        ?.animateToPage(
+          index,
+          duration: const Duration(milliseconds: 260),
+          curve: Curves.easeOutQuart,
+        )
+        // Completing or being interrupted both end the move, so this is where
+        // the input gate lifts.
+        .whenComplete(() {
+          if (!mounted) return;
+          _animating.value = false;
+        });
   }
 
   void jumpToPage(int index) {
@@ -204,67 +292,85 @@ class NativeCarouselState extends State<NativeCarousel> {
 
         return SizedBox(
           height: maxHeight,
-          child: Listener(
-            behavior: HitTestBehavior.translucent,
-            onPointerDown: (_) {
-              _pageChangeReason = CarouselPageChangeReason.manual;
-            },
-            child: PageView.builder(
-              controller: _pageController,
-              clipBehavior: Clip.none,
-              padEnds: true,
-              allowImplicitScrolling: true,
-              itemCount: widget.itemCount,
-              itemBuilder: (context, index) {
-                // Build the card exactly once and pass it as the
-                // ValueListenableBuilder's `child`. Only the cheap
-                // Opacity/Transform.scale envelope reacts to per-frame page
-                // scroll updates — the card subtree (which does disk reads and
-                // Image.file decoding) is NOT rebuilt on every scroll frame.
-                // RepaintBoundary lets the card's raster be cached and reused
-                // as the scale/opacity animate.
-                final card = RepaintBoundary(
-                  child: AspectRatio(
-                    aspectRatio: pageAspectRatio,
-                    child: widget.itemBuilder(context, index),
-                  ),
-                );
-                return ValueListenableBuilder<double>(
-                  valueListenable: _pageNotifier,
-                  child: card,
-                  builder: (context, page, child) {
-                    final distance = (index - page).abs() - 0.6;
-                    final depth = widget.depth;
-                    final scale = (1.0 - distance * depth.scaleFalloff).clamp(
-                      depth.minScale,
-                      1.0,
-                    );
-                    final opacity =
-                        (depth.opacityBase - distance * depth.opacityFalloff)
-                            .clamp(depth.minOpacity, 1.0);
-                    // Ramps in from the neighbours (distance 0.4 at rest) and
-                    // caps a page later, then signed toward the centre.
-                    final pull = depth.edgePull == 0.0
-                        ? 0.0
-                        : (distance - 0.4).clamp(0.0, 1.0) *
-                              depth.edgePull *
-                              pageWidth *
-                              (page - index).sign;
-
-                    return Opacity(
-                      opacity: opacity,
-                      child: Transform.translate(
-                        offset: Offset(pull, 0),
-                        child: Transform.scale(
-                          scale: scale,
-                          alignment: Alignment.center,
-                          child: child,
-                        ),
-                      ),
-                    );
-                  },
-                );
+          // While a page animation is in flight the carousel takes no pointers
+          // at all. A touch anywhere on it — including the gaps between cards —
+          // otherwise holds the scroll position and cancels the animation
+          // part-way, stranding the selection. Held as the builder's `child` so
+          // arming/disarming never rebuilds the PageView subtree.
+          child: ValueListenableBuilder<bool>(
+            valueListenable: _animating,
+            builder: (context, animating, child) =>
+                IgnorePointer(ignoring: animating, child: child),
+            child: Listener(
+              behavior: HitTestBehavior.translucent,
+              onPointerDown: (_) {
+                _pointerDown = true;
+                _pageChangeReason = CarouselPageChangeReason.manual;
               },
+              onPointerUp: (_) => _pointerDown = false,
+              onPointerCancel: (_) => _pointerDown = false,
+              child: PageView.builder(
+                controller: _pageController,
+                clipBehavior: Clip.none,
+                padEnds: true,
+                allowImplicitScrolling: true,
+                // Snapping is handled by the physics below; leaving it on would
+                // layer PageScrollPhysics back over them and restore the
+                // one-card-per-swipe cap.
+                pageSnapping: false,
+                physics: _FlingPageScrollPhysics(viewportFraction: vpFraction),
+                itemCount: widget.itemCount,
+                itemBuilder: (context, index) {
+                  // Build the card exactly once and pass it as the
+                  // ValueListenableBuilder's `child`. Only the cheap
+                  // Opacity/Transform.scale envelope reacts to per-frame page
+                  // scroll updates — the card subtree (which does disk reads and
+                  // Image.file decoding) is NOT rebuilt on every scroll frame.
+                  // RepaintBoundary lets the card's raster be cached and reused
+                  // as the scale/opacity animate.
+                  final card = RepaintBoundary(
+                    child: AspectRatio(
+                      aspectRatio: pageAspectRatio,
+                      child: widget.itemBuilder(context, index),
+                    ),
+                  );
+                  return ValueListenableBuilder<double>(
+                    valueListenable: _pageNotifier,
+                    child: card,
+                    builder: (context, page, child) {
+                      final distance = (index - page).abs() - 0.6;
+                      final depth = widget.depth;
+                      final scale = (1.0 - distance * depth.scaleFalloff).clamp(
+                        depth.minScale,
+                        1.0,
+                      );
+                      final opacity =
+                          (depth.opacityBase - distance * depth.opacityFalloff)
+                              .clamp(depth.minOpacity, 1.0);
+                      // Ramps in from the neighbours (distance 0.4 at rest) and
+                      // caps a page later, then signed toward the centre.
+                      final pull = depth.edgePull == 0.0
+                          ? 0.0
+                          : (distance - 0.4).clamp(0.0, 1.0) *
+                                depth.edgePull *
+                                pageWidth *
+                                (page - index).sign;
+
+                      return Opacity(
+                        opacity: opacity,
+                        child: Transform.translate(
+                          offset: Offset(pull, 0),
+                          child: Transform.scale(
+                            scale: scale,
+                            alignment: Alignment.center,
+                            child: child,
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
             ),
           ),
         );

--- a/test/game_list_view_tap_test.dart
+++ b/test/game_list_view_tap_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/models/system_model.dart';
+import 'package:neostation/screens/game_screen/game_list_view.dart';
+import 'package:neostation/services/sfx_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+GameModel game(String romname, String name) => GameModel(
+  romname: romname,
+  realname: name,
+  name: name,
+  year: '',
+  developer: '',
+  publisher: '',
+  genre: '',
+  players: '',
+  rating: 0,
+);
+
+final _system = SystemModel(
+  id: 'snes',
+  folderName: 'snes',
+  realName: 'Super Nintendo',
+  iconImage: '',
+  color: '#ff006a',
+);
+
+final _games = [
+  game('mario.sfc', 'Super Mario World'),
+  game('zelda.sfc', 'A Link to the Past'),
+  game('metroid.sfc', 'Super Metroid'),
+];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('xyz.luan/gamepads'),
+          (call) async => <dynamic>[],
+        );
+
+    await FlutterLocalization.instance.ensureInitialized();
+    FlutterLocalization.instance.init(
+      mapLocales: [MapLocale('en', AppLocale.en)],
+      initLanguageCode: 'en',
+    );
+
+    // Every tap plays a nav/enter sound; SoLoud has no place in a widget test,
+    // and disabling makes each play() return before touching the engine.
+    SfxService().setEnabled(false);
+  });
+
+  /// Pumps a [GameListView] with [selectedIndex] already selected, appending to
+  /// [selected]/[confirmed] as taps land. Both are lists so the caller observes
+  /// mutations after this returns.
+  Future<void> pumpList(
+    WidgetTester tester, {
+    required int selectedIndex,
+    required List<String> selected,
+    required List<int> confirmed,
+  }) async {
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(size: Size(1920, 1080)),
+        child: ScreenUtilInit(
+          designSize: const Size(1920, 1080),
+          builder: (context, child) => MaterialApp(
+            localizationsDelegates:
+                FlutterLocalization.instance.localizationsDelegates,
+            supportedLocales: FlutterLocalization.instance.supportedLocales,
+            home: Scaffold(
+              body: GameListView(
+                system: _system,
+                games: _games,
+                selectedIndex: selectedIndex,
+                systemColor: Colors.pink,
+                onGameSelected: (g) => selected.add(g.romname),
+                onGameConfirmed: () => confirmed.add(selectedIndex),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    // MarqueeText scrolls forever, so pumpAndSettle would never return.
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  Finder rowFor(String title) => find
+      .ancestor(of: find.text(title), matching: find.byType(GestureDetector))
+      .first;
+
+  /// Drains the centering-scroll timer the list schedules on init, which
+  /// otherwise outlives the widget tree and trips the pending-timer invariant.
+  Future<void> drain(WidgetTester tester) =>
+      tester.pump(const Duration(milliseconds: 500));
+
+  testWidgets('tapping an unselected row selects it without confirming', (
+    tester,
+  ) async {
+    final selected = <String>[];
+    final confirmed = <int>[];
+    await pumpList(
+      tester,
+      selectedIndex: 0,
+      selected: selected,
+      confirmed: confirmed,
+    );
+
+    await tester.tap(rowFor('A Link to the Past'));
+    await tester.pump();
+
+    expect(selected, ['zelda.sfc']);
+    expect(confirmed, isEmpty, reason: 'an unselected row must not launch');
+
+    await drain(tester);
+  });
+
+  testWidgets('tapping the already-selected row confirms it', (tester) async {
+    final selected = <String>[];
+    final confirmed = <int>[];
+    await pumpList(
+      tester,
+      selectedIndex: 1,
+      selected: selected,
+      confirmed: confirmed,
+    );
+
+    await tester.tap(rowFor('A Link to the Past'));
+    await tester.pump();
+
+    expect(confirmed, hasLength(1), reason: 'the selected row launches on tap');
+    expect(selected, isEmpty, reason: 'confirming must not re-fire selection');
+
+    await drain(tester);
+  });
+}

--- a/test/log_redaction_test.dart
+++ b/test/log_redaction_test.dart
@@ -4,16 +4,19 @@ import 'package:neostation/utils/log_redaction.dart';
 void main() {
   group('redactSecrets — the observed leak', () {
     test('strips the RetroAchievements web API key from a request URI', () {
-      // Verbatim shape of the line seen in app.log on the Thor: the key is in
-      // the URI carried by an http ClientException, not in our own message.
+      // Shape of the line seen in app.log on the Thor: the key is in the URI
+      // carried by an http ClientException, not in our own message.
+      // NOTE: the key below is a dummy of the same shape (32 chars, base62) —
+      // never paste a real key here, this file is public.
+      const fakeKey = 'EXAMPLEexample0123456789ABCDefgh';
       const line =
           'Error getting user profile: ClientException with SocketException: '
           'Failed host lookup, uri=https://retroachievements.org/API/'
-          'API_GetUserProfile.php?u=SomeUser&y=9lUpeq4qAbNeIdtGlGk7D4Co9xPinq2O';
+          'API_GetUserProfile.php?u=SomeUser&y=$fakeKey';
 
       final redacted = redactSecrets(line);
 
-      expect(redacted, isNot(contains('9lUpeq4qAbNeIdtGlGk7D4Co9xPinq2O')));
+      expect(redacted, isNot(contains(fakeKey)));
       expect(redacted, contains('y=<redacted>'));
       // Everything needed to debug the failure survives.
       expect(redacted, contains('u=SomeUser'));


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). Reviewed and tested on hardware by me before opening.

# Description

Implements discussion #266: on a handheld with both a touchscreen and physical controls, selecting by touch and confirming with the A button splits one action across two devices, so it never becomes automatic.

**Tapping a tile that is already selected now confirms it.** The first tap still only selects, so nothing launches without an explicit prior selection. Wired across the systems grid and carousel, the games grid, list and carousel, and the Android apps grid. The games carousel had no per-card tap handler at all; off-centre cards now centre and the centred one plays. Gamepad and keyboard paths are untouched.

`SystemCard`'s `InkWell` played the nav sound unconditionally before forwarding to `onTap`, stacking two sounds on the confirm tap; that choice moves into the card — enter sound when selected, nav sound otherwise.

**On the opt-in setting #266 asked for:** this is effectively backwards compatible — the first tap still only selects and the footer Play/Enter button is unchanged, so nothing that used to go through it was taken away. The only new capability is a second tap doing what that button does. A setting would buy no behavioural protection while costing a versioned config column, migration, localised settings entry, and a flag through six call sites. Happy to add the toggle if you'd rather have it.

**Second commit** — two pre-existing carousel bugs that tapping to navigate surfaced:

1. A pointer anywhere on the carousel, including the gaps between cards, held the scroll position and cancelled an in-flight page animation, leaving the selection unreported until it drifted back within 0.05 of a whole page. Tap-to-move lag was bimodal on device — ~0ms or 430–788ms, worst cases stranded 1465ms. The carousel now takes no pointer input while an animation runs, making the lag a uniform 165–183ms. It never gates while a finger is already down, nor for the `didUpdateWidget` reconcile that fires mid-swipe.
2. `PageScrollPhysics` capped a swipe at one page, so a hard fling through a 9,000-game library advanced a single card. Replaced with physics that lets momentum run and settles on the nearest card.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

(The second commit is a bug fix; the headline change is the feature.)

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works. — `test/game_list_view_tap_test.dart`: select-then-confirm, a first tap never launches, tapping a different tile only moves the selection.
- [ ] I have updated the corresponding documentation. — no user-facing docs describe tap behaviour.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. — no new assets.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable). — confirm paths untouched, exercised on device alongside touch.

`flutter analyze` clean, `flutter test` 436/436, verified on an AYN Thor across all six views.

## Screenshots (if applicable)

No visual change — this is an interaction change.
