### PR TITLE
feat: unified shimmering-logo intro across the whole startup sequence

### DIFF
--- a/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Modify this file to customize your launch splash screen -->
+<!-- Pre-Android-12 launch splash: solid app background. The logo itself is
+     drawn by Flutter's startup screen a moment later; keeping the native layer
+     to a matching solid color makes the handoff seamless. -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/ic_launcher_background" />
-
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+    <item android:drawable="@color/splash_background" />
 </layer-list>

--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Modify this file to customize your launch splash screen -->
+<!-- Pre-Android-12 launch splash: solid app background. The logo itself is
+     drawn by Flutter's startup screen a moment later; keeping the native layer
+     to a matching solid color makes the handoff seamless. -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/ic_launcher_background" />
-
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+    <item android:drawable="@color/splash_background" />
 </layer-list>

--- a/android/app/src/main/res/values-night-v31/styles.xml
+++ b/android/app/src/main/res/values-night-v31/styles.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Android 12+ system SplashScreen: same background as the Flutter
+         startup screens and NO icon — the OS renders its icon at a fixed
+         small size that can never match the 280dp Flutter logo, so the only
+         seamless handoff is a plain color splash with Flutter drawing the
+         first (and only) logo. -->
+    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowSplashScreenBackground">@color/splash_background</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@android:color/transparent</item>
+        <item name="android:windowBackground">@drawable/launch_background</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">false</item>
+        <item name="android:colorAccent">@android:color/transparent</item>
+        <item name="android:colorPrimary">@android:color/transparent</item>
+    </style>
+    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">false</item>
+        <item name="android:colorAccent">@android:color/transparent</item>
+        <item name="android:colorPrimary">@android:color/transparent</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values-v31/styles.xml
+++ b/android/app/src/main/res/values-v31/styles.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Android 12+ system SplashScreen: same background as the Flutter
+         startup screens and NO icon — the OS renders its icon at a fixed
+         small size that can never match the 280dp Flutter logo, so the only
+         seamless handoff is a plain color splash with Flutter drawing the
+         first (and only) logo. -->
+    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowSplashScreenBackground">@color/splash_background</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@android:color/transparent</item>
+        <item name="android:windowBackground">@drawable/launch_background</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">false</item>
+        <item name="android:colorAccent">@android:color/transparent</item>
+        <item name="android:colorPrimary">@android:color/transparent</item>
+    </style>
+    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">false</item>
+        <item name="android:colorAccent">@android:color/transparent</item>
+        <item name="android:colorPrimary">@android:color/transparent</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="ic_launcher_background">#1d2024</color>
+    <!-- Matches the Flutter dark theme scaffold (and the startup screens),
+         so the native splash hands off without a background jump. -->
+    <color name="splash_background">#15191e</color>
 </resources>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:neostation/services/steam_scraper_service.dart';
 import 'package:neostation/providers/system_background_provider.dart';
 import 'package:neostation/providers/neo_assets_provider.dart';
 import 'package:neostation/widgets/app_lifecycle_handler.dart';
+import 'package:neostation/widgets/shimmering_logo.dart';
 import 'package:neostation/widgets/permission_check_wrapper.dart';
 import 'package:neostation/utils/custom_scroll_behavior.dart';
 import 'package:flutter_localization/flutter_localization.dart';
@@ -419,9 +420,18 @@ String _startupString(String key) {
 /// Shared chrome for the pre-initialization screens: logo, wordmark and a
 /// caller-supplied status area.
 class _StartupScaffold extends StatelessWidget {
-  const _StartupScaffold({required this.children, this.onKeyEvent});
+  const _StartupScaffold({
+    required this.children,
+    this.onKeyEvent,
+    this.animatedLogo = false,
+  });
 
   final List<Widget> children;
+
+  /// Show the shimmering logo instead of the static one. Used by the loading
+  /// screen, where the shine doubles as the activity indicator; the error
+  /// screen keeps the static logo (a shine would imply progress).
+  final bool animatedLogo;
 
   /// Raw key handler used by the error screen. The gamepad navigation manager
   /// is not running this early, so gamepad buttons are read straight from the
@@ -433,39 +443,64 @@ class _StartupScaffold extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       home: Scaffold(
-        backgroundColor: const Color(0xFF090B10),
+        // Matches the dark theme's scaffold color so the handoff into the
+        // themed splash doesn't read as a background jump.
+        backgroundColor: const Color(0xFF15191e),
         body: Focus(
           autofocus: onKeyEvent != null,
           onKeyEvent: onKeyEvent == null
               ? null
               : (_, event) => onKeyEvent!(event),
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.all(32),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Image.asset(
-                    'assets/images/logo_transparent.png',
-                    width: 112,
-                    height: 112,
-                  ),
-                  const SizedBox(height: 24),
-                  const Text(
-                    'NeoStation',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 28,
-                      fontWeight: FontWeight.w600,
-                      letterSpacing: 1.2,
+          // Animated mode pins the logo at the exact screen centre — the same
+          // spot the Android 12+ splash icon occupies — with the status text
+          // hung below centre, so the native→Flutter handoff and the later
+          // screens never move the logo. The error screen keeps the simpler
+          // centred column with the wordmark.
+          child: animatedLogo
+              ? Stack(
+                  children: [
+                    const Center(child: ShimmeringLogo()),
+                    Align(
+                      // Same offset as the scan splash's progress detail so
+                      // the text/progress zone is one fixed place all intro.
+                      alignment: const Alignment(0, 0.55),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 32),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: children,
+                        ),
+                      ),
+                    ),
+                  ],
+                )
+              : Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(32),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Image.asset(
+                          'assets/images/logo_transparent.png',
+                          width: 112,
+                          height: 112,
+                        ),
+                        const SizedBox(height: 24),
+                        const Text(
+                          'NeoStation',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 28,
+                            fontWeight: FontWeight.w600,
+                            letterSpacing: 1.2,
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                        ...children,
+                      ],
                     ),
                   ),
-                  const SizedBox(height: 24),
-                  ...children,
-                ],
-              ),
-            ),
-          ),
+                ),
         ),
       ),
     );
@@ -473,28 +508,59 @@ class _StartupScaffold extends StatelessWidget {
 }
 
 /// Lightweight root displayed while the app waits for its persisted data.
-class StartupLoadingApp extends StatelessWidget {
+class StartupLoadingApp extends StatefulWidget {
   const StartupLoadingApp({super.key});
+
+  @override
+  State<StartupLoadingApp> createState() => _StartupLoadingAppState();
+}
+
+class _StartupLoadingAppState extends State<StartupLoadingApp> {
+  /// On a healthy device this screen lasts well under a second, so the
+  /// "waiting for storage" line would only ever flash. Keep it invisible
+  /// (but laid out, so nothing shifts) and fade it in once the wait has
+  /// gone on long enough to actually be a wait.
+  static const _textDelay = Duration(milliseconds: 1500);
+
+  bool _showText = false;
+  Timer? _textTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _textTimer = Timer(_textDelay, () {
+      if (mounted) setState(() => _showText = true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _textTimer?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return _StartupScaffold(
+      animatedLogo: true,
       children: [
-        const SizedBox(
-          width: 28,
-          height: 28,
-          child: CircularProgressIndicator(
-            strokeWidth: 3,
-            color: Color(0xFF70C8FF),
-          ),
-        ),
-        const SizedBox(height: 20),
-        ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 440),
-          child: Text(
-            _startupString(AppLocale.startupLoading),
-            textAlign: TextAlign.center,
-            style: const TextStyle(color: Color(0xFFC4CBD6), fontSize: 16),
+        AnimatedOpacity(
+          opacity: _showText ? 1.0 : 0.0,
+          duration: const Duration(milliseconds: 400),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 440),
+            child: Text(
+              _startupString(AppLocale.startupLoading),
+              textAlign: TextAlign.center,
+              // Same voice as the splash's status line: the app font (Anta),
+              // small and dimmed. GoogleFonts falls back gracefully for the
+              // first frames if the font isn't warmed up yet.
+              style: GoogleFonts.anta(
+                color: Colors.white.withValues(alpha: 0.6),
+                fontSize: 17,
+                letterSpacing: 0.3,
+              ),
+            ),
           ),
         ),
       ],

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -10,6 +10,7 @@ import 'package:neostation/providers/theme_provider.dart';
 import 'package:neostation/providers/neo_assets_provider.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/widgets/custom_notification.dart';
+import 'package:neostation/widgets/shimmering_logo.dart';
 import 'package:neostation/providers/retro_achievements_provider.dart';
 import 'package:video_player/video_player.dart';
 import 'package:provider/provider.dart';
@@ -638,92 +639,37 @@ class _SystemGamesListState extends State<SystemGamesList> {
     return LetterIndicator(letter: _currentLetter!, visible: _isLetterJumping);
   }
 
-  /// Visual placeholder for initial data hydration.
+  /// Visual placeholder for initial data hydration. Matches the startup
+  /// splash: shimmering logo with quiet supporting text, no card chrome.
   Widget _buildLoadingState() {
     return Center(
-      child: Container(
-        padding: EdgeInsets.all(32.w),
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
-          borderRadius:
-              Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-              BorderRadius.circular(14.r),
-          border: Border.all(
-            color: Theme.of(context).colorScheme.outline,
-            width: 1.r,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ShimmeringLogo(width: 200.r),
+          SizedBox(height: 24.r),
+          Text(
+            AppLocale.loadingGames.getString(context),
+            style: TextStyle(
+              fontSize: 20.r,
+              fontWeight: FontWeight.w600,
+              color: Theme.of(context).colorScheme.onSurface,
+              letterSpacing: 0.5,
+            ),
           ),
-          boxShadow: [
-            BoxShadow(
+          SizedBox(height: 8.r),
+          Text(
+            AppLocale.preparingLibrary.getString(context),
+            style: TextStyle(
+              fontSize: 14.r,
+              fontWeight: FontWeight.w400,
               color: Theme.of(
                 context,
-              ).colorScheme.shadow.withValues(alpha: 0.5),
-              blurRadius: 3.r,
-              offset: Offset(2.r, 2.r),
+              ).colorScheme.onSurface.withValues(alpha: 0.7),
+              letterSpacing: 0.3,
             ),
-          ],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              width: 64.r,
-              height: 64.r,
-              decoration: BoxDecoration(
-                color: Theme.of(
-                  context,
-                ).colorScheme.surface.withValues(alpha: 0.9),
-                borderRadius:
-                    Theme.of(
-                      context,
-                    ).extension<CornerRadii>()?.radiusExternal ??
-                    BorderRadius.circular(14.r),
-                border: Border.all(
-                  color: Theme.of(context).colorScheme.outline,
-                  width: 1.r,
-                ),
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.shadow.withValues(alpha: 0.5),
-                    blurRadius: 3.r,
-                    offset: Offset(2.r, 2.r),
-                  ),
-                ],
-              ),
-              child: Center(
-                child: CircularProgressIndicator(
-                  valueColor: AlwaysStoppedAnimation<Color>(
-                    Theme.of(context).colorScheme.onSurface,
-                  ),
-                  strokeWidth: 3.r,
-                ),
-              ),
-            ),
-            SizedBox(height: 24.r),
-            Text(
-              AppLocale.loadingGames.getString(context),
-              style: TextStyle(
-                fontSize: 20.r,
-                fontWeight: FontWeight.w600,
-                color: Theme.of(context).colorScheme.onSurface,
-                letterSpacing: 0.5,
-              ),
-            ),
-            SizedBox(height: 8.r),
-            Text(
-              AppLocale.preparingLibrary.getString(context),
-              style: TextStyle(
-                fontSize: 14.r,
-                fontWeight: FontWeight.w400,
-                color: Theme.of(
-                  context,
-                ).colorScheme.onSurface.withValues(alpha: 0.7),
-                letterSpacing: 0.3,
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/systems_screen/system_content.dart
+++ b/lib/screens/systems_screen/system_content.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:provider/provider.dart';
 import 'package:neostation/providers/theme_provider.dart';
+import 'package:neostation/widgets/shimmering_logo.dart';
 import '../../../providers/sqlite_config_provider.dart';
 import 'my_systems_section/my_systems_grid.dart';
 import 'my_systems_section/initial_setup_widget.dart';
@@ -11,7 +14,7 @@ import 'my_systems_section/initial_setup_widget.dart';
 ///
 /// Manages the visual state transition between the initial scanning/loading phase,
 /// the setup wizard for first-time users, and the primary system library grid.
-class SystemContent extends StatelessWidget {
+class SystemContent extends StatefulWidget {
   const SystemContent({super.key, this.selectedIndex = 0, this.onCardTapped});
 
   /// Index of the currently selected system card within the grid.
@@ -21,87 +24,170 @@ class SystemContent extends StatelessWidget {
   final Function(int index)? onCardTapped;
 
   @override
+  State<SystemContent> createState() => _SystemContentState();
+}
+
+class _SystemContentState extends State<SystemContent> {
+  /// Minimum time the splash stays visible once shown. A fast scan (sub-second
+  /// on a warm library) would otherwise blink the logo away before the shine
+  /// animation is even perceptible.
+  static const _minSplashDuration = Duration(milliseconds: 2500);
+
+  /// When the splash first appeared; null once it has been released.
+  DateTime? _splashShownAt;
+
+  Timer? _releaseTimer;
+
+  @override
+  void dispose() {
+    _releaseTimer?.cancel();
+    super.dispose();
+  }
+
+  /// Returns whether the splash must stay up even though loading has finished,
+  /// arming a one-shot timer that rebuilds when the minimum time is served.
+  bool _holdSplash(bool isLoading) {
+    if (isLoading) {
+      _splashShownAt ??= DateTime.now();
+      _releaseTimer?.cancel();
+      _releaseTimer = null;
+      return false;
+    }
+    final shownAt = _splashShownAt;
+    if (shownAt == null) return false;
+
+    final remaining = _minSplashDuration - DateTime.now().difference(shownAt);
+    if (remaining <= Duration.zero) {
+      _splashShownAt = null;
+      return false;
+    }
+    _releaseTimer ??= Timer(remaining, () {
+      if (mounted) setState(() => _splashShownAt = null);
+    });
+    return true;
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Consumer2<SqliteConfigProvider, ThemeProvider>(
       builder: (context, configProvider, themeProvider, child) {
         // Determine the current operational state of the library.
         final isLoading = configProvider.isLoading || configProvider.isScanning;
+        final showSplash = isLoading || _holdSplash(isLoading);
 
         // Show setup wizard if scan is finished but no systems were resolved.
         final showInitialSetup =
-            !isLoading &&
+            !showSplash &&
             !configProvider.hasDetectedSystems &&
             configProvider.scanCompleted;
 
         // Show primary library content only when initialization and scanning are complete.
         final showContent =
-            !isLoading && configProvider.scanCompleted && !showInitialSetup;
+            !showSplash && configProvider.scanCompleted && !showInitialSetup;
 
-        return Stack(
-          children: [
-            // PHASE 1: Loading and Initialization.
-            // Displays a progress indicator and status updates for the background ROM scan.
-            if (isLoading)
-              Center(
-                child: Container(
-                  constraints: const BoxConstraints(maxWidth: 400),
-                  padding: const EdgeInsets.all(32),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const CircularProgressIndicator(),
-                      const SizedBox(height: 24),
-                      Text(
-                        configProvider.isLoading
-                            ? AppLocale.applyingInitialConfig.getString(context)
-                            : AppLocale.scanningSystemsRoms.getString(context),
-                        style: Theme.of(context).textTheme.headlineSmall,
-                        textAlign: TextAlign.center,
-                      ),
-                      if (configProvider.isScanning) ...[
-                        const SizedBox(height: 16),
-                        Text(
-                          AppLocale.percentageCompleted
-                              .getString(context)
-                              .replaceFirst(
-                                '{percentage}',
-                                (configProvider.scanProgress * 100)
-                                    .toInt()
-                                    .toString(),
-                              ),
-                          style: Theme.of(context).textTheme.bodyMedium,
-                        ),
-                        const SizedBox(height: 12),
-                        LinearProgressIndicator(
-                          value: configProvider.scanProgress,
-                          backgroundColor: Theme.of(
-                            context,
-                          ).colorScheme.surface,
-                        ),
-                        const SizedBox(height: 12),
-                        Text(
-                          configProvider.scanStatus,
-                          style: Theme.of(context).textTheme.bodySmall,
-                          textAlign: TextAlign.center,
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
-              ),
+        // PHASE 1: Loading and Initialization — a shimmering NeoStation logo
+        // with a thin progress bar and the current scan step as quiet detail.
+        // PHASE 2: First-Run Experience / Initial Setup.
+        // PHASE 3: Primary System Library.
+        final Widget phase;
+        if (showSplash) {
+          phase = KeyedSubtree(
+            key: const ValueKey('splash'),
+            child: _buildSplash(context, configProvider),
+          );
+        } else if (showInitialSetup) {
+          phase = KeyedSubtree(
+            key: const ValueKey('setup'),
+            child: InitialSetupWidget(),
+          );
+        } else if (showContent) {
+          phase = KeyedSubtree(
+            key: const ValueKey('content'),
+            child: MySystems(
+              selectedIndex: widget.selectedIndex,
+              onCardTapped: widget.onCardTapped,
+            ),
+          );
+        } else {
+          phase = const SizedBox.shrink(key: ValueKey('empty'));
+        }
 
-            // PHASE 2: First-Run Experience / Initial Setup.
-            if (showInitialSetup) InitialSetupWidget(),
-
-            // PHASE 3: Primary System Library.
-            if (showContent)
-              MySystems(
-                selectedIndex: selectedIndex,
-                onCardTapped: onCardTapped,
-              ),
-          ],
+        // Cross-fade the splash into the library instead of a hard cut.
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 400),
+          child: phase,
         );
       },
+    );
+  }
+
+  Widget _buildSplash(
+    BuildContext context,
+    SqliteConfigProvider configProvider,
+  ) {
+    // The logo sits at the exact screen centre — the same spot it occupies on
+    // the native splash and the startup screens — with the progress detail
+    // hung below centre, so nothing shifts across the whole intro sequence.
+    return Stack(
+      children: [
+        Center(
+          child: ShimmeringLogo(
+            // Track the scan only once it is actually progressing. During the
+            // waiting-for-storage phase progress sits at 0, which would park
+            // the glint off-screen and leave the logo frozen for up to 30s —
+            // keep the ambient sweep running until there's real movement.
+            progress:
+                configProvider.isScanning && configProvider.scanProgress > 0
+                ? configProvider.scanProgress
+                : null,
+          ),
+        ),
+        if (configProvider.isScanning)
+          Align(
+            // 0.55 clears the 280-wide logo's bottom edge (~0.40 on the Thor's
+            // ~467dp-tall logical screen) with comfortable breathing room.
+            alignment: const Alignment(0, 0.55),
+            child: Container(
+              constraints: const BoxConstraints(maxWidth: 480),
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(
+                    width: 220,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(2),
+                      child: LinearProgressIndicator(
+                        value: configProvider.scanProgress,
+                        minHeight: 3,
+                        backgroundColor: Theme.of(
+                          context,
+                        ).colorScheme.onSurface.withValues(alpha: 0.12),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    configProvider.scanStatus.isNotEmpty
+                        ? configProvider.scanStatus
+                        : AppLocale.scanningSystemsRoms.getString(context),
+                    // 17 to match the startup screen's status line — the
+                    // theme's bodySmall (12) reads too small at couch distance.
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      fontSize: 17,
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.6),
+                    ),
+                    textAlign: TextAlign.center,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/widgets/permission_check_wrapper.dart
+++ b/lib/widgets/permission_check_wrapper.dart
@@ -4,6 +4,7 @@ import 'package:neostation/services/logger_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../providers/sqlite_config_provider.dart';
 import 'setup_wizard.dart';
+import 'shimmering_logo.dart';
 
 /// Widget that checks the initial configuration and shows the wizard if necessary
 class PermissionCheckWrapper extends StatefulWidget {
@@ -122,8 +123,9 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
   @override
   Widget build(BuildContext context) {
     if (_isChecking) {
-      // Show loading while checking
-      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+      // Show loading while checking — same shimmering logo as the rest of the
+      // startup chain, so this gate doesn't read as a separate plain screen.
+      return const Scaffold(body: Center(child: ShimmeringLogo()));
     }
 
     if (_needsSetup) {

--- a/lib/widgets/shimmering_logo.dart
+++ b/lib/widgets/shimmering_logo.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+/// The full-color NeoStation logo with a soft light band sweeping across it.
+///
+/// Used as the minimal startup indicator while the initial config is applied
+/// and the ROM scan runs. The glyph keeps its brand gradient; a translucent
+/// white glint travels over it via a [ShaderMask] in [BlendMode.srcATop],
+/// which paints the moving gradient only where the logo has pixels.
+///
+/// With [progress] set, the glint's position tracks that value — the shine
+/// crosses the logo exactly in step with the scan. With it null, the glint
+/// sweeps on its own on a repeating cycle.
+class ShimmeringLogo extends StatefulWidget {
+  const ShimmeringLogo({super.key, this.width = 280, this.progress});
+
+  /// Rendered width of the logo; height follows the asset's aspect ratio.
+  final double width;
+
+  /// Glint position, 0.0 (off the left edge) to 1.0 (off the right edge).
+  /// Null selects the ambient self-paced sweep.
+  final double? progress;
+
+  @override
+  State<ShimmeringLogo> createState() => _ShimmeringLogoState();
+}
+
+class _ShimmeringLogoState extends State<ShimmeringLogo>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2000),
+    );
+    final progress = widget.progress;
+    if (progress == null) {
+      _controller.repeat();
+    } else {
+      _controller.value = progress.clamp(0.0, 1.0);
+    }
+  }
+
+  @override
+  void didUpdateWidget(ShimmeringLogo oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final progress = widget.progress;
+    if (progress != null) {
+      // Ease toward the reported progress: scan updates arrive in discrete
+      // jumps, and a hard snap reads as flicker rather than a sweep.
+      _controller.stop();
+      _controller.animateTo(
+        progress.clamp(0.0, 1.0),
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOut,
+      );
+    } else if (oldWidget.progress != null) {
+      // Scan finished: resume the ambient sweep from wherever the band is,
+      // so the handoff is seamless.
+      _controller.repeat();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const glint = Colors.white;
+    final clear = glint.withValues(alpha: 0.0);
+    final shine = glint.withValues(alpha: 0.55);
+
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return ShaderMask(
+          shaderCallback: (bounds) {
+            return LinearGradient(
+              // Slightly diagonal so the band reads as a glint, not a wipe.
+              begin: const Alignment(-1.0, -0.4),
+              end: const Alignment(1.0, 0.4),
+              colors: [clear, clear, shine, clear, clear],
+              stops: const [0.0, 0.38, 0.5, 0.62, 1.0],
+              transform: _SlidingGradientTransform(_controller.value),
+            ).createShader(bounds);
+          },
+          // srcATop draws the glint over the logo but only where the logo has
+          // alpha, so the brand colors stay visible underneath the sweep.
+          blendMode: BlendMode.srcATop,
+          child: child,
+        );
+      },
+      child: Image.asset(
+        'assets/images/logo_transparent.png',
+        width: widget.width,
+        filterQuality: FilterQuality.medium,
+      ),
+    );
+  }
+}
+
+/// Slides the shine band across the glyph, 0 → fully off the left edge,
+/// 1 → fully off the right edge.
+///
+/// The travel range is wider than the logo so the band fully clears both
+/// edges — in ambient mode that also gives a short rest between passes.
+class _SlidingGradientTransform extends GradientTransform {
+  const _SlidingGradientTransform(this.progress);
+
+  final double progress;
+
+  @override
+  Matrix4? transform(Rect bounds, {TextDirection? textDirection}) {
+    final dx = bounds.width * (progress * 3.2 - 1.6);
+    return Matrix4.translationValues(dx, 0.0, 0.0);
+  }
+}


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). Reviewed and tested on hardware by me before opening.

# Description

The startup path currently shows a different loading treatment at every stage: the native splash draws a small OS-masked icon on its own background, the pre-init screen has a logo + wordmark + blue spinner, the permission gate is a bare spinner on a blank scaffold, and the scan phase is a `CircularProgressIndicator` with a large headline and percentage text. Each handoff jumps in background, layout, and logo size.

This PR replaces all of that with one continuous intro built around the full-color NeoStation logo with a sweeping light glint:

- **New `ShimmeringLogo` widget** — the brand logo with a translucent white glint swept across it via a `ShaderMask` (`srcATop`, painted only where the logo has pixels). While the ROM scan is progressing the glint's position tracks `scanProgress`, so the shine crosses the logo in step with the scan; during 0%-progress phases (config load, waiting for storage, post-scan hold) it falls back to an ambient repeating sweep.
- **Scan splash** — logo pinned at the exact screen centre with a thin progress bar and the current scan step hung below centre. The splash stays up a minimum of 2.5s so a fast warm scan doesn't blink it away, then cross-fades (400ms) into the systems grid. The minimum also applies to manual rescans, deliberately, for consistency.
- **Pre-init startup screen** — restyled to match: same background, no wordmark, status text in the app font. The "Preparing NeoStation. Waiting for storage and services..." line only fades in after 1.5s of actual waiting, so on a healthy device it never flashes. The storage *error* screen keeps its static logo and wordmark (a shine there would imply progress).
- **Permission gate and games-list loading** — same logo instead of bare spinners.
- **Native splash** — solid `#15191e` (the dark-theme scaffold colour) on all API levels, and no system splash icon on Android 12+: the OS renders its icon at a fixed small size that can never match the Flutter logo, so removing it lets Flutter draw the first (and only) logo and eliminates the size jump entirely.

Two locale keys (`applyingInitialConfig`, `percentageCompleted`) are no longer referenced by this screen; they're left in place across locales.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (no input-path changes; verified navigation still works after the splash).

Existing tests (447) pass; `dart format` and `flutter analyze` are clean. Verified on the AYN Thor at native resolution and under a 640x480 RG DS-class simulation, including the "Waiting for ROM storage (n/10)" phase (simulated by hiding the ROM folder) and a real schema-downgrade boot.

## Screenshots (if applicable)

The scan splash shows the centred logo with the glint mid-sweep, the thin progress bar, and the current system name below (verified at 1920x1080 and 640x480).
