### PR TITLE
fix(scan): stop symlinked alias folders from duplicating every ROM

### DIFF
--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -771,6 +771,24 @@ class SqliteDatabaseService {
         return (removed: 0, knownPaths: knownPaths);
       }
 
+      // Rows stored before the scan learned to skip symlinked alias folders
+      // still spell the path through the alias (…/roms/gamecube/x.rvz for a
+      // file the scan now keeps as …/roms/gc/x.rvz). Those files are not
+      // missing, so their play time, favourite flag and scraped ids have to be
+      // folded into the surviving row before the delete below discards them.
+      final renamed = await _mergeAliasDuplicateRoms(
+        romsToDelete,
+        existingRomPaths,
+        knownPaths,
+      );
+      if (renamed.isNotEmpty) {
+        romsToDelete.removeWhere(renamed.containsKey);
+        knownPaths.addAll(renamed.values);
+        if (romsToDelete.isEmpty) {
+          return (removed: 0, knownPaths: knownPaths);
+        }
+      }
+
       await db.transaction((txn) async {
         const batchSize = 100;
         for (int i = 0; i < romsToDelete.length; i += batchSize) {
@@ -792,6 +810,149 @@ class SqliteDatabaseService {
       _log.e('Error cleaning up orphaned ROMs for system $systemId: $e');
       return (removed: 0, knownPaths: <String>{});
     }
+  }
+
+  /// Folds rows that reach an already-scanned file through a symlinked alias
+  /// folder into the row the scan keeps, and returns the ones that were instead
+  /// renamed in place (orphan path -> surviving path).
+  ///
+  /// Only runs when a scan found orphans at all, so a warm rescan never pays
+  /// for it, and it resolves one directory at a time rather than one file at a
+  /// time. `content://` paths are skipped outright: a SAF URI is an opaque
+  /// DocumentsProvider identifier with no symbolic link to resolve.
+  static Future<Map<String, String>> _mergeAliasDuplicateRoms(
+    List<String> orphanPaths,
+    Set<String> scannedPaths,
+    Set<String> knownPaths,
+  ) async {
+    final dirCache = <String, String?>{};
+
+    Future<String?> canonicalDirOf(String dirPath) async {
+      if (dirCache.containsKey(dirPath)) return dirCache[dirPath];
+      String? resolved;
+      try {
+        resolved = await Directory(dirPath).resolveSymbolicLinks();
+      } catch (e) {
+        resolved = null;
+      }
+      dirCache[dirPath] = resolved;
+      return resolved;
+    }
+
+    // Index the scanned files by canonical path, so a row spelled through an
+    // alias can find the row the scan kept whatever the two spellings are.
+    final canonicalToScanned = <String, String>{};
+    for (final scanned in scannedPaths) {
+      if (scanned.startsWith('content://')) continue;
+      final dir = await canonicalDirOf(path.dirname(scanned));
+      if (dir == null) continue;
+      canonicalToScanned[path.join(dir, path.basename(scanned))] = scanned;
+    }
+    if (canonicalToScanned.isEmpty) return const {};
+
+    final renames = <String, String>{};
+    final merges = <String, String>{};
+    final claimed = <String>{};
+
+    for (final orphanPath in orphanPaths) {
+      if (orphanPath.startsWith('content://')) continue;
+      final dir = await canonicalDirOf(path.dirname(orphanPath));
+      if (dir == null) continue; // The directory is gone: a genuine orphan.
+
+      final survivor =
+          canonicalToScanned[path.join(dir, path.basename(orphanPath))];
+      if (survivor == null || survivor == orphanPath) continue;
+
+      if (knownPaths.contains(survivor) || claimed.contains(survivor)) {
+        merges[orphanPath] = survivor;
+      } else {
+        // Only the alias spelling was ever stored, so the row can simply move
+        // to the surviving path and keep everything it carries.
+        renames[orphanPath] = survivor;
+        claimed.add(survivor);
+      }
+    }
+
+    if (renames.isEmpty && merges.isEmpty) return const {};
+
+    int asInt(Object? value) =>
+        value is int ? value : int.tryParse('${value ?? ''}') ?? 0;
+
+    String? latest(Object? a, Object? b) {
+      final x = (a == null || a.toString().isEmpty) ? null : a.toString();
+      final y = (b == null || b.toString().isEmpty) ? null : b.toString();
+      if (x == null) return y;
+      if (y == null) return x;
+      return x.compareTo(y) >= 0 ? x : y;
+    }
+
+    const columns =
+        'is_favorite, play_time, last_played, id_ra, ra_hash, ss_hash, '
+        'app_emulator_unique_id, app_emulator_os_id, '
+        'app_alternative_emulators_id';
+
+    final db = await SqliteService.getDatabase();
+    await db.transaction((txn) async {
+      for (final entry in renames.entries) {
+        await txn.rawUpdate(
+          "UPDATE user_roms SET rom_path = ?, updated_at = datetime('now') "
+          'WHERE rom_path = ?',
+          [entry.value, entry.key],
+        );
+      }
+
+      for (final entry in merges.entries) {
+        final duplicateRows = await txn.rawQuery(
+          'SELECT $columns FROM user_roms WHERE rom_path = ?',
+          [entry.key],
+        );
+        final survivorRows = await txn.rawQuery(
+          'SELECT $columns FROM user_roms WHERE rom_path = ?',
+          [entry.value],
+        );
+        if (duplicateRows.isEmpty || survivorRows.isEmpty) continue;
+
+        final d = duplicateRows.first;
+        final s = survivorRows.first;
+
+        // The surviving row wins every scalar it already carries; the duplicate
+        // only fills gaps. Play time is summed because each launch was recorded
+        // against exactly one of the two rows.
+        await txn.rawUpdate(
+          '''
+          UPDATE user_roms SET
+            is_favorite = ?,
+            play_time = ?,
+            last_played = ?,
+            id_ra = ?,
+            ra_hash = ?,
+            ss_hash = ?,
+            app_emulator_unique_id = ?,
+            app_emulator_os_id = ?,
+            app_alternative_emulators_id = ?,
+            updated_at = datetime('now')
+          WHERE rom_path = ?
+          ''',
+          [
+            (asInt(s['is_favorite']) == 1 || asInt(d['is_favorite']) == 1)
+                ? 1
+                : 0,
+            asInt(s['play_time']) + asInt(d['play_time']),
+            latest(s['last_played'], d['last_played']),
+            s['id_ra'] ?? d['id_ra'],
+            s['ra_hash'] ?? d['ra_hash'],
+            s['ss_hash'] ?? d['ss_hash'],
+            s['app_emulator_unique_id'] ?? d['app_emulator_unique_id'],
+            s['app_emulator_os_id'] ?? d['app_emulator_os_id'],
+            s['app_alternative_emulators_id'] ??
+                d['app_alternative_emulators_id'],
+            entry.value,
+          ],
+        );
+      }
+    });
+
+    return renames;
   }
 
   /// Performs a specialized scan of installed Android applications.

--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -176,6 +176,14 @@ class SqliteDatabaseService {
 
     final List<RomEntry> romEntries = [];
 
+    // Resolve every alias folder to a concrete directory before walking any of
+    // them. A system's aliases can name the same physical directory: EmuDeck
+    // ships roms/gamecube as a symlink to roms/gc, and both are aliases of the
+    // GameCube system, so walking each alias in turn finds every file twice and
+    // stores it under two different rom_path spellings.
+    final scanTargets =
+        <({String dirPath, String canonicalPath, bool useSaf})>[];
+
     for (final romFolder in romFolders) {
       final bool useSaf =
           Platform.isAndroid && romFolder.startsWith('content://');
@@ -183,57 +191,70 @@ class SqliteDatabaseService {
 
       for (final folderToScan in allPossibleFolderNames) {
         try {
-          List<RomEntry> entries;
+          final String? dirPath;
 
           if (subdirsForRoot != null) {
-            final folderLower = folderToScan.toLowerCase();
-            final resolvedPath = subdirsForRoot[folderLower];
-
-            if (resolvedPath != null) {
-              if (useSaf) {
-                entries = await _scanSafUri(
-                  resolvedPath,
-                  validExtensionsSet,
-                  system.recursiveScan,
-                  ignoreHiddenFiles: ignoreHiddenFiles,
-                );
-              } else {
-                entries = await _scanStandardPath(
-                  resolvedPath,
-                  validExtensionsSet,
-                  system.recursiveScan,
-                  ignoreHiddenFiles: ignoreHiddenFiles,
-                );
-              }
-            } else {
-              continue;
-            }
+            dirPath = subdirsForRoot[folderToScan.toLowerCase()];
+          } else if (useSaf) {
+            dirPath = await _resolveSafSubfolderUri(
+              romFolder,
+              folderToScan,
+              ignoreHiddenFiles: ignoreHiddenFiles,
+            );
           } else {
-            if (useSaf) {
-              entries = await _scanSafFolder(
-                romFolder,
-                folderToScan,
-                validExtensionsSet,
-                system.recursiveScan,
-                ignoreHiddenFiles: ignoreHiddenFiles,
-              );
-            } else {
-              entries = await _scanStandardFolder(
-                romFolder,
-                folderToScan,
-                validExtensionsSet,
-                system.recursiveScan,
-                ignoreHiddenFiles: ignoreHiddenFiles,
-              );
-            }
+            dirPath = await _resolveStandardSubfolderPath(
+              romFolder,
+              folderToScan,
+              ignoreHiddenFiles: ignoreHiddenFiles,
+            );
           }
 
-          if (entries.isNotEmpty) {
-            romEntries.addAll(entries);
-          }
+          if (dirPath == null) continue;
+
+          scanTargets.add((
+            dirPath: dirPath,
+            canonicalPath: await _canonicalScanPath(dirPath, useSaf: useSaf),
+            useSaf: useSaf,
+          ));
         } catch (e) {
-          _log.e('Error scanning folder $folderToScan in $romFolder: $e');
+          _log.e('Error resolving folder $folderToScan in $romFolder: $e');
         }
+      }
+    }
+
+    // Walk real directories before symlinked aliases so the stored rom_path
+    // names the physical location: if the user later drops the alias link, the
+    // rows that survived still resolve.
+    final orderedTargets = [
+      ...scanTargets.where((t) => t.dirPath == t.canonicalPath),
+      ...scanTargets.where((t) => t.dirPath != t.canonicalPath),
+    ];
+
+    final walkedDirs = <String>{};
+    for (final target in orderedTargets) {
+      // An alias pointing at a directory already walked for this system.
+      if (!walkedDirs.add(target.canonicalPath)) continue;
+
+      try {
+        final entries = target.useSaf
+            ? await _scanSafUri(
+                target.dirPath,
+                validExtensionsSet,
+                system.recursiveScan,
+                ignoreHiddenFiles: ignoreHiddenFiles,
+              )
+            : await _scanStandardPath(
+                target.dirPath,
+                validExtensionsSet,
+                system.recursiveScan,
+                ignoreHiddenFiles: ignoreHiddenFiles,
+              );
+
+        if (entries.isNotEmpty) {
+          romEntries.addAll(entries);
+        }
+      } catch (e) {
+        _log.e('Error scanning folder ${target.dirPath}: $e');
       }
     }
 
@@ -892,18 +913,15 @@ class SqliteDatabaseService {
     return result;
   }
 
-  /// Scans for a system-specific subdirectory within a SAF root URI.
-  static Future<List<RomEntry>> _scanSafFolder(
+  /// Locates a system-specific subdirectory within a SAF root URI.
+  static Future<String?> _resolveSafSubfolderUri(
     String romFolderUri,
-    String folderName,
-    Set<String> validExtensions,
-    bool recursive, {
+    String folderName, {
     bool ignoreHiddenFiles = true,
   }) async {
     try {
       final children = await SafDirectoryService.listFiles(romFolderUri);
-      if (children.isEmpty) return [];
-      String? systemTargetUri;
+      if (children.isEmpty) return null;
       for (final child in children) {
         if (_shouldSkipSafEntry(child, ignoreHiddenFiles: ignoreHiddenFiles)) {
           continue;
@@ -911,20 +929,34 @@ class SqliteDatabaseService {
         if (child['isDirectory'] == true &&
             child['name'].toString().toLowerCase() ==
                 folderName.toLowerCase()) {
-          systemTargetUri = child['uri'].toString();
-          break;
+          return child['uri'].toString();
         }
       }
-      if (systemTargetUri == null) return [];
-      return await _scanSafUri(
-        systemTargetUri,
-        validExtensions,
-        recursive,
-        ignoreHiddenFiles: ignoreHiddenFiles,
-      );
+      return null;
     } catch (e) {
-      _log.e('Error scanning SAF folder $romFolderUri for $folderName: $e');
-      return [];
+      _log.e('Error resolving SAF folder $romFolderUri for $folderName: $e');
+      return null;
+    }
+  }
+
+  /// Returns the key identifying a scan target's physical directory, so alias
+  /// folders resolving to one place are only walked once.
+  ///
+  /// SAF URIs are opaque DocumentsProvider identifiers rather than filesystem
+  /// paths, so they are returned untouched: resolving symbolic links is
+  /// meaningless there, and quietly falling back to a real path would break the
+  /// `content://` rom_path identity the launcher depends on.
+  static Future<String> _canonicalScanPath(
+    String dirPath, {
+    required bool useSaf,
+  }) async {
+    if (useSaf) return dirPath;
+    try {
+      return await Directory(dirPath).resolveSymbolicLinks();
+    } catch (e) {
+      // Unreadable, or gone between listing and resolving. Fall back to the
+      // literal path so the directory is still walked exactly once.
+      return dirPath;
     }
   }
 
@@ -999,18 +1031,15 @@ class SqliteDatabaseService {
     return entries;
   }
 
-  /// Scans for a system-specific subdirectory within a standard filesystem path.
-  static Future<List<RomEntry>> _scanStandardFolder(
+  /// Locates a system-specific subdirectory within a standard filesystem path.
+  static Future<String?> _resolveStandardSubfolderPath(
     String romFolderPath,
-    String folderName,
-    Set<String> validExtensions,
-    bool recursive, {
+    String folderName, {
     bool ignoreHiddenFiles = true,
   }) async {
     try {
       final rootDir = Directory(romFolderPath);
-      if (!await rootDir.exists()) return [];
-      String? systemPath;
+      if (!await rootDir.exists()) return null;
       try {
         final List<FileSystemEntity> children = await rootDir.list().toList();
         for (final child in children) {
@@ -1023,27 +1052,20 @@ class SqliteDatabaseService {
           if (child is Directory &&
               path.basename(child.path).toLowerCase() ==
                   folderName.toLowerCase()) {
-            systemPath = child.path;
-            break;
+            return child.path;
           }
         }
       } catch (e) {
         _log.e('Error listing standard directory $romFolderPath: $e');
         final directPath = path.join(romFolderPath, folderName);
-        if (await Directory(directPath).exists()) systemPath = directPath;
+        if (await Directory(directPath).exists()) return directPath;
       }
-      if (systemPath == null) return [];
-      return await _scanStandardPath(
-        systemPath,
-        validExtensions,
-        recursive,
-        ignoreHiddenFiles: ignoreHiddenFiles,
-      );
+      return null;
     } catch (e) {
       _log.e(
-        'Error scanning standard folder $romFolderPath for $folderName: $e',
+        'Error resolving standard folder $romFolderPath for $folderName: $e',
       );
-      return [];
+      return null;
     }
   }
 

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -75,6 +75,7 @@ class DatabaseTestHelper {
         players TEXT,
         app_system_id TEXT,
         ra_hash TEXT,
+        ss_hash TEXT,
         id_ra INTEGER,
         is_favorite INTEGER DEFAULT 0,
         play_time INTEGER DEFAULT 0,
@@ -84,6 +85,7 @@ class DatabaseTestHelper {
         updated_at TEXT,
         app_emulator_unique_id TEXT,
         app_emulator_os_id INTEGER,
+        app_alternative_emulators_id INTEGER,
         box2d_aspect_ratio TEXT
       )
     ''');

--- a/test/rom_scan_symlink_alias_test.dart
+++ b/test/rom_scan_symlink_alias_test.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_database_service.dart';
+import 'package:neostation/models/system_model.dart';
+
+import 'database_test_helper.dart';
+
+/// EmuDeck ships alias directories as symlinks (roms/gamecube -> roms/gc), and
+/// both names are registered folders of the same system, so an unguarded scan
+/// finds every file twice and stores it under two rom_path spellings.
+void main() {
+  final dbHelper = DatabaseTestHelper();
+  late dynamic db;
+
+  const gcSystem = SystemModel(
+    id: 'gc',
+    realName: 'Nintendo GameCube',
+    folderName: 'gc',
+    iconImage: '',
+    color: '#000000',
+    recursiveScan: true,
+  );
+
+  setUp(() async {
+    db = await dbHelper.setUp();
+    await db.execute(
+      "INSERT INTO app_systems (id, real_name, folder_name) VALUES ('gc', 'Nintendo GameCube', 'gc')",
+    );
+    await db.execute(
+      "INSERT INTO app_system_extensions (system_id, extension) VALUES ('gc', 'rvz')",
+    );
+    for (final alias in ['GameCube', 'Nintendo GameCube', 'gc', 'ngc']) {
+      await db.rawInsert(
+        'INSERT INTO app_system_folders (system_id, folder_name) VALUES (?, ?)',
+        ['gc', alias],
+      );
+    }
+  });
+
+  tearDown(() async {
+    await dbHelper.tearDown();
+  });
+
+  /// Builds `<root>/gc` holding [filenames], plus a `<root>/gamecube` symlink
+  /// pointing at it, mirroring an EmuDeck layout.
+  Future<Directory> createAliasedRomTree(List<String> filenames) async {
+    final root = await Directory.systemTemp.createTemp('neostation_symlink_');
+    addTearDown(() async {
+      if (await root.exists()) await root.delete(recursive: true);
+    });
+
+    final real = Directory('${root.path}/gc')..createSync(recursive: true);
+    for (final name in filenames) {
+      File('${real.path}/$name').writeAsStringSync('rom');
+    }
+    Link('${root.path}/gamecube').createSync(real.path);
+    return root;
+  }
+
+  Future<List<Map<String, Object?>>> romRows() async {
+    return await db.rawQuery(
+      "SELECT filename, rom_path, is_favorite, play_time, last_played, id_ra "
+      "FROM user_roms WHERE app_system_id = 'gc' ORDER BY rom_path",
+    );
+  }
+
+  group('ROM scan across symlinked alias folders', () {
+    test('stores one row per physical file, at the real path', () async {
+      final root = await createAliasedRomTree(['18 Wheeler.rvz']);
+
+      await SqliteDatabaseService.scanSystemRoms(gcSystem, [root.path]);
+
+      final rows = await romRows();
+      expect(rows, hasLength(1));
+      expect(rows.single['rom_path'], '${root.path}/gc/18 Wheeler.rvz');
+    });
+
+    test('still scans an alias that is a real directory of its own', () async {
+      final root = await Directory.systemTemp.createTemp('neostation_symlink_');
+      addTearDown(() async {
+        if (await root.exists()) await root.delete(recursive: true);
+      });
+
+      Directory('${root.path}/gc').createSync(recursive: true);
+      Directory('${root.path}/ngc').createSync(recursive: true);
+      File('${root.path}/gc/A.rvz').writeAsStringSync('rom');
+      File('${root.path}/ngc/B.rvz').writeAsStringSync('rom');
+
+      await SqliteDatabaseService.scanSystemRoms(gcSystem, [root.path]);
+
+      final rows = await romRows();
+      expect(rows.map((r) => r['filename']), ['A.rvz', 'B.rvz']);
+    });
+
+    test(
+      'keeps the real directory when the primary folder is the link',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'neostation_symlink_',
+        );
+        addTearDown(() async {
+          if (await root.exists()) await root.delete(recursive: true);
+        });
+
+        // Reversed layout: the alias is the real directory, `gc` links to it.
+        final real = Directory('${root.path}/gamecube')
+          ..createSync(recursive: true);
+        File('${real.path}/Wave Race.rvz').writeAsStringSync('rom');
+        Link('${root.path}/gc').createSync(real.path);
+
+        await SqliteDatabaseService.scanSystemRoms(gcSystem, [root.path]);
+
+        final rows = await romRows();
+        expect(rows, hasLength(1));
+        expect(rows.single['rom_path'], '${real.path}/Wave Race.rvz');
+      },
+    );
+
+    test('deduplicates files held in subdirectories', () async {
+      final root = await Directory.systemTemp.createTemp('neostation_symlink_');
+      addTearDown(() async {
+        if (await root.exists()) await root.delete(recursive: true);
+      });
+
+      final sub = Directory('${root.path}/gc/Multi Disc')
+        ..createSync(recursive: true);
+      File('${sub.path}/Baten Kaitos.rvz').writeAsStringSync('rom');
+      Link('${root.path}/gamecube').createSync('${root.path}/gc');
+
+      await SqliteDatabaseService.scanSystemRoms(gcSystem, [root.path]);
+
+      expect(await romRows(), hasLength(1));
+    });
+  });
+}

--- a/test/rom_scan_symlink_alias_test.dart
+++ b/test/rom_scan_symlink_alias_test.dart
@@ -133,4 +133,71 @@ void main() {
       expect(await romRows(), hasLength(1));
     });
   });
+
+  group('Existing duplicate rows', () {
+    test('merges the alias row user data into the surviving row', () async {
+      final root = await createAliasedRomTree(['18 Wheeler.rvz']);
+      final realPath = '${root.path}/gc/18 Wheeler.rvz';
+      final aliasPath = '${root.path}/gamecube/18 Wheeler.rvz';
+
+      // The pre-fix state: both spellings stored, and the alias row is the one
+      // carrying the play time, the favourite flag and the scraped id.
+      await db.rawInsert(
+        'INSERT INTO user_roms (app_system_id, filename, rom_path, is_favorite, play_time) '
+        "VALUES ('gc', '18 Wheeler.rvz', ?, 0, 120)",
+        [realPath],
+      );
+      await db.rawInsert(
+        'INSERT INTO user_roms (app_system_id, filename, rom_path, is_favorite, play_time, last_played, id_ra) '
+        "VALUES ('gc', '18 Wheeler.rvz', ?, 1, 3600, '2026-08-01T10:00:00Z', 4242)",
+        [aliasPath],
+      );
+
+      await SqliteDatabaseService.scanSystemRoms(gcSystem, [root.path]);
+
+      final rows = await romRows();
+      expect(rows, hasLength(1));
+      final row = rows.single;
+      expect(row['rom_path'], realPath);
+      expect(row['is_favorite'], 1);
+      expect(row['play_time'], 3720); // Each launch hit exactly one row.
+      expect(row['last_played'], '2026-08-01T10:00:00Z');
+      expect(row['id_ra'], 4242);
+    });
+
+    test('adopts the alias row when no row exists at the real path', () async {
+      final root = await createAliasedRomTree(['18 Wheeler.rvz']);
+      final aliasPath = '${root.path}/gamecube/18 Wheeler.rvz';
+
+      await db.rawInsert(
+        'INSERT INTO user_roms (app_system_id, filename, rom_path, is_favorite, play_time, id_ra) '
+        "VALUES ('gc', '18 Wheeler.rvz', ?, 1, 900, 77)",
+        [aliasPath],
+      );
+
+      await SqliteDatabaseService.scanSystemRoms(gcSystem, [root.path]);
+
+      final rows = await romRows();
+      expect(rows, hasLength(1));
+      expect(rows.single['rom_path'], '${root.path}/gc/18 Wheeler.rvz');
+      expect(rows.single['is_favorite'], 1);
+      expect(rows.single['play_time'], 900);
+      expect(rows.single['id_ra'], 77);
+    });
+
+    test('still removes rows whose file is genuinely gone', () async {
+      final root = await createAliasedRomTree(['18 Wheeler.rvz']);
+
+      await db.rawInsert(
+        'INSERT INTO user_roms (app_system_id, filename, rom_path, play_time) '
+        "VALUES ('gc', 'Deleted.rvz', ?, 500)",
+        ['${root.path}/gc/Deleted.rvz'],
+      );
+
+      await SqliteDatabaseService.scanSystemRoms(gcSystem, [root.path]);
+
+      final rows = await romRows();
+      expect(rows.map((r) => r['filename']), ['18 Wheeler.rvz']);
+    });
+  });
 }


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

One physical ROM file could appear twice in the games list.

A system's registered folder aliases can name the same directory on disk. EmuDeck ships `roms/gamecube` as a **symlink** to `roms/gc`, and both `gamecube` and `gc` are registered aliases of the GameCube system, so the scan walked the same tree twice and stored every file under two `rom_path` spellings — two rows in `user_roms`, two cards in the UI. Verified on a Steam Deck: both paths reach the same inode, and both rows carry the same `app_system_id`.

This is not GameCube-specific — it is symlink-specific. Any alias symlink does it; `gamecube` just happened to be the only one on that device.

**Two commits:**

1. **Stop creating duplicates.** Resolve every alias to a concrete directory before walking any of them, then skip the ones that canonicalise to a directory already walked for this system. Real directories are walked before symlinked ones, so the stored path names the physical location — if the user later removes the alias link, the surviving rows still resolve. `rom_path` identity is untouched: no schema change, no migration.

2. **Heal the rows users already have.** Those rows are not orphans (the file is still there, via the alias), but the scan no longer visits that spelling, so the existing orphan cleanup would simply `DELETE` them — losing data, because the deleted row is often the one carrying the play time, favourite flag or scraped id. On the test Deck, one game had 6 seconds of play time on the row the scan keeps and **362 on the row that would have been dropped**. So before deleting, the duplicate is folded into the survivor: favourite OR'd, play time summed (each launch was recorded against exactly one row), `last_played` takes the later value, and scraped ids/hashes/emulator assignment fill gaps the survivor doesn't already have. Where only the alias spelling was ever stored, the row is renamed in place instead.

`_scanSafFolder` / `_scanStandardFolder` became `_resolveSafSubfolderUri` / `_resolveStandardSubfolderPath`. That collapses the two branches that reached the walk (pre-resolved `rootFoldersMap` vs. per-folder lookup) into one place, so the deduplication applies to both.

### Android / SAF

SAF is an **explicit no-op**, not a silent fallback. A `content://` URI is an opaque DocumentsProvider identifier with no symbolic link to resolve, and quietly swapping in a real path would break the `rom_path` identity the launcher depends on. `_canonicalScanPath` returns the URI unchanged when scanning SAF, and the merge pass skips `content://` outright.

### Performance

`rom_path` identity is what the scan's fast path keys on, so this deliberately resolves **one directory at a time, never one file at a time** — a per-file `realpath` would undo the earlier SAF-bypass optimisation. The merge pass only runs when a scan found orphans at all, so a warm rescan never pays for it.

Measured over a 2,000-file aliased tree, 3 runs each — it is **faster**, because the duplicate walk and 2,000 redundant upserts are gone:

| | cold | warm |
|---|---|---|
| this branch | 138–157 ms | 44–51 ms |
| before | 244–303 ms | 64–67 ms |

On Android the added cost is structurally zero: `rootFoldersMap` is pre-resolved, so lookup is a map hit and the canonicalisation short-circuits — no new syscalls.

Fixes # (no issue — found while hardware-testing #275, and deliberately scoped out of it since that was a launch fix and this touches ROM identity)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

### Tests

7 new tests in `test/rom_scan_symlink_alias_test.dart`, over real fixture trees containing a symlinked alias directory. 6 of them fail without the fix; the 7th is the regression guard that an alias which is a *real* directory of its own is still scanned. Full suite green (507 tests).

### Device verification

**Steam Deck (SteamOS, EmuDeck)** — the live reproduction. 2 rows → 1; the survivor is the real `/roms/gc/…` path; `play_time` reads **368 = 6 + 362**, so the merge preserved the play time that existed only on the alias row. Duplicate filenames library-wide: 9 → 0. Total 400 → 399, other systems untouched.

**AYN Thor (Android/SAF)** — 9,127 ROMs across 34 systems rescanned; **9,082 rows still `content://`**, confirming the fix is a genuine no-op on SAF. The 9 remaining duplicate filenames there are legitimate (the same game in a root folder *and* a curated subfolder like `32X Games (Genesis)`), not symlink artifacts.

## Screenshots (if applicable)

N/A — the visible change is one card instead of two.
