### PR TITLE
feat(gamelist): remember the chosen game details tab across games and systems

### DIFF
--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -171,6 +171,11 @@ class SqliteConfigService {
             (int.tryParse(userConfig?['legend_hidden']?.toString() ?? '0') ??
                 0) ==
             1,
+        // Missing column/row => the wheel tab (see migration v110).
+        gameDetailsTab:
+            userConfig?['game_details_tab']?.toString().isNotEmpty == true
+            ? userConfig!['game_details_tab'].toString()
+            : 'wheel',
         // Missing column/row => '0' => tab visible (see migration v106).
         hideTabSync:
             (int.tryParse(userConfig?['hide_tab_sync']?.toString() ?? '0') ??
@@ -269,6 +274,7 @@ class SqliteConfigService {
         themeName: config.themeName,
         hideRecentCard: config.hideRecentCard ? 1 : 0,
         legendHidden: config.legendHidden ? 1 : 0,
+        gameDetailsTab: config.gameDetailsTab,
         hideTabSync: config.hideTabSync ? 1 : 0,
         hideTabAchievements: config.hideTabAchievements ? 1 : 0,
         hideTabScraper: config.hideTabScraper ? 1 : 0,

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -333,6 +333,9 @@ class SqliteMigrations {
       case 109:
         await _migrateToVersion109(db);
         break;
+      case 110:
+        await _migrateToVersion110(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -5250,6 +5253,33 @@ class SqliteMigrations {
       _log.i('Migration v109 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v109: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v110: Persists the game details card tab last chosen with L1/R1
+  /// in `user_config.game_details_tab`, so the choice survives moving between
+  /// games and systems as well as a restart.
+  ///
+  /// Stores the `DetailTab` enum name; an unknown or empty value reads back as
+  /// the wheel tab, which is also the column default for existing rows.
+  static Future<void> _migrateToVersion110(Database db) async {
+    _log.i('Migration v110: Adding game_details_tab to user_config');
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_config)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+      if (!columns.contains('game_details_tab')) {
+        db.execute(
+          "ALTER TABLE user_config ADD COLUMN game_details_tab TEXT DEFAULT 'wheel'",
+        );
+        _log.i('Column game_details_tab added via v110');
+      } else {
+        _log.i('Column game_details_tab already exists');
+      }
+      _log.i('Migration v110 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v110: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 109;
+  static const int _databaseVersion = 110;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -1756,6 +1756,7 @@ class SqliteService {
         active_theme TEXT DEFAULT '',
         hide_recent_card INTEGER DEFAULT 0,
         legend_hidden INTEGER DEFAULT 0,
+        game_details_tab TEXT DEFAULT 'wheel',
         hide_tab_sync INTEGER DEFAULT 0,
         hide_tab_achievements INTEGER DEFAULT 0,
         hide_tab_scraper INTEGER DEFAULT 0,
@@ -2527,6 +2528,7 @@ class SqliteService {
     String? activeTheme,
     int? hideRecentCard,
     int? legendHidden,
+    String? gameDetailsTab,
     int? hideTabSync,
     int? hideTabAchievements,
     int? hideTabScraper,
@@ -2608,6 +2610,9 @@ class SqliteService {
     }
     if (legendHidden != null) {
       newConfig['legend_hidden'] = legendHidden;
+    }
+    if (gameDetailsTab != null) {
+      newConfig['game_details_tab'] = gameDetailsTab;
     }
     if (hideTabSync != null) {
       newConfig['hide_tab_sync'] = hideTabSync;

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -103,6 +103,15 @@ class ConfigModel {
   /// (list, grid, carousel). Toggled by the Select + B chord.
   final bool legendHidden;
 
+  /// The game details card tab the user last selected with L1/R1, stored as the
+  /// `DetailTab` enum name (e.g. 'wheel', 'box2d', 'screenshotVideo').
+  ///
+  /// Persisting it keeps the choice across games, systems and restarts. A tab
+  /// that is unavailable for the current game (no achievements, for instance)
+  /// falls back to the wheel for display only — the preference is kept so it
+  /// comes back on a game that supports it.
+  final String gameDetailsTab;
+
   /// Whether the Sync navigation tab is hidden from the header strip and the
   /// L1/R1 tab cycle.
   ///
@@ -190,6 +199,7 @@ class ConfigModel {
     this.appLanguage = 'es',
     this.hideRecentCard = false,
     this.legendHidden = false,
+    this.gameDetailsTab = 'wheel',
     this.hideTabSync = false,
     this.hideTabAchievements = false,
     this.hideTabScraper = false,
@@ -299,6 +309,9 @@ class ConfigModel {
           (json['legendHidden'] ?? json['legend_hidden'] ?? 0).toString() ==
               '1' ||
           (json['legendHidden'] ?? false).toString().toLowerCase() == 'true',
+      gameDetailsTab:
+          (json['gameDetailsTab'] ?? json['game_details_tab'] ?? 'wheel')
+              .toString(),
       // Absent key => false => tab visible. Keeps a config written by an older
       // build (or restored from cloud sync) from hiding tabs it never knew about.
       hideTabSync:
@@ -410,6 +423,7 @@ class ConfigModel {
       'appLanguage': appLanguage,
       'hideRecentCard': hideRecentCard,
       'legendHidden': legendHidden,
+      'gameDetailsTab': gameDetailsTab,
       'hideTabSync': hideTabSync,
       'hideTabAchievements': hideTabAchievements,
       'hideTabScraper': hideTabScraper,
@@ -454,6 +468,7 @@ class ConfigModel {
     String? appLanguage,
     bool? hideRecentCard,
     bool? legendHidden,
+    String? gameDetailsTab,
     bool? hideTabSync,
     bool? hideTabAchievements,
     bool? hideTabScraper,
@@ -495,6 +510,7 @@ class ConfigModel {
       appLanguage: appLanguage ?? this.appLanguage,
       hideRecentCard: hideRecentCard ?? this.hideRecentCard,
       legendHidden: legendHidden ?? this.legendHidden,
+      gameDetailsTab: gameDetailsTab ?? this.gameDetailsTab,
       hideTabSync: hideTabSync ?? this.hideTabSync,
       hideTabAchievements: hideTabAchievements ?? this.hideTabAchievements,
       hideTabScraper: hideTabScraper ?? this.hideTabScraper,

--- a/lib/providers/sqlite_config_provider/mutators.dart
+++ b/lib/providers/sqlite_config_provider/mutators.dart
@@ -91,6 +91,15 @@ extension SqliteConfigMutators on SqliteConfigProvider {
     _notify();
   }
 
+  /// Persists the game details card tab last chosen with L1/R1, as the
+  /// `DetailTab` enum name, so it carries across games, systems and restarts.
+  Future<void> updateGameDetailsTab(String tabName) async {
+    if (_config.gameDetailsTab == tabName) return;
+    _config = _config.copyWith(gameDetailsTab: tabName);
+    await SqliteConfigService.saveConfig(_config);
+    _notify();
+  }
+
   /// Shows or hides [tab] in the header strip and the L1/R1 tab cycle.
   ///
   /// Routed through the tab's [NavTabSpec] so a future tab needs only a spec

--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -250,10 +250,17 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
 
     _currentTab = DetailTab.wheel;
 
-    // Reset primary UI 'Game Info' overlay to ensure clean state transitions.
+    // Restore the last tab the user picked with L1/R1. Deferred to the first
+    // frame so _setTab can run its side effects (game info overlay, video
+    // delay) exactly as it would for a live tab change.
+    final restoredTab = _persistedTab();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
+      if (!mounted) return;
+      if (restoredTab == DetailTab.wheel) {
+        // Reset primary UI 'Game Info' overlay to ensure clean state transitions.
         context.read<SqliteConfigProvider>().updateShowGameInfo(false);
+      } else {
+        _setTab(restoredTab, persist: false);
       }
     });
 
@@ -319,9 +326,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
       () => _currentTab != DetailTab.wheel,
       () => _currentTab == DetailTab.achievements,
     );
-    widget.onRegisterCloseOverlays?.call(() {
-      _setTab(DetailTab.wheel);
-    });
+    widget.onRegisterCloseOverlays?.call(_closeAllOverlays);
     widget.onRegisterTabNavigation?.call(_handleTabNavigation);
     widget.onRegisterSelectButton?.call(_handleSelectAction);
     widget.onRegisterScrapeAction?.call(_onScrapeGameCompact);
@@ -707,7 +712,8 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
         description.trim().isEmpty;
 
     if (!widget.isSecondaryScreenActive) {
-      _setTab(DetailTab.screenshotVideo);
+      // Scraping forces the media tab; it isn't the user picking one.
+      _setTab(DetailTab.screenshotVideo, persist: false);
     }
     _startSingleGameScrape(forceOverwrite: !isDescriptionMissing);
   }
@@ -733,7 +739,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
   /// Handles secondary hardware actions (typically mapped to X or RB).
   void _handleSecondaryAction() {
     if (!_isGameInfoHidden) {
-      _setTab(DetailTab.screenshotVideo);
+      _setTab(DetailTab.screenshotVideo, persist: false);
     } else {
       return;
     }
@@ -743,15 +749,35 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
     _startSingleGameScrape();
   }
 
+  /// Whether [tab] can be shown for the current game and display setup.
+  bool _isTabAvailable(DetailTab tab) {
+    if (tab == DetailTab.screenshotVideo && _isGameInfoHidden) return false;
+    if (tab == DetailTab.achievements && !_hasRetroAchievements) return false;
+    return true;
+  }
+
+  /// Resolves the persisted tab preference into a tab usable right now.
+  ///
+  /// An unknown name (config written by another build) or a tab this game
+  /// can't show falls back to the wheel, leaving the stored preference intact
+  /// so it returns on a game that supports it.
+  DetailTab _persistedTab() {
+    final storedName = context
+        .read<SqliteConfigProvider>()
+        .config
+        .gameDetailsTab;
+    final tab = DetailTab.values.firstWhere(
+      (t) => t.name == storedName,
+      orElse: () => DetailTab.wheel,
+    );
+    return _isTabAvailable(tab) ? tab : DetailTab.wheel;
+  }
+
   /// Processes tab navigation via hardware bumpers (LB/RB).
   bool _handleTabNavigation(bool isRight) {
     if (!mounted) return false;
 
-    final availableTabs = DetailTab.values.where((tab) {
-      if (tab == DetailTab.screenshotVideo && _isGameInfoHidden) return false;
-      if (tab == DetailTab.achievements && !_hasRetroAchievements) return false;
-      return true;
-    }).toList();
+    final availableTabs = DetailTab.values.where(_isTabAvailable).toList();
 
     int currentIndexInAvailable = availableTabs.indexOf(_currentTab);
     if (currentIndexInAvailable == -1) currentIndexInAvailable = 0;
@@ -764,7 +790,12 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
     return true; // Input consumed.
   }
 
-  void _setTab(DetailTab tab) {
+  /// Switches to [tab].
+  ///
+  /// [persist] records the tab as the user's preference so it carries across
+  /// games, systems and restarts; it is disabled for tabs the app forces on the
+  /// user (a scrape jumping to the media tab, or restoring the stored tab).
+  void _setTab(DetailTab tab, {bool persist = true}) {
     if (_currentTab == tab) return;
 
     final wasScreenshotVideo = _currentTab == DetailTab.screenshotVideo;
@@ -773,6 +804,9 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
       _currentTab = tab;
 
       final config = context.read<SqliteConfigProvider>();
+      if (persist) {
+        config.updateGameDetailsTab(tab.name);
+      }
       if (tab == DetailTab.screenshotVideo) {
         config.updateShowGameInfo(true);
         widget.videoController?.setVolume(0);
@@ -794,7 +828,8 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
   }
 
   void _closeAllOverlays() {
-    _setTab(DetailTab.wheel);
+    // Dismissing an overlay isn't a tab choice, so it leaves the preference be.
+    _setTab(DetailTab.wheel, persist: false);
   }
 
   /// Orchestrates a metadata acquisition process via ScreenScraperService.

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -118,6 +118,7 @@ class DatabaseTestHelper {
         auto_update_systems INTEGER,
         system_grid_columns TEXT DEFAULT 'M',
         use_12_hour_clock INTEGER DEFAULT 0,
+        game_details_tab TEXT DEFAULT 'wheel',
         esde_folder_path TEXT
       )
     ''');

--- a/test/game_details_tab_persistence_test.dart
+++ b/test/game_details_tab_persistence_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/config_model.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+import 'package:neostation/screens/game_screen/game_details_card/widgets/game_details_tabs_header.dart';
+
+import 'database_test_helper.dart';
+
+void main() {
+  group('ConfigModel.gameDetailsTab serialization', () {
+    test('defaults to the wheel tab', () {
+      expect(const ConfigModel().gameDetailsTab, 'wheel');
+    });
+
+    test('copyWith updates the tab', () {
+      const base = ConfigModel();
+      expect(
+        base.copyWith(gameDetailsTab: 'screenshotVideo').gameDetailsTab,
+        'screenshotVideo',
+      );
+      // Omitting the field preserves the previous value.
+      final changed = base.copyWith(gameDetailsTab: 'box2d');
+      expect(changed.copyWith().gameDetailsTab, 'box2d');
+    });
+
+    test('round-trips through toJson/fromJson', () {
+      const stored = ConfigModel(gameDetailsTab: 'achievements');
+      final restored = ConfigModel.fromJson(stored.toJson());
+      expect(restored.gameDetailsTab, 'achievements');
+    });
+
+    test('fromJson accepts snake_case and falls back when absent', () {
+      expect(
+        ConfigModel.fromJson({'game_details_tab': 'gameInfo'}).gameDetailsTab,
+        'gameInfo',
+      );
+      expect(ConfigModel.fromJson({}).gameDetailsTab, 'wheel');
+    });
+
+    test('stored names line up with the DetailTab enum', () {
+      // The column holds enum names, so every tab must survive a lookup.
+      for (final tab in DetailTab.values) {
+        final config = ConfigModel(gameDetailsTab: tab.name);
+        final resolved = DetailTab.values.firstWhere(
+          (t) => t.name == config.gameDetailsTab,
+          orElse: () => DetailTab.wheel,
+        );
+        expect(resolved, tab);
+      }
+    });
+  });
+
+  group('game_details_tab persistence (SQLite)', () {
+    final dbHelper = DatabaseTestHelper();
+
+    setUp(() async => dbHelper.setUp());
+    tearDown(() async => dbHelper.tearDown());
+
+    test('defaults to the wheel tab when never set', () async {
+      await SqliteService.saveUserConfig(appLanguage: 'en');
+      final config = await SqliteService.getUserConfig();
+      expect(config?['game_details_tab'].toString(), 'wheel');
+    });
+
+    test('persists a chosen tab across save/load', () async {
+      await SqliteService.saveUserConfig(gameDetailsTab: 'screenshotVideo');
+      final config = await SqliteService.getUserConfig();
+      expect(config?['game_details_tab'].toString(), 'screenshotVideo');
+    });
+
+    test('can be changed again', () async {
+      await SqliteService.saveUserConfig(gameDetailsTab: 'achievements');
+      await SqliteService.saveUserConfig(gameDetailsTab: 'wheel');
+      final config = await SqliteService.getUserConfig();
+      expect(config?['game_details_tab'].toString(), 'wheel');
+    });
+  });
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

The game details card resets to the wheel tab every time its state is rebuilt, so a user who prefers the box art, media or achievements view has to re-select it with L1/R1 on entering each system — and always after a restart.

This persists the chosen tab in `user_config.game_details_tab` (the `DetailTab` enum name), so it carries across games, across systems and across restarts.

**How it behaves**

- Only tabs the user actually chooses are recorded: the bumpers, the header taps, and the info/achievements toggles.
- Tabs the app *forces* pass `persist: false` — a scrape jumping to the media tab, or dismissing an overlay back to the wheel, no longer overwrites the preference.
- A stored tab the current game can't show (achievements without RetroAchievements, the media tab hidden by the secondary display) falls back to the wheel **for display only**, leaving the preference intact so it returns on a game that supports it.
- The restore runs through `_setTab` on the first frame, so it triggers the same side effects as a live switch (game info overlay, video delay) rather than leaving them inconsistent with the tab on screen.

**Two design calls worth your opinion**

1. The preference is **global**, not per-system — someone who wants box art on arcade but the wheel on consoles doesn't get that.
2. It is **always on**; there's no setting to turn "remember my tab" off. That matches how `legend_hidden` behaves, but it is a new implicit behaviour.

Happy to change either.

## ⚠️ Database version bump

This takes the schema to **v110** (migration adds `user_config.game_details_tab TEXT DEFAULT 'wheel'`, idempotent, plus the column in `CREATE TABLE` for fresh installs).

`_onDowngrade` recreates the database, so **if you install this branch on a test device and then go back to a v109 build, that device's local data is wiped.** Worth knowing before you flash it onto a daily driver.

## Notes for review

- Each tab change now writes the config row and calls `notifyListeners`. Previously only media-tab transitions did (via `updateShowGameInfo`). Tab changes are user-paced rather than per-frame, so this shouldn't show up, but flagging it given past gamelist perf work.
- `user_config` isn't part of the NeoSync payload, so no sync-side plumbing was needed.
- No new user-facing strings, so no `AppLocale` changes.

No tracking issue — raised directly.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. *(no new assets)*
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

**Test coverage, precisely:** the new `test/game_details_tab_persistence_test.dart` covers the `ConfigModel` round-trip and the SQLite column (default, persist, change). The **UI restore path is not unit-tested** — it was verified on device instead.

**Device verification** (AYN Thor, Android):

- `PRAGMA user_version` = 110 and `user_config.game_details_tab` present after upgrading from a v109 database.
- Tab selection survives an app restart.
- Tab selection survives leaving a system and entering a different one.

Local gate: `dart format` clean, `flutter analyze` clean, `flutter test` 455 passing.

## Screenshots (if applicable)

No visual change — the tabs header and its contents are untouched; only which tab is selected on entry differs.
