### PR TITLE
fix(nav): shorten the hold before alphabet jumping kicks in

### DIFF
--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -185,10 +185,10 @@ class GamepadNavigation {
 
   /// How long a direction must be held before repeats escalate from stepping
   /// item-by-item to ES-DE style alphabetical jumping (see [onLetterJump]).
-  /// Long enough that the accelerated step scroll (~30 items by this point) is
-  /// the normal way to browse, and letter jumping only takes over on a
-  /// deliberate hold.
-  static const Duration _letterJumpAfter = Duration(milliseconds: 1600);
+  /// Long enough that the accelerated step scroll (~17 items by this point) is
+  /// still the normal way to browse a short list, but short enough that holding
+  /// a direction to skim a big library reaches the alphabet quickly.
+  static const Duration _letterJumpAfter = Duration(milliseconds: 1200);
 
   /// Dwell time on each letter while letter jumping — long enough to read the
   /// letter and release on it, short enough to cross the alphabet quickly.


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested on hardware by the author.

# Description

Holding a direction in the games list or carousel waited **1600ms** before repeats escalated from stepping item-by-item to the ES-DE style alphabetical jump. When skimming a large system that wait was noticeably long — you hold the D-pad expecting the alphabet to take over and it keeps creeping through single games.

This lowers the threshold to **1200ms**.

The accelerated step scroll has covered roughly 17 items by that point, so browsing a short list still happens by stepping and letter jumping only takes over on a deliberate hold — it just gets there sooner on a big library.

`_letterJumpAfter` in `lib/utils/gamepad_nav.dart` is shared by both game views, so this covers held D-pad **up/down in the list** and **left/right in the carousel** in one place. The per-letter dwell time (`_letterJumpInterval`, 360ms) is unchanged.

Arrived at by testing on device: 800ms was tried first and overshot — it started jumping while still browsing normally — so 1200ms is the compromise that felt right in hand.

Fixes # (no issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. — no test added; the change is a single timing constant whose value is a feel judgement, verified by hand on device. The existing suite (510 tests) passes.
- [x] I have updated the corresponding documentation. — the doc comment on the constant now reflects the new value and reasoning.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. — no assets changed.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable). — this *is* the gamepad path; verified on an AYN Thor in both the list (up/down) and the carousel (left/right).

## Screenshots (if applicable)

Not applicable — the change is a timing value, not a visual one.
