### PR TITLE
fix(neosync): make the login form controller navigable off Android TV

### DIFF
--- a/lib/widgets/auth_form.dart
+++ b/lib/widgets/auth_form.dart
@@ -1,14 +1,16 @@
 import 'dart:async';
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/services/game_service.dart'
+    show GamepadNavigationManager;
 import 'package:neostation/services/neosync/auth_service.dart';
-import 'package:neostation/services/permission_service.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/utils/login_form_selection.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:neostation/screens/app_screen.dart' show AppNavigation;
 import 'package:neostation/services/logger_service.dart';
 
 class AuthForm extends StatefulWidget {
@@ -20,7 +22,7 @@ class AuthForm extends StatefulWidget {
   AuthFormState createState() => AuthFormState();
 }
 
-class AuthFormState extends State<AuthForm> {
+class AuthFormState extends State<AuthForm> with LoginFormSelection<AuthForm> {
   final _formKey = GlobalKey<FormState>();
   final _usernameController = TextEditingController();
   final _emailController = TextEditingController();
@@ -29,7 +31,7 @@ class AuthFormState extends State<AuthForm> {
   final _resetTokenController = TextEditingController();
   final _newPasswordController = TextEditingController();
 
-  // TV navigation focus nodes
+  // Gamepad navigation focus nodes
   final _usernameFocus = FocusNode();
   final _emailFocus = FocusNode();
   final _passwordFocus = FocusNode();
@@ -51,35 +53,14 @@ class AuthFormState extends State<AuthForm> {
   Timer? _pollingTimer;
   String? _pendingVerificationEmail;
 
-  // TV mode state
-  bool _isTelevision = false;
-  int _tvFieldIndex = 0;
-  GamepadNavigation? _tvNav;
+  GamepadNavigation? _gamepadNav;
 
+  /// The slots the D-pad walks, which change with the form's mode: register
+  /// carries a username that login doesn't, the verification step is a pair of
+  /// buttons with no field, and the reset flow swaps in its own two fields.
+  /// A null entry is an action button rather than something to focus.
   @override
-  void initState() {
-    super.initState();
-    _initTvMode();
-  }
-
-  Future<void> _initTvMode() async {
-    if (!Platform.isAndroid) return;
-    final isTV = await PermissionService.isTelevision();
-    if (!mounted) return;
-    setState(() => _isTelevision = isTV);
-    if (!isTV) return;
-    _tvNav = GamepadNavigation(
-      onNavigateUp: () => _tvMove(-1),
-      onNavigateDown: () => _tvMove(1),
-      onSelectItem: _tvSelect,
-      onBack: _tvBack,
-    );
-    _tvNav!.initialize();
-    _tvNav!.activate();
-  }
-
-  // Returns ordered list of FocusNodes (null = action button) for current state
-  List<FocusNode?> _getCurrentTvFields() {
+  List<FocusNode?> get selectionSlots {
     if (_showResetPassword) return [_resetTokenFocus, _newPasswordFocus, null];
     if (_showForgotPassword) return [_emailFocus, null];
     if (_showVerification && !_showEmailVerification) {
@@ -90,38 +71,66 @@ class AuthFormState extends State<AuthForm> {
     return [_usernameFocus, _emailFocus, _passwordFocus, null];
   }
 
-  bool _isAnyFieldFocused() {
-    return _usernameFocus.hasFocus ||
-        _emailFocus.hasFocus ||
-        _passwordFocus.hasFocus ||
-        _verificationTokenFocus.hasFocus ||
-        _resetTokenFocus.hasFocus ||
-        _newPasswordFocus.hasFocus;
-  }
+  /// Every node the form owns, not just the ones the current mode shows, so
+  /// focus tracking survives a mode switch.
+  @override
+  List<FocusNode> get ownedFocusNodes => [
+    _usernameFocus,
+    _emailFocus,
+    _passwordFocus,
+    _verificationTokenFocus,
+    _resetTokenFocus,
+    _newPasswordFocus,
+  ];
 
-  void _tvMove(int delta) {
-    if (!_isTelevision || _isAnyFieldFocused()) return;
-    final fields = _getCurrentTvFields();
-    setState(() {
-      _tvFieldIndex = (_tvFieldIndex + delta).clamp(0, fields.length - 1);
+  @override
+  void initState() {
+    super.initState();
+    attachFocusSelectionListeners();
+    // Deferred by a frame because NeoSyncContent pushes its own layer in a
+    // post-frame callback. This form has to land on top of it, and pushing
+    // synchronously here would put it underneath.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _initControllerNavigation();
     });
   }
 
-  void _tvSelect() {
-    if (!_isTelevision) return;
-    final fields = _getCurrentTvFields();
-    if (_tvFieldIndex >= fields.length) return;
-    final node = fields[_tvFieldIndex];
-    if (node != null) {
-      node.requestFocus();
-    } else {
-      _tvHandleAction();
-    }
+  /// Registers the form's own navigation layer.
+  ///
+  /// Not gated on Android TV: the form is the only thing on screen whenever it
+  /// is shown, so the D-pad has to drive it on handhelds and the Deck too.
+  /// Going through the manager rather than calling `activate()` directly is
+  /// what stops this handler and NeoSyncContent's both seeing the same press.
+  void _initControllerNavigation() {
+    _gamepadNav = GamepadNavigation(
+      onNavigateUp: () => moveSelection(-1),
+      onNavigateDown: () => moveSelection(1),
+      onSelectItem: _selectCurrent,
+      onPreviousTab: AppNavigation.previousTab,
+      onNextTab: AppNavigation.nextTab,
+      onLeftBumper: AppNavigation.previousTab,
+      onRightBumper: AppNavigation.nextTab,
+      allowRepeat: false,
+      isTextFieldFocused: isAnyFieldFocused,
+      onBack: _handleBack,
+    );
+    _gamepadNav!.initialize();
+    GamepadNavigationManager.pushLayer(
+      'auth_form',
+      onActivate: () => _gamepadNav?.activate(),
+      onDeactivate: () => _gamepadNav?.deactivate(),
+    );
   }
 
-  void _tvHandleAction() {
+  void _selectCurrent() {
+    if (focusSelectedField()) return;
+    _handleAction();
+  }
+
+  void _handleAction() {
     if (_showEmailVerification) {
-      if (_tvFieldIndex == 0) {
+      if (isSelected(0)) {
         _resendVerification();
       } else {
         _goBackToLogin();
@@ -143,7 +152,13 @@ class AuthFormState extends State<AuthForm> {
     _submitForm();
   }
 
-  void _tvBack() {
+  /// B leaves a focused field first — that is what it does everywhere else in
+  /// the app — and only steps back to the login form once nothing is focused.
+  void _handleBack() {
+    if (isAnyFieldFocused()) {
+      exitTextEntry();
+      return;
+    }
     if (_showForgotPassword ||
         _showResetPassword ||
         _showVerification ||
@@ -161,21 +176,15 @@ class AuthFormState extends State<AuthForm> {
       _showResetPassword = false;
       _isPolling = false;
       _message = null;
-      _tvFieldIndex = 0;
+      resetSelectionInPlace();
     });
   }
 
-  void _resetTvIndex() {
-    if (_isTelevision) {
-      _tvFieldIndex = 0;
-    }
-  }
-
-  bool _isTvSelected(int slot) => _isTelevision && _tvFieldIndex == slot;
-
   @override
   void dispose() {
-    _tvNav?.dispose();
+    GamepadNavigationManager.popLayer('auth_form');
+    _gamepadNav?.dispose();
+    detachFocusSelectionListeners();
     _usernameFocus.dispose();
     _emailFocus.dispose();
     _passwordFocus.dispose();
@@ -434,7 +443,7 @@ class AuthFormState extends State<AuthForm> {
       _message = AppLocale.emailNotVerified.getString(context);
       _showEmailVerification = true;
       _showVerification = false;
-      _tvFieldIndex = 0;
+      resetSelectionInPlace();
     });
   }
 
@@ -443,7 +452,7 @@ class AuthFormState extends State<AuthForm> {
       _message = AppLocale.registrationSuccessCheckEmail.getString(context);
       _showEmailVerification = true;
       _showVerification = false;
-      _tvFieldIndex = 0;
+      resetSelectionInPlace();
     });
     _startEmailVerificationPolling();
   }
@@ -477,9 +486,8 @@ class AuthFormState extends State<AuthForm> {
         setState(() {
           _showForgotPassword = false;
           _showResetPassword = true;
-          _tvFieldIndex = 0;
+          resetSelectionInPlace();
         });
-        _resetTvIndex();
       }
     } catch (e) {
       setState(() {
@@ -532,9 +540,8 @@ class AuthFormState extends State<AuthForm> {
             _message = AppLocale.passwordResetSuccess.getString(context);
             _resetTokenController.clear();
             _newPasswordController.clear();
-            _tvFieldIndex = 0;
+            resetSelectionInPlace();
           });
-          _resetTvIndex();
         });
       }
     } catch (e) {
@@ -623,7 +630,7 @@ class AuthFormState extends State<AuthForm> {
                       AppLocale.verificationToken.getString(context),
                       AppLocale.enterTokenFromEmail.getString(context),
                       Symbols.mark_email_read_rounded,
-                      isTvHighlighted: _isTvSelected(0),
+                      isHighlighted: isSelected(0),
                     ),
                     validator: (value) {
                       if (value == null || value.isEmpty) {
@@ -644,7 +651,7 @@ class AuthFormState extends State<AuthForm> {
               ],
 
               if (!_showEmailVerification)
-                _buildTvActionButton(
+                _buildActionButton(
                   context: context,
                   slot: 1,
                   onPressed: _isLoading ? null : _verifyEmail,
@@ -652,15 +659,15 @@ class AuthFormState extends State<AuthForm> {
                 ),
               SizedBox(height: 8.r),
 
-              // Email verification buttons with TV highlight
-              _buildTvTextButton(
+              // Email verification buttons
+              _buildSecondaryButton(
                 context: context,
                 slot: _showEmailVerification ? 0 : -1,
                 onPressed: _isLoading ? null : _resendVerification,
                 label: AppLocale.resendVerificationEmail.getString(context),
                 fontSize: 10.r,
               ),
-              _buildTvTextButton(
+              _buildSecondaryButton(
                 context: context,
                 slot: _showEmailVerification ? 1 : -1,
                 onPressed: () => _goBackToLogin(),
@@ -685,7 +692,7 @@ class AuthFormState extends State<AuthForm> {
                         AppLocale.username.getString(context),
                         AppLocale.chooseUsername.getString(context),
                         Symbols.person_outline_rounded,
-                        isTvHighlighted: _isTvSelected(0),
+                        isHighlighted: isSelected(0),
                       ),
                       validator: (value) {
                         if (value == null || value.isEmpty) {
@@ -715,7 +722,7 @@ class AuthFormState extends State<AuthForm> {
                       AppLocale.email.getString(context),
                       'you@example.com',
                       Symbols.email_rounded,
-                      isTvHighlighted: _isTvSelected(_isLogin ? 0 : 1),
+                      isHighlighted: isSelected(_isLogin ? 0 : 1),
                     ),
                     validator: (value) {
                       if (value == null || value.isEmpty) {
@@ -749,7 +756,7 @@ class AuthFormState extends State<AuthForm> {
                           AppLocale.password.getString(context),
                           AppLocale.enterPassword.getString(context),
                           Symbols.lock_outline_rounded,
-                          isTvHighlighted: _isTvSelected(_isLogin ? 1 : 2),
+                          isHighlighted: isSelected(_isLogin ? 1 : 2),
                         ).copyWith(
                           suffixIcon: IconButton(
                             icon: Icon(
@@ -787,7 +794,7 @@ class AuthFormState extends State<AuthForm> {
                 SizedBox(height: 8.r),
               ],
 
-              _buildTvActionButton(
+              _buildActionButton(
                 context: context,
                 slot: _isLogin ? 2 : 3,
                 onPressed: _isLoading ? null : _submitForm,
@@ -810,9 +817,8 @@ class AuthFormState extends State<AuthForm> {
                     setState(() {
                       _isLogin = !_isLogin;
                       _message = null;
-                      _tvFieldIndex = 0;
+                      resetSelectionInPlace();
                     });
-                    _resetTvIndex();
                   },
                   child: Text(
                     _isLogin
@@ -834,9 +840,8 @@ class AuthFormState extends State<AuthForm> {
                       setState(() {
                         _showForgotPassword = true;
                         _message = null;
-                        _tvFieldIndex = 0;
+                        resetSelectionInPlace();
                       });
-                      _resetTvIndex();
                     },
                     child: Text(
                       AppLocale.forgotPasswordQuestion.getString(context),
@@ -867,9 +872,9 @@ class AuthFormState extends State<AuthForm> {
     );
   }
 
-  // Wraps a field with a TV selection highlight border
+  // Wraps a field with the gamepad selection highlight border
   Widget _buildFieldHighlight({required int slot, required Widget child}) {
-    if (!_isTelevision || !_isTvSelected(slot)) return child;
+    if (!isSelected(slot)) return child;
     final theme = Theme.of(context);
     return Container(
       decoration: BoxDecoration(
@@ -886,17 +891,17 @@ class AuthFormState extends State<AuthForm> {
     );
   }
 
-  // TV-aware ElevatedButton for submit actions
-  Widget _buildTvActionButton({
+  // Submit button carrying the gamepad selection glow
+  Widget _buildActionButton({
     required BuildContext context,
     required int slot,
     required VoidCallback? onPressed,
     required String label,
   }) {
     final theme = Theme.of(context);
-    final isSelected = _isTvSelected(slot);
+    final selected = isSelected(slot);
     return Container(
-      decoration: isSelected
+      decoration: selected
           ? BoxDecoration(
               borderRadius: BorderRadius.circular(8.r),
               boxShadow: [
@@ -941,8 +946,8 @@ class AuthFormState extends State<AuthForm> {
     );
   }
 
-  // TV-aware TextButton for secondary actions (slot=-1 means no TV highlight)
-  Widget _buildTvTextButton({
+  // Secondary action button; slot = -1 means it is not gamepad-selectable
+  Widget _buildSecondaryButton({
     required BuildContext context,
     required int slot,
     required VoidCallback? onPressed,
@@ -950,9 +955,9 @@ class AuthFormState extends State<AuthForm> {
     required double fontSize,
   }) {
     final theme = Theme.of(context);
-    final isSelected = slot >= 0 && _isTvSelected(slot);
+    final selected = slot >= 0 && isSelected(slot);
     return Container(
-      decoration: isSelected
+      decoration: selected
           ? BoxDecoration(
               borderRadius: BorderRadius.circular(6.r),
               border: Border.all(
@@ -990,7 +995,7 @@ class AuthFormState extends State<AuthForm> {
     String label,
     String hint,
     IconData icon, {
-    bool isTvHighlighted = false,
+    bool isHighlighted = false,
   }) {
     final theme = Theme.of(context);
     return InputDecoration(
@@ -1019,10 +1024,10 @@ class AuthFormState extends State<AuthForm> {
       enabledBorder: OutlineInputBorder(
         borderRadius: BorderRadius.circular(8.r),
         borderSide: BorderSide(
-          color: isTvHighlighted
+          color: isHighlighted
               ? theme.colorScheme.primary
               : theme.colorScheme.primary.withValues(alpha: 0.1),
-          width: isTvHighlighted ? 2.r : 1.r,
+          width: isHighlighted ? 2.r : 1.r,
         ),
       ),
       focusedBorder: OutlineInputBorder(
@@ -1048,7 +1053,7 @@ class AuthFormState extends State<AuthForm> {
               AppLocale.email.getString(context),
               AppLocale.enterRegisteredEmail.getString(context),
               Symbols.email_rounded,
-              isTvHighlighted: _isTvSelected(0),
+              isHighlighted: isSelected(0),
             ),
             validator: (value) {
               if (value == null || value.isEmpty) {
@@ -1063,7 +1068,7 @@ class AuthFormState extends State<AuthForm> {
           _buildMessageBox(context),
           SizedBox(height: 12.r),
         ],
-        _buildTvActionButton(
+        _buildActionButton(
           context: context,
           slot: 1,
           onPressed: _isLoading ? null : _sendForgotPasswordEmail,
@@ -1090,7 +1095,7 @@ class AuthFormState extends State<AuthForm> {
               AppLocale.resetTokenLabel.getString(context),
               AppLocale.enterTokenFromEmail.getString(context),
               Symbols.vpn_key_rounded,
-              isTvHighlighted: _isTvSelected(0),
+              isHighlighted: isSelected(0),
             ),
           ),
         ),
@@ -1110,7 +1115,7 @@ class AuthFormState extends State<AuthForm> {
                   AppLocale.newPassword.getString(context),
                   AppLocale.atLeast8Characters.getString(context),
                   Symbols.lock_outline_rounded,
-                  isTvHighlighted: _isTvSelected(1),
+                  isHighlighted: isSelected(1),
                 ).copyWith(
                   suffixIcon: IconButton(
                     icon: Icon(
@@ -1134,7 +1139,7 @@ class AuthFormState extends State<AuthForm> {
           _buildMessageBox(context),
           SizedBox(height: 12.r),
         ],
-        _buildTvActionButton(
+        _buildActionButton(
           context: context,
           slot: 2,
           onPressed: _isLoading ? null : _resetPassword,

--- a/lib/widgets/auth_form.dart
+++ b/lib/widgets/auth_form.dart
@@ -61,14 +61,20 @@ class AuthFormState extends State<AuthForm> with LoginFormSelection<AuthForm> {
   /// A null entry is an action button rather than something to focus.
   @override
   List<FocusNode?> get selectionSlots {
-    if (_showResetPassword) return [_resetTokenFocus, _newPasswordFocus, null];
-    if (_showForgotPassword) return [_emailFocus, null];
+    if (_showResetPassword) {
+      return [_resetTokenFocus, _newPasswordFocus, null, null]; // reset + back
+    }
+    if (_showForgotPassword) return [_emailFocus, null, null]; // send + back
     if (_showVerification && !_showEmailVerification) {
       return [_verificationTokenFocus, null];
     }
     if (_showEmailVerification) return [null, null]; // resend + back
-    if (_isLogin) return [_emailFocus, _passwordFocus, null];
-    return [_usernameFocus, _emailFocus, _passwordFocus, null];
+    if (_isLogin) {
+      // login + "sign up" + "forgot password"
+      return [_emailFocus, _passwordFocus, null, null, null];
+    }
+    // sign up + "already have an account"
+    return [_usernameFocus, _emailFocus, _passwordFocus, null, null];
   }
 
   /// Every node the form owns, not just the ones the current mode shows, so
@@ -138,18 +144,46 @@ class AuthFormState extends State<AuthForm> with LoginFormSelection<AuthForm> {
       return;
     }
     if (_showResetPassword) {
-      _resetPassword();
+      isSelected(3) ? _goBackToLogin() : _resetPassword();
       return;
     }
     if (_showForgotPassword) {
-      _sendForgotPasswordEmail();
+      isSelected(2) ? _goBackToLogin() : _sendForgotPasswordEmail();
       return;
     }
     if (_showVerification) {
       _verifyEmail();
       return;
     }
+    // The mode-switch link trails the submit button, so it sits one slot later
+    // in register, which carries a username field the login form doesn't.
+    if (isSelected(_isLogin ? 3 : 4)) {
+      _toggleMode();
+      return;
+    }
+    if (_isLogin && isSelected(4)) {
+      _openForgotPassword();
+      return;
+    }
     _submitForm();
+  }
+
+  /// Tapping a link and pressing A on it both land here, so the two paths
+  /// can't drift on what a mode switch resets.
+  void _toggleMode() {
+    setState(() {
+      _isLogin = !_isLogin;
+      _message = null;
+      resetSelectionInPlace();
+    });
+  }
+
+  void _openForgotPassword() {
+    setState(() {
+      _showForgotPassword = true;
+      _message = null;
+      resetSelectionInPlace();
+    });
   }
 
   /// B leaves a focused field first — that is what it does everywhere else in
@@ -812,57 +846,39 @@ class AuthFormState extends State<AuthForm> with LoginFormSelection<AuthForm> {
                 !_showEmailVerification) ...[
               SizedBox(
                 height: 24.r,
-                child: TextButton(
-                  onPressed: () {
-                    setState(() {
-                      _isLogin = !_isLogin;
-                      _message = null;
-                      resetSelectionInPlace();
-                    });
-                  },
-                  child: Text(
-                    _isLogin
-                        ? AppLocale.dontHaveAccount.getString(context)
-                        : AppLocale.alreadyHaveAccount.getString(context),
-                    style: TextStyle(
-                      fontSize: 8.r,
-                      color: theme.colorScheme.secondary.withValues(alpha: 0.9),
-                    ),
-                  ),
+                child: _buildSecondaryButton(
+                  context: context,
+                  slot: _isLogin ? 3 : 4,
+                  onPressed: _toggleMode,
+                  label: _isLogin
+                      ? AppLocale.dontHaveAccount.getString(context)
+                      : AppLocale.alreadyHaveAccount.getString(context),
+                  fontSize: 8.r,
+                  color: theme.colorScheme.secondary.withValues(alpha: 0.9),
                 ),
               ),
               SizedBox(height: 6.r),
               if (_isLogin)
                 SizedBox(
                   height: 24.r,
-                  child: TextButton(
-                    onPressed: () {
-                      setState(() {
-                        _showForgotPassword = true;
-                        _message = null;
-                        resetSelectionInPlace();
-                      });
-                    },
-                    child: Text(
-                      AppLocale.forgotPasswordQuestion.getString(context),
-                      style: TextStyle(
-                        fontSize: 8.r,
-                        color: theme.colorScheme.secondary.withValues(
-                          alpha: 0.9,
-                        ),
-                      ),
-                    ),
+                  child: _buildSecondaryButton(
+                    context: context,
+                    slot: 4,
+                    onPressed: _openForgotPassword,
+                    label: AppLocale.forgotPasswordQuestion.getString(context),
+                    fontSize: 8.r,
+                    color: theme.colorScheme.secondary.withValues(alpha: 0.9),
                   ),
                 ),
             ] else if (_showForgotPassword || _showResetPassword) ...[
               SizedBox(
                 height: 24.r,
-                child: TextButton(
-                  onPressed: () => _goBackToLogin(),
-                  child: Text(
-                    AppLocale.backToLogin.getString(context),
-                    style: TextStyle(fontSize: 8.r),
-                  ),
+                child: _buildSecondaryButton(
+                  context: context,
+                  slot: _showForgotPassword ? 2 : 3,
+                  onPressed: _goBackToLogin,
+                  label: AppLocale.backToLogin.getString(context),
+                  fontSize: 8.r,
                 ),
               ),
             ],
@@ -953,6 +969,7 @@ class AuthFormState extends State<AuthForm> with LoginFormSelection<AuthForm> {
     required VoidCallback? onPressed,
     required String label,
     required double fontSize,
+    Color? color,
   }) {
     final theme = Theme.of(context);
     final selected = slot >= 0 && isSelected(slot);
@@ -968,7 +985,10 @@ class AuthFormState extends State<AuthForm> with LoginFormSelection<AuthForm> {
           : null,
       child: TextButton(
         onPressed: onPressed,
-        child: Text(label, style: TextStyle(fontSize: fontSize)),
+        child: Text(
+          label,
+          style: TextStyle(fontSize: fontSize, color: color),
+        ),
       ),
     );
   }
@@ -1139,19 +1159,13 @@ class AuthFormState extends State<AuthForm> with LoginFormSelection<AuthForm> {
           _buildMessageBox(context),
           SizedBox(height: 12.r),
         ],
+        // No back link here: the shared one below the form covers both this
+        // mode and the forgot-password one, and two of them rendered at once.
         _buildActionButton(
           context: context,
           slot: 2,
           onPressed: _isLoading ? null : _resetPassword,
           label: AppLocale.resetPassword.getString(context),
-        ),
-        SizedBox(height: 6.r),
-        TextButton(
-          onPressed: () => _goBackToLogin(),
-          child: Text(
-            AppLocale.backToLogin.getString(context),
-            style: TextStyle(fontSize: 10.r),
-          ),
         ),
       ],
     );

--- a/test/login_form_selection_test.dart
+++ b/test/login_form_selection_test.dart
@@ -45,8 +45,10 @@ class _TestFormState extends State<_TestForm>
 }
 
 /// Form whose slot list changes with its mode, the shape the NeoSync login has:
-/// register carries a username the login state doesn't, and the verification
-/// step is a pair of buttons with no field at all.
+/// register carries a username the login state doesn't, the verification step
+/// is a pair of buttons with no field at all, and both entry modes end in a run
+/// of controls — submit followed by the links that switch mode or start a
+/// password reset.
 class _ModalForm extends StatefulWidget {
   const _ModalForm();
 
@@ -66,8 +68,10 @@ class _ModalFormState extends State<_ModalForm>
 
   @override
   List<FocusNode?> get selectionSlots => switch (mode) {
-    _Mode.login => [emailFocus, passwordFocus, null],
-    _Mode.register => [usernameFocus, emailFocus, passwordFocus, null],
+    // login + "sign up" + "forgot password"
+    _Mode.login => [emailFocus, passwordFocus, null, null, null],
+    // sign up + "already have an account"
+    _Mode.register => [usernameFocus, emailFocus, passwordFocus, null, null],
     _Mode.verify => [null, null],
   };
 
@@ -236,9 +240,9 @@ void main() {
     state.moveSelection(-1);
     await tester.pump();
     expect(state.selectedSlot, state.submitSlot);
-    expect(state.selectedSlot, 3);
+    expect(state.selectedSlot, 4);
 
-    // Verification drops to two button slots, stranding the index at 3.
+    // Verification drops to two button slots, stranding the index at 4.
     state.switchTo(_Mode.verify);
     await tester.pump();
 
@@ -260,6 +264,25 @@ void main() {
     await tester.pump();
     state.moveSelection(-1);
     await tester.pump();
+
+    expect(state.selectedFocusNode, isNull);
+    expect(state.focusSelectedField(), isFalse);
+  });
+
+  testWidgets('every control after the submit button is still reachable', (
+    tester,
+  ) async {
+    final state = await _pumpModalForm(tester);
+
+    // Login ends in three controls — submit, then the sign-up and
+    // forgot-password links — and the D-pad has to walk all of them rather
+    // than stopping at the button in the middle.
+    expect(state.slotCount, 5);
+    for (final slot in [1, 2, 3, 4]) {
+      expect(state.moveSelection(1), isTrue);
+      await tester.pump();
+      expect(state.selectedSlot, slot);
+    }
 
     expect(state.selectedFocusNode, isNull);
     expect(state.focusSelectedField(), isFalse);


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). Reviewed and tested on hardware by me before opening.

# Description

The third login form, left behind when #255 fixed the RetroAchievements and ScreenScraper ones.

**`PermissionService.isTelevision()` is false on a handheld**, so `_tvNav` was never constructed and none of the email, password, username, verification-token or reset-token fields — nor the submit button — could be reached without touch or a mouse. Verified on an AYN Thor with its Odin controller. The gate is gone; the form is the only thing on screen whenever it is shown, so the D-pad has to drive it everywhere.

**It also never registered with `GamepadNavigationManager`**, calling `_tvNav!.activate()` directly while `NeoSyncContent` pushes a layer of its own around it. Nothing ever deactivated it, so lifting the gate alone would have put two handlers on the same D-pad event — the double-dispatch bug #255 fixed in `app_screen`, reproduced one layer down. It pushes an `'auth_form'` layer now, deferred a frame so it lands on top of the one `NeoSyncContent` pushes in its own post-frame callback, and pops it on dispose so NeoSync takes focus back on login.

**The slot list is dynamic**, which is what kept this from being a copy of the other two: register carries a username login doesn't, verification is a pair of buttons with no field, and the reset flow swaps in its own two. That is the shape `LoginFormSelection` (from #272) describes, so the form supplies the current list and the mixin resolves focus against it live and clamps the cursor on read — a switch to a shorter mode can no longer strand it past the end. The seven hand-written index resets become `resetSelectionInPlace()`.

**The sign-up and reset links were tap-only.** The slot list stopped at the submit button, so with a controller you could log in and nothing else — registration and password reset had no gamepad path at all, which is the same reachability gap this issue is about. Both links are slots now, trailing the submit button, rendered through `_buildSecondaryButton` so a selected one takes the same border the verification screen's buttons already used. The back link in the forgot and reset flows is selectable for the same reason; B still leaves those modes, but the way out shouldn't be an invisible convention. Tapping a link and pressing A on it run the same `_toggleMode` / `_openForgotPassword`, rather than the setState being spelled out at the tap site only.

Smaller things in passing:

- B now leaves a focused field before it steps back to the login form, matching the rest of the app; before, it always jumped straight back and the soft keyboard stayed up.
- Holding a direction no longer spins the repeat timer, and the bumpers change tabs the way they do on the other two forms.
- The reset flow rendered two "Back to login" buttons, its own and the shared one below the form. The form's copy is gone.
- Nothing here is TV-specific any more, so `_isTvSelected`, `_buildTvActionButton`, `_buildTvTextButton` and the `isTvHighlighted` parameter lose the prefix.

Fixes #263

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

`test/login_form_selection_test.dart` gains coverage for the dynamic-slot cases this form introduces: a shorter mode clamping a cursor that would otherwise strand past the end, a mode switch wrapping over the new slot count, and every control after the submit button staying reachable. Tested on an AYN Thor with its Odin controller, including at simulated RG DS geometry (640x480 4:3) to confirm the run of controls below the submit button still fits on a small 4:3 panel.

## Screenshots (if applicable)

n/a
