### PR TITLE
chore(deps): refresh the SDK bounds recorded in pubspec.lock

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1251,5 +1251,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

`pubspec.lock` recorded `dart >=3.11.0` / `flutter >=3.41.0`. Stable is now 3.44.8 / Dart 3.12.2, so every `flutter pub get` rewrote those two lines — leaving the lockfile permanently dirty in a working tree and inviting it into unrelated commits.

**No package versions change.** The diff is two lines in the `sdks:` block, and it is exactly what CI already regenerates on every run: the workflows resolve on `channel: stable` with a plain `flutter pub get` and no `--enforce-lockfile`, so the stale bounds were never enforced — just perpetually rewritten and discarded.

Split out of #275, where it kept reappearing as unrelated noise.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring *(housekeeping — no code or dependency changes)*

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. *(not applicable — no behaviour change)*
- [ ] I have updated the corresponding documentation. *(not applicable)*
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. *(no new assets)*
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable). *(not applicable)*
