### PR TITLE
feat(search): make the search results selectable by touch

### DIFF
--- a/lib/screens/search_screen/search_screen.dart
+++ b/lib/screens/search_screen/search_screen.dart
@@ -278,6 +278,12 @@ class _SearchScreenState extends State<SearchScreen> {
   /// Shows/hides the filter chip row, moving focus to follow.
   void _toggleFilters() {
     setState(() {
+      // Activating a control other than the field itself ends text entry —
+      // reachable by touch while the keyboard is up, and by gamepad because
+      // Left/Right off the field deliberately leave it focused (B is the way
+      // out of a field, so the keyboard has to be dismissed on use, not on
+      // direction).
+      _nameFocus.unfocus();
       _filtersExpanded = !_filtersExpanded;
       if (_filtersExpanded) {
         _region = _FocusRegion.filters;
@@ -292,11 +298,27 @@ class _SearchScreenState extends State<SearchScreen> {
 
   /// Empties the name query, leaving the filter chips as they are, and hands
   /// focus back to the field the user was typing in.
+  ///
+  /// Also claims the search band: the X is tappable from anywhere on screen, so
+  /// a touch user can clear the query while the selection sits in the results.
   void _clearQuery() {
     setState(() {
       _nameController.clear();
+      _region = _FocusRegion.search;
       _searchIndex = 0;
       _recompute();
+    });
+    SfxService().playNavSound();
+  }
+
+  /// Claims the search band for the text field, so touching into the field
+  /// moves the on-screen selection there instead of leaving it stranded on a
+  /// result or a filter chip while the user types.
+  void _focusNameField() {
+    if (_region == _FocusRegion.search && _searchIndex == 0) return;
+    setState(() {
+      _region = _FocusRegion.search;
+      _searchIndex = 0;
     });
     SfxService().playNavSound();
   }
@@ -605,6 +627,33 @@ class _SearchScreenState extends State<SearchScreen> {
       _recompute();
     });
     SfxService().playNavSound();
+  }
+
+  /// Touch handler for a result row.
+  ///
+  /// Follows the same two-step contract as the games list/grid: touch users
+  /// have no A button, so the first tap only moves the selection onto the row
+  /// and a second tap on that same row confirms it — here opening the
+  /// Go-to-game / Play chooser, exactly as [_handleSelect] does.
+  void _handleResultTap(int index) {
+    if (_region == _FocusRegion.results && _resultIndex == index) {
+      SfxService().playEnterSound();
+      setState(() {
+        _actionTarget = _results[index];
+        _actionIndex = 0;
+        _region = _FocusRegion.action;
+      });
+      return;
+    }
+
+    setState(() {
+      _nameFocus.unfocus();
+      _region = _FocusRegion.results;
+      _resultIndex = index;
+    });
+    SfxService().playNavSound();
+    // Deliberately no _scrollResultIntoView(): the row is already under the
+    // user's finger, and recentring it would slide it out from under them.
   }
 
   void _scrollResultIntoView() {
@@ -1021,6 +1070,7 @@ class _SearchScreenState extends State<SearchScreen> {
         controller: _nameController,
         focusNode: _nameFocus,
         textInputAction: TextInputAction.done,
+        onTap: _focusNameField,
         onChanged: (_) => setState(_recompute),
         onSubmitted: (_) => _nameFocus.unfocus(),
         decoration: InputDecoration(
@@ -1090,6 +1140,7 @@ class _SearchScreenState extends State<SearchScreen> {
     return GestureDetector(
       onTap: () {
         setState(() {
+          _nameFocus.unfocus();
           _region = _FocusRegion.filters;
           _barIndex = _barItems.indexOf(key);
         });
@@ -1154,7 +1205,17 @@ class _SearchScreenState extends State<SearchScreen> {
   Widget _buildClearChip(ThemeData theme, bool isFocused) {
     final scheme = theme.colorScheme;
     return GestureDetector(
-      onTap: _clearFilters,
+      onTap: () {
+        // Tapping Clear also lands focus on it, so gamepad navigation carries
+        // on from the chip the user just used rather than from wherever the
+        // selection happened to be.
+        setState(() {
+          _nameFocus.unfocus();
+          _region = _FocusRegion.filters;
+          _barIndex = _barItems.indexOf('clear');
+        });
+        _clearFilters();
+      },
       child: Container(
         margin: EdgeInsets.only(right: 8.r),
         padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 8.r),
@@ -1400,67 +1461,71 @@ class _SearchScreenState extends State<SearchScreen> {
         g.developer!.trim(),
     ];
 
-    return Padding(
-      padding: EdgeInsets.symmetric(vertical: 3.r),
-      child: Container(
-        padding: EdgeInsets.symmetric(horizontal: 10.r, vertical: 6.r),
-        decoration: BoxDecoration(
-          color: isFocused
-              ? scheme.primary.withValues(alpha: 0.18)
-              : scheme.surface.withValues(alpha: 0.5),
-          borderRadius: BorderRadius.circular(12.r),
-          border: Border.all(
-            color: isFocused ? scheme.primary : Colors.transparent,
-            width: 2.r,
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => _handleResultTap(index),
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: 3.r),
+        child: Container(
+          padding: EdgeInsets.symmetric(horizontal: 10.r, vertical: 6.r),
+          decoration: BoxDecoration(
+            color: isFocused
+                ? scheme.primary.withValues(alpha: 0.18)
+                : scheme.surface.withValues(alpha: 0.5),
+            borderRadius: BorderRadius.circular(12.r),
+            border: Border.all(
+              color: isFocused ? scheme.primary : Colors.transparent,
+              width: 2.r,
+            ),
           ),
-        ),
-        child: Row(
-          children: [
-            _buildBoxArt(theme, g),
-            SizedBox(width: 10.r),
-            Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    g.realName ?? g.filename,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 13.r,
-                      fontWeight: FontWeight.w700,
-                      color: scheme.onSurface,
-                    ),
-                  ),
-                  if (subtitleParts.isNotEmpty)
+          child: Row(
+            children: [
+              _buildBoxArt(theme, g),
+              SizedBox(width: 10.r),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitleParts.join('  •  '),
+                      g.realName ?? g.filename,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
-                        fontSize: 11.r,
-                        color: scheme.onSurface.withValues(alpha: 0.6),
+                        fontSize: 13.r,
+                        fontWeight: FontWeight.w700,
+                        color: scheme.onSurface,
                       ),
                     ),
-                ],
-              ),
-            ),
-            if (g.rating != null && g.rating! > 0) ...[
-              SizedBox(width: 8.r),
-              Icon(Symbols.star_rounded, size: 14.r, color: scheme.primary),
-              SizedBox(width: 2.r),
-              Text(
-                // Stored 0..20, shown out of 10 as everywhere else in the app.
-                searchRatingScore(g.rating!).toStringAsFixed(1),
-                style: TextStyle(
-                  fontSize: 12.r,
-                  fontWeight: FontWeight.w600,
-                  color: scheme.onSurface.withValues(alpha: 0.8),
+                    if (subtitleParts.isNotEmpty)
+                      Text(
+                        subtitleParts.join('  •  '),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 11.r,
+                          color: scheme.onSurface.withValues(alpha: 0.6),
+                        ),
+                      ),
+                  ],
                 ),
               ),
+              if (g.rating != null && g.rating! > 0) ...[
+                SizedBox(width: 8.r),
+                Icon(Symbols.star_rounded, size: 14.r, color: scheme.primary),
+                SizedBox(width: 2.r),
+                Text(
+                  // Stored 0..20, shown out of 10 as everywhere else in the app.
+                  searchRatingScore(g.rating!).toStringAsFixed(1),
+                  style: TextStyle(
+                    fontSize: 12.r,
+                    fontWeight: FontWeight.w600,
+                    color: scheme.onSurface.withValues(alpha: 0.8),
+                  ),
+                ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

The results list on the Search tab was the only interactive element on that screen with no tap handler at all — the filter chips, the Filters toggle, the value picker and the result-action chooser all had one. On a touchscreen the results were dead: reachable only with the D-pad.

Each result tile now follows the same two-step contract the games list and grid already use (`game_list_view.dart`, `my_games_grid.dart`): **the first tap moves the selection onto the row, a second tap on that same row confirms it.** Touch users have no A button, so confirming opens the existing Go-to-game / Play chooser rather than launching outright — launching stays an explicit step on both input methods. The tile deliberately does *not* scroll itself into view on tap: the row is already under the user's finger, and recentring would slide it away.

While in there, the rest of the screen was tightened to the same rule — **whatever you touch takes the focus, and touching anything other than the field ends text entry.** Four handlers were incomplete:

| Control | Was | Now |
|---|---|---|
| Search text field | no `onTap` at all — you typed with the selection stranded on a result or chip | claims the search band |
| Clear-query ✕ | set `_searchIndex` but not `_region` | also claims the search band |
| Clear-filters chip | set nothing focus-wise | claims the chip row at the Clear chip |
| Filters toggle | set the region, but left the keyboard up | also unfocuses the field |
| Filter chip | set region + index | also unfocuses the field |

Direction still never escapes a focused field (per the convention established when #255 was rejected): the field is unfocused when another control is *used*, never when one is merely moved past, so **B remains the only way out of text entry.** The action chooser, its scrim, and the filter-menu options/scrim already did the right thing and are untouched.

Fixes # (no issue — spotted in use)

Related: #276 — while testing this I confirmed the Android landscape IME takes over the whole screen in extract mode when the search field is focused. That is not something this PR can address: Flutter's `TextInputPlugin` already sets `IME_FLAG_NO_FULLSCREEN` (`0x2000000`) unconditionally on every `TextField`, and the device's keyboard ignores it. A native on-screen keyboard is the real fix.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. *(no test — the change is tap wiring on a `StatefulWidget` with no extracted logic; the existing 510 tests still pass)*
- [ ] I have updated the corresponding documentation. *(n/a)*
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. *(no new assets)*
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** — D-pad navigation through all five regions is unchanged; the field/keyboard behaviour above was the one deliberate gamepad-facing change.

## Verification

Tested on an AYN Thor (dev build), driving the UI by touch and screenshotting each step:

1. Field focused → tap a result → the focus ring moves to that row and off the field.
2. Tap the same row again → the Go-to-game / Play chooser opens, titled with that game.
3. Tap back into the field → the field reclaims focus, the row highlight clears.
4. Tap Filters → the toggle takes focus and text entry ends.
5. Tap a filter chip *from the results region* → its menu opens with no stale row highlight; cancelling leaves focus on that chip.
6. Tap Clear filters → focus lands on the Clear chip.

Exactly one focus ring is on screen at every step.

`dart format` clean, `flutter analyze` clean, 510/510 tests pass.
