### PR TITLE
fix(linux): find Flatpak and EmuDeck emulators instead of failing to launch

### DIFF
--- a/assets/systems/2600.json
+++ b/assets/systems/2600.json
@@ -49,6 +49,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L stella_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -181,6 +183,7 @@
         },
         "linux": {
           "executable": "stella",
+          "flatpak": "io.github.stella_emu.Stella",
           "args": "{file.path}"
         },
         "macos": {

--- a/assets/systems/32x.json
+++ b/assets/systems/32x.json
@@ -63,6 +63,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/3do.json
+++ b/assets/systems/3do.json
@@ -49,6 +49,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L opera_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/3ds.json
+++ b/assets/systems/3ds.json
@@ -52,6 +52,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L citra_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -75,6 +77,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L citra2018_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -98,6 +102,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L citra_canary_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -189,6 +195,8 @@
         },
         "linux": {
           "executable": "azahar.AppImage",
+          "flatpak": "org.azahar_emu.Azahar",
+          "emudeck_launcher": "azahar.sh",
           "args": "\"{file.path}\""
         },
         "macos": {

--- a/assets/systems/5200.json
+++ b/assets/systems/5200.json
@@ -103,6 +103,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L atari800_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -127,6 +129,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L a5200_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/7800.json
+++ b/assets/systems/7800.json
@@ -49,6 +49,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L prosystem_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/a2.json
+++ b/assets/systems/a2.json
@@ -60,6 +60,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L applewin_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -83,6 +85,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mamemess_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -107,6 +111,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L applewin_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -142,6 +148,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L applewin_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/a2001.json
+++ b/assets/systems/a2001.json
@@ -48,6 +48,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mamemess_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/amiga.json
+++ b/assets/systems/amiga.json
@@ -118,6 +118,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L puae_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -141,6 +143,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L puae2021_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/arc.json
+++ b/assets/systems/arc.json
@@ -47,6 +47,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -70,6 +72,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbalpha2012_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -139,6 +143,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mamearcade_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -162,6 +168,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mame2003_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -185,6 +193,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mame2003_midway_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -208,6 +218,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mame2003_plus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -231,6 +243,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mame2000_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -254,6 +268,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mame2010_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/ard.json
+++ b/assets/systems/ard.json
@@ -43,6 +43,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L arduous_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -67,6 +69,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L ardens_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/ast.json
+++ b/assets/systems/ast.json
@@ -76,6 +76,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L hatari_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/aw.json
+++ b/assets/systems/aw.json
@@ -106,6 +106,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L flycast_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/bbcmicro.json
+++ b/assets/systems/bbcmicro.json
@@ -69,6 +69,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L b2_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/c64.json
+++ b/assets/systems/c64.json
@@ -145,6 +145,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vice_x64sc_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -169,6 +171,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vice_x64_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -192,6 +196,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L frodo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/cdi.json
+++ b/assets/systems/cdi.json
@@ -72,6 +72,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L same_cdi_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/chf.json
+++ b/assets/systems/chf.json
@@ -73,6 +73,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L freechaf_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/cpc.json
+++ b/assets/systems/cpc.json
@@ -101,6 +101,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L crocods_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -125,6 +127,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L cap32_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/cps1.json
+++ b/assets/systems/cps1.json
@@ -120,6 +120,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -143,6 +145,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbalpha2012_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -166,6 +170,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbalpha2012_cps1_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/cps2.json
+++ b/assets/systems/cps2.json
@@ -117,6 +117,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -140,6 +142,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbalpha2012_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -163,6 +167,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbalpha2012_cps2_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/cps3.json
+++ b/assets/systems/cps3.json
@@ -117,6 +117,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -140,6 +142,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbalpha2012_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -163,6 +167,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbalpha2012_cps3_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/cv.json
+++ b/assets/systems/cv.json
@@ -104,6 +104,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bluemsx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -127,6 +129,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gearcoleco_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -162,6 +166,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/dc.json
+++ b/assets/systems/dc.json
@@ -111,6 +111,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L flycast_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/dos.json
+++ b/assets/systems/dos.json
@@ -127,6 +127,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L dosbox_pure_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -150,6 +152,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L dosbox_svn_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -173,6 +177,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L dosbox_core_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/ds.json
+++ b/assets/systems/ds.json
@@ -48,6 +48,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L melonds_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -71,6 +73,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L melondsds_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -94,6 +98,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L desmume_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -186,6 +192,8 @@
         },
         "linux": {
           "executable": "melonds.AppImage",
+          "flatpak": "net.kuribo64.melonDS",
+          "emudeck_launcher": "melonds.sh",
           "args": "\"{file.path}\""
         },
         "macos": {

--- a/assets/systems/duck.json
+++ b/assets/systems/duck.json
@@ -70,6 +70,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L sameduck_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/fbneo.json
+++ b/assets/systems/fbneo.json
@@ -53,6 +53,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -76,6 +78,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbalpha2012_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/fc.json
+++ b/assets/systems/fc.json
@@ -184,6 +184,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L nestopia_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -208,6 +210,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fceumm_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -231,6 +235,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -254,6 +260,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L quicknes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -277,6 +285,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bnes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -300,6 +310,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/fds.json
+++ b/assets/systems/fds.json
@@ -149,6 +149,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L nestopia_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -173,6 +175,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fceumm_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -196,6 +200,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/gb-hacks.json
+++ b/assets/systems/gb-hacks.json
@@ -298,6 +298,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gambatte_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -321,6 +323,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gearboy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -344,6 +348,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L sameboy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -367,6 +373,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L tgbdual_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -390,6 +398,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L DoubleCherryGB_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -413,6 +423,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen-s_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -436,6 +448,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vbam_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -459,6 +473,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mgba_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/gb.json
+++ b/assets/systems/gb.json
@@ -299,6 +299,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gambatte_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -322,6 +324,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gearboy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -345,6 +349,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L sameboy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -368,6 +374,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L tgbdual_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -391,6 +399,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L DoubleCherryGB_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -414,6 +424,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen-s_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -437,6 +449,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vbam_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -460,6 +474,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mgba_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -505,6 +521,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/gba-hacks.json
+++ b/assets/systems/gba-hacks.json
@@ -265,6 +265,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vba_next_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -288,6 +290,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vbam_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -312,6 +316,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mgba_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -335,6 +341,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_gba_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -358,6 +366,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gpsp_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -381,6 +391,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L meteor_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/gba.json
+++ b/assets/systems/gba.json
@@ -264,6 +264,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vba_next_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -287,6 +289,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vbam_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -311,6 +315,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mgba_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -334,6 +340,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_gba_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -357,6 +365,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gpsp_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -380,6 +390,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L meteor_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/gbc-hacks.json
+++ b/assets/systems/gbc-hacks.json
@@ -309,6 +309,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gambatte_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -332,6 +334,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gearboy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -355,6 +359,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L sameboy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -378,6 +384,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L tgbdual_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -401,6 +409,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L DoubleCherryGB_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -424,6 +434,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen-s_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -447,6 +459,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vbam_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -470,6 +484,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mgba_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/gbc.json
+++ b/assets/systems/gbc.json
@@ -308,6 +308,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gambatte_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -331,6 +333,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gearboy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -354,6 +358,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L sameboy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -377,6 +383,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L tgbdual_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -400,6 +408,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L DoubleCherryGB_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -423,6 +433,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen-s_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -446,6 +458,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vbam_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -469,6 +483,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mgba_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -514,6 +530,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/gc.json
+++ b/assets/systems/gc.json
@@ -96,15 +96,17 @@
         },
         "windows": {
           "executable": "dolphin.exe",
-          "launch_arguments": "-e \"{file.path}\""
+          "args": "-e \"{file.path}\""
         },
         "linux": {
           "executable": "dolphin",
-          "launch_arguments": "-e \"{file.path}\""
+          "flatpak": "org.DolphinEmu.dolphin-emu",
+          "emudeck_launcher": "dolphin-emu.sh",
+          "args": "-e \"{file.path}\""
         },
         "macos": {
           "executable": "dolphin",
-          "launch_arguments": "-e \"{file.path}\""
+          "args": "-e \"{file.path}\""
         }
       }
     },
@@ -147,6 +149,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L dolphin_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/genesis-hacks.json
+++ b/assets/systems/genesis-hacks.json
@@ -164,6 +164,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -187,6 +189,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -210,6 +214,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -233,6 +239,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/genesis.json
+++ b/assets/systems/genesis.json
@@ -162,6 +162,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -185,6 +187,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -208,6 +212,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -231,6 +237,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/gg-hacks.json
+++ b/assets/systems/gg-hacks.json
@@ -209,6 +209,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -232,6 +234,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -255,6 +259,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L smsplus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -278,6 +284,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -301,6 +309,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gearsystem_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -324,6 +334,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/gg.json
+++ b/assets/systems/gg.json
@@ -208,6 +208,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -231,6 +233,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -254,6 +258,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L smsplus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -277,6 +283,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -300,6 +308,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gearsystem_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -323,6 +333,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/gw.json
+++ b/assets/systems/gw.json
@@ -82,6 +82,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gw_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -105,6 +107,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mamemess_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/intv.json
+++ b/assets/systems/intv.json
@@ -72,6 +72,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L freeintv_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/jag.json
+++ b/assets/systems/jag.json
@@ -60,6 +60,7 @@
         },
         "linux": {
           "executable": "bigpemu",
+          "emudeck_launcher": "bigpemu.sh",
           "args": "\"{file.path}\""
         }
       }
@@ -104,6 +105,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L virtualjaguar_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/jagcd.json
+++ b/assets/systems/jagcd.json
@@ -43,6 +43,7 @@
         },
         "linux": {
           "executable": "bigpemu",
+          "emudeck_launcher": "bigpemu.sh",
           "args": "\"{file.path}\""
         }
       }

--- a/assets/systems/lynx.json
+++ b/assets/systems/lynx.json
@@ -125,6 +125,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_lynx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -149,6 +151,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L handy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -172,6 +176,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L holani_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/mame.json
+++ b/assets/systems/mame.json
@@ -202,6 +202,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mame2003_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -225,6 +227,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mame2003_midway_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -248,6 +252,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mame2003_plus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -272,6 +278,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mamearcade_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -295,6 +303,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mame2000_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -318,6 +328,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mame2010_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/mark3.json
+++ b/assets/systems/mark3.json
@@ -195,6 +195,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -218,6 +220,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -241,6 +245,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L smsplus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -264,6 +270,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -287,6 +295,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gearsystem_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -310,6 +320,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/mcd.json
+++ b/assets/systems/mcd.json
@@ -142,6 +142,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -165,6 +167,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -188,6 +192,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/md-hacks.json
+++ b/assets/systems/md-hacks.json
@@ -167,6 +167,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -190,6 +192,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -213,6 +217,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -236,6 +242,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/md.json
+++ b/assets/systems/md.json
@@ -166,6 +166,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -189,6 +191,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -212,6 +216,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -235,6 +241,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/mini.json
+++ b/assets/systems/mini.json
@@ -72,6 +72,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L pokemini_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/mo2.json
+++ b/assets/systems/mo2.json
@@ -72,6 +72,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L o2em_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/msx.json
+++ b/assets/systems/msx.json
@@ -115,6 +115,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fmsx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -139,6 +141,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bluemsx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -162,6 +166,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/n64.json
+++ b/assets/systems/n64.json
@@ -160,6 +160,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mupen64plus_next_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -206,6 +208,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L parallel_n64_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/naomi.json
+++ b/assets/systems/naomi.json
@@ -83,6 +83,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L flycast_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/naomi2.json
+++ b/assets/systems/naomi2.json
@@ -83,6 +83,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L flycast_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/naomigd.json
+++ b/assets/systems/naomigd.json
@@ -83,6 +83,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L flycast_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/neogeo.json
+++ b/assets/systems/neogeo.json
@@ -149,6 +149,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -172,6 +174,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbalpha2012_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -195,6 +199,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbalpha2012_neogeo_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -218,6 +224,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L geolith_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/nes-hacks.json
+++ b/assets/systems/nes-hacks.json
@@ -187,6 +187,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L nestopia_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -211,6 +213,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fceumm_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -234,6 +238,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -257,6 +263,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L quicknes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -280,6 +288,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bnes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -303,6 +313,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/nes.json
+++ b/assets/systems/nes.json
@@ -186,6 +186,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L nestopia_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -210,6 +212,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fceumm_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -233,6 +237,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -256,6 +262,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L quicknes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -279,6 +287,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bnes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -302,6 +312,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/ngcd.json
+++ b/assets/systems/ngcd.json
@@ -71,6 +71,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L neocd_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -94,6 +96,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/ngp.json
+++ b/assets/systems/ngp.json
@@ -107,6 +107,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_ngp_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -130,6 +132,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L race_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -153,6 +157,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/ngpc.json
+++ b/assets/systems/ngpc.json
@@ -107,6 +107,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_ngp_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -130,6 +132,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L race_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -153,6 +157,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/pc88.json
+++ b/assets/systems/pc88.json
@@ -50,6 +50,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L quasi88_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/pccd.json
+++ b/assets/systems/pccd.json
@@ -133,6 +133,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_supergrafx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -156,6 +158,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_pce_fast_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -179,6 +183,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_pce_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/pce.json
+++ b/assets/systems/pce.json
@@ -132,6 +132,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_supergrafx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -155,6 +157,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_pce_fast_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -178,6 +182,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_pce_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -201,6 +207,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/pcfx.json
+++ b/assets/systems/pcfx.json
@@ -72,6 +72,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_pcfx_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/pet.json
+++ b/assets/systems/pet.json
@@ -91,6 +91,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vice_xpet_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/pico.json
+++ b/assets/systems/pico.json
@@ -70,6 +70,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/ps1.json
+++ b/assets/systems/ps1.json
@@ -59,6 +59,8 @@
         },
         "linux": {
           "executable": "duckstation",
+          "flatpak": "org.duckstation.DuckStation",
+          "emudeck_launcher": "duckstation.sh",
           "args": "-batch {file.path}"
         },
         "macos": {
@@ -240,6 +242,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_psx_hw_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -263,6 +267,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_psx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -286,6 +292,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L duckstation_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -309,6 +317,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L pcsx_rearmed_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -332,6 +342,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L swanstation_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/ps2.json
+++ b/assets/systems/ps2.json
@@ -85,6 +85,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L pcsx2_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -105,6 +107,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L pcsx2_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -125,6 +129,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L pcsx2_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -145,6 +151,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L pcsx2_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -165,6 +173,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L pcsx2_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -185,6 +195,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L pcsx2_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -294,6 +306,8 @@
         },
         "linux": {
           "executable": "pcsx2",
+          "flatpak": "net.pcsx2.PCSX2",
+          "emudeck_launcher": "pcsx2-qt.sh",
           "args": "{file.path}"
         },
         "macos": {

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -52,6 +52,8 @@
         },
         "linux": {
           "executable": "rpcs3",
+          "flatpak": "net.rpcs3.RPCS3",
+          "emudeck_launcher": "rpcs3.sh",
           "args": "--no-gui \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/psp.json
+++ b/assets/systems/psp.json
@@ -49,6 +49,8 @@
         },
         "linux": {
           "executable": "ppsspp",
+          "flatpak": "org.ppsspp.PPSSPP",
+          "emudeck_launcher": "ppsspp.sh",
           "args": "-f {file.path}"
         },
         "macos": {
@@ -119,6 +121,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L ppsspp_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/sat.json
+++ b/assets/systems/sat.json
@@ -176,6 +176,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_saturn_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -199,6 +201,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L yabasanshiro_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -222,6 +226,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L yabause_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/satellaview.json
+++ b/assets/systems/satellaview.json
@@ -269,6 +269,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -292,6 +294,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_supafaust_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -315,6 +319,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_snes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -338,6 +344,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2002_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -361,6 +369,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2005_plus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -384,6 +394,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2005_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -407,6 +419,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2010_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -430,6 +444,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -453,6 +469,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen-s_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/scd.json
+++ b/assets/systems/scd.json
@@ -141,6 +141,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -164,6 +166,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -187,6 +191,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/scummvm.json
+++ b/assets/systems/scummvm.json
@@ -89,6 +89,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L scummvm_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/sfc-hacks.json
+++ b/assets/systems/sfc-hacks.json
@@ -490,6 +490,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -513,6 +515,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L higan_sfc_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -536,6 +540,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L higan_sfc_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -559,6 +565,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_supafaust_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -582,6 +590,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_snes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -605,6 +615,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2002_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -628,6 +640,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2005_plus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -651,6 +665,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2005_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -674,6 +690,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2010_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -697,6 +715,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_accuracy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -720,6 +740,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -743,6 +765,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_performance_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -766,6 +790,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_cplusplus98_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -789,6 +815,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -812,6 +840,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_hd_beta_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -835,6 +865,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_accuracy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -858,6 +890,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -881,6 +915,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_performance_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -904,6 +940,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen-s_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -927,6 +965,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/sfc.json
+++ b/assets/systems/sfc.json
@@ -490,6 +490,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -513,6 +515,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L higan_sfc_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -536,6 +540,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L higan_sfc_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -559,6 +565,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_supafaust_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -582,6 +590,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_snes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -605,6 +615,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2002_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -628,6 +640,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2005_plus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -651,6 +665,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2005_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -674,6 +690,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2010_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -697,6 +715,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_accuracy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -720,6 +740,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -743,6 +765,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_performance_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -766,6 +790,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_cplusplus98_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -789,6 +815,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -812,6 +840,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_hd_beta_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -835,6 +865,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_accuracy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -858,6 +890,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -881,6 +915,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_performance_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -904,6 +940,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen-s_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -927,6 +965,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/sg1k.json
+++ b/assets/systems/sg1k.json
@@ -151,6 +151,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -174,6 +176,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -197,6 +201,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gearsystem_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -220,6 +226,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bluemsx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -243,6 +251,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/sharpx68000.json
+++ b/assets/systems/sharpx68000.json
@@ -81,6 +81,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L px68k_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/sms.json
+++ b/assets/systems/sms.json
@@ -198,6 +198,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -221,6 +223,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -244,6 +248,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L smsplus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -267,6 +273,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L picodrive_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -290,6 +298,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L gearsystem_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -313,6 +323,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/snes-hacks.json
+++ b/assets/systems/snes-hacks.json
@@ -493,6 +493,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -516,6 +518,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L higan_sfc_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -539,6 +543,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L higan_sfc_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -562,6 +568,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_supafaust_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -585,6 +593,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_snes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -608,6 +618,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2002_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -631,6 +643,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2005_plus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -654,6 +668,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2005_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -677,6 +693,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2010_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -700,6 +718,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_accuracy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -723,6 +743,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -746,6 +768,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_performance_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -769,6 +793,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_cplusplus98_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -792,6 +818,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -815,6 +843,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_hd_beta_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -838,6 +868,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_accuracy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -861,6 +893,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -884,6 +918,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_performance_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -907,6 +943,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen-s_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -930,6 +968,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/snes.json
+++ b/assets/systems/snes.json
@@ -492,6 +492,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -515,6 +517,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L higan_sfc_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -538,6 +542,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L higan_sfc_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -561,6 +567,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_supafaust_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -584,6 +592,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_snes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -607,6 +617,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2002_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -630,6 +642,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2005_plus_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -653,6 +667,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2005_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -676,6 +692,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L snes9x2010_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -699,6 +717,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_accuracy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -722,6 +742,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -745,6 +767,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes2014_performance_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -768,6 +792,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_cplusplus98_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -791,6 +817,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -814,6 +842,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_hd_beta_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -837,6 +867,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_accuracy_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -860,6 +892,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_balanced_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -883,6 +917,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L bsnes_mercury_performance_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -906,6 +942,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mesen-s_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -929,6 +967,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/switch.json
+++ b/assets/systems/switch.json
@@ -58,6 +58,7 @@
         },
         "linux": {
           "executable": "eden",
+          "emudeck_launcher": "eden.sh",
           "args": "{file.path}"
         }
       }
@@ -129,6 +130,7 @@
         },
         "linux": {
           "executable": "yuzu",
+          "emudeck_launcher": "yuzu.sh",
           "args": "{file.path}"
         }
       }
@@ -181,6 +183,7 @@
         },
         "linux": {
           "executable": "citron",
+          "emudeck_launcher": "citron.sh",
           "args": "{file.path}"
         }
       }

--- a/assets/systems/tg16.json
+++ b/assets/systems/tg16.json
@@ -132,6 +132,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_supergrafx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -155,6 +157,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_pce_fast_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -178,6 +182,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_pce_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -201,6 +207,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/tgcd.json
+++ b/assets/systems/tgcd.json
@@ -131,6 +131,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_supergrafx_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -154,6 +156,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_pce_fast_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -177,6 +181,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_pce_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/tic80.json
+++ b/assets/systems/tic80.json
@@ -68,6 +68,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L tic80_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/uze.json
+++ b/assets/systems/uze.json
@@ -70,6 +70,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L uzem_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/vb.json
+++ b/assets/systems/vb.json
@@ -84,6 +84,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_vb_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/vect.json
+++ b/assets/systems/vect.json
@@ -70,6 +70,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vecx_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/vic20.json
+++ b/assets/systems/vic20.json
@@ -104,6 +104,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L vice_xvic_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/vita.json
+++ b/assets/systems/vita.json
@@ -44,6 +44,7 @@
         },
         "linux": {
           "executable": "vita3k",
+          "emudeck_launcher": "vita3k.sh",
           "args": "--fullscreen -r {tags.vita_game_id}"
         },
         "macos": {

--- a/assets/systems/wasm4.json
+++ b/assets/systems/wasm4.json
@@ -67,6 +67,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L wasm4_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/wii.json
+++ b/assets/systems/wii.json
@@ -94,15 +94,17 @@
         },
         "windows": {
           "executable": "dolphin.exe",
-          "launch_arguments": "-e \"{file.path}\""
+          "args": "-e \"{file.path}\""
         },
         "linux": {
           "executable": "dolphin",
-          "launch_arguments": "-e \"{file.path}\""
+          "flatpak": "org.DolphinEmu.dolphin-emu",
+          "emudeck_launcher": "dolphin-emu.sh",
+          "args": "-e \"{file.path}\""
         },
         "macos": {
           "executable": "dolphin",
-          "launch_arguments": "-e \"{file.path}\""
+          "args": "-e \"{file.path}\""
         }
       }
     },
@@ -145,6 +147,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L dolphin_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/wiiu.json
+++ b/assets/systems/wiiu.json
@@ -49,6 +49,8 @@
         },
         "linux": {
           "executable": "cemu",
+          "flatpak": "info.cemu.Cemu",
+          "emudeck_launcher": "cemu.sh",
           "args": "-g \"{file.path}\" -f"
         },
         "macos": {

--- a/assets/systems/ws.json
+++ b/assets/systems/ws.json
@@ -85,6 +85,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_wswan_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/wsc.json
+++ b/assets/systems/wsc.json
@@ -86,6 +86,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L mednafen_wswan_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/wsv.json
+++ b/assets/systems/wsv.json
@@ -72,6 +72,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L potator_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/x1.json
+++ b/assets/systems/x1.json
@@ -79,6 +79,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L x1_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/xbox360.json
+++ b/assets/systems/xbox360.json
@@ -86,6 +86,7 @@
         },
         "linux": {
           "executable": "Xenia.AppImage",
+          "emudeck_launcher": "xenia.sh",
           "args": "\"{file.path}\""
         }
       }

--- a/assets/systems/zx81.json
+++ b/assets/systems/zx81.json
@@ -71,6 +71,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L 81_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/assets/systems/zxspectrum.json
+++ b/assets/systems/zxspectrum.json
@@ -80,6 +80,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fuse_libretro.so \"{file.path}\""
         },
         "macos": {
@@ -103,6 +105,8 @@
         },
         "linux": {
           "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
           "args": "-L fbneo_libretro.so \"{file.path}\""
         },
         "macos": {

--- a/lib/services/game/emulator_launch_diagnostics.dart
+++ b/lib/services/game/emulator_launch_diagnostics.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:neostation/services/logger_service.dart';
+
+/// Records what a launched emulator was told to do and what it said back, so a
+/// failed launch can explain itself.
+///
+/// Two things conspire to make a Linux launch failure invisible. The launch
+/// path drained the emulator's stdout and stderr into empty callbacks, throwing
+/// away the only account of what went wrong; and on a Steam Deck the exit code
+/// is not the emulator's at all — EmuDeck's launcher scripts run their own
+/// cleanup after the emulator returns, so the script reports *that* command's
+/// status. A RetroArch that rejected its ROM and a RetroArch the user quit both
+/// arrive as "exited with code 0", instantly, with no other trace.
+///
+/// Diagnosing one such report meant reconstructing the command by hand and
+/// re-running it on the device. Everything needed was in the emulator's output,
+/// already being read and discarded.
+class EmulatorLaunchDiagnostics {
+  static final _log = LoggerService.instance;
+
+  /// How many of the emulator's most recent output lines to keep.
+  ///
+  /// The interesting part of a failure is the end — the error and whatever
+  /// context immediately preceded it. Emulators are verbose enough that
+  /// retaining more would push a real log into the noise.
+  static const int maxCapturedLines = 12;
+
+  /// Below this, an exit is treated as a failed launch rather than a session.
+  ///
+  /// Nobody starts a game and quits within a few seconds, whereas every failure
+  /// mode seen so far — a missing libretro core, an incomplete ROM set — gives
+  /// up in about a second.
+  static const Duration suspiciouslyFast = Duration(seconds: 10);
+
+  final String executable;
+  final Stopwatch _elapsed;
+  final List<String> _tail = [];
+
+  EmulatorLaunchDiagnostics(this.executable, {Stopwatch? elapsed})
+    : _elapsed = elapsed ?? (Stopwatch()..start());
+
+  /// Logs the resolved command and starts capturing [process]'s output.
+  ///
+  /// The command is logged in full because it is the thing no one can
+  /// reconstruct afterwards: by this point the executable has been through
+  /// discovery and the arguments through core-absolutisation, so neither
+  /// matches what the systems JSON says.
+  static EmulatorLaunchDiagnostics attach(
+    Process process,
+    String executable,
+    List<String> args,
+  ) {
+    _log.i('Launching: ${formatCommand(executable, args)}');
+    final diagnostics = EmulatorLaunchDiagnostics(executable);
+    diagnostics._capture(process.stdout);
+    diagnostics._capture(process.stderr);
+    return diagnostics;
+  }
+
+  void _capture(Stream<List<int>> stream) {
+    stream
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .transform(const LineSplitter())
+        .listen(addLine, onError: (_) {});
+  }
+
+  /// Retains [line], dropping the oldest once [maxCapturedLines] is reached.
+  void addLine(String line) {
+    final trimmed = line.trim();
+    if (trimmed.isEmpty) return;
+    _tail.add(trimmed);
+    if (_tail.length > maxCapturedLines) _tail.removeAt(0);
+  }
+
+  /// Logs why the launch looks failed, or stays quiet when it looks like a
+  /// normal play session.
+  void reportExit(int exitCode) {
+    final report = describeExit(exitCode, _elapsed.elapsed);
+    if (report != null) _log.w(report);
+  }
+
+  /// Returns the diagnostic for an emulator that exited after [elapsed], or
+  /// `null` when the exit looks like an ordinary end to a play session.
+  String? describeExit(int exitCode, Duration elapsed) {
+    if (elapsed >= suspiciouslyFast) return null;
+
+    final report = StringBuffer()
+      ..writeln(
+        '$executable exited after ${elapsed.inMilliseconds}ms with code '
+        '$exitCode — too fast to be a play session, so the launch most likely '
+        'failed.',
+      )
+      ..writeln(
+        'Treat the code as unreliable: an EmuDeck launcher script runs its own '
+        'cleanup after the emulator, so it reports that cleanup\'s status '
+        'rather than the emulator\'s.',
+      );
+
+    if (_tail.isEmpty) {
+      report.write('The emulator wrote nothing before exiting.');
+    } else {
+      report.writeln('Last ${_tail.length} line(s) from the emulator:');
+      report.write(_tail.map((line) => '  $line').join('\n'));
+    }
+    return report.toString();
+  }
+
+  /// Renders a command in a form that can be pasted into a shell.
+  ///
+  /// ROM paths routinely contain spaces, and an unquoted one turns a copied
+  /// command into a different, working-by-accident command — or a broken one.
+  static String formatCommand(String executable, List<String> args) {
+    return [
+      executable,
+      ...args,
+    ].map((part) => part.contains(' ') ? '"$part"' : part).join(' ');
+  }
+}

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -14,6 +14,7 @@ import '../../utils/emulator_loader.dart';
 import '../config_service.dart';
 import '../android_service.dart';
 import '../launcher_service.dart';
+import '../linux_emulator_discovery.dart';
 import 'favorites_service.dart';
 import 'game_session_manager.dart';
 import '../gamepad/gamepad_navigation_manager.dart';
@@ -482,7 +483,33 @@ class GameLaunchService {
     try {
       final detectedEmulators =
           await EmulatorRepository.getUserDetectedEmulators();
-      final retroArch = detectedEmulators['RetroArch'];
+      var retroArch = detectedEmulators['RetroArch'];
+
+      // On Linux a database entry is not required to find RetroArch: it ships
+      // as a Flatpak or behind an EmuDeck launcher script, both of which live
+      // at well-known paths. Discovery runs when there is no configured path or
+      // the configured one has gone stale, so a working install is not reported
+      // as "not detected" just because the user never opened the file picker.
+      if (Platform.isLinux &&
+          (retroArch == null || !await File(retroArch.path).exists())) {
+        final discovered = await LinuxEmulatorDiscovery.resolveExecutable(
+          executable: 'retroarch',
+          flatpakId: 'org.libretro.RetroArch',
+          emudeckLauncher: 'retroarch.sh',
+        );
+        if (discovered != null) {
+          _log.i('Discovered RetroArch on Linux at $discovered');
+          retroArch =
+              (retroArch ??
+                      const EmulatorModel(
+                        name: 'RetroArch',
+                        path: '',
+                        detected: false,
+                      ))
+                  .copyWith(path: discovered, detected: true);
+        }
+      }
+
       if (!context.mounted) return GameLaunchResult.failure('', '');
       if (retroArch == null) {
         return GameLaunchResult.failure(
@@ -666,6 +693,27 @@ class GameLaunchService {
               'RetroArch',
             );
           }
+        }
+      }
+
+      // Last resort on Linux: nothing the database knows about resolved to a
+      // real file. Emulators there are Flatpaks, EmuDeck launcher scripts or
+      // AppImages rather than binaries sitting next to the frontend, so the
+      // bare `executable` from the systems JSON ("retroarch", "dolphin") never
+      // exists as written and every launch failed until the user hunted the
+      // real path down in a file picker. Only runs when the configured path is
+      // already broken, so an explicit user choice is never overridden.
+      if (Platform.isLinux && !await File(executable).exists()) {
+        final discovered = await LinuxEmulatorDiscovery.resolveExecutable(
+          executable: executable,
+          flatpakId: launchCmd['flatpak']?.toString(),
+          emudeckLauncher: launchCmd['emudeck_launcher']?.toString(),
+        );
+        if (discovered != null) {
+          _log.i(
+            'Resolved "$executable" to $discovered via Linux emulator discovery',
+          );
+          executable = discovered;
         }
       }
 

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -728,7 +728,28 @@ class GameLaunchService {
       }
 
       final argsStr = launchCmd['args']?.toString() ?? '';
-      final args = LauncherService.splitArgs(argsStr);
+      var args = LauncherService.splitArgs(argsStr);
+
+      // The systems JSON names cores by filename alone (`-L snes9x_libretro.so`),
+      // which RetroArch resolves against the working directory — ours, not its
+      // own. macOS already rewrote these to absolute paths; Linux did not, and
+      // there the cores are further away than anywhere a relative lookup could
+      // reach (a Flatpak keeps them under ~/.var, a distro under /usr/lib).
+      if (Platform.isLinux &&
+          executable.toLowerCase().contains('retroarch') &&
+          args.contains('-L')) {
+        final coresDir = await LinuxEmulatorDiscovery.resolveRetroArchCoresDir(
+          executable,
+        );
+        if (coresDir != null) {
+          args = await _absolutizeRetroArchCore(args, coresDir);
+        } else {
+          _log.w(
+            'No RetroArch cores directory found for $executable; passing the '
+            'core name through unchanged',
+          );
+        }
+      }
 
       final env = Map<String, String>.from(Platform.environment);
       if (Platform.isMacOS) {
@@ -1351,6 +1372,41 @@ class GameLaunchService {
     return result;
   }
 
+  /// Rewrites a relative `-L <core>` argument to an absolute path in [coresDir].
+  ///
+  /// Leaves the value alone when it is already absolute, and when the file is
+  /// not actually in [coresDir] — a wrong absolute path turns RetroArch's own
+  /// "core not found" message into a silent black screen, so an unresolvable
+  /// name is better left for RetroArch to report.
+  @visibleForTesting
+  static Future<List<String>> absolutizeRetroArchCore(
+    List<String> args,
+    String coresDir,
+  ) => _absolutizeRetroArchCore(args, coresDir);
+
+  static Future<List<String>> _absolutizeRetroArchCore(
+    List<String> args,
+    String coresDir,
+  ) async {
+    final out = List<String>.from(args);
+    for (var i = 0; i < out.length - 1; i++) {
+      if (out[i] != '-L') continue;
+
+      final core = out[i + 1];
+      if (core.isEmpty || path.isAbsolute(core)) continue;
+
+      // Some entries write `cores/foo_libretro.so`; only the filename is ours
+      // to relocate.
+      final resolved = path.join(coresDir, path.basename(core));
+      if (await File(resolved).exists()) {
+        out[i + 1] = resolved;
+      } else {
+        _log.w('RetroArch core "$core" not found in $coresDir');
+      }
+    }
+    return out;
+  }
+
   /// Resolves the absolute path for a specific RetroArch core library.
   static Future<String?> _getCoreFullPath(String coreName) async {
     try {
@@ -1422,21 +1478,21 @@ class GameLaunchService {
     final retroArchDir = path.dirname(retroArch.path);
 
     if (Platform.isLinux) {
-      final homeDir = Platform.environment['HOME'] ?? '';
+      // Cores are almost never beside the executable here, and the install type
+      // is not readable from the path: an EmuDeck launcher script is a
+      // `flatpak run` wrapper but looks like a plain shell script, so the old
+      // `path.contains('flatpak')` test missed it and sent the launch at a
+      // cores directory that does not exist. Probe the known layouts instead.
+      final resolved = await LinuxEmulatorDiscovery.resolveRetroArchCoresDir(
+        retroArch.path,
+      );
+      if (resolved != null) return resolved;
 
-      if (retroArch.path.contains('flatpak')) {
-        return path.join(
-          homeDir,
-          '.var/app/org.libretro.RetroArch/config/retroarch/cores',
-        );
-      }
-
-      final configCores = path.join(homeDir, '.config/retroarch/cores');
-      if (await Directory(configCores).exists()) {
-        return configCores;
-      }
-
-      return path.join(retroArchDir, 'cores');
+      // Nothing exists yet; hand back the most likely location so the caller's
+      // "cores directory not found" message names somewhere actionable.
+      return LinuxEmulatorDiscovery.retroArchCoresDirCandidates(
+        retroArch.path,
+      ).first;
     } else if (Platform.isMacOS) {
       final homeDir = ConfigService.getRealHomePath();
       return path.join(homeDir, 'Library/Application Support/RetroArch/cores');

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -16,6 +16,7 @@ import '../android_service.dart';
 import '../launcher_service.dart';
 import '../linux_emulator_discovery.dart';
 import '../linux_host_process.dart';
+import 'emulator_launch_diagnostics.dart';
 import 'favorites_service.dart';
 import 'game_session_manager.dart';
 import '../gamepad/gamepad_navigation_manager.dart';
@@ -567,33 +568,37 @@ class GameLaunchService {
       }
 
       Process process;
+      String executable = retroArch.path;
+      List<String> args;
 
       if (Platform.isMacOS) {
-        String executable = retroArch.path;
         if (executable.endsWith('.app')) {
           executable = path.join(executable, 'Contents', 'MacOS', 'RetroArch');
         }
 
-        final args = ['-L', coreFullPath, game.romPath!];
+        args = ['-L', coreFullPath, game.romPath!];
         final env = Map<String, String>.from(Platform.environment);
         env['HOME'] = ConfigService.getRealHomePath();
 
         process = await Process.start(executable, args, environment: env);
       } else {
-        String executable = retroArch.path;
-        final args = ['-f', '-L', coreFullPath, game.romPath!];
+        args = ['-f', '-L', coreFullPath, game.romPath!];
 
         process = await LinuxHostProcess.start(executable, args);
       }
 
-      process.stdout.listen((_) {});
-      process.stderr.listen((_) {});
+      final diagnostics = EmulatorLaunchDiagnostics.attach(
+        process,
+        executable,
+        args,
+      );
 
       GamepadNavigationManager.deactivateAll();
 
       process.exitCode
           .then((exitCode) async {
             _log.i('RetroArch exited with code: $exitCode');
+            diagnostics.reportExit(exitCode);
             await Future.delayed(Duration(seconds: 2));
             bool stillRunning = await _isDefaultEmulatorRunning();
 
@@ -763,14 +768,18 @@ class GameLaunchService {
         environment: env,
       );
 
-      process.stdout.listen((_) {});
-      process.stderr.listen((_) {});
+      final diagnostics = EmulatorLaunchDiagnostics.attach(
+        process,
+        executable,
+        args,
+      );
 
       GamepadNavigationManager.deactivateAll();
 
       process.exitCode
           .then((exitCode) async {
             _log.i('Process exited with code: $exitCode');
+            diagnostics.reportExit(exitCode);
             await Future.delayed(Duration(seconds: 2));
             bool stillRunning = false;
             if (GameSessionManager.launchedEmulatorExe != null) {
@@ -1201,14 +1210,18 @@ class GameLaunchService {
       final argList = _parseCommandArguments(args);
       final process = await LinuxHostProcess.start(emulatorPath, argList);
 
-      process.stdout.listen((_) {});
-      process.stderr.listen((_) {});
+      final diagnostics = EmulatorLaunchDiagnostics.attach(
+        process,
+        emulatorPath,
+        argList,
+      );
 
       GamepadNavigationManager.deactivateAll();
 
       process.exitCode
           .then((exitCode) async {
             _log.i('Standalone emulator exited with code: $exitCode');
+            diagnostics.reportExit(exitCode);
             await Future.delayed(Duration(seconds: 2));
             bool stillRunning = false;
             if (GameSessionManager.launchedEmulatorExe != null) {

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -15,6 +15,7 @@ import '../config_service.dart';
 import '../android_service.dart';
 import '../launcher_service.dart';
 import '../linux_emulator_discovery.dart';
+import '../linux_host_process.dart';
 import 'favorites_service.dart';
 import 'game_session_manager.dart';
 import '../gamepad/gamepad_navigation_manager.dart';
@@ -582,7 +583,7 @@ class GameLaunchService {
         String executable = retroArch.path;
         final args = ['-f', '-L', coreFullPath, game.romPath!];
 
-        process = await Process.start(executable, args);
+        process = await LinuxHostProcess.start(executable, args);
       }
 
       process.stdout.listen((_) {});
@@ -756,7 +757,11 @@ class GameLaunchService {
         env['HOME'] = ConfigService.getRealHomePath();
       }
 
-      final process = await Process.start(executable, args, environment: env);
+      final process = await LinuxHostProcess.start(
+        executable,
+        args,
+        environment: env,
+      );
 
       process.stdout.listen((_) {});
       process.stderr.listen((_) {});
@@ -1194,7 +1199,7 @@ class GameLaunchService {
           .replaceAll('{emulator_path}', emulatorPath);
 
       final argList = _parseCommandArguments(args);
-      final process = await Process.start(emulatorPath, argList);
+      final process = await LinuxHostProcess.start(emulatorPath, argList);
 
       process.stdout.listen((_) {});
       process.stderr.listen((_) {});
@@ -1534,7 +1539,13 @@ class GameLaunchService {
     if (!Platform.isLinux && !Platform.isMacOS) return false;
 
     try {
-      final result = await Process.run('pgrep', ['-i', '-f', processName]);
+      // On the host, because a sandbox has its own PID namespace and would see
+      // none of the emulators it started.
+      final result = await LinuxHostProcess.run('pgrep', [
+        '-i',
+        '-f',
+        processName,
+      ]);
       return result.exitCode == 0;
     } catch (e) {
       _log.e('Error checking if $processName is running (unix): $e');

--- a/lib/services/launcher_service.dart
+++ b/lib/services/launcher_service.dart
@@ -233,6 +233,17 @@ class LauncherService {
         result['executable'] = platformConfig['executable'];
       }
 
+      // Linux discovery hints. These let the launcher find a Flatpak or an
+      // EmuDeck-installed emulator without the user pointing a file picker at
+      // it, and they live in the systems JSON so a systems update can correct
+      // an app id without an app release. Absent on other platforms.
+      if (platformConfig.containsKey('flatpak')) {
+        result['flatpak'] = platformConfig['flatpak'];
+      }
+      if (platformConfig.containsKey('emudeck_launcher')) {
+        result['emudeck_launcher'] = platformConfig['emudeck_launcher'];
+      }
+
       if (player.containsKey('unique_id')) {
         result['unique_id'] = player['unique_id'];
       }

--- a/lib/services/launcher_service.dart
+++ b/lib/services/launcher_service.dart
@@ -72,6 +72,36 @@ class LauncherService {
     );
   }
 
+  /// Returns the Linux discovery hints for one emulator, or `null` when the
+  /// system config isn't loaded or the emulator declares no Linux block.
+  ///
+  /// The map holds `executable` plus the optional `flatpak` / `emudeck_launcher`
+  /// hints — everything [LinuxEmulatorDiscovery] needs to decide whether an
+  /// emulator is actually present. It exists so the *emulator list* can answer
+  /// "is this installed?" without a game in hand, which `getLaunchCommand`
+  /// requires. Keeping the platform-block shape known to this class alone means
+  /// callers never learn the JSON layout.
+  Map<String, String>? getLinuxDiscoveryHints(
+    String systemId,
+    String uniqueId,
+  ) {
+    final player = getPlayerConfig(systemId, uniqueId);
+    if (player == null) return null;
+    final platforms = player['platforms'] as Map<String, dynamic>?;
+    final linux = platforms?['linux'] as Map<String, dynamic>?;
+    if (linux == null) return null;
+
+    final executable = linux['executable']?.toString();
+    if (executable == null || executable.isEmpty) return null;
+
+    return {
+      'executable': executable,
+      if (linux['flatpak'] != null) 'flatpak': linux['flatpak'].toString(),
+      if (linux['emudeck_launcher'] != null)
+        'emudeck_launcher': linux['emudeck_launcher'].toString(),
+    };
+  }
+
   /// Generates a comprehensive launch command or intent specification for a game.
   ///
   /// Resolves placeholders, platform-specific arguments, and Android intent

--- a/lib/services/linux_emulator_discovery.dart
+++ b/lib/services/linux_emulator_discovery.dart
@@ -1,0 +1,499 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:path/path.dart' as p;
+
+import 'logger_service.dart';
+
+/// Locates emulator executables on Linux and SteamOS without asking the user to
+/// hunt for them in a file picker.
+///
+/// On Linux an emulator is almost never a plain binary sitting next to the
+/// frontend. It is usually one of:
+///
+/// - an **EmuDeck launcher script** in `<Emulation>/tools/launchers/*.sh`, which
+///   wraps whatever EmuDeck actually installed (a Flatpak for RetroArch and
+///   Dolphin, a bare AppImage for Azahar, DuckStation, PCSX2…) and forwards
+///   `"$@"` to it. This is the only entry point that is uniform across those
+///   cases, which is why it is tried first;
+/// - a **Flatpak export wrapper** at `…/flatpak/exports/bin/<app-id>`;
+/// - a distro package on `PATH`;
+/// - an **AppImage** dropped in `~/Applications`.
+///
+/// The per-emulator knowledge (Flatpak app id, launcher script name) lives in
+/// the systems JSON under `platforms.linux`, not here, so it can be corrected by
+/// a systems update instead of an app release:
+///
+/// ```json
+/// "linux": {
+///   "executable": "dolphin",
+///   "flatpak": "org.DolphinEmu.dolphin-emu",
+///   "emudeck_launcher": "dolphin-emu.sh",
+///   "args": "-e \"{file.path}\""
+/// }
+/// ```
+///
+/// Everything here is a read-only probe of paths the user already has; nothing
+/// is installed, written, or executed during discovery.
+class LinuxEmulatorDiscovery {
+  LinuxEmulatorDiscovery._();
+
+  static final _log = LoggerService.instance;
+
+  /// Resolved executables, keyed by the hints that produced them.
+  static final Map<String, String?> _resolveCache = {};
+
+  /// Resolved EmuDeck `tools/launchers` directory (`null` = probed, not found).
+  static String? _launchersDir;
+  static bool _launchersDirProbed = false;
+
+  /// Clears every cached probe result.
+  ///
+  /// Discovery caches aggressively because a single emulator-list rebuild asks
+  /// about dozens of emulators. Call this after the user installs something or
+  /// changes an emulator path so the next lookup re-probes the filesystem.
+  static void invalidateCache() {
+    _resolveCache.clear();
+    _launchersDir = null;
+    _launchersDirProbed = false;
+  }
+
+  /// Resolves an absolute, existing path to an emulator executable, or `null`
+  /// when none of the known locations hold it.
+  ///
+  /// [executable] is the bare name from the systems JSON (`retroarch`,
+  /// `azahar.AppImage`); [flatpakId] and [emudeckLauncher] are the optional
+  /// hints from the same block. Returning `null` is a real answer — the caller
+  /// should keep whatever the user configured rather than substitute a guess.
+  static Future<String?> resolveExecutable({
+    String? executable,
+    String? flatpakId,
+    String? emudeckLauncher,
+  }) async {
+    if (!Platform.isLinux) return null;
+
+    final cacheKey = '$executable|$flatpakId|$emudeckLauncher';
+    if (_resolveCache.containsKey(cacheKey)) return _resolveCache[cacheKey];
+
+    // Discovery runs inside the launch path and is only ever an optimisation
+    // over asking the user for a path, so a probe that fails for a reason we
+    // did not anticipate must degrade to "not found" rather than take the
+    // launch down with it.
+    String? resolved;
+    try {
+      resolved = await _resolve(
+        executable: executable,
+        flatpakId: flatpakId,
+        emudeckLauncher: emudeckLauncher,
+      );
+    } catch (e) {
+      _log.w('LinuxEmulatorDiscovery: probe for "$executable" failed: $e');
+      resolved = null;
+    }
+
+    if (resolved != null) {
+      _log.i(
+        'LinuxEmulatorDiscovery: resolved '
+        '"${executable ?? flatpakId ?? emudeckLauncher}" to $resolved',
+      );
+    }
+    _resolveCache[cacheKey] = resolved;
+    return resolved;
+  }
+
+  static Future<String?> _resolve({
+    String? executable,
+    String? flatpakId,
+    String? emudeckLauncher,
+  }) async {
+    // 1. EmuDeck launcher script. Preferred over probing the Flatpak or the
+    //    AppImage directly: the script also applies EmuDeck's own per-emulator
+    //    setup (save-sync hooks, netplay flags) that a raw invocation skips.
+    if (emudeckLauncher != null && emudeckLauncher.isNotEmpty) {
+      final dir = await _emuDeckLaunchersDir();
+      if (dir != null) {
+        final script = p.join(dir, emudeckLauncher);
+        if (await _isRunnable(script)) return script;
+      }
+    }
+
+    // 2. Flatpak export wrapper, user installation before system-wide.
+    if (flatpakId != null && flatpakId.isNotEmpty) {
+      for (final dir in _flatpakExportBinDirs()) {
+        final wrapper = p.join(dir, flatpakId);
+        if (await _isRunnable(wrapper)) return wrapper;
+      }
+    }
+
+    if (executable == null || executable.isEmpty) return null;
+
+    // 3. An absolute path in the JSON is authoritative when it exists.
+    if (p.isAbsolute(executable)) {
+      return await _isRunnable(executable) ? executable : null;
+    }
+
+    // 4. PATH, then the usual system locations for distro packages.
+    for (final dir in _binarySearchDirs()) {
+      final candidate = p.join(dir, executable);
+      if (await _isRunnable(candidate)) return candidate;
+    }
+
+    // 5. AppImages. EmuDeck drops these in ~/Applications under names that
+    //    carry a version suffix (`Azahar-2120.AppImage`), so match by prefix
+    //    the same way EmuDeck's own launchers do.
+    return await _findAppImage(executable);
+  }
+
+  // ── EmuDeck layout ─────────────────────────────────────────────────────────
+
+  /// Locates EmuDeck's `tools/launchers` directory.
+  ///
+  /// EmuDeck records the user's chosen install root in
+  /// `~/.config/EmuDeck/settings.sh`, which matters because the Deck's
+  /// `Emulation` folder is frequently on the SD card rather than in `$HOME`.
+  /// The declared path wins; the documented defaults are only fallbacks.
+  static Future<String?> _emuDeckLaunchersDir() async {
+    if (_launchersDirProbed) return _launchersDir;
+    _launchersDirProbed = true;
+
+    final candidates = <String>[];
+
+    final settings = await _readEmuDeckSettings();
+    final toolsPath = settings['toolsPath'];
+    if (toolsPath != null) candidates.add(p.join(toolsPath, 'launchers'));
+    final emulationPath = settings['emulationPath'];
+    if (emulationPath != null) {
+      candidates.add(p.join(emulationPath, 'tools', 'launchers'));
+    }
+
+    final home = _home();
+    if (home != null) {
+      candidates.add(p.join(home, 'Emulation', 'tools', 'launchers'));
+    }
+
+    for (final dir in candidates) {
+      if (await _dirExists(dir)) return _rememberLaunchersDir(dir);
+    }
+
+    // Only if none of the recorded or default locations answered: SteamOS
+    // mounts removable media under /run/media, either directly or nested under
+    // the user name depending on the OS version. Searching it is a last resort
+    // because it walks mount points belonging to other users.
+    for (final dir in await _globEmulationRoots(removableMediaRoot)) {
+      return _rememberLaunchersDir(dir);
+    }
+    return null;
+  }
+
+  /// Where removable media is mounted. Overridable so the scan — including the
+  /// unreadable-mount case that a real Deck has — can be exercised against a
+  /// fixture tree instead of the host's actual `/run/media`.
+  @visibleForTesting
+  static String removableMediaRoot = '/run/media';
+
+  static String _rememberLaunchersDir(String dir) {
+    _log.i('LinuxEmulatorDiscovery: EmuDeck launchers at $dir');
+    _launchersDir = dir;
+    return dir;
+  }
+
+  /// Parses the `key=value` assignments EmuDeck writes to its settings file.
+  ///
+  /// This is a shell script, but the path entries are plain assignments, so a
+  /// line scan is enough — and far safer than sourcing it.
+  static Future<Map<String, String>> _readEmuDeckSettings() async {
+    final home = _home();
+    if (home == null) return const {};
+
+    final file = File(p.join(home, '.config', 'EmuDeck', 'settings.sh'));
+
+    try {
+      if (!await file.exists()) return const {};
+      final result = <String, String>{};
+      final wanted = {'toolsPath', 'emulationPath'};
+      for (final raw in await file.readAsLines()) {
+        final line = raw.trim();
+        if (line.isEmpty || line.startsWith('#')) continue;
+        final eq = line.indexOf('=');
+        if (eq <= 0) continue;
+        final key = line.substring(0, eq).trim();
+        if (!wanted.contains(key)) continue;
+        final expanded = _expandHome(_unquote(line.substring(eq + 1).trim()));
+        if (expanded != null && expanded.isNotEmpty) result[key] = expanded;
+      }
+      return result;
+    } catch (e) {
+      _log.w('LinuxEmulatorDiscovery: could not read EmuDeck settings: $e');
+      return const {};
+    }
+  }
+
+  /// Removes the quoting from a shell assignment value.
+  ///
+  /// EmuDeck quotes only the *install root* and concatenates the rest onto it —
+  /// a real Steam Deck writes
+  /// `toolsPath="/run/media/deck/Deck"/Emulation/tools`. The shell joins those
+  /// segments into a single word, so the quotes sit mid-value rather than
+  /// around it; stripping only a matched outer pair leaves them embedded and
+  /// yields a path that can never exist.
+  static String _unquote(String value) {
+    final out = StringBuffer();
+    String? open;
+    for (var i = 0; i < value.length; i++) {
+      final ch = value[i];
+      if (open == null && (ch == '"' || ch == "'")) {
+        open = ch;
+      } else if (open == ch) {
+        open = null;
+      } else {
+        out.write(ch);
+      }
+    }
+    return out.toString();
+  }
+
+  /// Expands the `$HOME` / `${HOME}` / `~` forms EmuDeck writes into its
+  /// settings file. Any other shell expansion is left alone and rejected,
+  /// because a half-expanded path would probe a directory that is not the
+  /// user's.
+  static String? _expandHome(String value) {
+    final home = _home();
+    if (home == null) return value.contains(r'$') ? null : value;
+
+    var out = value;
+    if (out == '~') return home;
+    if (out.startsWith('~/')) out = p.join(home, out.substring(2));
+    out = out.replaceAll(r'${HOME}', home).replaceAll(r'$HOME', home);
+
+    // Anything still holding a shell variable is not a path we can trust.
+    return out.contains(r'$') ? null : out;
+  }
+
+  /// Finds `Emulation/tools/launchers` directories under a removable-media root.
+  ///
+  /// Scans at most two levels (`/run/media/<label>` and
+  /// `/run/media/<user>/<label>`), which covers both SteamOS mount layouts
+  /// without walking the whole card.
+  static Future<List<String>> _globEmulationRoots(String root) async {
+    final found = <String>[];
+    final dir = Directory(root);
+    if (!await _dirExists(root)) return found;
+
+    Future<void> scan(Directory d, int depth) async {
+      if (depth > 2) return;
+      List<FileSystemEntity> entries;
+      try {
+        entries = await d.list(followLinks: false).toList();
+      } catch (_) {
+        return; // unreadable mount point — not an error worth surfacing
+      }
+      for (final entry in entries) {
+        if (entry is! Directory) continue;
+        final candidate = p.join(entry.path, 'Emulation', 'tools', 'launchers');
+        if (await _dirExists(candidate)) {
+          found.add(candidate);
+        } else if (depth < 2) {
+          await scan(entry, depth + 1);
+        }
+      }
+    }
+
+    await scan(dir, 1);
+    return found;
+  }
+
+  // ── Search locations ───────────────────────────────────────────────────────
+
+  /// Flatpak's exported-binary directories, user installation first.
+  static List<String> _flatpakExportBinDirs() {
+    final dirs = <String>[];
+    final home = _home();
+    final xdgData = Platform.environment['XDG_DATA_HOME'];
+
+    if (xdgData != null && xdgData.isNotEmpty) {
+      dirs.add(p.join(xdgData, 'flatpak', 'exports', 'bin'));
+    }
+    if (home != null) {
+      dirs.add(p.join(home, '.local', 'share', 'flatpak', 'exports', 'bin'));
+    }
+    dirs.add('/var/lib/flatpak/exports/bin');
+    return dirs;
+  }
+
+  /// `PATH` entries followed by the standard binary locations, de-duplicated.
+  static List<String> _binarySearchDirs() {
+    final dirs = <String>[];
+    final path = Platform.environment['PATH'] ?? '';
+    for (final dir in path.split(':')) {
+      if (dir.isNotEmpty) dirs.add(dir);
+    }
+    dirs.addAll(const ['/usr/bin', '/usr/local/bin', '/bin', '/usr/games']);
+
+    final home = _home();
+    if (home != null) {
+      dirs.add(p.join(home, '.local', 'bin'));
+      dirs.add(p.join(home, 'Applications'));
+    }
+    return dirs.toSet().toList();
+  }
+
+  /// Directories where AppImage-based emulators land, EmuDeck's first.
+  static List<String> _appImageDirs() {
+    final home = _home();
+    if (home == null) return const [];
+    return [
+      p.join(home, 'Applications'),
+      p.join(home, '.local', 'bin'),
+      p.join(home, 'Applications', 'AppImages'),
+      p.join(home, 'Desktop'),
+      p.join(home, 'Downloads'),
+    ];
+  }
+
+  /// Finds an AppImage whose name starts with [executable]'s base name.
+  ///
+  /// AppImages carry version suffixes that change on every update, so an exact
+  /// filename match would go stale immediately. When several match, the last in
+  /// sort order wins — the same "newest build" heuristic EmuDeck's launchers
+  /// use.
+  static Future<String?> _findAppImage(String executable) async {
+    var base = executable;
+    if (base.toLowerCase().endsWith('.appimage')) {
+      base = base.substring(0, base.length - '.appimage'.length);
+    }
+    if (base.isEmpty) return null;
+    final needle = base.toLowerCase();
+
+    for (final dir in _appImageDirs()) {
+      final directory = Directory(dir);
+      if (!await _dirExists(dir)) continue;
+
+      final matches = <String>[];
+      try {
+        await for (final entry in directory.list(followLinks: false)) {
+          if (entry is! File) continue;
+          final name = p.basename(entry.path).toLowerCase();
+          if (name.startsWith(needle) && name.endsWith('.appimage')) {
+            matches.add(entry.path);
+          }
+        }
+      } catch (_) {
+        continue;
+      }
+
+      if (matches.isNotEmpty) {
+        matches.sort();
+        final best = matches.last;
+        if (await _isRunnable(best)) return best;
+      }
+    }
+    return null;
+  }
+
+  // ── RetroArch cores ────────────────────────────────────────────────────────
+
+  /// Resolves the directory holding RetroArch's libretro cores for the install
+  /// that [retroArchPath] points at.
+  ///
+  /// The cores are not next to the executable for either of the two ways Linux
+  /// users actually get RetroArch. A Flatpak keeps them under
+  /// `~/.var/app/org.libretro.RetroArch/config/retroarch/cores`, and an EmuDeck
+  /// launcher script is a `flatpak run` wrapper, so it lands in the same place
+  /// while looking nothing like a Flatpak path. Both are probed before falling
+  /// back to a native layout.
+  ///
+  /// Returns the first candidate that exists, or `null` when none do — the
+  /// caller is expected to report that rather than launch into a missing core.
+  static Future<String?> resolveRetroArchCoresDir(String retroArchPath) async {
+    for (final dir in retroArchCoresDirCandidates(retroArchPath)) {
+      if (await _dirExists(dir)) return dir;
+    }
+    return null;
+  }
+
+  /// The ordered cores-directory candidates for [retroArchPath].
+  ///
+  /// Exposed separately so callers can report what was searched when nothing
+  /// matched.
+  static List<String> retroArchCoresDirCandidates(String retroArchPath) {
+    final candidates = <String>[];
+    final home = _home();
+
+    if (home != null) {
+      // Flatpak, however it was launched: an exports/bin wrapper, an EmuDeck
+      // tools/launchers script, or `flatpak run` by hand.
+      candidates.add(
+        p.join(
+          home,
+          '.var',
+          'app',
+          'org.libretro.RetroArch',
+          'config',
+          'retroarch',
+          'cores',
+        ),
+      );
+      candidates.add(p.join(home, '.config', 'retroarch', 'cores'));
+      candidates.add(p.join(home, '.local', 'share', 'retroarch', 'cores'));
+    }
+
+    // Native and AppImage installs keep cores beside the binary or under the
+    // distro's library directory.
+    if (retroArchPath.isNotEmpty) {
+      candidates.add(p.join(p.dirname(retroArchPath), 'cores'));
+    }
+    candidates.add('/usr/lib/libretro');
+    candidates.add('/usr/lib64/libretro');
+    candidates.add('/usr/local/lib/libretro');
+
+    return candidates.toSet().toList();
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  /// Stands in for `$HOME` under test.
+  ///
+  /// Every location this service probes hangs off the home directory, and Dart
+  /// cannot rewrite its own environment, so a fixture tree is the only way to
+  /// exercise the real resolution order rather than a re-implementation of it.
+  @visibleForTesting
+  static String? homeOverride;
+
+  static String? _home() {
+    if (homeOverride != null) return homeOverride;
+    final home = Platform.environment['HOME'];
+    return (home == null || home.isEmpty) ? null : home;
+  }
+
+  /// Whether [path] is a directory that can be read.
+  ///
+  /// `Directory.exists()` throws rather than returning false when a parent is
+  /// unreadable — `/run/media/root` on a Steam Deck is mode 700 and owned by
+  /// another user, so probing it raises `PathAccessException`. Discovery runs
+  /// inside the launch path, where an escaping exception aborts the launch
+  /// outright, and "I am not allowed to look" is indistinguishable from "not
+  /// there" for our purposes.
+  static Future<bool> _dirExists(String path) async {
+    try {
+      return await Directory(path).exists();
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Whether [path] is a file the user could actually execute.
+  ///
+  /// Flatpak wrappers and EmuDeck launchers are scripts, and a non-executable
+  /// match is a stale leftover rather than something we should hand to
+  /// `Process.start`, so the mode bits are checked as well as existence.
+  static Future<bool> _isRunnable(String path) async {
+    try {
+      final stat = await FileStat.stat(path);
+      if (stat.type == FileSystemEntityType.notFound) return false;
+      if (stat.type == FileSystemEntityType.directory) return false;
+      return (stat.mode & 0x49) != 0; // any of the three execute bits
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/services/linux_host_process.dart
+++ b/lib/services/linux_host_process.dart
@@ -17,10 +17,14 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 /// NeoStation is sandboxed, and the day the Flatpak build is abandoned this
 /// file is the only thing to delete.
 ///
-/// NeoStation ships as an AppImage today, so on every machine this has run on
-/// [isSandboxed] is false and [start] is a plain [Process.start]. The sandboxed
-/// branch is a fallback for a Flatpak build that does not exist yet, and has
-/// therefore never executed anywhere: treat it as unverified.
+/// The release path ships an AppImage, so on every machine this has run on
+/// [isSandboxed] is false and [start] is a plain [Process.start] — the
+/// sandboxed branch has never executed, and should be treated as unverified.
+/// That is a statement about what has been *exercised*, not about what exists:
+/// `linux/flatpak/` builds a working Flatpak, and one was installed on a Steam
+/// Deck as recently as 2026-07-27. Verifying this branch is a matter of
+/// building that manifest and launching a game from it, not of waiting for a
+/// packaging format that has yet to arrive.
 class LinuxHostProcess {
   LinuxHostProcess._();
 

--- a/lib/services/linux_host_process.dart
+++ b/lib/services/linux_host_process.dart
@@ -1,0 +1,88 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
+/// Starts emulators on the host when NeoStation itself is packaged as a Flatpak.
+///
+/// A Flatpak cannot `exec` a host binary: its process namespace holds only the
+/// runtime, so `Process.start('/usr/bin/retroarch', …)` fails with "no such
+/// file" even though the file plainly exists on the machine. The escape hatch
+/// is `flatpak-spawn --host`, which asks the session's Flatpak portal to start
+/// the command outside the sandbox.
+///
+/// That capability requires `--talk-name=org.freedesktop.Flatpak`, which is
+/// effectively arbitrary host command execution as the user — so it is confined
+/// to this one file rather than spread across the launch paths. Everything that
+/// starts an emulator goes through [start]; nothing else needs to know whether
+/// NeoStation is sandboxed, and the day the Flatpak build is abandoned this
+/// file is the only thing to delete.
+///
+/// NeoStation ships as an AppImage today, so on every machine this has run on
+/// [isSandboxed] is false and [start] is a plain [Process.start]. The sandboxed
+/// branch is a fallback for a Flatpak build that does not exist yet, and has
+/// therefore never executed anywhere: treat it as unverified.
+class LinuxHostProcess {
+  LinuxHostProcess._();
+
+  /// The portal helper every Flatpak runtime provides at a fixed path.
+  static const _spawnCommand = 'flatpak-spawn';
+
+  /// Overrides sandbox detection in tests, where `/.flatpak-info` is not ours
+  /// to create.
+  @visibleForTesting
+  static bool? sandboxOverride;
+
+  static bool? _detected;
+
+  /// Whether this process is running inside a Flatpak sandbox.
+  ///
+  /// Flatpak writes `/.flatpak-info` into every sandbox, which is the check its
+  /// own documentation recommends — and unlike `FLATPAK_ID` it cannot be
+  /// inherited by a child process that is no longer sandboxed.
+  static bool get isSandboxed {
+    if (sandboxOverride != null) return sandboxOverride!;
+    return _detected ??=
+        Platform.isLinux && File('/.flatpak-info').existsSync();
+  }
+
+  /// Clears the cached [isSandboxed] result. For tests.
+  @visibleForTesting
+  static void reset() {
+    sandboxOverride = null;
+    _detected = null;
+  }
+
+  /// Rewrites a command so it runs outside the sandbox when there is one.
+  ///
+  /// Returns [executable] and [args] untouched when not sandboxed, so callers
+  /// can route every launch through here regardless of platform.
+  ///
+  /// [executable] is always passed as a separate argument rather than
+  /// interpolated into a string: it comes from a user-chosen path or from
+  /// discovery, and `flatpak-spawn` must never see it as anything but the
+  /// command word.
+  static (String, List<String>) command(String executable, List<String> args) =>
+      isSandboxed
+      ? (_spawnCommand, ['--host', executable, ...args])
+      : (executable, args);
+
+  /// [Process.start], on the host when sandboxed.
+  static Future<Process> start(
+    String executable,
+    List<String> args, {
+    Map<String, String>? environment,
+  }) {
+    final (exe, argv) = command(executable, args);
+    return Process.start(exe, argv, environment: environment);
+  }
+
+  /// [Process.run], on the host when sandboxed.
+  ///
+  /// Needed for more than launching: a sandbox has its own PID namespace, so
+  /// `pgrep` inside it cannot see the emulator it just started on the host and
+  /// would report every running game as closed.
+  static Future<ProcessResult> run(String executable, List<String> args) {
+    final (exe, argv) = command(executable, args);
+    return Process.run(exe, argv);
+  }
+}

--- a/lib/utils/emulator_loader.dart
+++ b/lib/utils/emulator_loader.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:neostation/models/core_emulator_model.dart';
 import 'package:neostation/models/system_model.dart';
 import 'package:neostation/repositories/emulator_repository.dart';
+import 'package:neostation/services/launcher_service.dart';
 import 'package:neostation/services/linux_emulator_discovery.dart';
 import 'package:neostation/services/logger_service.dart';
 
@@ -92,6 +93,45 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
       emulators = emulators
           .map((e) => e.copyWith(isInstalled: e.hasConfiguredPath))
           .toList();
+
+      // Linux: nothing configures a path on a Deck — emulators arrive as
+      // Flatpaks and EmuDeck launcher scripts — so the baseline above reports
+      // every standalone as uninstalled. Selection then cannot see that a
+      // working standalone exists and falls back to the JSON default, which for
+      // several systems is a RetroArch core the user never installed: RetroArch
+      // rejects the missing core at parse time, exits 0, and the game "launches"
+      // and instantly closes (verified on a Steam Deck with GameCube, where
+      // Standalone Dolphin was installed and discoverable the whole time).
+      //
+      // Ask discovery instead. A resolvable executable is the same evidence a
+      // configured path is, just gathered rather than typed in.
+      if (Platform.isLinux) {
+        await LauncherService.instance.loadSystemConfig(
+          '${system.folderName}.json',
+        );
+        final updated = <CoreEmulatorModel>[];
+        for (final e in emulators) {
+          if (e.isInstalled || !e.isStandalone) {
+            updated.add(e);
+            continue;
+          }
+          final hints = LauncherService.instance.getLinuxDiscoveryHints(
+            system.folderName,
+            e.uniqueId,
+          );
+          if (hints == null) {
+            updated.add(e);
+            continue;
+          }
+          final resolved = await LinuxEmulatorDiscovery.resolveExecutable(
+            executable: hints['executable']!,
+            flatpakId: hints['flatpak'],
+            emudeckLauncher: hints['emudeck_launcher'],
+          );
+          updated.add(e.copyWith(isInstalled: resolved != null));
+        }
+        emulators = updated;
+      }
 
       if (retroArchPath != null && retroArchPath.isNotEmpty) {
         // Linux keeps cores away from the executable (Flatpak's ~/.var tree,

--- a/lib/utils/emulator_loader.dart
+++ b/lib/utils/emulator_loader.dart
@@ -94,10 +94,18 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
           .toList();
 
       if (retroArchPath != null && retroArchPath.isNotEmpty) {
-        final coresDir =
-            '${File(retroArchPath).parent.path}'
-            '${Platform.pathSeparator}cores';
-        final coresDirReadable = await Directory(coresDir).exists();
+        // Linux keeps cores away from the executable (Flatpak's ~/.var tree,
+        // or a distro's /usr/lib/libretro), so assuming a sibling `cores/`
+        // marks every genuinely-installed core as missing. Ask the discovery
+        // service, which probes the layouts that actually occur.
+        final coresDir = Platform.isLinux
+            ? await LinuxEmulatorDiscovery.resolveRetroArchCoresDir(
+                retroArchPath,
+              )
+            : '${File(retroArchPath).parent.path}'
+                  '${Platform.pathSeparator}cores';
+        final coresDirReadable =
+            coresDir != null && await Directory(coresDir).exists();
         final updated = <CoreEmulatorModel>[];
         for (final e in emulators) {
           final uid = e.uniqueId;

--- a/lib/utils/emulator_loader.dart
+++ b/lib/utils/emulator_loader.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:neostation/models/core_emulator_model.dart';
 import 'package:neostation/models/system_model.dart';
 import 'package:neostation/repositories/emulator_repository.dart';
+import 'package:neostation/services/linux_emulator_discovery.dart';
 import 'package:neostation/services/logger_service.dart';
 
 /// Hydrates the list of supported emulators for [system], verifying package
@@ -68,8 +69,21 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
       // locate a readable cores dir (layout varies by platform/install), fail
       // OPEN and keep the executable-based assumption rather than hide a
       // genuinely-installed core.
-      final retroArchPath =
-          await EmulatorRepository.getRetroArchExecutablePath();
+      var retroArchPath = await EmulatorRepository.getRetroArchExecutablePath();
+
+      // Linux ships RetroArch as a Flatpak or behind an EmuDeck launcher
+      // script, so the database holds no path for it until the user points a
+      // file picker at one — which this feature exists to avoid. Without
+      // discovery here the probe below is skipped entirely and every core is
+      // reported uninstalled on a machine that has all of them installed.
+      if (Platform.isLinux &&
+          (retroArchPath == null || retroArchPath.isEmpty)) {
+        retroArchPath = await LinuxEmulatorDiscovery.resolveExecutable(
+          executable: 'retroarch',
+          flatpakId: 'org.libretro.RetroArch',
+          emudeckLauncher: 'retroarch.sh',
+        );
+      }
 
       // Baseline: on desktop a configured executable path is the only evidence
       // the database holds, so it stands in as the install verdict for anything

--- a/linux/flatpak/com.neogamelab.neostation.flathub.yml
+++ b/linux/flatpak/com.neogamelab.neostation.flathub.yml
@@ -32,7 +32,17 @@ finish-args:
   - --share=network
   - --allow=bluetooth
   - --filesystem=home
+  # EmuDeck is commonly installed to an SD card, and system-wide Flatpaks keep
+  # their export wrappers and RetroArch cores outside $HOME. Read-only: these
+  # are probed for emulators, never written to.
+  - --filesystem=/run/media:ro
+  - --filesystem=/var/lib/flatpak:ro
   - --talk-name=org.freedesktop.secrets
+  # Required to start an emulator at all: a sandbox cannot exec a host binary.
+  # See LinuxHostProcess — this is the only thing that uses it. Note that
+  # Flathub review treats this as a full sandbox escape and there is no portal
+  # to offer instead; a Flathub submission has to argue for it explicitly.
+  - --talk-name=org.freedesktop.Flatpak
 
 cleanup:
   - /include

--- a/linux/flatpak/com.neogamelab.neostation.yml
+++ b/linux/flatpak/com.neogamelab.neostation.yml
@@ -14,7 +14,15 @@ finish-args:
   - --share=network
   - --allow=bluetooth
   - --filesystem=home
+  # EmuDeck is commonly installed to an SD card, and system-wide Flatpaks keep
+  # their export wrappers and RetroArch cores outside $HOME. Read-only: these
+  # are probed for emulators, never written to.
+  - --filesystem=/run/media:ro
+  - --filesystem=/var/lib/flatpak:ro
   - --talk-name=org.freedesktop.secrets
+  # Required to start an emulator at all: a sandbox cannot exec a host binary.
+  # See LinuxHostProcess — this is the only thing that uses it.
+  - --talk-name=org.freedesktop.Flatpak
 
 cleanup:
   - /include

--- a/test/emulator_launch_diagnostics_test.dart
+++ b/test/emulator_launch_diagnostics_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/game/emulator_launch_diagnostics.dart';
+
+/// Pins the behaviour that turns a silent launch failure into a readable one.
+///
+/// On a Steam Deck a failed launch and a finished game look identical: the
+/// EmuDeck launcher script exits 0 either way, because it runs its own cleanup
+/// after the emulator. The emulator's own output is the only witness, and it
+/// used to be read into an empty callback and dropped.
+void main() {
+  group('describeExit', () {
+    test('stays quiet when the emulator ran long enough to be played', () {
+      final diagnostics = EmulatorLaunchDiagnostics('retroarch.sh')
+        ..addLine('some chatter');
+
+      expect(
+        diagnostics.describeExit(0, const Duration(minutes: 12)),
+        isNull,
+        reason: 'a normal play session must not be reported as a failure',
+      );
+    });
+
+    test('reports a launch that died instantly, even on exit code 0', () {
+      // The exact shape of the arcade report: RetroArch rejected an incomplete
+      // ROM set and gave up in about a second, but the launcher script's
+      // trailing cleanup returned 0, so the app called it a finished session.
+      final diagnostics = EmulatorLaunchDiagnostics('retroarch.sh')
+        ..addLine('[libretro ERROR] [MAME 2003+] readroms failed')
+        ..addLine('[ERROR] [Content] Failed to load content.');
+
+      final report = diagnostics.describeExit(0, const Duration(seconds: 1));
+
+      expect(report, isNotNull);
+      expect(report, contains('readroms failed'));
+      expect(report, contains('Failed to load content'));
+      // The caveat matters as much as the lines: a reader who trusts the 0
+      // stops looking exactly where the answer is.
+      expect(report, contains('unreliable'));
+    });
+
+    test('says so explicitly when the emulator wrote nothing', () {
+      final diagnostics = EmulatorLaunchDiagnostics('dolphin-emu.sh');
+
+      final report = diagnostics.describeExit(1, const Duration(seconds: 2));
+
+      expect(report, contains('wrote nothing'));
+    });
+
+    test('keeps the newest lines and discards the oldest', () {
+      final diagnostics = EmulatorLaunchDiagnostics('retroarch.sh');
+      for (var i = 0; i < EmulatorLaunchDiagnostics.maxCapturedLines + 5; i++) {
+        diagnostics.addLine('line $i');
+      }
+
+      final report = diagnostics.describeExit(0, Duration.zero)!;
+
+      // The error is always at the end, so the tail is the part worth keeping.
+      expect(report, contains('line 16'));
+      expect(report, isNot(contains('line 0')));
+    });
+
+    test('ignores blank output', () {
+      final diagnostics = EmulatorLaunchDiagnostics('retroarch.sh')
+        ..addLine('   ')
+        ..addLine('');
+
+      expect(
+        diagnostics.describeExit(0, Duration.zero),
+        contains('wrote nothing'),
+      );
+    });
+  });
+
+  group('formatCommand', () {
+    test('quotes arguments containing spaces', () {
+      // An unquoted ROM path silently becomes several arguments when pasted
+      // back into a shell, which is how a copied command "works" differently
+      // from the one that actually ran.
+      final command = EmulatorLaunchDiagnostics.formatCommand('retroarch.sh', [
+        '-L',
+        '/cores/fbneo_libretro.so',
+        '/roms/arcade/Some Game (USA).zip',
+      ]);
+
+      expect(
+        command,
+        'retroarch.sh -L /cores/fbneo_libretro.so '
+        '"/roms/arcade/Some Game (USA).zip"',
+      );
+    });
+
+    test('renders a command with no arguments', () {
+      expect(
+        EmulatorLaunchDiagnostics.formatCommand('/usr/bin/retroarch', const []),
+        '/usr/bin/retroarch',
+      );
+    });
+  });
+}

--- a/test/launcher_service_linux_hints_test.dart
+++ b/test/launcher_service_linux_hints_test.dart
@@ -77,4 +77,32 @@ void main() {
     expect(command['emudeck_launcher'], 'retroarch.sh');
     expect(command['args'].toString(), contains('dolphin_libretro.so'));
   });
+
+  group('getLinuxDiscoveryHints', () {
+    // The emulator *list* has to answer "is this installed?" with no game in
+    // hand, so it cannot go through getLaunchCommand. Without these hints a
+    // standalone emulator reads as uninstalled on any machine where the user
+    // never file-pickered a path — every Steam Deck — and selection falls back
+    // to a RetroArch core that may not be installed. That combination launched
+    // and instantly closed on a real Deck.
+    test('exposes the hints an install check needs', () {
+      final hints = service.getLinuxDiscoveryHints(
+        'gc',
+        'gc.org.dolphinemu.dolphinemu',
+      );
+
+      expect(hints, isNotNull);
+      expect(hints!['executable'], 'dolphin');
+      expect(hints['flatpak'], 'org.DolphinEmu.dolphin-emu');
+      expect(hints['emudeck_launcher'], 'dolphin-emu.sh');
+    });
+
+    test('returns null for an emulator the config does not define', () {
+      expect(service.getLinuxDiscoveryHints('gc', 'gc.does.not.exist'), isNull);
+    });
+
+    test('returns null for a system that was never loaded', () {
+      expect(service.getLinuxDiscoveryHints('not-a-system', 'x'), isNull);
+    });
+  });
 }

--- a/test/launcher_service_linux_hints_test.dart
+++ b/test/launcher_service_linux_hints_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/models/system_model.dart';
+import 'package:neostation/services/launcher_service.dart';
+
+/// Pins the Linux discovery hints all the way through to the launch command.
+///
+/// [LauncherService] copies a fixed set of keys out of the platform block, so a
+/// hint it does not name is dropped silently — the launch then falls back to
+/// the bare `executable`, which is exactly the failure discovery exists to
+/// prevent. Reading the real `assets/systems/gc.json` also keeps the JSON's key
+/// spelling and this code honest about each other.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final service = LauncherService.instance;
+
+  final system = SystemModel(
+    id: 'gc',
+    folderName: 'gc',
+    realName: 'Nintendo GameCube',
+    iconImage: '',
+    color: '#7E57C2',
+  );
+  const game = GameModel(
+    romname: 'game.rvz',
+    realname: 'Game',
+    name: 'Game',
+    year: '2003',
+    developer: '',
+    publisher: '',
+    genre: '',
+    players: '1',
+    rating: 0,
+    romPath: '/roms/gc/game.rvz',
+    systemFolderName: 'gc',
+  );
+
+  setUpAll(() async {
+    expect(await service.loadSystemConfig('gc.json'), isTrue);
+  });
+
+  test('carries flatpak and emudeck_launcher into the launch command', () {
+    // Platform-gated: getLaunchCommand only fills a desktop command when the
+    // host is desktop, and the suite runs on Linux.
+    final command = service.getLaunchCommand(
+      system,
+      game,
+      'gc.org.dolphinemu.dolphinemu',
+    );
+
+    expect(command['executable'], 'dolphin');
+    expect(command['flatpak'], 'org.DolphinEmu.dolphin-emu');
+    expect(command['emudeck_launcher'], 'dolphin-emu.sh');
+  });
+
+  test('passes the ROM to Dolphin instead of opening its game list', () {
+    // The desktop blocks used to carry Android's `launch_arguments` key, which
+    // LauncherService does not read on desktop. The command came back with no
+    // arguments at all, so Dolphin started and sat on its own game list — the
+    // one system users reported having to pick the game by hand for.
+    final command = service.getLaunchCommand(
+      system,
+      game,
+      'gc.org.dolphinemu.dolphinemu',
+    );
+
+    expect(command['args'], isNotNull);
+    expect(command['args'].toString(), contains('/roms/gc/game.rvz'));
+  });
+
+  test('resolves a RetroArch core entry with its hints', () {
+    final command = service.getLaunchCommand(system, game, 'gc.ra.dolphin');
+
+    expect(command['executable'], 'retroarch');
+    expect(command['flatpak'], 'org.libretro.RetroArch');
+    expect(command['emudeck_launcher'], 'retroarch.sh');
+    expect(command['args'].toString(), contains('dolphin_libretro.so'));
+  });
+}

--- a/test/linux_emulator_discovery_test.dart
+++ b/test/linux_emulator_discovery_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/game/game_launch_service.dart';
 import 'package:neostation/services/linux_emulator_discovery.dart';
 import 'package:path/path.dart' as p;
 
@@ -228,6 +229,84 @@ void main() {
           emudeckLauncher: 'not-installed.sh',
         ),
         isNull,
+      );
+    });
+  });
+
+  group('RetroArch core arguments', () {
+    test('rewrites a bare core filename to an absolute path', () async {
+      final cores = Directory(p.join(home.path, 'cores'))
+        ..createSync(recursive: true);
+      File(p.join(cores.path, 'snes9x_libretro.so')).writeAsStringSync('');
+
+      expect(
+        await GameLaunchService.absolutizeRetroArchCore([
+          '-L',
+          'snes9x_libretro.so',
+          '/roms/snes/game.sfc',
+        ], cores.path),
+        ['-L', p.join(cores.path, 'snes9x_libretro.so'), '/roms/snes/game.sfc'],
+      );
+    });
+
+    test('strips a "cores/" prefix before relocating', () async {
+      final cores = Directory(p.join(home.path, 'cores'))
+        ..createSync(recursive: true);
+      File(
+        p.join(cores.path, 'genesis_plus_gx_libretro.so'),
+      ).writeAsStringSync('');
+
+      expect(
+        await GameLaunchService.absolutizeRetroArchCore([
+          '-L',
+          'cores/genesis_plus_gx_libretro.so',
+          '/roms/md/game.md',
+        ], cores.path),
+        [
+          '-L',
+          p.join(cores.path, 'genesis_plus_gx_libretro.so'),
+          '/roms/md/game.md',
+        ],
+      );
+    });
+
+    test('leaves an already-absolute core path untouched', () async {
+      final cores = Directory(p.join(home.path, 'cores'))
+        ..createSync(recursive: true);
+
+      expect(
+        await GameLaunchService.absolutizeRetroArchCore([
+          '-L',
+          '/opt/retroarch/cores/mgba_libretro.so',
+          '/roms/gba/game.gba',
+        ], cores.path),
+        ['-L', '/opt/retroarch/cores/mgba_libretro.so', '/roms/gba/game.gba'],
+      );
+    });
+
+    test(
+      'leaves a core that is not in the directory for RetroArch to report',
+      () async {
+        // Pointing at a path that does not exist turns RetroArch's own
+        // "core not found" error into a silent black screen.
+        final cores = Directory(p.join(home.path, 'cores'))
+          ..createSync(recursive: true);
+
+        expect(
+          await GameLaunchService.absolutizeRetroArchCore([
+            '-L',
+            'not_installed_libretro.so',
+            '/roms/nes/game.nes',
+          ], cores.path),
+          ['-L', 'not_installed_libretro.so', '/roms/nes/game.nes'],
+        );
+      },
+    );
+
+    test('ignores a trailing -L with no value', () async {
+      expect(
+        await GameLaunchService.absolutizeRetroArchCore(['-L'], home.path),
+        ['-L'],
       );
     });
   });

--- a/test/linux_emulator_discovery_test.dart
+++ b/test/linux_emulator_discovery_test.dart
@@ -1,0 +1,277 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/linux_emulator_discovery.dart';
+import 'package:path/path.dart' as p;
+
+/// Linux emulators are never where the systems JSON says they are.
+///
+/// The JSON names them the way the launch command does — `retroarch`,
+/// `dolphin` — but on a real Linux or SteamOS install those resolve to a
+/// Flatpak wrapper, an EmuDeck launcher script, or a versioned AppImage. Until
+/// discovery existed the launch just failed and the user had to hunt the path
+/// down in a file picker, so these tests pin the resolution order against a
+/// fixture tree shaped like the real thing.
+void main() {
+  late Directory home;
+
+  /// Creates an executable file, and the directories leading to it.
+  File exe(String relativePath, [String contents = '#!/bin/bash\n']) {
+    final file = File(p.join(home.path, relativePath));
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(contents);
+    Process.runSync('chmod', ['+x', file.path]);
+    return file;
+  }
+
+  setUp(() {
+    home = Directory.systemTemp.createTempSync('neostation_linux_discovery');
+    LinuxEmulatorDiscovery.homeOverride = home.path;
+    // Point the removable-media scan at an empty fixture path by default, so a
+    // test never depends on whether the host running it has an SD card mounted.
+    LinuxEmulatorDiscovery.removableMediaRoot = p.join(home.path, 'no-media');
+    LinuxEmulatorDiscovery.invalidateCache();
+  });
+
+  tearDown(() {
+    LinuxEmulatorDiscovery.homeOverride = null;
+    LinuxEmulatorDiscovery.removableMediaRoot = '/run/media';
+    LinuxEmulatorDiscovery.invalidateCache();
+    if (home.existsSync()) home.deleteSync(recursive: true);
+  });
+
+  group('executable resolution', () {
+    test('finds the EmuDeck launcher script at the default Emulation root', () {
+      final script = exe('Emulation/tools/launchers/retroarch.sh');
+
+      return expectLater(
+        LinuxEmulatorDiscovery.resolveExecutable(
+          executable: 'retroarch',
+          flatpakId: 'org.libretro.RetroArch',
+          emudeckLauncher: 'retroarch.sh',
+        ),
+        completion(script.path),
+      );
+    });
+
+    test(
+      'follows the Emulation root EmuDeck recorded in settings.sh',
+      () async {
+        // The Deck's Emulation folder is routinely on the SD card, so the
+        // recorded path has to win over the in-$HOME default.
+        final sd = Directory(p.join(home.path, 'sdcard'))
+          ..createSync(recursive: true);
+        final script = exe('sdcard/Emulation/tools/launchers/dolphin-emu.sh');
+        exe('Emulation/tools/launchers/dolphin-emu.sh'); // decoy at the default
+
+        File(p.join(home.path, '.config/EmuDeck/settings.sh'))
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(
+            '#!/bin/bash\n'
+            'emulationPath="${sd.path}/Emulation"\n'
+            'toolsPath="${sd.path}/Emulation/tools"\n',
+          );
+
+        expect(
+          await LinuxEmulatorDiscovery.resolveExecutable(
+            executable: 'dolphin',
+            flatpakId: 'org.DolphinEmu.dolphin-emu',
+            emudeckLauncher: 'dolphin-emu.sh',
+          ),
+          script.path,
+        );
+      },
+    );
+
+    test('reads the mid-value quoting a real Deck writes', () async {
+      // Verified on a Steam Deck (SteamOS 3.x, EmuDeck): only the install root
+      // is quoted and the rest is concatenated onto it —
+      // `toolsPath="/run/media/deck/Deck"/Emulation/tools`. Treating that as a
+      // wrapped value leaves the quotes inside the path, so the recorded root
+      // is silently ignored and discovery falls through to the defaults.
+      final sd = Directory(p.join(home.path, 'sdcard'))
+        ..createSync(recursive: true);
+      final script = exe('sdcard/Emulation/tools/launchers/retroarch.sh');
+
+      File(p.join(home.path, '.config/EmuDeck/settings.sh'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(
+          '#!/bin/bash\n'
+          'emulationPath="${sd.path}"/Emulation\n'
+          'toolsPath="${sd.path}"/Emulation/tools\n',
+        );
+
+      expect(
+        await LinuxEmulatorDiscovery.resolveExecutable(
+          executable: 'retroarch',
+          flatpakId: 'org.libretro.RetroArch',
+          emudeckLauncher: 'retroarch.sh',
+        ),
+        script.path,
+      );
+    });
+
+    test('expands the \$HOME form EmuDeck writes into settings.sh', () async {
+      final script = exe('Emulation/tools/launchers/pcsx2-qt.sh');
+
+      File(p.join(home.path, '.config/EmuDeck/settings.sh'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync('toolsPath="\$HOME/Emulation/tools"\n');
+
+      expect(
+        await LinuxEmulatorDiscovery.resolveExecutable(
+          executable: 'pcsx2',
+          emudeckLauncher: 'pcsx2-qt.sh',
+        ),
+        script.path,
+      );
+    });
+
+    test('finds an Emulation root nested under a removable mount', () async {
+      // SteamOS mounts the SD card as /run/media/<user>/<label>, so the
+      // launchers land two levels below the media root rather than one.
+      final script = exe('media/deck/Deck/Emulation/tools/launchers/mame.sh');
+      LinuxEmulatorDiscovery.removableMediaRoot = p.join(home.path, 'media');
+
+      expect(
+        await LinuxEmulatorDiscovery.resolveExecutable(
+          executable: 'mame',
+          emudeckLauncher: 'mame.sh',
+        ),
+        script.path,
+      );
+    });
+
+    test('survives a mount it is not allowed to read', () async {
+      // Reproduces a launch failure seen on a real Steam Deck: /run/media/root
+      // is mode 700 and owned by another user, and Directory.exists() *throws*
+      // PathAccessException there rather than returning false. Discovery is
+      // called from the launch path, so that escaping exception aborted the
+      // launch outright — a denied directory has to read as "not here".
+      final media = Directory(p.join(home.path, 'media'))
+        ..createSync(recursive: true);
+      final denied = Directory(p.join(media.path, 'root'))
+        ..createSync(recursive: true);
+      LinuxEmulatorDiscovery.removableMediaRoot = media.path;
+      final wrapper = exe(
+        '.local/share/flatpak/exports/bin/org.libretro.RetroArch',
+      );
+      addTearDown(() => Process.runSync('chmod', ['700', denied.path]));
+      Process.runSync('chmod', ['000', denied.path]);
+
+      expect(
+        await LinuxEmulatorDiscovery.resolveExecutable(
+          executable: 'retroarch',
+          flatpakId: 'org.libretro.RetroArch',
+          emudeckLauncher: 'retroarch.sh',
+        ),
+        wrapper.path,
+      );
+    });
+
+    test('falls back to the Flatpak export wrapper', () async {
+      final wrapper = exe(
+        '.local/share/flatpak/exports/bin/org.libretro.RetroArch',
+      );
+
+      expect(
+        await LinuxEmulatorDiscovery.resolveExecutable(
+          executable: 'retroarch',
+          flatpakId: 'org.libretro.RetroArch',
+          emudeckLauncher: 'retroarch.sh',
+        ),
+        wrapper.path,
+      );
+    });
+
+    test('matches a versioned AppImage by prefix, newest last', () async {
+      exe('Applications/Azahar-2100.AppImage');
+      final newest = exe('Applications/Azahar-2120.AppImage');
+
+      expect(
+        await LinuxEmulatorDiscovery.resolveExecutable(
+          executable: 'azahar.AppImage',
+          flatpakId: 'org.azahar_emu.Azahar',
+          emudeckLauncher: 'azahar.sh',
+        ),
+        newest.path,
+      );
+    });
+
+    test('ignores a match that is not executable', () async {
+      // A leftover non-executable file is not something to hand to
+      // Process.start; the launch should keep looking.
+      final script = File(
+        p.join(home.path, 'Emulation/tools/launchers/rpcs3.sh'),
+      )..parent.createSync(recursive: true);
+      script.writeAsStringSync('#!/bin/bash\n');
+      Process.runSync('chmod', ['-x', script.path]);
+
+      final wrapper = exe('.local/share/flatpak/exports/bin/net.rpcs3.RPCS3');
+
+      expect(
+        await LinuxEmulatorDiscovery.resolveExecutable(
+          executable: 'rpcs3',
+          flatpakId: 'net.rpcs3.RPCS3',
+          emudeckLauncher: 'rpcs3.sh',
+        ),
+        wrapper.path,
+      );
+    });
+
+    test('returns null rather than guessing when nothing is installed', () async {
+      expect(
+        await LinuxEmulatorDiscovery.resolveExecutable(
+          // A name no distro ships, so a stray PATH hit cannot mask the result.
+          executable: 'neostation-nonexistent-emulator',
+          flatpakId: 'com.example.NotInstalled',
+          emudeckLauncher: 'not-installed.sh',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('RetroArch cores directory', () {
+    test('prefers the Flatpak config tree over a sibling cores dir', () async {
+      final flatpakCores = Directory(
+        p.join(
+          home.path,
+          '.var/app/org.libretro.RetroArch/config/retroarch/cores',
+        ),
+      )..createSync(recursive: true);
+      // A launcher script has a sibling directory that is *not* the cores dir.
+      Directory(
+        p.join(home.path, 'Emulation/tools/launchers/cores'),
+      ).createSync(recursive: true);
+
+      expect(
+        await LinuxEmulatorDiscovery.resolveRetroArchCoresDir(
+          p.join(home.path, 'Emulation/tools/launchers/retroarch.sh'),
+        ),
+        flatpakCores.path,
+      );
+    });
+
+    test('finds a native install cores dir next to the binary', () async {
+      final cores = Directory(p.join(home.path, 'bin/cores'))
+        ..createSync(recursive: true);
+
+      expect(
+        await LinuxEmulatorDiscovery.resolveRetroArchCoresDir(
+          p.join(home.path, 'bin/retroarch'),
+        ),
+        cores.path,
+      );
+    });
+
+    test('reports null when no cores directory exists at all', () async {
+      expect(
+        await LinuxEmulatorDiscovery.resolveRetroArchCoresDir(
+          p.join(home.path, 'nowhere/retroarch'),
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/linux_host_process_test.dart
+++ b/test/linux_host_process_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/linux_host_process.dart';
+
+void main() {
+  tearDown(LinuxHostProcess.reset);
+
+  group('unsandboxed', () {
+    setUp(() => LinuxHostProcess.sandboxOverride = false);
+
+    test('passes the command through untouched', () {
+      final (exe, args) = LinuxHostProcess.command('/usr/bin/retroarch', [
+        '-f',
+        '-L',
+        '/usr/lib/libretro/snes9x_libretro.so',
+        '/roms/snes/game.sfc',
+      ]);
+
+      expect(exe, '/usr/bin/retroarch');
+      expect(args, [
+        '-f',
+        '-L',
+        '/usr/lib/libretro/snes9x_libretro.so',
+        '/roms/snes/game.sfc',
+      ]);
+    });
+
+    test('passes an empty argument list through', () {
+      final (exe, args) = LinuxHostProcess.command('/usr/bin/dolphin-emu', []);
+
+      expect(exe, '/usr/bin/dolphin-emu');
+      expect(args, isEmpty);
+    });
+  });
+
+  group('sandboxed', () {
+    setUp(() => LinuxHostProcess.sandboxOverride = true);
+
+    test('routes the command through flatpak-spawn --host', () {
+      final (exe, args) = LinuxHostProcess.command('/usr/bin/retroarch', [
+        '-f',
+        '/roms/snes/game.sfc',
+      ]);
+
+      expect(exe, 'flatpak-spawn');
+      expect(args, [
+        '--host',
+        '/usr/bin/retroarch',
+        '-f',
+        '/roms/snes/game.sfc',
+      ]);
+    });
+
+    test('keeps the executable as its own argument', () {
+      // The path comes from discovery or from a file the user picked, so it can
+      // hold spaces and shell metacharacters. It must reach flatpak-spawn as
+      // one argv entry rather than as part of a command string.
+      final (_, args) = LinuxHostProcess.command(
+        '/home/deck/Emulation/tools/launchers/retro arch;rm -rf.sh',
+        ['/roms/game.zip'],
+      );
+
+      expect(
+        args[1],
+        '/home/deck/Emulation/tools/launchers/retro arch;rm -rf.sh',
+      );
+      expect(args, hasLength(3));
+    });
+
+    test('preserves argument order and duplicates', () {
+      final (_, args) = LinuxHostProcess.command('emu', [
+        '-L',
+        'core.so',
+        '-L',
+        'other.so',
+      ]);
+
+      expect(args, ['--host', 'emu', '-L', 'core.so', '-L', 'other.so']);
+    });
+  });
+}

--- a/test/systems_linux_hints_test.dart
+++ b/test/systems_linux_hints_test.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the Linux discovery hints in `assets/systems/*.json`.
+///
+/// `flatpak` and `emudeck_launcher` are how the launcher finds an emulator that
+/// the user installed through Flathub or EmuDeck instead of pointing a file
+/// picker at it. A typo in either is invisible — discovery simply finds nothing
+/// and the launch fails the way it did before the hints existed — so the values
+/// are pinned here rather than left to review.
+void main() {
+  /// Launcher scripts shipped in dragoonDorise/EmuDeck `tools/launchers`.
+  const emuDeckLaunchers = {
+    'ares-emu.sh',
+    'azahar.sh',
+    'bigpemu.sh',
+    'cemu-native.sh',
+    'cemu.sh',
+    'citra.sh',
+    'citron.sh',
+    'dolphin-emu.sh',
+    'duckstation.sh',
+    'eden.sh',
+    'flycast.sh',
+    'lime3ds.sh',
+    'mame.sh',
+    'melonds.sh',
+    'mgba.sh',
+    'model-2-emulator.sh',
+    'pcsx2-qt.sh',
+    'ppsspp.sh',
+    'primehack.sh',
+    'retroarch.sh',
+    'rosaliesmupengui.sh',
+    'rpcs3.sh',
+    'ryujinx.sh',
+    'scummvm.sh',
+    'shadps4.sh',
+    'supermodel.sh',
+    'suyu.sh',
+    'vita3k.sh',
+    'xemu-emu.sh',
+    'xenia.sh',
+    'yuzu.sh',
+  };
+
+  /// App ids confirmed present on Flathub.
+  const knownFlatpakIds = {
+    'org.libretro.RetroArch',
+    'org.DolphinEmu.dolphin-emu',
+    'net.pcsx2.PCSX2',
+    'net.rpcs3.RPCS3',
+    'org.duckstation.DuckStation',
+    'org.ppsspp.PPSSPP',
+    'org.azahar_emu.Azahar',
+    'net.kuribo64.melonDS',
+    'info.cemu.Cemu',
+    'io.github.stella_emu.Stella',
+  };
+
+  late List<({String file, String uniqueId, Map<String, dynamic> linux})>
+  linuxBlocks;
+
+  setUpAll(() {
+    final dir = Directory('assets/systems');
+    expect(
+      dir.existsSync(),
+      isTrue,
+      reason: 'run from the project root so assets/systems is visible',
+    );
+
+    linuxBlocks = [];
+    for (final entity in dir.listSync()) {
+      if (entity is! File || !entity.path.endsWith('.json')) continue;
+      final json =
+          jsonDecode(entity.readAsStringSync()) as Map<String, dynamic>;
+      final emulators = (json['emulators'] ?? json['players'] ?? []) as List;
+      for (final emulator in emulators) {
+        final platforms = (emulator as Map)['platforms'];
+        if (platforms is! Map) continue;
+        final linux = platforms['linux'];
+        if (linux is! Map) continue;
+        linuxBlocks.add((
+          file: entity.uri.pathSegments.last,
+          uniqueId: (emulator['unique_id'] ?? '?').toString(),
+          linux: Map<String, dynamic>.from(linux),
+        ));
+      }
+    }
+    expect(linuxBlocks, isNotEmpty);
+  });
+
+  test('every emudeck_launcher names a real EmuDeck launcher script', () {
+    for (final block in linuxBlocks) {
+      final launcher = block.linux['emudeck_launcher'];
+      if (launcher == null) continue;
+      expect(
+        emuDeckLaunchers,
+        contains(launcher),
+        reason: '${block.file} / ${block.uniqueId}',
+      );
+    }
+  });
+
+  test('every flatpak hint is an app id known to exist on Flathub', () {
+    for (final block in linuxBlocks) {
+      final id = block.linux['flatpak'];
+      if (id == null) continue;
+      expect(
+        knownFlatpakIds,
+        contains(id),
+        reason: '${block.file} / ${block.uniqueId}',
+      );
+    }
+  });
+
+  test('one executable always maps to the same hints', () {
+    // The same emulator appears in dozens of system files; a hint corrected in
+    // one and missed in the others is the failure this catches.
+    final seen = <String, Map<String, dynamic>>{};
+    for (final block in linuxBlocks) {
+      final executable = block.linux['executable']?.toString();
+      if (executable == null) continue;
+      final hints = {
+        'flatpak': block.linux['flatpak'],
+        'emudeck_launcher': block.linux['emudeck_launcher'],
+      };
+      final first = seen[executable];
+      if (first == null) {
+        seen[executable] = hints;
+      } else {
+        expect(
+          hints,
+          first,
+          reason:
+              '$executable is annotated inconsistently '
+              '(${block.file} / ${block.uniqueId})',
+        );
+      }
+    }
+  });
+
+  test('desktop blocks use "args", never Android\'s "launch_arguments"', () {
+    // LauncherService only reads `args` off a desktop platform block. An entry
+    // carrying `launch_arguments` instead launches the emulator with no ROM at
+    // all, which is how Dolphin ended up opening its own game list on Linux.
+    final dir = Directory('assets/systems');
+    for (final entity in dir.listSync()) {
+      if (entity is! File || !entity.path.endsWith('.json')) continue;
+      final json =
+          jsonDecode(entity.readAsStringSync()) as Map<String, dynamic>;
+      final emulators = (json['emulators'] ?? json['players'] ?? []) as List;
+      for (final emulator in emulators) {
+        final platforms = (emulator as Map)['platforms'];
+        if (platforms is! Map) continue;
+        for (final entry in platforms.entries) {
+          if (entry.key == 'android') continue;
+          final config = entry.value;
+          if (config is! Map) continue;
+          expect(
+            config.containsKey('launch_arguments'),
+            isFalse,
+            reason:
+                '${entity.uri.pathSegments.last} / ${emulator['unique_id']} '
+                '(${entry.key}) uses launch_arguments; desktop reads args',
+          );
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). Every change here was reviewed and tested on real hardware by me before opening this PR.

**Update (2026-08-04): [#271](https://github.com/misobadev/neostation-frontend/pull/271) has merged, and this branch now sits directly on top of it.** The question this draft was posing — which implementation should be the base — is settled: #271 is the base. Everything here is additive, applies cleanly, and the whole suite is green on top of it.

Since that landed, a further Steam Deck session found and fixed two faults that only hardware could have surfaced. Both are in the table below and detailed under **What the second device session changed**.

# Description

Launching a game on Linux or SteamOS failed for anyone who had not manually pointed a file picker at every emulator. The systems JSON names emulators by bare executable (`retroarch`, `dolphin`), but on Linux an emulator is almost never a plain binary: it is a Flatpak, an EmuDeck launcher script, or a versioned AppImage. Nothing existed at the name as written, so the launch was rejected before it started, and the emulator list reported every core as not installed on machines that had them all.

Five commits, each standing on its own:

| | |
|---|---|
| `feat(systems)` | Carry the Flatpak app id and EmuDeck launcher name beside the executable under `platforms.linux`, and surface both through `LauncherService`. Per-emulator knowledge lives in the systems data, so a wrong app id is a systems update rather than an app release. No behaviour change. |
| `feat(linux)` | `LinuxEmulatorDiscovery`: given those hints, find where the emulator actually lives. Nothing calls it yet. |
| `fix(linux)` | Use it at the two launch sites and in the emulator-list probe. |
| `fix(linux)` | Resolve the RetroArch cores directory by probing, and rewrite the bare `-L core.so` to an absolute path. |
| `feat(linux)` | `LinuxHostProcess`: start emulators via `flatpak-spawn --host` when NeoStation is itself sandboxed. |
| `fix(linux)` | Treat a **discoverable** emulator as installed, so selection can see the standalone that works. |
| `feat(launch)` | Say why an emulator that exits immediately failed, instead of reporting it as a finished game. |
| `docs(linux)` | State precisely what is unverified about the Flatpak path. |

### Discovery order

1. **EmuDeck launcher script** (`<Emulation>/tools/launchers/*.sh`) — first because it wraps whatever EmuDeck installed and applies EmuDeck's own per-emulator setup, which invoking the Flatpak or AppImage directly skips. The root comes from `~/.config/EmuDeck/settings.sh`, not an assumed `$HOME/Emulation`, since SD-card installs are common on a Deck.
2. **Flatpak export wrapper** — user installation before system-wide.
3. **An absolute path** from the JSON, when one is given.
4. **`PATH`**, then `/usr/bin`, `/usr/local/bin`, `/bin`, `/usr/games`, `~/.local/bin`, `~/Applications`.
5. **AppImage matched by prefix**, so a version bump (`Azahar-2120.AppImage`) doesn't break the match.

Discovery only runs when the configured path is absent or already broken, so an explicit user choice is never overridden, and "not found" is returned as a real answer rather than replaced by a guess.

### RetroArch cores

Cores are never beside the executable here — a Flatpak keeps them under `~/.var`, a distro under `/usr/lib/libretro` — and the previous `path.contains('flatpak')` test missed the EmuDeck case, since its launcher is a `flatpak run` wrapper that looks like a plain shell script. Cores are now located by probing, and the bare `-L core.so` from the JSON is rewritten to an absolute path: RetroArch resolved it against *our* working directory, not its own. A core that cannot be found is left untouched so RetroArch reports it, because a wrong absolute path turns that message into a silent black screen.

### Two faults the device found that unit tests had not

- EmuDeck quotes only the install root and concatenates the rest onto it (`toolsPath="/run/media/deck/Deck"/Emulation/tools`). Stripping a matched outer pair leaves the quotes embedded, so the recorded root was silently ignored.
- `Directory.exists()` *throws* rather than returning false on an unreadable mount (`/run/media/root` is mode 700 and owned by another user). That exception escaped discovery and took the whole launch down with it.

Both now have regression tests that fail without the fix.

### What the second device session changed

Tested again on a Deck with an **SD-card EmuDeck install** and an **empty `user_emulator_config`** — nothing configured at all, so every launch below was discovery doing the entire job.

**GameCube launched and instantly closed.** Nothing configures an executable path on a Deck, so the desktop install signal — "the user file-pickered a path" — reported every standalone as uninstalled. Selection could not see that a working standalone existed, fell through to the JSON default, and for GameCube that is a RetroArch core the user never installed. RetroArch rejects a missing core at parse time and exits 0, so the game "launched" and closed at once, with Standalone Dolphin installed and discoverable the whole time.

`isInstalled` now comes from discovery on Linux: a resolvable executable is the same evidence a configured path is, only gathered rather than typed in. Selection already preferred a genuinely-installed standalone — it just had no way to see one. Confirmed on the Deck afterwards:

```
[EmuSel] emulator=gc.org.dolphinemu.dolphinemu  source=auto-resolved default
  - gc.ra.dolphin        standalone=false installed=false isDefault=true  core=dolphin_libretro.so
  - gc.org.dolphinemu…   standalone=true  installed=true  isDefault=false
Resolved "dolphin" to /run/media/deck/Deck/Emulation/tools/launchers/dolphin-emu.sh
```

Dolphin then booted the ROM directly — window title `… | 18 Wheeler: American Pro Trucker (GWEE51)` — rather than opening its own game list.

**A failed launch explained nothing.** Diagnosing the above meant reconstructing the command by hand and re-running it on the device, because the launch path drained the emulator's stdout and stderr into empty callbacks. The exit code cannot stand in for that either: an EmuDeck launcher script runs its own cleanup after the emulator returns, so the script reports *that* command's status. A RetroArch that rejected its ROM and a user quitting a game both arrive as "exited with code 0", instantly and identically.

The resolved command is now logged — after discovery and core-absolutisation it no longer resembles what the JSON says, so it is the one thing nobody can reconstruct afterwards — and the emulator's last lines are kept and reported when it exits too fast to have been played. A launch that works is unaffected, and the capture is bounded.

This paid for itself immediately: an arcade game that "didn't launch" turned out to be an incomplete ROM set for MAME 2003 Plus (`readroms failed`), with the frontend having done everything correctly and said none of it. The same ROM runs on FBNeo and FBAlpha 2012.

**Also settled here:** Flatpak RetroArch *does* accept an absolute `~/.var/…` core path from inside its sandbox — `[Core] Loading dynamic libretro core from: "/home/deck/.var/app/org.libretro.RetroArch/config/retroarch/cores/…"`. That was previously listed as unverified.

No issue to close — this came from two Discord reports: a user who could not find the RetroArch executable after installing everything through EmuDeck, and a second who observed that the JSON should point at the Flatpaks directly. Related to #192, the same class of problem on Android: an emulator reported ready when its core is not installed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors. *(clean on every commit individually)*
- [x] I have added tests demonstrating that my fix or feature works. *(5 test files; 487 passing overall)*
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. *(no new assets)*
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [ ] Android
- [x] **Gamepad support verified** (if applicable). *(unchanged by this PR)*

## Verification

Verified end to end on a Steam Deck running SteamOS 3.x + EmuDeck, across two sessions: 1941 boots through `tools/launchers/retroarch.sh` with an absolute fbneo core path, the emulator list's Ready / Not-configured verdicts match the cores on disk exactly for all eight arcade entries, and GameCube boots the ROM directly through Standalone Dolphin on a Deck with nothing configured.

The second session's Deck had EmuDeck installed on the **SD card**, so the recorded-root parsing is now exercised against a real `/run/media` install rather than a fixture. The Flatpak app ids and EmuDeck launcher names were also checked against upstream EmuDeck's current `main`, not merely the install under test, so the hints are not pinned to one machine's vintage.

**What is *not* verified, stated plainly:**

- The EmuDeck path is the one that ran on hardware, because EmuDeck was installed on the test Deck. Strategies 2–5 (plain Flatpak, `PATH`, AppImage) are covered by unit tests only.
- `LinuxHostProcess` has never executed its sandboxed branch anywhere: the release path ships an AppImage, so `isSandboxed` is false on every machine this has run on. The command rewriting is unit-tested; the portal round trip is not. That makes it unverified rather than unbuildable — `linux/flatpak/` does build a working Flatpak, and one was installed on the test Deck as recently as 2026-07-27 — so verifying it is a matter of building that manifest and launching from it. It stays confined to one file so it can be deleted whole if the Flatpak build is abandoned.
- Emulators installed by a distro package under host `/usr` stay invisible *when sandboxed*, since a Flatpak's `/usr` is the runtime's. Reaching those needs `--filesystem=host-os` and a `/run/host` prefix in the probe paths. Flatpak and EmuDeck installs — the ones a Deck actually has — resolve.

## Screenshots (if applicable)

n/a — no visual change.

