### PR TITLE
docs: add agent instructions (CLAUDE.md + AGENTS.md) and refresh stale doc facts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+@CLAUDE.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ Key providers:
 - `SqliteConfigProvider` — main app state (ROM folders, systems, scanning)
 - `SqliteDatabaseProvider` — game library data
 - `NeoSyncProvider` — cloud save sync state
-- `ThemeProvider` — theme switching (6 themes)
+- `ThemeProvider` — theme switching (14 built-in themes + user custom themes)
 - `RetroAchievementsProvider` — RA user data and achievements
 
 ### Business Logic Layer
@@ -57,6 +57,7 @@ Key providers:
 
 Key services:
 - `NeoSyncService` — cloud file synchronization
+- `SyncManager` (`lib/sync/`) — provider-agnostic save-sync orchestration; cloud backends implement `ISyncProvider` (NeoSync adapter under `lib/sync/providers/`)
 - `RetroAchievementsService` — RA API client
 - `ScreenScraperService` — metadata scraping with concurrency control
 - `GameService` — game launching and session tracking
@@ -104,6 +105,7 @@ Database migrations are versioned in `lib/data/datasources/sqlite_migrations.dar
 
 - **Desktop (Windows/Linux/macOS)**: Uses `window_manager` and `fullscreen_window` for fullscreen toggling. Supports `Alt+Enter` shortcut.
 - **Android**: Uses immersive sticky mode, landscape lock, and a custom directory picker for Android TV.
+- **Dual-screen handhelds (Android)**: the secondary display runs a second Flutter engine (`subDisplay()` entrypoint in `main.dart`, via the `sub_screen` package) rendering `lib/screens/secondary_screen/`. It is a separate isolate: no shared memory with the main engine — state is shared only through the SQLite database.
 - **Gamepad input**: Handled via the local `gamepads` plugin with custom navigation logic in `lib/utils/gamepad_nav.dart`.
 
 ## Local Packages (Vendored)
@@ -112,7 +114,6 @@ To maintain stability and performance, some libraries are maintained within the 
 
 - **`gamepads`**: A modified version of Flame Engine's gamepad library, optimized for low-latency UI navigation and multi-controller support.
 - **`flutter_7zip`**: FFI bindings for the 7-Zip library. Used for efficient extraction of compressed ROMs (7z, zip, rar) with progress tracking.
-- **`flutter_soloud`**: Low-level audio engine. Bypasses standard Flutter audio plugins to provide the low-latency SFX and background music required for a console-like experience.
 
 ## Asset Bootstrap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+NeoStation is a landscape-only, gamepad-driven Flutter emulation frontend for **Windows, Linux, macOS, and Android** (no web, no iOS). Two existing docs are authoritative and worth reading before non-trivial work:
+- `ARCHITECTURE.md` — layered architecture, providers/services/repositories/datasources, code conventions.
+- `README.md` — build-time configuration (`--dart-define`), Android signing, CI secrets, vendored packages.
+
+This file captures the commands and the cross-cutting rules that aren't obvious from any single file.
+
+`AGENTS.md` just includes this file (`@CLAUDE.md`), so agents that look for either name get the same instructions.
+Personal, machine-specific notes belong in an untracked `CLAUDE.local.md` (already gitignored via `*.local.md`).
+
+## Commands
+
+```bash
+flutter pub get
+flutter analyze                 # must be clean (no errors/warnings) — CI enforces it
+dart format .                   # CI fails on unformatted code (--set-exit-if-changed)
+flutter test                    # all tests — CI enforces it
+flutter test test/game_service_test.dart                       # a single test file
+flutter test test/game_service_test.dart --plain-name "name"   # tests matching a name
+```
+
+CI (`.github/workflows/build-and-deploy.yml`) runs format check + analyze + test before the platform build matrix.
+
+Run/build need build-time secrets via `--dart-define` (`SCREENSCRAPER_DEV_ID`, `SCREENSCRAPER_DEV_PASSWORD`) — without them, ScreenScraper features degrade but the app still runs. RetroAchievements has no build-time key: each user signs in with their own web API key at runtime. See README for the full matrix.
+
+```bash
+flutter run   --dart-define=SCREENSCRAPER_DEV_ID=... --dart-define=SCREENSCRAPER_DEV_PASSWORD=...
+flutter build apk --release   <same --dart-define flags>
+```
+
+There is no release-keystore requirement for local work: if `android/key.properties` is absent, the Android build falls back to debug signing automatically.
+
+## Cross-cutting rules (read multiple files to get right)
+
+**Layer dependency direction is strict** (see ARCHITECTURE.md): UI → providers → services → repositories → datasources. Services must NOT touch `lib/data/datasources/` directly — go through a repository. Repositories are the only layer allowed to call `SqliteService`/datasources. Cloud-save sync goes through the provider-agnostic `lib/sync/` layer (`SyncManager` + `ISyncProvider`), with NeoSync as the adapter under `sync/providers/`.
+
+**Database schema changes touch two files and several queries:**
+- **New columns go in a versioned migration, not the on-launch ALTER pattern** (maintainer's rule, PR #57). Add an idempotent step to the `migrateToVersion` switch in `lib/data/datasources/sqlite_migrations.dart` and bump `_databaseVersion` in `lib/data/datasources/sqlite_service.dart`. Also add the column to the `CREATE TABLE` in `sqlite_service.dart` so fresh installs get it. The defensive `_ensure*Columns` methods (which run on every launch and ALTER-add missing columns) are a legacy safety net — don't rely on them for new work.
+- A new `user_system_settings` column must also be **selected in every system-loading query** or it silently reads as default. There are several: `loadSystemsFromDb`, `getUserDetectedSystems`, `getAllSystems`, and the explicit column read in `getSystemByFolderName` (which `copyWith`s settings onto the cached model). Thread it through all of them, plus `SystemModel` (`fromJson`/`toJson`/`copyWith`) and a `SystemRepository`/`SqliteService` setter.
+- The downgrade path **recreates the database** (`_onDowngrade`), so running a lower-`_databaseVersion` build over a newer database wipes local data — relevant when switching branches on a test device.
+
+**Dual-display devices run a second Flutter engine.** `subDisplay()` in `lib/main.dart` (tagged `@pragma('vm:entry-point')`, driven by the `sub_screen` package) renders `lib/screens/secondary_screen/` on dual-screen Android handhelds. It is a separate engine/isolate: it initializes localization and config independently and shares **nothing in memory** with the main engine — both open the same SQLite database. Any state that must appear on both screens has to be persisted or re-derived, not assumed shared.
+
+**Android ROM paths are SAF content URIs, not filesystem paths.** `GameModel.romPath` on Android looks like `content://…/document/primary%3Aemu%2Froms%2Fnes%2FGame.zip` (separators URL-encoded as `%2F`). Desktop uses plain paths. Any path parsing (subfolder/directory logic) must handle the URL-encoded SAF form. **Test path logic on a device, not just desktop** — unit tests use plain paths and won't catch this.
+
+**Localization is custom and map-based** (the `flutter_localization` package, not gen-l10n/ARB). Adding a string requires: a `static const String` key in `lib/l10n/app_locale.dart`, then a value in **every** `lib/l10n/app_locale_<lang>.dart` file (12 languages: de, en, es, fr, id, it, ja, ko, pt, ru, zh, zh_hant). A missing key in any file is an analyzer error.
+
+**Gamepad navigation is custom** (`lib/utils/gamepad_nav.dart` + `GamepadNavigationManager` layer stack). Screens own their selection index and drive child views via `selectedIndex`; the list/grid/carousel widgets are largely presentational. Every interactive element must be reachable by D-pad/controller, not just touch/mouse; B is the app-wide back/cancel action, including escaping a focused text field. Injected Android `adb input keyevent` D-pad events are NOT picked up by this nav (use `input tap` when scripting the UI).
+
+**Android keycode buttons arrive action-encoded and inverted.** On Android (confirmed on the AYN Thor) the gamepads plugin reports keycode-backed buttons with press = `0.0` and release = `1.0` — the opposite of the analog convention. The translator historically un-inverted only the D-pad, so face/shoulder buttons fired on *release* and held modifiers (Select, L1/R1) latched stuck. When adding a button binding, check how that button's value is decoded before assuming `> 0.5` means pressed; press/release edges for modifier keys are read at the raw key level.
+
+**System/emulator definitions live in this repo.** `assets/systems/*.json` is the single source of truth for systems, emulator definitions, and launch arguments — PRs for emulator fixes belong here (the separate `neostation-systems` repo is defunct). The bundled `assets/manifest.json` drives the over-the-air systems update mechanism, so compatible changes reach existing installs without an app release. `assets/data/` SQL files seed the database on first run.
+
+**Prefer JSON over Kotlin for emulator launch fixes (maintainer's architectural rule).** Keep `EmulatorLauncher.kt` emulator-agnostic — do **not** add new conditionals / hardcoded package lists there unless strictly necessary. First try to fix launch behaviour by editing the emulator's `launch_arguments` in its `assets/systems/<sys>.json` — usually swapping the path placeholder is enough:
+- `{file.path}` → best-effort real filesystem path (resolves SAF `content://` to a raw path; for emulators that need a real path).
+- `{file.localuri}` → keeps a `content://` SAF URI as-is (so `launchGenericIntent` can grant it read permission); falls back to `file://` for bare paths.
+- `{file.uri}` → `content://`/`file://` pass through; bare paths → `file://`.
+The opt-out from our FileProvider rewrap (for emulators that need the original SAF `content://` URI — e.g. Flycast's `.zip` loading, DraStic) is **config-driven**, not a hardcoded Kotlin package list: set `"keep_saf_uri": true` in the emulator's `android` block in `assets/systems/<sys>.json`. The flag threads through `LauncherService` → `game_service.dart` (method channel) → `EmulatorLauncher.kt`, which keeps the Kotlin emulator-agnostic. Example: issue #50/#66 (DraStic) was fixed by `{file.path}`→`{file.localuri}` **plus** `"keep_saf_uri": true` — no Kotlin change. Only touch `EmulatorLauncher.kt` if a genuinely new mechanism (not just another opt-out emulator) is needed.
+
+**Testing embedded `assets/systems/` changes locally:** the app prefers previously downloaded systems over the bundle unless the bundle's version is higher. To force it to read your local edits, bump `latest_version` in `assets/manifest.json` above whatever value is currently there; on launch you'll see `SystemsUpdateService: bundled vX > cached "Y", clearing cache`.
+
+**Vendored packages** live in `/packages/` (`gamepads*`, `flutter_7zip`) — modified upstream libraries wired in as a pub workspace; prefer fixing there over working around them.
+
+## Conventions
+
+Beyond standard Dart/Flutter (and the items in ARCHITECTURE.md — `Color.withValues(alpha:)` not `withOpacity`, `mounted` guards after `await`, `flutter_screenutil` for all sizing, English comments): widgets `PascalCase`, variables `camelCase`, files `snake_case`. Conventional Commits (`feat:`, `fix:`, …); branches `feature/…`, `fix/…`, `refactor/…`, `docs/…`; PRs use `.github/PULL_REQUEST_TEMPLATE.md`. All user-facing UI text goes through `AppLocale` — never hardcoded strings.
+
+## Commits (per AI_GUIDELINES.md)
+
+- **Never** add a DCO sign-off from an AI (no `git commit -s` / `Signed-off-by:`).
+- For significant AI-assisted work, add an `AI-Assisted: NAME:VERSION` trailer (e.g. `AI-Assisted: Claude:Fable-5`). A `Co-Authored-By:` trailer is fine and used in practice.
+- Code must pass `dart format`, `flutter analyze` (clean), and `flutter test` (all passing) before commit — CI enforces all three.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ NeoStation provides a fast, lightweight, and customizable experience for managin
 - **RetroAchievements support**: Track achievements and leaderboard progress.
 - **ScreenScraper integration**: Automatic metadata and media scraping.
 - **Gamepad & keyboard navigation**: Full controller support across all platforms.
-- **10 languages supported**: English, Spanish, Portuguese, Russian, Chinese, French, German, Italian, Indonesian, Japanese.
+- **12 languages supported**: English, Spanish, Portuguese, Russian, Chinese (Simplified & Traditional), French, German, Italian, Indonesian, Japanese, Korean.
 
 ## Multi-disc ROM Organization
 
@@ -190,12 +190,13 @@ flutter build macos --release $DART_DEFINES
 lib/
 ├── data/
 │   └── datasources/     # SQLite access, migrations, raw queries
-├── l10n/               # Localization files (10 languages)
+├── l10n/               # Localization files (12 languages)
 ├── models/             # Data models
 ├── providers/          # ChangeNotifier state management
 ├── repositories/       # Data access abstraction layer
 ├── screens/            # Application pages
 ├── services/           # Business logic and external APIs
+├── sync/               # Provider-agnostic cloud sync (SyncManager + adapters)
 ├── themes/             # App themes
 ├── utils/              # Helpers and utilities
 ├── widgets/            # Reusable UI components
@@ -215,7 +216,6 @@ These packages are "vendored" within the /packages directory to ensure long-term
 |---------|-------------|
 | `gamepads` | Cross-platform gamepad input (based on Flame Engine's gamepads) |
 | `flutter_7zip` | FFI bindings for 7-Zip archive extraction |
-| `flutter_soloud` | Low-level audio playback using the SoLoud engine |
 
 ## Systems & Emulator Definitions
 

--- a/THEMES.md
+++ b/THEMES.md
@@ -2,6 +2,8 @@
 
 Welcome to the NeoStation theme system. This document will explain how to create new themes following established conventions.
 
+> **Note:** This guide covers the app's **UI color themes** (`lib/themes/`). It is unrelated to **System Art packs** — the downloadable system card backgrounds and logos (formerly also called "themes"; their manifest and cache paths still use `theme.json` naming).
+
 ---
 
 ## 📋 Theme Structure


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). Reviewed by me before opening.

# Description

Adds committed agent instructions and fixes stale facts in the existing docs.

- **New `CLAUDE.md`** — guidance for AI coding agents working in this repo: commands (single-test invocations, CI-enforced format/analyze/test), the strict layer rule, the two-file DB migration procedure and `user_system_settings` query threading, SAF content-URI paths, the map-based localization workflow, custom gamepad navigation and the Android keycode inversion gotcha, the JSON-over-Kotlin launcher rule (`launch_arguments` placeholders, `keep_saf_uri`), and the `assets/manifest.json` version-bump trick for testing bundled systems locally. `AGENTS.md` is a one-line pointer to it so tools that look for either name find the same instructions.
- **README**: 12 supported languages (Korean and Traditional Chinese were missing), `flutter_soloud` removed from the vendored-packages table (it is a regular pub dependency; `/packages` has no copy), `lib/sync/` added to the project structure.
- **ARCHITECTURE**: same `flutter_soloud` correction, theme count 6 → 14 built-in + user custom themes, documents `SyncManager`/`ISyncProvider` and the dual-screen second-engine `subDisplay()` entrypoint.
- **THEMES**: note disambiguating UI color themes from System Art packs.

Fixes # (n/a)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors. (docs-only change — no Dart touched)
- [ ] I have added tests demonstrating that my fix or feature works. (n/a, docs only)
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. (no assets)
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android (n/a, docs only)
- [ ] **Gamepad support verified** (if applicable). (n/a)

## Screenshots (if applicable)

n/a — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)