### PR TITLE
fix(scraper): refresh scraped artwork immediately across the game views

### DIFF
--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -3,7 +3,6 @@ import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:video_player/video_player.dart';
-import 'dart:io';
 import 'dart:async';
 import '../../../models/system_model.dart';
 import '../../../models/game_model.dart';
@@ -13,6 +12,7 @@ import '../../../sync/i_sync_provider.dart';
 import '../../../models/retro_achievements_game_info.dart';
 import '../../../repositories/game_repository.dart';
 import '../../../services/retro_achievements_helper.dart';
+import '../../../utils/artwork_cache.dart';
 import '../../../utils/gamepad_nav.dart';
 import 'package:flutter/foundation.dart';
 
@@ -648,6 +648,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
               system: _effectiveSystem,
               game: _game,
               fileProvider: widget.fileProvider,
+              imageVersion: _imageVersion,
               androidAppIconFuture: _androidAppIconFuture,
             ),
           if (_currentTab == DetailTab.box2d)
@@ -655,6 +656,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
               system: _effectiveSystem,
               game: _game,
               fileProvider: widget.fileProvider,
+              imageVersion: _imageVersion,
             ),
           Visibility(
             visible: _currentTab == DetailTab.screenshotVideo,
@@ -922,31 +924,12 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
 
       if (mounted) {
         if (result['success'] == true) {
-          // Protocol: Evict all cached artwork to force immediate UI refresh with new assets.
-          try {
-            final imagesToEvict = [
-              _game.getScreenshotPath(targetSystemFolder),
-              _game.getImagePath(
-                targetSystemFolder,
-                'wheels',
-                widget.fileProvider,
-              ),
-              _game.getImagePath(
-                targetSystemFolder,
-                'fanarts',
-                widget.fileProvider,
-              ),
-            ];
-
-            for (final imagePath in imagesToEvict) {
-              final imageFile = File(imagePath);
-              if (await imageFile.exists()) {
-                await FileImage(imageFile).evict();
-              }
-            }
-          } catch (e) {
-            _log.e('Image cache eviction failed: $e');
-          }
+          // Evict every artwork file the scrape may have rewritten — box art
+          // included — so the tabs below reload them instead of redrawing the
+          // decoded copies they were already showing.
+          await evictScrapedArtwork(
+            scrapedArtworkPaths(_game, targetSystemFolder, widget.fileProvider),
+          );
 
           if (!context.mounted) return;
 

--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -903,14 +903,8 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
 
     if (!mounted) return;
 
-    // Surface immediate feedback — a scrape takes several seconds and can be
-    // triggered "blind" via the Select + A chord from the games list.
-    AppNotification.showNotification(
-      context,
-      AppLocale.scrapingGameData.getString(context),
-      type: NotificationType.info,
-    );
-
+    // No "scraping…" toast: the progress panel above says the same thing for
+    // the whole run, wherever the scrape was started from.
     final secondaryState = context.read<SecondaryDisplayState?>();
     if (secondaryState != null && widget.isSecondaryScreenActive) {
       secondaryState.updateState(

--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -49,6 +49,12 @@ class GameDetailsCardList extends StatefulWidget {
   final ISyncProvider syncProvider;
   final String? localizedDescription;
 
+  /// Bumped by the games list whenever this game's artwork files change on
+  /// disk — a scrape, or a media file replaced from the settings dialog. The
+  /// card folds it into its own version so the artwork tabs reload; without it
+  /// they keep the decode they already resolved until another game is selected.
+  final int artworkVersion;
+
   /// True when an external (list-level) scrape is running for this game, e.g.
   /// triggered by the Select button. Drives the scrape button spinner so the
   /// feedback matches a scrape started from the button itself.
@@ -120,6 +126,7 @@ class GameDetailsCardList extends StatefulWidget {
     required this.retroAchievementsProvider,
     required this.syncProvider,
     this.localizedDescription,
+    this.artworkVersion = 0,
     this.isExternallyScraping = false,
     this.onDeactivateNavigation,
     this.onReactivateNavigation,
@@ -190,6 +197,10 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
   final ScrollController _achievementsScrollController = ScrollController();
   int _imageVersion =
       0; // Cache-busting version for images after metadata refreshes.
+
+  /// Cache-busting version for the artwork tabs, covering both the card's own
+  /// scrape and artwork the games list saw change underneath it.
+  int get _artworkImageVersion => _imageVersion + widget.artworkVersion;
 
   Future<Uint8List?>? _androidAppIconFuture;
   SecondaryDisplayState? _secondaryState;
@@ -648,7 +659,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
               system: _effectiveSystem,
               game: _game,
               fileProvider: widget.fileProvider,
-              imageVersion: _imageVersion,
+              imageVersion: _artworkImageVersion,
               androidAppIconFuture: _androidAppIconFuture,
             ),
           if (_currentTab == DetailTab.box2d)
@@ -656,7 +667,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
               system: _effectiveSystem,
               game: _game,
               fileProvider: widget.fileProvider,
-              imageVersion: _imageVersion,
+              imageVersion: _artworkImageVersion,
             ),
           Visibility(
             visible: _currentTab == DetailTab.screenshotVideo,
@@ -668,7 +679,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
               screenshotPath: screenshotPath,
               isVideoDelayActive: _isVideoDelayActive,
               videoController: widget.videoController,
-              imageVersion: _imageVersion,
+              imageVersion: _artworkImageVersion,
               onToggleVideoMute: _toggleVideoMute,
             ),
           ),

--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -26,6 +26,7 @@ import 'package:neostation/widgets/custom_notification.dart';
 import '../../../models/secondary_display_state.dart';
 import 'widgets/game_details_footer.dart';
 import 'widgets/game_details_tabs_header.dart';
+import 'widgets/scraping_progress_panel.dart';
 import 'tabs/game_details_general_tab.dart';
 import 'tabs/game_details_box2d_tab.dart';
 import 'tabs/game_details_screenshot_video_tab.dart';
@@ -59,6 +60,11 @@ class GameDetailsCardList extends StatefulWidget {
   /// triggered by the Select button. Drives the scrape button spinner so the
   /// feedback matches a scrape started from the button itself.
   final bool isExternallyScraping;
+
+  /// Progress and step of that external scrape, so the card's progress panel
+  /// reports it exactly as it reports a scrape the card started itself.
+  final double? externalScrapeProgress;
+  final String? externalScrapeStatus;
 
   final VoidCallback? onDeactivateNavigation;
   final VoidCallback? onReactivateNavigation;
@@ -128,6 +134,8 @@ class GameDetailsCardList extends StatefulWidget {
     this.localizedDescription,
     this.artworkVersion = 0,
     this.isExternallyScraping = false,
+    this.externalScrapeProgress,
+    this.externalScrapeStatus,
     this.onDeactivateNavigation,
     this.onReactivateNavigation,
     this.onShowAchievements,
@@ -694,9 +702,6 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
                       ? AppLocale.noDescription.getString(context)
                       : _game.getDescriptionForLanguage('en')),
               isScrapingGame: _isScrapingGame || widget.isExternallyScraping,
-              scrapeProgress: _scrapeProgress,
-              scrapeStatus: _scrapeStatus,
-              isSecondaryScreenActive: widget.isSecondaryScreenActive,
               onScrapeGame: _onScrapeGameCompact,
             ),
           if (_currentTab == DetailTab.achievements)
@@ -705,6 +710,19 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
               gameInfo: _currentGameInfo,
               isLoading: _isLoadingAchievements,
               onRefresh: refreshAchievements,
+            ),
+
+          // Scrape feedback for every tab. A scrape can start from any of them
+          // (the Scrape button, Select + A, or the games list), so it is drawn
+          // over the tab panels rather than inside one of them.
+          if (_isScrapingGame || widget.isExternallyScraping)
+            ScrapingProgressPanel(
+              progress: _isScrapingGame
+                  ? _scrapeProgress
+                  : (widget.externalScrapeProgress ?? 0.0),
+              status: _isScrapingGame
+                  ? _scrapeStatus
+                  : (widget.externalScrapeStatus ?? ''),
             ),
         ],
       ),

--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -742,10 +742,9 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
         description == AppLocale.noDescription.getString(context) ||
         description.trim().isEmpty;
 
-    if (!widget.isSecondaryScreenActive) {
-      // Scraping forces the media tab; it isn't the user picking one.
-      _setTab(DetailTab.screenshotVideo, persist: false);
-    }
+    // No tab switch at all: the progress panel overlays whichever tab is open,
+    // so the user stays where they were — and the tab they chose stays the
+    // remembered one (#284).
     _startSingleGameScrape(forceOverwrite: !isDescriptionMissing);
   }
 
@@ -769,11 +768,10 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
 
   /// Handles secondary hardware actions (typically mapped to X or RB).
   void _handleSecondaryAction() {
-    if (!_isGameInfoHidden) {
-      _setTab(DetailTab.screenshotVideo, persist: false);
-    } else {
-      return;
-    }
+    // Unchanged condition — the action stays tied to the screenshot tab being
+    // available — but it no longer switches to that tab: the progress panel
+    // overlays whichever tab the user is on.
+    if (_isGameInfoHidden) return;
 
     if (_isScrapingGame) return;
 

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_box2d_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_box2d_tab.dart
@@ -11,11 +11,17 @@ class GameDetailsBox2dTab extends StatefulWidget {
   final GameModel game;
   final FileProvider fileProvider;
 
+  /// Bumped when a scrape rewrites the artwork. It keys the image so a
+  /// re-scraped box art is resolved again instead of being redrawn from the
+  /// copy this widget already holds.
+  final int imageVersion;
+
   const GameDetailsBox2dTab({
     super.key,
     required this.system,
     required this.game,
     required this.fileProvider,
+    this.imageVersion = 0,
   });
 
   @override
@@ -128,7 +134,8 @@ class _GameDetailsBox2dTabState extends State<GameDetailsBox2dTab> {
                   ? Image.file(
                       File(box2dPath),
                       key: ValueKey(
-                        'box2d_${widget.game.romPath ?? widget.game.romname}',
+                        'box2d_${widget.game.romPath ?? widget.game.romname}'
+                        '_v${widget.imageVersion}',
                       ),
                       fit: BoxFit.contain,
                       cacheWidth: 640,

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_game_info_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_game_info_tab.dart
@@ -16,10 +16,9 @@ class GameDetailsGameInfoTab extends StatefulWidget {
   final GameModel game;
   final FileProvider fileProvider;
   final String description;
+
+  /// Hides the metadata pills while the card's scrape panel covers this tab.
   final bool isScrapingGame;
-  final double scrapeProgress;
-  final String scrapeStatus;
-  final bool isSecondaryScreenActive;
   final VoidCallback onScrapeGame;
 
   const GameDetailsGameInfoTab({
@@ -29,9 +28,6 @@ class GameDetailsGameInfoTab extends StatefulWidget {
     required this.fileProvider,
     required this.description,
     required this.isScrapingGame,
-    required this.scrapeProgress,
-    required this.scrapeStatus,
-    required this.isSecondaryScreenActive,
     required this.onScrapeGame,
   });
 
@@ -200,11 +196,9 @@ class _GameDetailsGameInfoTabState extends State<GameDetailsGameInfoTab> {
                 padding: EdgeInsets.all(8.r),
                 child: LayoutBuilder(
                   builder: (context, constraints) {
-                    if (widget.isScrapingGame &&
-                        !widget.isSecondaryScreenActive) {
-                      return _buildScrapingProgressView();
-                    }
-
+                    // While scraping, the card lays ScrapingProgressPanel over
+                    // this whole region — every tab gets the same feedback, so
+                    // this tab no longer draws its own copy.
                     return showScrapeView
                         ? _buildNonScrapedView()
                         : _buildScrapedView();
@@ -214,66 +208,6 @@ class _GameDetailsGameInfoTabState extends State<GameDetailsGameInfoTab> {
             ),
           ],
         ),
-      ),
-    );
-  }
-
-  Widget _buildScrapingProgressView() {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            padding: EdgeInsets.all(16.r),
-            decoration: BoxDecoration(
-              color: Theme.of(
-                context,
-              ).colorScheme.primary.withValues(alpha: 0.1),
-              shape: BoxShape.circle,
-            ),
-            child: SizedBox(
-              width: 24.r,
-              height: 24.r,
-              child: CircularProgressIndicator(
-                strokeWidth: 3,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-            ),
-          ),
-          SizedBox(height: 24.r),
-          Text(
-            AppLocale.scrapingGameData.getString(context),
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurface,
-              fontSize: 18.r,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          SizedBox(height: 12.r),
-          SizedBox(
-            width: 250.r,
-            child: Column(
-              children: [
-                LinearProgressIndicator(
-                  value: widget.scrapeProgress,
-                  backgroundColor: Colors.white10,
-                  color: Theme.of(context).colorScheme.primary,
-                  borderRadius: BorderRadius.circular(4.r),
-                ),
-                SizedBox(height: 8.r),
-                Text(
-                  widget.scrapeStatus,
-                  style: TextStyle(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.onSurface.withValues(alpha: 0.6),
-                    fontSize: 10.r,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_general_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_general_tab.dart
@@ -14,6 +14,11 @@ class GameDetailsGeneralTab extends StatelessWidget {
   final SystemModel system;
   final GameModel game;
   final FileProvider fileProvider;
+
+  /// Bumped when a scrape rewrites the artwork. It keys the wheel images so a
+  /// re-scraped logo is resolved again instead of being redrawn from the copy
+  /// this widget already holds.
+  final int imageVersion;
   final Future<Uint8List?>? androidAppIconFuture;
 
   const GameDetailsGeneralTab({
@@ -21,6 +26,7 @@ class GameDetailsGeneralTab extends StatelessWidget {
     required this.system,
     required this.game,
     required this.fileProvider,
+    this.imageVersion = 0,
     this.androidAppIconFuture,
   });
 
@@ -58,7 +64,8 @@ class GameDetailsGeneralTab extends StatelessWidget {
                       ? Image.file(
                           File(wheelPath),
                           key: ValueKey(
-                            'wheel_shadow_${game.romPath ?? game.romname}',
+                            'wheel_shadow_${game.romPath ?? game.romname}'
+                            '_v$imageVersion',
                           ),
                           fit: BoxFit.contain,
                           filterQuality: FilterQuality.low,
@@ -115,7 +122,10 @@ class GameDetailsGeneralTab extends StatelessWidget {
                 child: wheelExists
                     ? Image.file(
                         File(wheelPath),
-                        key: ValueKey('wheel_${game.romPath ?? game.romname}'),
+                        key: ValueKey(
+                          'wheel_${game.romPath ?? game.romname}'
+                          '_v$imageVersion',
+                        ),
                         fit: BoxFit.contain,
                         cacheWidth: 640,
                         height: 140.r,

--- a/lib/screens/game_screen/game_details_card/widgets/scraping_progress_panel.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/scraping_progress_panel.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import '../../../../themes/corner_radii.dart';
+
+/// Progress panel shown over the details card while a single game is scraped.
+///
+/// It occupies the same region as the tab panels, so whichever tab is open the
+/// scrape reports itself in one consistent place. A scrape can be started from
+/// any tab (the Scrape button, the Select + A chord, or the games list), so
+/// tying this to one tab would leave most of them with no feedback at all.
+class ScrapingProgressPanel extends StatelessWidget {
+  /// Fraction of the scrape completed, 0..1.
+  final double progress;
+
+  /// Localized description of the step in flight, e.g. downloading media.
+  final String status;
+
+  const ScrapingProgressPanel({
+    super.key,
+    required this.progress,
+    required this.status,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Positioned(
+      left: 12.r,
+      right: 12.r,
+      top: 55.r,
+      bottom: 110.r,
+      child: Container(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface.withValues(alpha: 0.9),
+          borderRadius:
+              theme.extension<CornerRadii>()?.radiusExternal ??
+              BorderRadius.circular(14.r),
+          border: Border.all(color: theme.colorScheme.outline, width: 1.r),
+          boxShadow: [
+            BoxShadow(
+              color: theme.colorScheme.shadow.withValues(alpha: 0.25),
+              blurRadius: 2.r,
+              offset: Offset(2.0.r, 2.0.r),
+            ),
+          ],
+        ),
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                padding: EdgeInsets.all(16.r),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.1),
+                  shape: BoxShape.circle,
+                ),
+                child: SizedBox(
+                  width: 24.r,
+                  height: 24.r,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 3,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+              SizedBox(height: 24.r),
+              Text(
+                AppLocale.scrapingGameData.getString(context),
+                style: TextStyle(
+                  color: theme.colorScheme.onSurface,
+                  fontSize: 18.r,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              SizedBox(height: 12.r),
+              SizedBox(
+                width: 250.r,
+                child: Column(
+                  children: [
+                    LinearProgressIndicator(
+                      value: progress,
+                      backgroundColor: Colors.white10,
+                      color: theme.colorScheme.primary,
+                      borderRadius: BorderRadius.circular(4.r),
+                    ),
+                    SizedBox(height: 8.r),
+                    Text(
+                      status,
+                      style: TextStyle(
+                        color: theme.colorScheme.onSurface.withValues(
+                          alpha: 0.6,
+                        ),
+                        fontSize: 10.r,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/game_screen/game_settings_dialog/game_settings_scrapping_tab.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_scrapping_tab.dart
@@ -18,6 +18,7 @@ import 'package:neostation/screens/game_screen/my_games_grid.dart';
 import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/services/screenscraper_service.dart';
 import 'package:neostation/services/sfx_service.dart';
+import 'package:neostation/utils/artwork_cache.dart';
 import 'package:neostation/widgets/custom_notification.dart';
 
 /// Sub-tabs inside the Scrapping tab of [GameSettingsDialog].
@@ -247,29 +248,8 @@ class GameSettingsScrappingTabState extends State<GameSettingsScrappingTab> {
 
   // ── Force rescrape ──────────────────────────────────────────────────────
 
-  List<String> _artworkPaths() {
-    final folder = _folder;
-    return [
-      widget.game.getImagePath(folder, 'fanarts', widget.fileProvider),
-      widget.game.getImagePath(folder, 'wheels', widget.fileProvider),
-      widget.game.getImagePath(folder, 'box2d', widget.fileProvider),
-      widget.game.getScreenshotPath(folder, widget.fileProvider),
-    ];
-  }
-
-  /// Evicts Flutter's [ImageCache] entries for the given artwork [paths] and
-  /// clears live images so every visible widget reloads the fresh files.
-  Future<void> _evictArtworkFromFlutterCache(Iterable<String> paths) async {
-    final imageCache = PaintingBinding.instance.imageCache;
-    for (final path in paths) {
-      final file = File(path);
-      if (await file.exists()) {
-        await FileImage(file).evict();
-      }
-    }
-    imageCache.clear();
-    imageCache.clearLiveImages();
-  }
+  List<String> _artworkPaths() =>
+      scrapedArtworkPaths(widget.game, _folder, widget.fileProvider);
 
   Future<void> _forceRescrape() async {
     if (_isScraping) return;
@@ -310,7 +290,7 @@ class GameSettingsScrappingTabState extends State<GameSettingsScrappingTab> {
       );
 
       // Bust cached artwork so the fresh media shows up everywhere.
-      await _evictArtworkFromFlutterCache(_artworkPaths());
+      await evictScrapedArtwork(_artworkPaths());
       GamesGrid.evictArtworkCaches(_artworkPaths());
       GamesCarousel.evictArtworkCaches(_artworkPaths());
 
@@ -353,7 +333,7 @@ class GameSettingsScrappingTabState extends State<GameSettingsScrappingTab> {
       final targetPath = _pathForImageType(type);
       await File(targetPath).parent.create(recursive: true);
       await File(srcPath).copy(targetPath);
-      await _evictArtworkFromFlutterCache([targetPath]);
+      await evictScrapedArtwork([targetPath]);
       GamesGrid.evictArtworkCaches([targetPath]);
       GamesCarousel.evictArtworkCaches([targetPath]);
 

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -48,6 +48,7 @@ import '../../widgets/game_action_buttons.dart';
 import '../../widgets/legend_edge_reshow_zone.dart';
 import '../../widgets/letter_indicator.dart';
 import '../../constants/system_folder_names.dart';
+import '../../utils/artwork_cache.dart';
 import '../../utils/game_list_update.dart';
 import '../../themes/corner_radii.dart';
 
@@ -273,7 +274,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
   void _invalidateArtworkCaches() {
     GamesGrid.evictArtworkCaches(const []);
     GamesCarousel.evictArtworkCaches(const []);
-    PaintingBinding.instance.imageCache.clear();
+    final imageCache = PaintingBinding.instance.imageCache;
+    imageCache.clear();
+    imageCache.clearLiveImages();
   }
 
   /// Synchronizes UI state with global configuration changes.
@@ -1515,11 +1518,11 @@ class _SystemGamesListState extends State<SystemGamesList> {
       if (updatedGame != null) {
         final artworkFolder =
             updatedGame.systemFolderName ?? widget.system.primaryFolderName;
-        final artworkPaths = [
-          updatedGame.getScreenshotPath(artworkFolder, _fileProvider),
-          updatedGame.getImagePath(artworkFolder, 'box2d', _fileProvider),
-          updatedGame.getImagePath(artworkFolder, 'fanarts', _fileProvider),
-        ];
+        final artworkPaths = scrapedArtworkPaths(
+          updatedGame,
+          artworkFolder,
+          _fileProvider,
+        );
         GamesGrid.evictArtworkCaches(artworkPaths);
         GamesCarousel.evictArtworkCaches(artworkPaths);
         setState(() {
@@ -1639,22 +1642,12 @@ class _SystemGamesListState extends State<SystemGamesList> {
 
       if (!mounted) return;
       if (result['success'] == true) {
-        // Evict cached artwork so the grid rebuilds with the new assets.
-        try {
-          final imagesToEvict = [
-            game.getScreenshotPath(targetSystemFolder, _fileProvider),
-            game.getImagePath(targetSystemFolder, 'wheels', _fileProvider),
-            game.getImagePath(targetSystemFolder, 'fanarts', _fileProvider),
-          ];
-          for (final imagePath in imagesToEvict) {
-            final imageFile = File(imagePath);
-            if (await imageFile.exists()) {
-              await FileImage(imageFile).evict();
-            }
-          }
-        } catch (e) {
-          _log.e('Image cache eviction failed: $e');
-        }
+        // Drop the decoded copies of every artwork file the scrape may have
+        // rewritten, so the rebuild below reads the new files from disk.
+        await evictScrapedArtwork(
+          scrapedArtworkPaths(game, targetSystemFolder, _fileProvider),
+        );
+        if (!mounted) return;
 
         await _handleGameUpdated();
         if (mounted) {

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1542,7 +1542,10 @@ class _SystemGamesListState extends State<SystemGamesList> {
         _reorderGamesListFollowingGame(updatedGame.romname);
 
         if (mounted && _selectedGame != null) {
-          _updateSecondaryDisplay(updatedGame);
+          // A re-scrape rewrites the art at the same paths, so the dedup in
+          // the push below would skip it and the secondary engine would keep
+          // showing the bitmap it already decoded.
+          _updateSecondaryDisplay(updatedGame, forceMediaRefresh: true);
           _updateBackground(updatedGame);
           _startVideoTimer();
         }

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -176,6 +176,10 @@ class _SystemGamesListState extends State<SystemGamesList> {
   // carousel views, which have no details card to own the scrape).
   bool _isScrapingSelectedGame = false;
 
+  // Localized step of that scrape, forwarded to the details card so its
+  // progress panel reads the same whoever started the scrape.
+  String _selectedScrapeStatus = '';
+
   // Bumped whenever artwork is replaced so background/detail images rebuild.
   int _artworkVersion = 0;
 
@@ -1399,6 +1403,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
         isExternallyScraping: _scrapingGameRomnames.contains(
           _selectedGame!.romname,
         ),
+        externalScrapeProgress: _scrapeProgress[_selectedGame!.romname],
+        externalScrapeStatus: _selectedScrapeStatus,
         isNavigatingFast: _isNavigatingFast,
         isSecondaryScreenActive:
             _secondaryDisplayState?.value?.isSecondaryActive ?? false,
@@ -1599,6 +1605,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
     setState(() {
       _scrapingGameRomnames.add(game.romname);
       _scrapeProgress[game.romname] = 0.0;
+      _selectedScrapeStatus = AppLocale.scrapingGameData.getString(context);
     });
 
     AppNotification.showNotification(
@@ -1632,12 +1639,14 @@ class _SystemGamesListState extends State<SystemGamesList> {
         forceOverwrite: forceOverwrite,
         onProgress: (statusKey, progress) {
           if (!mounted) return;
+          final localizedStatus = statusKey.getString(context);
           setState(() {
             _scrapeProgress[game.romname] = progress;
+            _selectedScrapeStatus = localizedStatus;
           });
           if (secondaryState != null && isSecondaryActive) {
             secondaryState.updateState(
-              scrapeStatus: statusKey.getString(context),
+              scrapeStatus: localizedStatus,
               scrapeProgress: progress,
             );
           }
@@ -1683,6 +1692,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
         setState(() {
           _scrapingGameRomnames.remove(game.romname);
           _scrapeProgress.remove(game.romname);
+          _selectedScrapeStatus = '';
         });
         if (secondaryState != null && isSecondaryActive) {
           // Latency buffer so file descriptors release before the secondary

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1395,6 +1395,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
         retroAchievementsProvider: _retroAchievementsProvider,
         syncProvider: syncManager.active!,
         localizedDescription: _localizedDescription,
+        artworkVersion: _artworkVersion,
         isExternallyScraping: _scrapingGameRomnames.contains(
           _selectedGame!.romname,
         ),

--- a/lib/utils/artwork_cache.dart
+++ b/lib/utils/artwork_cache.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:flutter/painting.dart';
+
+import '../models/game_model.dart';
+import '../providers/file_provider.dart';
+
+/// The media folders a single-game scrape can add to or overwrite.
+const List<String> scrapedArtworkTypes = [
+  'fanarts',
+  'wheels',
+  'box2d',
+  'screenshots',
+];
+
+/// Resolves every artwork file a scrape may have written for [game].
+List<String> scrapedArtworkPaths(
+  GameModel game,
+  String systemFolderName, [
+  FileProvider? fileProvider,
+]) {
+  return [
+    for (final type in scrapedArtworkTypes)
+      game.getImagePath(systemFolderName, type, fileProvider),
+  ];
+}
+
+/// Drops every cached decode of the given artwork [paths] so the next build
+/// reads them from disk again.
+///
+/// Evicting the [FileImage] alone is not enough: the game views render artwork
+/// through `Image.file(..., cacheWidth: n)`, which wraps the provider in a
+/// [ResizeImage] and caches the resized bitmap under the ResizeImage key. The
+/// widths differ per view (256, 388, 512, 640, 1024, 1920), so clearing is the
+/// only path-agnostic way to reach every variant — without it a re-scrape kept
+/// showing the old art until something unrelated cleared the cache.
+///
+/// Callers must also give the affected widgets a new key (see the
+/// `artworkVersion` / `imageVersion` counters), because an [Image] whose
+/// provider compares equal never re-resolves on its own.
+Future<void> evictScrapedArtwork(Iterable<String> paths) async {
+  for (final path in paths) {
+    if (path.isEmpty) continue;
+    try {
+      final file = File(path);
+      if (await file.exists()) {
+        await FileImage(file).evict();
+      }
+    } catch (_) {
+      // An unreadable file has nothing cached to evict.
+    }
+  }
+
+  final imageCache = PaintingBinding.instance.imageCache;
+  imageCache.clear();
+  imageCache.clearLiveImages();
+}

--- a/test/artwork_cache_test.dart
+++ b/test/artwork_cache_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/utils/artwork_cache.dart';
+
+GameModel game(String romname) => GameModel(
+  romname: romname,
+  realname: romname,
+  name: romname,
+  year: '',
+  developer: '',
+  publisher: '',
+  genre: '',
+  players: '',
+  rating: 0,
+);
+
+void main() {
+  test('a scrape refresh covers every artwork kind the scraper writes', () {
+    // Box art used to be missing here, so a re-scrape kept showing the old
+    // cover until something unrelated cleared the image cache.
+    expect(
+      scrapedArtworkTypes,
+      containsAll(['fanarts', 'wheels', 'box2d', 'screenshots']),
+    );
+  });
+
+  test('evicting the bare file image cannot reach a resized decode', () async {
+    // Why the eviction clears the cache instead of evicting path by path: the
+    // game views render artwork with a cacheWidth, and Image.file wraps the
+    // provider in a ResizeImage that caches under its own key.
+    final file = File('media/nes/box2d/mario.png');
+    final fileImage = FileImage(file);
+    final resized = ResizeImage(fileImage, width: 640);
+
+    final fileKey = await fileImage.obtainKey(ImageConfiguration.empty);
+    final resizedKey = await resized.obtainKey(ImageConfiguration.empty);
+
+    expect(resizedKey, isNot(equals(fileKey)));
+  });
+
+  test('paths resolve one file per artwork kind for the given system', () {
+    final paths = scrapedArtworkPaths(game('mario.nes'), 'nes');
+
+    expect(paths, hasLength(scrapedArtworkTypes.length));
+    for (final type in scrapedArtworkTypes) {
+      expect(paths, contains(contains('nes/$type/mario.png')));
+    }
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was written with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

Scraped artwork did not appear until something unrelated happened — leaving and re-entering the system, launching a game, or visiting the systems screen. #210 and #248 both attacked this and both left it broken, because the eviction underneath their plumbing never hit the entries that were actually on screen.

Fixes #203

**Root cause.** The game views render artwork with `Image.file(..., cacheWidth: n)`. That wraps the provider in a `ResizeImage`, and the decoded bitmap is cached under the `ResizeImage` key — but both single-game scrape paths evicted the bare `FileImage`, a different key, so the copy being displayed survived untouched. Box art was also missing from the evict lists entirely, and the wheel and box-art tabs keyed their images on the ROM name alone, so their `Image` state never re-resolved even once the cache was clean. The secondary engine had already diagnosed exactly this — `secondary_screen.dart` notes that a full clear *"correctly drops the wheel's ResizeImage-wrapped entries, which a bare FileImage.evict would miss"* — but the primary engine never got the same treatment.

**The fixes, one per commit:**

1. **`fix(scraper): refresh scraped artwork immediately in the game views`** — new `utils/artwork_cache.dart` resolves every artwork kind a scrape writes (fanarts, wheels, **box2d**, screenshots) and drops every decode of them; the wheel and box-art tabs get the same `imageVersion` key the screenshot tab already had. The game settings dialog, which had a correct private copy of this logic, now delegates to the shared helper.
2. **`fix(game-details): reload the details card when a media file is replaced`** — the list bumped its artwork version for the grid, carousel and fanart background, but never told the details card, so replacing a media file in the per-game settings showed nothing until another game was selected. This is #203's exact repro.
3. **`fix(secondary): refresh the second screen's artwork after a re-scrape`** — `_updateSecondaryDisplay` has taken a `forceMediaRefresh` flag for precisely this case since it was written, and no caller ever passed it, so the second screen kept the stale art.

**Progress feedback** (the remaining commits, prompted by review on-device): the scrape progress panel lived inside the Game Info tab and was suppressed whenever the secondary screen mirrored it — but a scrape starts from any tab, and the card opens on the wheel tab, so most of the time a scrape looked like nothing was happening. The panel moves out into `ScrapingProgressPanel`, laid over the tab region by the card, so it appears wherever the scrape was started from. Starting a scrape no longer switches the user to the screenshot tab (that switch existed only to put them where the progress used to be drawn), and the now-duplicated "scraping…" toast is gone from that path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works. (`test/artwork_cache_test.dart` — covers the artwork kinds and pins the `ResizeImage`/`FileImage` key difference the bug rested on, so it cannot silently regress.)
- [ ] I have updated the corresponding documentation. (N/A — no documented behaviour changes.)
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. (N/A — no new assets.)
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

Verified on an AYN Thor (dual-screen, Android): re-scraping a game with existing art updates the box art, wheel, screenshot and fanart background in place; replacing a media file in the per-game settings updates without changing selection; the second screen picks up the new art; and the progress panel appears over whichever tab the scrape was started from, including via the Select + A chord. Not tested on desktop — the change is platform-agnostic Dart, but the artwork paths differ (SAF content URIs vs plain paths), so a desktop sanity check is welcome.

### Reviewer notes

- `evictScrapedArtwork` clears the image cache rather than evicting path by path. Every view uses a different `cacheWidth` (256, 388, 512, 640, 1024, 1920), and there is no path-keyed way to reach those `ResizeImage` entries; enumerating the widths would silently rot the moment a widget changed one. The cost is a one-off re-decode of visible thumbnails after a scrape, and it matches what the settings dialog already did.
- The secondary-screen progress panel is no longer suppressed on the primary display when a second screen is attached — showing it in both places is deliberate, since the primary display is where the user is looking.
