### PR TITLE
ci: group Dependabot updates into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+    groups:
+      pub-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -20,3 +24,7 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
> [!NOTE]
> This PR was written with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

Weekly Dependabot pub bumps currently arrive as one PR per package — five are open right now (#171, #173, #174, #205, #206) — and each needs its own review/rebase/merge cycle even though they're all minor/patch bumps of direct dependencies (majors are already ignored by the existing config).

This adds Dependabot `groups` so each weekly run opens **a single combined PR per ecosystem**: one for pub, one for github-actions. One PR per week means one review/test cycle instead of five, and (once #279 lands) one CI run.

Notes:
- The already-open per-package PRs won't retroactively combine; on the next weekly run Dependabot notices the config change, closes them, and opens a grouped one.
- If one package in a group misbehaves, `@dependabot ignore this dependency`/`ignore this minor version` on the grouped PR excludes it and the group re-opens without it — grouping doesn't remove per-package control.
- No change to the update policy itself: still weekly, direct deps only, no majors.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [ ] I have run `flutter analyze` and there are no errors. (N/A — no Dart code touched.)
- [ ] I have added tests demonstrating that my fix or feature works. (N/A — Dependabot configuration.)
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. (No new assets.)
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android (N/A — no app change.)
- [ ] **Gamepad support verified** (N/A).

## Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
