### PR TITLE
fix: resolve macOS emulator app paths

### DIFF
--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -4562,6 +4562,7 @@ class SqliteService {
           path: '',
           detected: false,
           possiblePaths: {},
+          uniqueId: row['unique_identifier']?.toString(),
         ),
       );
     }

--- a/lib/models/emulator_model.dart
+++ b/lib/models/emulator_model.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import '../services/macos_application_service.dart';
+
 /// Represents an emulator installation or a target application for launching ROMs.
 class EmulatorModel {
   /// The human-readable name of the emulator (e.g., 'RetroArch', 'DuckStation').
@@ -93,6 +95,20 @@ class EmulatorModel {
             lastDetection: DateTime.now(),
           );
         }
+      }
+    }
+
+    if (platform == 'macos') {
+      final executable = await MacOsApplicationService.findInstalledApplication(
+        applicationNames: [name],
+        bundleIdentifierHint: uniqueId,
+      );
+      if (executable != null) {
+        return copyWith(
+          path: executable,
+          detected: true,
+          lastDetection: DateTime.now(),
+        );
       }
     }
 

--- a/lib/repositories/emulator_repository.dart
+++ b/lib/repositories/emulator_repository.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import '../models/core_emulator_model.dart';
+import '../services/macos_application_service.dart';
 import '../models/emulator_model.dart';
 import '../data/datasources/sqlite_service.dart';
 import '../services/android_service.dart';
@@ -65,15 +68,44 @@ class EmulatorRepository {
   static Future<void> setStandaloneEmulatorPath(
     String emulatorUniqueId,
     String path,
-  ) => SqliteService.setStandaloneEmulatorPath(emulatorUniqueId, path);
+  ) async {
+    final resolvedPath = await _resolveMacOsPath(
+      path,
+      bundleIdentifierHint: emulatorUniqueId,
+    );
+    await SqliteService.setStandaloneEmulatorPath(
+      emulatorUniqueId,
+      resolvedPath,
+    );
+  }
 
   static Future<void> saveDetectedEmulatorPath({
     required String emulatorName,
     required String emulatorPath,
-  }) => SqliteService.saveDetectedEmulatorPath(
-    emulatorName: emulatorName,
-    emulatorPath: emulatorPath,
-  );
+  }) async {
+    final resolvedPath = await _resolveMacOsPath(
+      emulatorPath,
+      applicationName: emulatorName,
+    );
+    await SqliteService.saveDetectedEmulatorPath(
+      emulatorName: emulatorName,
+      emulatorPath: resolvedPath,
+    );
+  }
+
+  static Future<String> _resolveMacOsPath(
+    String configuredPath, {
+    String? applicationName,
+    String? bundleIdentifierHint,
+  }) async {
+    if (!Platform.isMacOS) return configuredPath;
+    return await MacOsApplicationService.resolveExecutable(
+          configuredPath,
+          applicationName: applicationName,
+          bundleIdentifierHint: bundleIdentifierHint,
+        ) ??
+        configuredPath;
+  }
 
   // ── Default emulator resolution ───────────────────────────────────────────
 

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -16,6 +16,7 @@ import '../android_service.dart';
 import '../launcher_service.dart';
 import '../linux_emulator_discovery.dart';
 import '../linux_host_process.dart';
+import '../macos_application_service.dart';
 import 'emulator_launch_diagnostics.dart';
 import 'favorites_service.dart';
 import 'game_session_manager.dart';
@@ -639,7 +640,7 @@ class GameLaunchService {
     try {
       String executable = launchCmd['executable'].toString();
 
-      if ((Platform.isWindows || Platform.isLinux)) {
+      if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
         final detected = await EmulatorRepository.getUserDetectedEmulators();
 
         if (executable.toLowerCase().contains('retroarch')) {
@@ -680,24 +681,21 @@ class GameLaunchService {
             executable = resolvedPath;
           }
         }
-      } else if (Platform.isMacOS &&
-          executable.toLowerCase().contains('retroarch')) {
-        final detected = await EmulatorRepository.getUserDetectedEmulators();
-        final ra = detected['RetroArch'];
-        if (ra != null && ra.path.isNotEmpty) {
-          if (executable != ra.path) {
+
+        if (Platform.isMacOS) {
+          final resolvedExecutable =
+              await MacOsApplicationService.resolveExecutable(
+                executable,
+                applicationName: launchCmd['player_name']?.toString(),
+                bundleIdentifierHint: launchCmd['unique_id']?.toString(),
+                homePath: ConfigService.getRealHomePath(),
+              );
+          if (resolvedExecutable != null && resolvedExecutable != executable) {
             _log.i(
-              'Resolving RetroArch executable on macOS from "$executable" to user-configured path: ${ra.path}',
+              'Resolving macOS application "$executable" to executable: '
+              '$resolvedExecutable',
             );
-          }
-          executable = ra.path;
-          if (executable.endsWith('.app')) {
-            executable = path.join(
-              executable,
-              'Contents',
-              'MacOS',
-              'RetroArch',
-            );
+            executable = resolvedExecutable;
           }
         }
       }

--- a/lib/services/macos_application_service.dart
+++ b/lib/services/macos_application_service.dart
@@ -1,0 +1,283 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+/// Resolves macOS application bundles to the executable stored inside them.
+///
+/// Emulator configuration commonly deals in `.app` bundles, while
+/// [Process.start] requires the bundle's `Contents/MacOS` executable.
+class MacOsApplicationService {
+  MacOsApplicationService._();
+
+  static const _applicationCacheLifetime = Duration(seconds: 2);
+  static Future<List<_InstalledApplication>>? _applicationCache;
+  static DateTime? _applicationCacheUpdatedAt;
+
+  static Future<String?> resolveExecutable(
+    String configuredPath, {
+    String? applicationName,
+    String? bundleIdentifierHint,
+    String? homePath,
+    List<String>? applicationRoots,
+  }) async {
+    final value = configuredPath.trim();
+    if (value.isEmpty) return null;
+
+    final expandedPath = _expandHome(value, homePath);
+    final file = File(expandedPath);
+    if (await file.exists()) return file.path;
+
+    final directory = Directory(expandedPath);
+    if (await directory.exists() &&
+        path.extension(expandedPath).toLowerCase() == '.app') {
+      return _resolveBundleExecutable(directory);
+    }
+
+    // A missing absolute/relative path is not an application name to search.
+    if (path.isAbsolute(expandedPath) ||
+        expandedPath.contains('/') ||
+        expandedPath.contains(r'\')) {
+      return null;
+    }
+
+    return findInstalledApplication(
+      applicationNames: [?applicationName, configuredPath],
+      bundleIdentifierHint: bundleIdentifierHint,
+      homePath: homePath,
+      applicationRoots: applicationRoots,
+    );
+  }
+
+  static Future<String?> findInstalledApplication({
+    required List<String> applicationNames,
+    String? bundleIdentifierHint,
+    String? homePath,
+    List<String>? applicationRoots,
+  }) async {
+    final names = applicationNames
+        .map(_normalizedApplicationName)
+        .where((name) => name.isNotEmpty)
+        .toSet();
+    if (names.isEmpty && bundleIdentifierHint == null) return null;
+
+    final resolvedHome = homePath ?? Platform.environment['HOME'] ?? '';
+    final roots =
+        applicationRoots ??
+        <String>[
+          '/Applications',
+          '/System/Applications',
+          if (resolvedHome.isNotEmpty) path.join(resolvedHome, 'Applications'),
+        ];
+
+    final applications = await _installedApplications(
+      roots,
+      cache: applicationRoots == null,
+    );
+    for (final application in applications) {
+      final identifierMatches =
+          bundleIdentifierHint != null &&
+          application.bundleIdentifier != null &&
+          bundleIdentifierHint.toLowerCase().contains(
+            application.bundleIdentifier!.toLowerCase(),
+          );
+
+      if (identifierMatches ||
+          names.contains(application.bundleName) ||
+          names.contains(application.executableName)) {
+        return application.executablePath;
+      }
+    }
+
+    return null;
+  }
+
+  static Future<List<_InstalledApplication>> _installedApplications(
+    List<String> roots, {
+    required bool cache,
+  }) {
+    final cached = _applicationCache;
+    final cacheUpdatedAt = _applicationCacheUpdatedAt;
+    if (cache &&
+        cached != null &&
+        (cacheUpdatedAt == null ||
+            DateTime.now().difference(cacheUpdatedAt) <
+                _applicationCacheLifetime)) {
+      return cached;
+    }
+
+    final scan = _scanInstalledApplications(roots);
+    if (!cache) return scan;
+    _applicationCache = scan.then((applications) {
+      _applicationCacheUpdatedAt = DateTime.now();
+      return applications;
+    });
+    return _applicationCache!;
+  }
+
+  static Future<List<_InstalledApplication>> _scanInstalledApplications(
+    List<String> roots,
+  ) async {
+    final applications = <_InstalledApplication>[];
+    for (final root in roots) {
+      final directory = Directory(root);
+      if (!await directory.exists()) continue;
+
+      List<FileSystemEntity> entries;
+      try {
+        entries = await directory.list(followLinks: false).toList();
+      } on FileSystemException {
+        continue;
+      }
+
+      for (final entry in entries.whereType<Directory>()) {
+        if (path.extension(entry.path).toLowerCase() != '.app') continue;
+
+        final metadata = await _readBundleMetadata(entry);
+        final bundleName = _normalizedApplicationName(
+          path.basenameWithoutExtension(entry.path),
+        );
+        final executableName = _normalizedApplicationName(
+          metadata.executableName ?? '',
+        );
+        final executable = await _resolveBundleExecutable(
+          entry,
+          executableName: metadata.executableName,
+        );
+        if (executable == null) continue;
+        applications.add(
+          _InstalledApplication(
+            bundleName: bundleName,
+            executableName: executableName,
+            bundleIdentifier: metadata.bundleIdentifier,
+            executablePath: executable,
+          ),
+        );
+      }
+    }
+    return applications;
+  }
+
+  static Future<String?> _resolveBundleExecutable(
+    Directory bundle, {
+    String? executableName,
+  }) async {
+    final macOsDirectory = Directory(
+      path.join(bundle.path, 'Contents', 'MacOS'),
+    );
+    if (!await macOsDirectory.exists()) return null;
+
+    final metadata = executableName == null
+        ? await _readBundleMetadata(bundle)
+        : null;
+    final declaredName = executableName ?? metadata?.executableName;
+    if (declaredName != null && declaredName.isNotEmpty) {
+      final declaredExecutable = File(
+        path.join(macOsDirectory.path, declaredName),
+      );
+      if (await declaredExecutable.exists()) return declaredExecutable.path;
+    }
+
+    final bundleName = _normalizedApplicationName(
+      path.basenameWithoutExtension(bundle.path),
+    );
+    final files = await macOsDirectory.list(followLinks: false).toList();
+    final executables = files.whereType<File>().toList();
+    for (final candidate in executables) {
+      if (_normalizedApplicationName(path.basename(candidate.path)) ==
+          bundleName) {
+        return candidate.path;
+      }
+    }
+
+    // Well-formed emulator bundles normally contain one top-level launcher.
+    return executables.length == 1 ? executables.single.path : null;
+  }
+
+  static Future<_BundleMetadata> _readBundleMetadata(Directory bundle) async {
+    final plist = File(path.join(bundle.path, 'Contents', 'Info.plist'));
+    if (!await plist.exists()) return const _BundleMetadata();
+
+    try {
+      final contents = await plist.readAsString();
+      final metadata = _BundleMetadata(
+        executableName: _readXmlPlistString(contents, 'CFBundleExecutable'),
+        bundleIdentifier: _readXmlPlistString(contents, 'CFBundleIdentifier'),
+      );
+      if (metadata.executableName != null ||
+          metadata.bundleIdentifier != null) {
+        return metadata;
+      }
+    } on FileSystemException {
+      return const _BundleMetadata();
+    } on FormatException {
+      // Binary plists are handled by plutil below on macOS.
+    }
+
+    if (!Platform.isMacOS || !File('/usr/bin/plutil').existsSync()) {
+      return const _BundleMetadata();
+    }
+    return _BundleMetadata(
+      executableName: await _readPlistValue(plist.path, 'CFBundleExecutable'),
+      bundleIdentifier: await _readPlistValue(plist.path, 'CFBundleIdentifier'),
+    );
+  }
+
+  static Future<String?> _readPlistValue(String plistPath, String key) async {
+    try {
+      final result = await Process.run('/usr/bin/plutil', [
+        '-extract',
+        key,
+        'raw',
+        '-o',
+        '-',
+        plistPath,
+      ]);
+      if (result.exitCode != 0) return null;
+      final value = result.stdout.toString().trim();
+      return value.isEmpty ? null : value;
+    } on ProcessException {
+      return null;
+    }
+  }
+
+  static String? _readXmlPlistString(String contents, String key) {
+    final match = RegExp(
+      '<key>\\s*${RegExp.escape(key)}\\s*</key>\\s*<string>([^<]+)</string>',
+      caseSensitive: false,
+    ).firstMatch(contents);
+    return match?.group(1)?.trim();
+  }
+
+  static String _expandHome(String value, String? homePath) {
+    if (value != '~' && !value.startsWith('~/')) return value;
+    final home = homePath ?? Platform.environment['HOME'] ?? '';
+    if (home.isEmpty) return value;
+    return value == '~' ? home : path.join(home, value.substring(2));
+  }
+
+  static String _normalizedApplicationName(String value) => value
+      .toLowerCase()
+      .replaceAll(RegExp(r'\b(standalone|emulator|application|app)\b'), '')
+      .replaceAll(RegExp('[^a-z0-9]'), '');
+}
+
+class _BundleMetadata {
+  final String? executableName;
+  final String? bundleIdentifier;
+
+  const _BundleMetadata({this.executableName, this.bundleIdentifier});
+}
+
+class _InstalledApplication {
+  final String bundleName;
+  final String executableName;
+  final String? bundleIdentifier;
+  final String executablePath;
+
+  const _InstalledApplication({
+    required this.bundleName,
+    required this.executableName,
+    required this.bundleIdentifier,
+    required this.executablePath,
+  });
+}

--- a/test/macos_application_service_test.dart
+++ b/test/macos_application_service_test.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/macos_application_service.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  late Directory temporaryDirectory;
+  late Directory applicationsDirectory;
+  late String duckStationBundle;
+  late String duckStationExecutable;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'neostation_macos_apps_',
+    );
+    applicationsDirectory = await Directory(
+      path.join(temporaryDirectory.path, 'Applications'),
+    ).create();
+    duckStationBundle = path.join(
+      applicationsDirectory.path,
+      'DuckStation.app',
+    );
+    final contentsDirectory = await Directory(
+      path.join(duckStationBundle, 'Contents'),
+    ).create(recursive: true);
+    final macOsDirectory = await Directory(
+      path.join(contentsDirectory.path, 'MacOS'),
+    ).create();
+    duckStationExecutable = path.join(macOsDirectory.path, 'DuckStation');
+    await File(duckStationExecutable).writeAsString('executable');
+    await File(path.join(contentsDirectory.path, 'Info.plist')).writeAsString(
+      '''
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>DuckStation</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.github.stenzek.duckstation</string>
+</dict>
+</plist>
+''',
+    );
+  });
+
+  tearDown(() async {
+    await temporaryDirectory.delete(recursive: true);
+  });
+
+  test('resolves a selected app bundle to its executable', () async {
+    final result = await MacOsApplicationService.resolveExecutable(
+      duckStationBundle,
+    );
+
+    expect(result, duckStationExecutable);
+  });
+
+  test('finds an installed app from a standalone emulator name', () async {
+    final result = await MacOsApplicationService.findInstalledApplication(
+      applicationNames: ['DuckStation Standalone'],
+      applicationRoots: [applicationsDirectory.path],
+    );
+
+    expect(result, duckStationExecutable);
+  });
+
+  test('finds an installed app from its bundle identifier', () async {
+    final result = await MacOsApplicationService.findInstalledApplication(
+      applicationNames: ['Unexpected database name'],
+      bundleIdentifierHint: 'ps1.com.github.stenzek.duckstation',
+      applicationRoots: [applicationsDirectory.path],
+    );
+
+    expect(result, duckStationExecutable);
+  });
+
+  test('resolves a configured command name through Applications', () async {
+    final result = await MacOsApplicationService.resolveExecutable(
+      'duckstation',
+      applicationName: 'Standalone Duckstation',
+      applicationRoots: [applicationsDirectory.path],
+    );
+
+    expect(result, duckStationExecutable);
+  });
+
+  test('does not reinterpret a missing absolute path as an app name', () async {
+    final result = await MacOsApplicationService.resolveExecutable(
+      path.join(temporaryDirectory.path, 'missing', 'duckstation'),
+      applicationRoots: [applicationsDirectory.path],
+    );
+
+    expect(result, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- discover macOS emulator `.app` bundles in `/Applications`, `/System/Applications`, and `~/Applications`
- resolve bundle metadata and `Contents/MacOS` executables for automatic detection, manual configuration, and game launch
- apply configured path resolution to standalone emulators rather than only RetroArch
- cache application discovery and support XML and binary property lists
- add focused bundle-resolution coverage

## Root cause
macOS player configurations expose command names such as `duckstation`, but the desktop launcher treated those names as literal filesystem paths. Automatic detection also received emulator models with empty possible-path lists, and manually selected `.app` paths were not converted to their internal executables.

## Impact
Installed apps such as DuckStation can now be detected and launched through their bundle executables. Manually selected `.app` bundles are normalized before persistence, and the behavior applies generically to other standalone macOS emulators.

## Validation
- `flutter analyze`
- `flutter test test/macos_application_service_test.dart test/emulator_repository_test.dart`
- macOS debug build completed successfully with code signing disabled for local validation
- full test suite has one pre-existing failure in `test/emulator_seed_authority_test.dart`, reproduced unchanged on a clean `upstream/main` worktree
