### PR TITLE
fix: persist RetroAchievements login on macOS

### DIFF
--- a/lib/repositories/retro_achievements_repository.dart
+++ b/lib/repositories/retro_achievements_repository.dart
@@ -11,6 +11,11 @@ class RetroAchievementsRepository {
   // behaviour turns a temporary read failure into a permanent logout.
   static const FlutterSecureStorage _storage = FlutterSecureStorage(
     aOptions: AndroidOptions(resetOnError: false, migrateWithBackup: true),
+    // NeoStation's macOS builds are also distributed outside the App Store.
+    // The classic Keychain remains encrypted by macOS without requiring the
+    // restricted Keychain Sharing entitlement used by the data-protection
+    // Keychain, so ad-hoc-signed builds can persist the API key securely.
+    mOptions: MacOsOptions(usesDataProtectionKeychain: false),
   );
 
   /// Returns local ROM counts: total and RA-compatible (has ra_hash).

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,10 +10,6 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)com.neogamelab.neostation</string>
-	</array>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>


### PR DESCRIPTION
## Summary
- use the classic encrypted macOS Keychain for RetroAchievements API-key storage
- keep the existing secure-storage backends unchanged on Android and other platforms
- remove the Keychain Sharing entitlement that prevented ad-hoc macOS builds from launching

## Root cause
`flutter_secure_storage` defaults to the macOS Data Protection Keychain. That backend requires a restricted Keychain Sharing entitlement and an Apple development or distribution signature. NeoStation's ad-hoc-signed macOS builds therefore either failed to launch with the entitlement or appeared to save the API key without retaining it when the entitlement was removed.

## Impact
RetroAchievements login now survives a full quit and relaunch on macOS while the API key remains encrypted in the system Keychain. No sensitive credential is written to SQLite, shared preferences, or another plaintext store.

## Validation
- `flutter analyze`
- `flutter test test/retro_achievements_credentials_test.dart test/retro_achievements_repository_test.dart`
- `plutil -lint` for all macOS entitlement profiles
- macOS debug build with Xcode 27 beta
- deep code-signature verification and normal LaunchServices launch
- manual login, full quit, and relaunch confirmed persistence on macOS
