### PR TITLE
fix: follow-ups from the #255 login-form review

### DIFF
--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -400,11 +400,13 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
 
   /// Returns whether the selection moved, so the gamepad handler can suppress
   /// the nav sound when repeating against the start/end of a list.
-  bool _navigateContentDown(bool repeat) {
+  ///
+  /// The achievements tab is absent: `RAContent` pushes its own navigation
+  /// layer unconditionally, so this handler is deactivated whenever that tab is
+  /// mounted. Keeping a second route to the same screen is what caused the
+  /// double-dispatch bug fixed in #255.
+  bool _navigateContentDown() {
     if (_selectedTabIndex == AppTabs.systems) return true;
-    if (_selectedTabIndex == AppTabs.achievements) {
-      return RAContent.navigateDown(repeat: repeat);
-    }
     if (_selectedTabIndex == AppTabs.scraper) {
       NewScraperOptionsScreen.navigateDown();
       return true;
@@ -415,11 +417,8 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
     return true;
   }
 
-  bool _navigateContentUp(bool repeat) {
+  bool _navigateContentUp() {
     if (_selectedTabIndex == AppTabs.systems) return true;
-    if (_selectedTabIndex == AppTabs.achievements) {
-      return RAContent.navigateUp(repeat: repeat);
-    }
     if (_selectedTabIndex == AppTabs.scraper) {
       NewScraperOptionsScreen.navigateUp();
       return true;

--- a/lib/screens/retro_achievements_screen/ra_content.dart
+++ b/lib/screens/retro_achievements_screen/ra_content.dart
@@ -13,41 +13,42 @@ import '../../services/game_service.dart' show GamepadNavigationManager;
 import '../app_screen.dart' show AppNavigation;
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import '../../utils/login_form_selection.dart';
 import 'ra_dashboard.dart';
 
 class RAContent extends StatefulWidget {
   const RAContent({super.key});
 
-  /// Returns whether the selection/scroll actually moved, so the gamepad
-  /// handler can suppress the nav sound when repeating against a boundary.
-  static bool navigateUp({bool repeat = false}) =>
-      _RAContentState.navigateUp(repeat: repeat);
-
-  static bool navigateDown({bool repeat = false}) =>
-      _RAContentState.navigateDown(repeat: repeat);
-
   @override
   State<RAContent> createState() => _RAContentState();
 }
 
-class _RAContentState extends State<RAContent> {
-  static _RAContentState? _currentInstance;
-
+class _RAContentState extends State<RAContent>
+    with LoginFormSelection<RAContent> {
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _apiKeyController = TextEditingController();
   final FocusNode _usernameFocus = FocusNode();
   final FocusNode _apiKeyFocus = FocusNode();
   final ScrollController _dashboardScrollController = ScrollController();
 
-  int _selectedFieldIndex = 0;
-  bool _dashboardLogoutSelected = true;
+  /// Connected dashboard: whether the cursor is parked on the header's logout
+  /// button. Nothing is selected at rest — Right parks on it, Left releases it,
+  /// and Up/Down stay dedicated to scrolling the dashboard.
+  bool _logoutSelected = false;
+
+  /// Set while Right is scrolling the header back into view, so the scroll
+  /// listener doesn't read that movement as the user leaving the button.
+  bool _scrollingToLogout = false;
   GamepadNavigation? _gamepadNav;
+
+  @override
+  List<FocusNode?> get selectionSlots => [_usernameFocus, _apiKeyFocus, null];
 
   @override
   void initState() {
     super.initState();
-    _currentInstance = this;
-    _dashboardScrollController.addListener(_updateDashboardSelection);
+    attachFocusSelectionListeners();
+    _dashboardScrollController.addListener(_releaseLogoutOnScroll);
     _initControllerNavigation();
   }
 
@@ -55,13 +56,16 @@ class _RAContentState extends State<RAContent> {
     _gamepadNav = GamepadNavigation(
       onNavigateUp: _handleNavigateUp,
       onNavigateDown: _handleNavigateDown,
+      onNavigateLeft: _handleNavigateLeft,
+      onNavigateRight: _handleNavigateRight,
       onSelectItem: _selectCurrent,
       onPreviousTab: AppNavigation.previousTab,
       onNextTab: AppNavigation.nextTab,
       onLeftBumper: AppNavigation.previousTab,
       onRightBumper: AppNavigation.nextTab,
-      isTextFieldFocused: _isAnyFieldFocused,
-      onBack: _exitTextEntry,
+      allowRepeat: false,
+      isTextFieldFocused: isAnyFieldFocused,
+      onBack: exitTextEntry,
     );
     _gamepadNav!.initialize();
     GamepadNavigationManager.pushLayer(
@@ -71,43 +75,31 @@ class _RAContentState extends State<RAContent> {
     );
   }
 
-  bool _moveSelection(int delta) {
-    if (_isAnyFieldFocused()) return false;
-    setState(() {
-      _selectedFieldIndex = (_selectedFieldIndex + delta + 3) % 3;
-    });
-    return true;
-  }
-
   void _selectCurrent() {
     final raProvider = context.read<RetroAchievementsProvider>();
     if (raProvider.isConnected) {
-      if (_dashboardLogoutSelected) _requestDisconnect();
+      if (_logoutSelected) _requestDisconnect();
       return;
     }
-    if (_selectedFieldIndex == 0) {
-      _usernameFocus.requestFocus();
-    } else if (_selectedFieldIndex == 1) {
-      _apiKeyFocus.requestFocus();
-    } else {
-      _connectToRA();
-    }
+    if (focusSelectedField()) return;
+    _connectToRA();
   }
 
-  bool _isAnyFieldFocused() => _usernameFocus.hasFocus || _apiKeyFocus.hasFocus;
-
-  void _exitTextEntry() {
-    if (_isAnyFieldFocused()) FocusScope.of(context).unfocus();
+  bool _setLogoutSelected(bool selected) {
+    if (!mounted || _logoutSelected == selected) return false;
+    setState(() => _logoutSelected = selected);
+    return true;
   }
 
-  bool _isSelected(int slot) => _selectedFieldIndex == slot;
-
-  void _updateDashboardSelection() {
-    if (!_dashboardScrollController.hasClients) return;
+  /// Releases the logout parking when the dashboard scrolls off the top by any
+  /// means, so a touch scroll can't leave the button armed behind the content.
+  void _releaseLogoutOnScroll() {
+    if (_scrollingToLogout) return;
+    if (!_logoutSelected || !_dashboardScrollController.hasClients) return;
     final position = _dashboardScrollController.position;
-    final selected = position.pixels <= position.minScrollExtent + 1;
-    if (selected == _dashboardLogoutSelected || !mounted) return;
-    setState(() => _dashboardLogoutSelected = selected);
+    if (position.pixels > position.minScrollExtent + 1) {
+      _setLogoutSelected(false);
+    }
   }
 
   Future<void> _requestDisconnect() async {
@@ -121,10 +113,8 @@ class _RAContentState extends State<RAContent> {
     if (!confirmed || !mounted) return;
     context.read<RetroAchievementsProvider>().disconnect(clearSavedUser: true);
     if (!mounted) return;
-    setState(() {
-      _selectedFieldIndex = 0;
-      _dashboardLogoutSelected = true;
-    });
+    resetSelection();
+    _setLogoutSelected(false);
     AppNotification.showNotification(
       context,
       AppLocale.disconnectedRA.getString(context),
@@ -158,11 +148,9 @@ class _RAContentState extends State<RAContent> {
 
   @override
   void dispose() {
-    if (identical(_currentInstance, this)) {
-      _currentInstance = null;
-    }
     GamepadNavigationManager.popLayer('ra_content');
     _gamepadNav?.dispose();
+    detachFocusSelectionListeners();
     _usernameController.dispose();
     _apiKeyController.dispose();
     _usernameFocus.dispose();
@@ -171,28 +159,51 @@ class _RAContentState extends State<RAContent> {
     super.dispose();
   }
 
-  static bool navigateUp({bool repeat = false}) =>
-      _currentInstance?._handleNavigateUp(repeat) ?? true;
-
-  static bool navigateDown({bool repeat = false}) =>
-      _currentInstance?._handleNavigateDown(repeat) ?? true;
-
-  bool _handleNavigateUp(bool repeat) {
-    final raProvider = context.read<RetroAchievementsProvider>();
-    if (!raProvider.isConnected) {
-      if (repeat) return false;
-      return _moveSelection(-1);
+  /// Returns whether the selection/scroll actually moved, so the gamepad
+  /// handler can suppress the nav sound at a boundary.
+  bool _handleNavigateUp() {
+    if (!context.read<RetroAchievementsProvider>().isConnected) {
+      return moveSelection(-1);
     }
     return _scrollDashboard(-160.r);
   }
 
-  bool _handleNavigateDown(bool repeat) {
-    final raProvider = context.read<RetroAchievementsProvider>();
-    if (!raProvider.isConnected) {
-      if (repeat) return false;
-      return _moveSelection(1);
+  bool _handleNavigateDown() {
+    if (!context.read<RetroAchievementsProvider>().isConnected) {
+      return moveSelection(1);
     }
     return _scrollDashboard(160.r);
+  }
+
+  /// Right parks the cursor on the header's logout button.
+  ///
+  /// The header scrolls with the content, so anything below the top has to come
+  /// back into view first — parking on a button that is off screen would leave
+  /// the highlight invisible and A destructive-looking out of nowhere.
+  bool _handleNavigateRight() {
+    if (!context.read<RetroAchievementsProvider>().isConnected) return false;
+    if (_logoutSelected) return false;
+    _scrollHeaderIntoView();
+    return _setLogoutSelected(true);
+  }
+
+  bool _handleNavigateLeft() {
+    if (!context.read<RetroAchievementsProvider>().isConnected) return false;
+    return _setLogoutSelected(false);
+  }
+
+  void _scrollHeaderIntoView() {
+    if (!_dashboardScrollController.hasClients) return;
+    final position = _dashboardScrollController.position;
+    if (position.pixels <= position.minScrollExtent + 1) return;
+    _scrollingToLogout = true;
+    _dashboardScrollController
+        .animateTo(
+          position.minScrollExtent,
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOutCubic,
+        )
+        .whenComplete(() => _scrollingToLogout = false);
   }
 
   bool _scrollDashboard(double delta) {
@@ -267,7 +278,7 @@ class _RAContentState extends State<RAContent> {
               child: RepaintBoundary(
                 child: RADashboardHub(
                   scrollController: _dashboardScrollController,
-                  logoutSelected: _dashboardLogoutSelected,
+                  logoutSelected: _logoutSelected,
                   onDisconnectRequested: _requestDisconnect,
                 ),
               ),
@@ -283,7 +294,7 @@ class _RAContentState extends State<RAContent> {
     required ThemeData theme,
     required Widget child,
   }) {
-    if (!_isSelected(slot)) return child;
+    if (!isSelected(slot)) return child;
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(8.r),
@@ -373,10 +384,10 @@ class _RAContentState extends State<RAContent> {
                     enabledBorder: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(8.r),
                       borderSide: BorderSide(
-                        color: _isSelected(0)
+                        color: isSelected(0)
                             ? theme.colorScheme.primary
                             : theme.colorScheme.primary.withValues(alpha: 0.1),
-                        width: _isSelected(0) ? 2.r : 1.r,
+                        width: isSelected(0) ? 2.r : 1.r,
                       ),
                     ),
                     focusedBorder: OutlineInputBorder(
@@ -437,10 +448,10 @@ class _RAContentState extends State<RAContent> {
                     enabledBorder: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(8.r),
                       borderSide: BorderSide(
-                        color: _isSelected(1)
+                        color: isSelected(1)
                             ? theme.colorScheme.primary
                             : theme.colorScheme.primary.withValues(alpha: 0.1),
-                        width: _isSelected(1) ? 2.r : 1.r,
+                        width: isSelected(1) ? 2.r : 1.r,
                       ),
                     ),
                     focusedBorder: OutlineInputBorder(
@@ -463,7 +474,7 @@ class _RAContentState extends State<RAContent> {
           // Connect button
           Container(
             constraints: BoxConstraints(maxWidth: 220.r),
-            decoration: _isSelected(2)
+            decoration: isSelected(submitSlot)
                 ? BoxDecoration(
                     borderRadius: BorderRadius.circular(8.r),
                     boxShadow: [

--- a/lib/screens/retro_achievements_screen/ra_dashboard.dart
+++ b/lib/screens/retro_achievements_screen/ra_dashboard.dart
@@ -266,18 +266,15 @@ class _RADashboardHubState extends State<RADashboardHub> {
             ),
           ),
           Container(
-            decoration: widget.logoutSelected
-                ? BoxDecoration(
-                    borderRadius: BorderRadius.circular(8.r),
-                    boxShadow: [
-                      BoxShadow(
-                        color: theme.colorScheme.error.withValues(alpha: 0.45),
-                        blurRadius: 8.r,
-                        spreadRadius: 1.r,
-                      ),
-                    ],
-                  )
-                : null,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8.r),
+              border: Border.all(
+                color: widget.logoutSelected
+                    ? theme.colorScheme.primary
+                    : Colors.transparent,
+                width: 2.r,
+              ),
+            ),
             child: IconButton(
               onPressed: widget.onDisconnectRequested,
               icon: Icon(

--- a/lib/screens/scraper_screen/scraper_contents/account_content.dart
+++ b/lib/screens/scraper_screen/scraper_contents/account_content.dart
@@ -151,27 +151,33 @@ class AccountContent extends StatelessWidget {
             ),
           ),
           SizedBox(width: 8.r),
-          Container(
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(8.r),
-              border: Border.all(
-                color: isContentFocused && selectedContentIndex == 0
-                    ? theme.colorScheme.primary
-                    : Colors.transparent,
-                width: 2.r,
-              ),
-            ),
-            child: IconButton(
-              onPressed: onLogout,
-              icon: Icon(
-                Symbols.logout_rounded,
-                size: 20.r,
-                color: theme.colorScheme.error,
-              ),
-              tooltip: AppLocale.disconnectAccount.getString(context),
-            ),
-          ),
+          _buildLogoutButton(context, theme),
         ],
+      ),
+    );
+  }
+
+  /// The border keeps this in step with the other option lists, and with the
+  /// RA dashboard's logout, so a destructive slot reads the same way on both
+  /// accounts.
+  Widget _buildLogoutButton(BuildContext context, ThemeData theme) {
+    final selected = isContentFocused && selectedContentIndex == 0;
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8.r),
+        border: Border.all(
+          color: selected ? theme.colorScheme.primary : Colors.transparent,
+          width: 2.r,
+        ),
+      ),
+      child: IconButton(
+        onPressed: onLogout,
+        icon: Icon(
+          Symbols.logout_rounded,
+          size: 20.r,
+          color: theme.colorScheme.error,
+        ),
+        tooltip: AppLocale.disconnectAccount.getString(context),
       ),
     );
   }

--- a/lib/screens/scraper_screen/scraper_login_screen.dart
+++ b/lib/screens/scraper_screen/scraper_login_screen.dart
@@ -10,6 +10,7 @@ import '../../services/game_service.dart' show GamepadNavigationManager;
 import '../app_screen.dart' show AppNavigation;
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import '../../utils/login_form_selection.dart';
 
 class ScraperLoginScreen extends StatefulWidget {
   final VoidCallback? onLoginSuccess;
@@ -20,9 +21,9 @@ class ScraperLoginScreen extends StatefulWidget {
   State<ScraperLoginScreen> createState() => _ScraperLoginScreenState();
 }
 
-class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
+class _ScraperLoginScreenState extends State<ScraperLoginScreen>
+    with LoginFormSelection<ScraperLoginScreen> {
   GamepadNavigation? _gamepadNav;
-  int _selectedFieldIndex = 0; // 0: username, 1: password, 2: login button
 
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
@@ -33,8 +34,12 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
   bool _isLoading = false;
 
   @override
+  List<FocusNode?> get selectionSlots => [_usernameFocus, _passwordFocus, null];
+
+  @override
   void initState() {
     super.initState();
+    attachFocusSelectionListeners();
     _initControllerNavigation();
   }
 
@@ -47,8 +52,9 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
       onNextTab: AppNavigation.nextTab,
       onLeftBumper: AppNavigation.previousTab,
       onRightBumper: AppNavigation.nextTab,
-      isTextFieldFocused: _isAnyFieldFocused,
-      onBack: _exitTextEntry,
+      allowRepeat: false,
+      isTextFieldFocused: isAnyFieldFocused,
+      onBack: exitTextEntry,
     );
     _gamepadNav!.initialize();
     GamepadNavigationManager.pushLayer(
@@ -62,6 +68,7 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
   void dispose() {
     GamepadNavigationManager.popLayer('scraper_login_screen');
     _gamepadNav?.dispose();
+    detachFocusSelectionListeners();
     _usernameController.dispose();
     _passwordController.dispose();
     _usernameFocus.dispose();
@@ -69,46 +76,14 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
     super.dispose();
   }
 
-  bool _isAnyFieldFocused() =>
-      _usernameFocus.hasFocus || _passwordFocus.hasFocus;
+  bool _navigateUp() => moveSelection(-1);
 
-  void _exitTextEntry() {
-    if (_isAnyFieldFocused()) FocusScope.of(context).unfocus();
-  }
-
-  bool _navigateUp(bool repeat) {
-    if (_isAnyFieldFocused()) return false;
-    if (repeat) return false;
-    setState(() {
-      _selectedFieldIndex = (_selectedFieldIndex - 1 + 3) % 3;
-    });
-    return true;
-  }
-
-  bool _navigateDown(bool repeat) {
-    if (_isAnyFieldFocused()) return false;
-    if (repeat) return false;
-    setState(() {
-      _selectedFieldIndex = (_selectedFieldIndex + 1) % 3;
-    });
-    return true;
-  }
+  bool _navigateDown() => moveSelection(1);
 
   void _selectCurrentField() {
-    switch (_selectedFieldIndex) {
-      case 0:
-        _usernameFocus.requestFocus();
-        break;
-      case 1:
-        _passwordFocus.requestFocus();
-        break;
-      case 2:
-        _performLogin();
-        break;
-    }
+    if (focusSelectedField()) return;
+    _performLogin();
   }
-
-  bool _isSelected(int slot) => _selectedFieldIndex == slot;
 
   Future<void> _performLogin() async {
     if (_usernameController.text.isEmpty || _passwordController.text.isEmpty) {
@@ -405,7 +380,7 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
           // Username field
           Container(
             constraints: BoxConstraints(maxWidth: 220.r),
-            decoration: _isSelected(0)
+            decoration: isSelected(0)
                 ? BoxDecoration(
                     borderRadius: BorderRadius.circular(8.r),
                     boxShadow: [
@@ -451,10 +426,10 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
                   enabledBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(8.r),
                     borderSide: BorderSide(
-                      color: _isSelected(0)
+                      color: isSelected(0)
                           ? theme.colorScheme.primary
                           : theme.colorScheme.primary.withValues(alpha: 0.1),
-                      width: _isSelected(0) ? 2.r : 1.r,
+                      width: isSelected(0) ? 2.r : 1.r,
                     ),
                   ),
                   focusedBorder: OutlineInputBorder(
@@ -477,7 +452,7 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
           // Password field
           Container(
             constraints: BoxConstraints(maxWidth: 220.r),
-            decoration: _isSelected(1)
+            decoration: isSelected(1)
                 ? BoxDecoration(
                     borderRadius: BorderRadius.circular(8.r),
                     boxShadow: [
@@ -529,10 +504,10 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
                   enabledBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(8.r),
                     borderSide: BorderSide(
-                      color: _isSelected(1)
+                      color: isSelected(1)
                           ? theme.colorScheme.primary
                           : theme.colorScheme.primary.withValues(alpha: 0.1),
-                      width: _isSelected(1) ? 2.r : 1.r,
+                      width: isSelected(1) ? 2.r : 1.r,
                     ),
                   ),
                   focusedBorder: OutlineInputBorder(
@@ -569,7 +544,7 @@ class _ScraperLoginScreenState extends State<ScraperLoginScreen> {
           // Login button
           Container(
             constraints: BoxConstraints(maxWidth: 320.r),
-            decoration: _isSelected(2)
+            decoration: isSelected(submitSlot)
                 ? BoxDecoration(
                     borderRadius: BorderRadius.circular(8.r),
                     boxShadow: [

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -97,6 +97,12 @@ class GamepadNavigation {
   /// cursor — a fixed cadence there stays in step with the cache.
   final bool accelerateRepeats;
 
+  /// Whether holding a direction auto-repeats. Turn it off for small fixed
+  /// layouts (login forms, dialogs) where one move per press is the whole
+  /// interaction: with a wrapping selection there is no boundary to stop the
+  /// timer, so a held direction would otherwise spin the cursor round the form.
+  final bool allowRepeat;
+
   /// Optional override that reports whether a text field is currently focused
   /// in the active UI layer. When provided, it takes precedence over the global
   /// focus search, preventing off-stage text fields from blocking navigation.
@@ -289,6 +295,7 @@ class GamepadNavigation {
     this.onLetterJump,
     this.letterJumpAxis = LetterJumpAxis.vertical,
     this.accelerateRepeats = false,
+    this.allowRepeat = true,
     this.isTextFieldFocused,
   });
 
@@ -1175,6 +1182,8 @@ class GamepadNavigation {
       cancelAllRepeatTimers();
       return;
     }
+
+    if (!allowRepeat) return;
 
     _startRepeatTimer(key, action);
   }

--- a/lib/utils/login_form_selection.dart
+++ b/lib/utils/login_form_selection.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+/// Gamepad cursor state shared by the app's login forms.
+///
+/// Every login form is the same shape: an ordered list of slots the D-pad
+/// walks, where each slot is either a text field to focus or a control to
+/// activate, driven by Up/Down and A.
+///
+/// The slot list is read fresh each time rather than captured, so forms whose
+/// fields change with their mode — register showing a username the login state
+/// doesn't, a verification step replacing both — describe the current state and
+/// nothing here has to be told it changed.
+mixin LoginFormSelection<T extends StatefulWidget> on State<T> {
+  /// The form's selectable slots in cursor order. A null entry is an action
+  /// control (a button) rather than a text field.
+  List<FocusNode?> get selectionSlots;
+
+  /// Every focus node the form owns, including any absent from the current
+  /// [selectionSlots]. Forms whose slot list varies must widen this so focus
+  /// tracking survives a mode switch; a fixed form can leave it alone.
+  List<FocusNode> get ownedFocusNodes =>
+      selectionSlots.whereType<FocusNode>().toList();
+
+  final List<VoidCallback> _focusListeners = [];
+  List<FocusNode> _listenedNodes = const [];
+
+  int _selectedSlot = 0;
+
+  /// Total selectable slots in the form's current state.
+  int get slotCount => selectionSlots.length;
+
+  /// Slot the gamepad cursor is on.
+  ///
+  /// Clamped on read so a mode switch that shortens the form can never leave
+  /// the cursor pointing past the end of the new slot list.
+  int get selectedSlot {
+    final count = slotCount;
+    if (count == 0) return 0;
+    return _selectedSlot.clamp(0, count - 1);
+  }
+
+  /// The form's last slot, which on a simple form is its submit button. Forms
+  /// with several action controls should name their slots explicitly instead.
+  int get submitSlot => slotCount == 0 ? 0 : slotCount - 1;
+
+  bool isSelected(int slot) => selectedSlot == slot;
+
+  /// The focus node under the cursor, or null when it is on a control.
+  FocusNode? get selectedFocusNode {
+    final slots = selectionSlots;
+    return slots.isEmpty ? null : slots[selectedSlot];
+  }
+
+  bool isAnyFieldFocused() => ownedFocusNodes.any((node) => node.hasFocus);
+
+  /// Focuses the selected slot when it is a text field.
+  ///
+  /// Returns false when the cursor is on an action control, which is the
+  /// screen's cue to run whatever that control does.
+  bool focusSelectedField() {
+    final node = selectedFocusNode;
+    if (node == null) return false;
+    node.requestFocus();
+    return true;
+  }
+
+  /// Drops focus (and the soft keyboard) so the D-pad can move again. B is the
+  /// app-wide way out of a focused text field.
+  void exitTextEntry() {
+    if (isAnyFieldFocused()) FocusScope.of(context).unfocus();
+  }
+
+  /// Moves the cursor by [delta], wrapping around the form.
+  ///
+  /// Refuses while a text field has focus so the highlight can't drift away
+  /// from where typing actually lands — on a desktop gamepad the directional
+  /// event reaches this layer even though the keystrokes go to the field.
+  ///
+  /// Returns whether the cursor moved, which drives the nav sound.
+  bool moveSelection(int delta) {
+    if (isAnyFieldFocused()) return false;
+    final count = slotCount;
+    if (count == 0) return false;
+    setState(() {
+      _selectedSlot = (selectedSlot + delta + count) % count;
+    });
+    return true;
+  }
+
+  /// Puts the cursor back on the first slot, e.g. after logging out or on a
+  /// switch to a different form mode.
+  void resetSelection() {
+    if (_selectedSlot == 0) return;
+    setState(() => _selectedSlot = 0);
+  }
+
+  /// [resetSelection] for use inside an enclosing [setState] — typically a mode
+  /// switch that is already rebuilding, where a nested setState would throw.
+  void resetSelectionInPlace() => _selectedSlot = 0;
+
+  /// Keeps the highlight on whichever field the platform focused.
+  ///
+  /// [moveSelection] is not the only thing that moves focus: the IME "next"
+  /// action jumps field to field via `onFieldSubmitted`, and a tap or click
+  /// focuses a field directly. Without this the highlight and the real focus
+  /// disagree, and a later A fires whatever the stale highlight landed on.
+  ///
+  /// Call from `initState`, and [detachFocusSelectionListeners] from `dispose`.
+  void attachFocusSelectionListeners() {
+    detachFocusSelectionListeners();
+    _listenedNodes = List.of(ownedFocusNodes);
+    for (final node in _listenedNodes) {
+      void listener() {
+        if (!node.hasFocus || !mounted) return;
+        // Resolved against the live slot list: a node's slot moves when the
+        // form does, and a node absent from the current state has none.
+        final slot = selectionSlots.indexOf(node);
+        if (slot < 0 || _selectedSlot == slot) return;
+        setState(() => _selectedSlot = slot);
+      }
+
+      node.addListener(listener);
+      _focusListeners.add(listener);
+    }
+  }
+
+  void detachFocusSelectionListeners() {
+    for (var i = 0; i < _focusListeners.length; i++) {
+      _listenedNodes[i].removeListener(_focusListeners[i]);
+    }
+    _focusListeners.clear();
+    _listenedNodes = const [];
+  }
+}

--- a/test/login_form_selection_test.dart
+++ b/test/login_form_selection_test.dart
@@ -1,0 +1,281 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/login_form_selection.dart';
+
+/// Minimal two-field login form, the shape both real login screens have.
+class _TestForm extends StatefulWidget {
+  const _TestForm();
+
+  @override
+  State<_TestForm> createState() => _TestFormState();
+}
+
+class _TestFormState extends State<_TestForm>
+    with LoginFormSelection<_TestForm> {
+  final FocusNode usernameFocus = FocusNode();
+  final FocusNode passwordFocus = FocusNode();
+
+  @override
+  List<FocusNode?> get selectionSlots => [usernameFocus, passwordFocus, null];
+
+  @override
+  void initState() {
+    super.initState();
+    attachFocusSelectionListeners();
+  }
+
+  @override
+  void dispose() {
+    detachFocusSelectionListeners();
+    usernameFocus.dispose();
+    passwordFocus.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TextField(focusNode: usernameFocus),
+        TextField(focusNode: passwordFocus),
+        const Text('submit'),
+      ],
+    );
+  }
+}
+
+/// Form whose slot list changes with its mode, the shape the NeoSync login has:
+/// register carries a username the login state doesn't, and the verification
+/// step is a pair of buttons with no field at all.
+class _ModalForm extends StatefulWidget {
+  const _ModalForm();
+
+  @override
+  State<_ModalForm> createState() => _ModalFormState();
+}
+
+enum _Mode { login, register, verify }
+
+class _ModalFormState extends State<_ModalForm>
+    with LoginFormSelection<_ModalForm> {
+  final FocusNode usernameFocus = FocusNode();
+  final FocusNode emailFocus = FocusNode();
+  final FocusNode passwordFocus = FocusNode();
+
+  _Mode mode = _Mode.login;
+
+  @override
+  List<FocusNode?> get selectionSlots => switch (mode) {
+    _Mode.login => [emailFocus, passwordFocus, null],
+    _Mode.register => [usernameFocus, emailFocus, passwordFocus, null],
+    _Mode.verify => [null, null],
+  };
+
+  @override
+  List<FocusNode> get ownedFocusNodes => [
+    usernameFocus,
+    emailFocus,
+    passwordFocus,
+  ];
+
+  void switchTo(_Mode next) => setState(() => mode = next);
+
+  @override
+  void initState() {
+    super.initState();
+    attachFocusSelectionListeners();
+  }
+
+  @override
+  void dispose() {
+    detachFocusSelectionListeners();
+    usernameFocus.dispose();
+    emailFocus.dispose();
+    passwordFocus.dispose();
+    super.dispose();
+  }
+
+  // Every node stays mounted regardless of mode; only the slot list changes.
+  // A node that is not in the tree cannot take focus, and this test is about
+  // which slot focus maps to.
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TextField(focusNode: usernameFocus),
+        TextField(focusNode: emailFocus),
+        TextField(focusNode: passwordFocus),
+      ],
+    );
+  }
+}
+
+Future<_TestFormState> _pumpForm(WidgetTester tester) async {
+  await tester.pumpWidget(const MaterialApp(home: Scaffold(body: _TestForm())));
+  return tester.state<_TestFormState>(find.byType(_TestForm));
+}
+
+Future<_ModalFormState> _pumpModalForm(WidgetTester tester) async {
+  await tester.pumpWidget(
+    const MaterialApp(home: Scaffold(body: _ModalForm())),
+  );
+  return tester.state<_ModalFormState>(find.byType(_ModalForm));
+}
+
+void main() {
+  testWidgets('slot count covers every field plus the submit control', (
+    tester,
+  ) async {
+    final state = await _pumpForm(tester);
+
+    expect(state.slotCount, 3);
+    expect(state.submitSlot, 2);
+    expect(state.isSelected(0), isTrue);
+  });
+
+  testWidgets('the selection wraps in both directions', (tester) async {
+    final state = await _pumpForm(tester);
+
+    expect(state.moveSelection(-1), isTrue);
+    await tester.pump();
+    expect(state.selectedSlot, state.submitSlot);
+
+    expect(state.moveSelection(1), isTrue);
+    await tester.pump();
+    expect(state.selectedSlot, 0);
+  });
+
+  testWidgets('the selection refuses to move while a field is focused', (
+    tester,
+  ) async {
+    final state = await _pumpForm(tester);
+
+    state.usernameFocus.requestFocus();
+    await tester.pump();
+
+    expect(state.moveSelection(1), isFalse);
+    await tester.pump();
+    expect(state.selectedSlot, 0);
+  });
+
+  testWidgets('focusing a field by any means moves the selection to it', (
+    tester,
+  ) async {
+    final state = await _pumpForm(tester);
+
+    // Stands in for the IME "next" action and for a direct tap, neither of
+    // which goes through moveSelection.
+    state.passwordFocus.requestFocus();
+    await tester.pump();
+
+    expect(state.selectedSlot, 1);
+    expect(state.isSelected(1), isTrue);
+  });
+
+  testWidgets('exiting text entry drops focus and frees the D-pad', (
+    tester,
+  ) async {
+    final state = await _pumpForm(tester);
+
+    state.passwordFocus.requestFocus();
+    await tester.pump();
+    expect(state.isAnyFieldFocused(), isTrue);
+
+    state.exitTextEntry();
+    await tester.pump();
+
+    expect(state.isAnyFieldFocused(), isFalse);
+    expect(state.moveSelection(1), isTrue);
+    await tester.pump();
+    expect(state.selectedSlot, state.submitSlot);
+  });
+
+  testWidgets('resetting puts the cursor back on the first field', (
+    tester,
+  ) async {
+    final state = await _pumpForm(tester);
+
+    state.moveSelection(1);
+    await tester.pump();
+    expect(state.selectedSlot, 1);
+
+    state.resetSelection();
+    await tester.pump();
+    expect(state.selectedSlot, 0);
+  });
+
+  testWidgets(
+    'focusing a field reports the slot it holds in the current mode',
+    (tester) async {
+      final state = await _pumpModalForm(tester);
+
+      // Email is slot 0 while logging in and slot 1 once a username appears.
+      state.emailFocus.requestFocus();
+      await tester.pump();
+      expect(state.selectedSlot, 0);
+
+      // A mode switch drops focus first, the way the real forms do.
+      state.exitTextEntry();
+      await tester.pump();
+      state.switchTo(_Mode.register);
+      await tester.pump();
+
+      state.emailFocus.requestFocus();
+      await tester.pump();
+      expect(state.selectedSlot, 1);
+    },
+  );
+
+  testWidgets('a shorter mode cannot leave the cursor past the last slot', (
+    tester,
+  ) async {
+    final state = await _pumpModalForm(tester);
+    state.switchTo(_Mode.register);
+    await tester.pump();
+
+    state.moveSelection(-1);
+    await tester.pump();
+    expect(state.selectedSlot, state.submitSlot);
+    expect(state.selectedSlot, 3);
+
+    // Verification drops to two button slots, stranding the index at 3.
+    state.switchTo(_Mode.verify);
+    await tester.pump();
+
+    expect(state.slotCount, 2);
+    expect(state.selectedSlot, 1);
+    expect(state.selectedFocusNode, isNull);
+  });
+
+  testWidgets('a button slot declines focus so the screen runs its action', (
+    tester,
+  ) async {
+    final state = await _pumpModalForm(tester);
+
+    expect(state.focusSelectedField(), isTrue);
+    await tester.pump();
+    expect(state.emailFocus.hasFocus, isTrue);
+
+    state.exitTextEntry();
+    await tester.pump();
+    state.moveSelection(-1);
+    await tester.pump();
+
+    expect(state.selectedFocusNode, isNull);
+    expect(state.focusSelectedField(), isFalse);
+  });
+
+  testWidgets('a mode switch wraps over the new slot count', (tester) async {
+    final state = await _pumpModalForm(tester);
+    state.switchTo(_Mode.verify);
+    await tester.pump();
+
+    expect(state.moveSelection(1), isTrue);
+    await tester.pump();
+    expect(state.selectedSlot, 1);
+
+    expect(state.moveSelection(1), isTrue);
+    await tester.pump();
+    expect(state.selectedSlot, 0);
+  });
+}


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). Reviewed and tested on hardware by me before opening.

# Description

Follow-ups recorded on the #255 review, none of which needed to block that PR landing.

**The highlight could disagree with where typing actually went.** Moving the cursor was the only thing that wrote the selected slot, but the IME "next" action (`onFieldSubmitted`) and a plain tap both move focus without it. Type in Username, hit next, and you are editing the API Key while the highlight sits on Username — a later A then fires whatever the stale highlight landed on. A focus listener per node now follows the platform's focus, so the two can't drift apart.

**The connected RetroAchievements dashboard derived its logout selection from scroll offset alone, starting at `true`**, so its resting state was "logout armed" and the red glow rendered permanently on touch-only devices. Logout is an explicit slot now with its own axis: nothing is selected at rest, Right parks on it and Left releases it, while Up and Down stay dedicated to scrolling. Because the header scrolls with the content, Right brings it back into view first rather than arming a button that is off screen, and the scroll listener stands down for that one programmatic scroll so it doesn't read it as the user leaving.

**`if (repeat) return false` never actually stopped a repeat.** `_startRepeatTimer` reschedules regardless, and the return value only gates the nav sound, so holding a direction on a login form spun a no-op timer down to the minimum interval until release. `GamepadNavigation` carries an `allowRepeat` flag instead, which says it once for a whole layer rather than at four call sites.

**`RAContent` pushes its navigation layer on every platform now**, which means `AppScreen`'s layer is always deactivated on the achievements tab and its `AppTabs.achievements` branch is unreachable. Keeping two live routes to the same screen is what caused the double-dispatch bug in the first place, so the branch and the `_currentInstance`/static plumbing behind it are gone rather than maintained.

**The two forms had grown verbatim copies** of the slot index, its wrap arithmetic, `isSelected`, `isAnyFieldFocused` and `exitTextEntry`. Those live in a `LoginFormSelection` mixin now, which describes a form as an ordered list of slots where a null entry is a button rather than a field. That shape also fits the NeoSync form, whose slot list changes with its mode, so the list is read live rather than captured and the cursor is clamped on read.

**The logout selection reads the same on both accounts.** The RA dashboard drew its selection as an error-tinted glow while the ScreenScraper account button used the primary border every other option list on that screen uses. Both use the border now, laid out at all times with only its colour changing, so arming the slot doesn't shift the icon under it.

Fixes # (no issue — review follow-ups on #255)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

`test/login_form_selection_test.dart` covers the mixin: wrap in both directions, the refusal to move while a field is focused, focus-by-any-means moving the selection, and the dynamic-slot cases — a shorter mode clamping a stranded cursor, and a button slot declining focus so the screen runs its action instead.

## Screenshots (if applicable)

n/a — the visible change is a selection border on the two logout buttons.
