### PR TITLE
Improve RetroAchievements API key login guidance

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -993,6 +993,8 @@ mixin AppLocale {
   static const String raRateLimited = 'ra_rate_limited';
   static const String raApiKey = 'ra_api_key';
   static const String raEnterApiKey = 'ra_enter_api_key';
+  static const String raGetApiKey = 'ra_get_api_key';
+  static const String raApiKeyHelp = 'ra_api_key_help';
   static const String raNoRecentUnlocks = 'ra_no_recent_unlocks';
   static const String raRecentlyPlayedTitle = 'ra_recently_played_title';
   static const String raNoRecentlyPlayed = 'ra_no_recently_played';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -962,6 +962,9 @@ const Map<String, dynamic> appLocaleDe = {
       'RetroAchievements ist gerade ausgelastet. Bitte warte einen Moment und versuche es erneut.',
   AppLocale.raApiKey: 'API-Schlüssel',
   AppLocale.raEnterApiKey: 'Gib deinen API-Schlüssel ein',
+  AppLocale.raGetApiKey: 'API-Schlüssel holen',
+  AppLocale.raApiKeyHelp:
+      'Öffne dein RetroAchievements-Kontrollzentrum, um deinen persönlichen Web-API-Schlüssel zu kopieren.',
   AppLocale.raNoRecentUnlocks:
       'Keine kürzlichen Freischaltungen in den letzten 30 Tagen',
   AppLocale.raRecentlyPlayedTitle: 'Kürzlich Gespielt',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -930,6 +930,9 @@ const Map<String, dynamic> appLocaleEn = {
       'RetroAchievements is busy right now. Please wait a moment and try again.',
   AppLocale.raApiKey: 'API Key',
   AppLocale.raEnterApiKey: 'Enter your API key',
+  AppLocale.raGetApiKey: 'Get API Key',
+  AppLocale.raApiKeyHelp:
+      'Open your RetroAchievements control panel to copy your personal Web API key.',
   AppLocale.raNoRecentUnlocks: 'No recent unlocks in the last 30 days',
   AppLocale.raRecentlyPlayedTitle: 'Recently Played',
   AppLocale.raNoRecentlyPlayed: 'No recently played games',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -958,6 +958,9 @@ const Map<String, dynamic> appLocaleEs = {
       'RetroAchievements está ocupado en este momento. Espera un momento e inténtalo de nuevo.',
   AppLocale.raApiKey: 'Clave API',
   AppLocale.raEnterApiKey: 'Introduce tu clave API',
+  AppLocale.raGetApiKey: 'Obtener clave API',
+  AppLocale.raApiKeyHelp:
+      'Abre tu panel de control de RetroAchievements para copiar tu clave API web personal.',
   AppLocale.raNoRecentUnlocks:
       'No hay desbloqueos recientes en los últimos 30 días',
   AppLocale.raRecentlyPlayedTitle: 'Jugados Recientemente',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -966,6 +966,9 @@ const Map<String, dynamic> appLocaleFr = {
       'RetroAchievements est occupé pour le moment. Veuillez patienter un instant et réessayer.',
   AppLocale.raApiKey: 'Clé API',
   AppLocale.raEnterApiKey: 'Entrez votre clé API',
+  AppLocale.raGetApiKey: 'Obtenir la clé API',
+  AppLocale.raApiKeyHelp:
+      'Ouvrez votre panneau de contrôle RetroAchievements pour copier votre clé API Web personnelle.',
   AppLocale.raNoRecentUnlocks:
       'Aucun déblocage récent au cours des 30 derniers jours',
   AppLocale.raRecentlyPlayedTitle: 'Joués Récemment',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -934,6 +934,9 @@ const Map<String, dynamic> appLocaleId = {
       'RetroAchievements sedang sibuk saat ini. Tunggu sebentar lalu coba lagi.',
   AppLocale.raApiKey: 'Kunci API',
   AppLocale.raEnterApiKey: 'Masukkan kunci API Anda',
+  AppLocale.raGetApiKey: 'Dapatkan Kunci API',
+  AppLocale.raApiKeyHelp:
+      'Buka panel kontrol RetroAchievements untuk menyalin kunci API Web pribadi Anda.',
   AppLocale.raNoRecentUnlocks:
       'Tidak ada pembukaan baru dalam 30 hari terakhir',
   AppLocale.raRecentlyPlayedTitle: 'Baru Dimainkan',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -955,6 +955,9 @@ const Map<String, dynamic> appLocaleIt = {
       'RetroAchievements è occupato in questo momento. Attendi un momento e riprova.',
   AppLocale.raApiKey: 'Chiave API',
   AppLocale.raEnterApiKey: 'Inserisci la tua chiave API',
+  AppLocale.raGetApiKey: 'Ottieni chiave API',
+  AppLocale.raApiKeyHelp:
+      'Apri il pannello di controllo RetroAchievements per copiare la tua chiave API Web personale.',
   AppLocale.raNoRecentUnlocks: 'Nessuno sblocco recente negli ultimi 30 giorni',
   AppLocale.raRecentlyPlayedTitle: 'Giocati di Recente',
   AppLocale.raNoRecentlyPlayed: 'Nessun gioco giocato di recente',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -848,6 +848,8 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.raRateLimited: 'RetroAchievements は現在混雑しています。少し待ってからもう一度お試しください。',
   AppLocale.raApiKey: 'APIキー',
   AppLocale.raEnterApiKey: 'APIキーを入力',
+  AppLocale.raGetApiKey: 'APIキーを取得',
+  AppLocale.raApiKeyHelp: 'RetroAchievementsのコントロールパネルを開き、個人用Web APIキーをコピーします。',
   AppLocale.raNoRecentUnlocks: '過去30日間に解除した実績はありません',
   AppLocale.raRecentlyPlayedTitle: '最近プレイ',
   AppLocale.raNoRecentlyPlayed: '最近プレイしたゲームはありません',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -842,6 +842,8 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.raRateLimited: 'RetroAchievements 서버가 혼잡합니다. 잠시 후 다시 시도해 주세요.',
   AppLocale.raApiKey: 'API 키',
   AppLocale.raEnterApiKey: 'API 키를 입력하세요',
+  AppLocale.raGetApiKey: 'API 키 가져오기',
+  AppLocale.raApiKeyHelp: 'RetroAchievements 제어판을 열어 개인 Web API 키를 복사하세요.',
   AppLocale.raNoRecentUnlocks: '최근 30일 동안 달성한 업적이 없습니다',
   AppLocale.raRecentlyPlayedTitle: '최근 플레이한 게임',
   AppLocale.raNoRecentlyPlayed: '최근에 플레이한 게임이 없습니다',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -944,6 +944,9 @@ const Map<String, dynamic> appLocalePt = {
       'O RetroAchievements está ocupado no momento. Aguarde um instante e tente novamente.',
   AppLocale.raApiKey: 'Chave de API',
   AppLocale.raEnterApiKey: 'Digite sua chave de API',
+  AppLocale.raGetApiKey: 'Obter chave API',
+  AppLocale.raApiKeyHelp:
+      'Abra o painel de controlo do RetroAchievements para copiar a sua chave API Web pessoal.',
   AppLocale.raNoRecentUnlocks: 'Nenhum desbloqueio recente nos últimos 30 dias',
   AppLocale.raRecentlyPlayedTitle: 'Jogados Recentemente',
   AppLocale.raNoRecentlyPlayed: 'Nenhum jogo jogado recentemente',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -932,6 +932,9 @@ const Map<String, dynamic> appLocaleRu = {
       'RetroAchievements сейчас перегружен. Подождите немного и попробуйте снова.',
   AppLocale.raApiKey: 'API-ключ',
   AppLocale.raEnterApiKey: 'Введите ваш API-ключ',
+  AppLocale.raGetApiKey: 'Получить API-ключ',
+  AppLocale.raApiKeyHelp:
+      'Откройте панель управления RetroAchievements, чтобы скопировать личный Web API-ключ.',
   AppLocale.raNoRecentUnlocks: 'Нет недавних достижений за последние 30 дней',
   AppLocale.raRecentlyPlayedTitle: 'Недавно сыгранные',
   AppLocale.raNoRecentlyPlayed: 'Нет недавно сыгранных игр',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -834,6 +834,8 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.raRateLimited: 'RetroAchievements 当前繁忙。请稍等片刻后重试。',
   AppLocale.raApiKey: 'API 密钥',
   AppLocale.raEnterApiKey: '输入您的 API 密钥',
+  AppLocale.raGetApiKey: '获取 API 密钥',
+  AppLocale.raApiKeyHelp: '打开 RetroAchievements 控制面板以复制您的个人 Web API 密钥。',
   AppLocale.raNoRecentUnlocks: '最近 30 天内没有解锁记录',
   AppLocale.raRecentlyPlayedTitle: '最近游玩',
   AppLocale.raNoRecentlyPlayed: '没有最近游玩的游戏',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -834,6 +834,8 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.raRateLimited: 'RetroAchievements 目前忙碌中。請稍候片刻後再試一次。',
   AppLocale.raApiKey: 'API 金鑰',
   AppLocale.raEnterApiKey: '輸入您的 API 金鑰',
+  AppLocale.raGetApiKey: '取得 API 金鑰',
+  AppLocale.raApiKeyHelp: '開啟 RetroAchievements 控制台以複製您的個人 Web API 金鑰。',
   AppLocale.raNoRecentUnlocks: '最近 30 天內沒有解鎖紀錄',
   AppLocale.raRecentlyPlayedTitle: '最近遊玩',
   AppLocale.raNoRecentlyPlayed: '沒有最近遊玩的遊戲',

--- a/lib/screens/retro_achievements_screen/ra_content.dart
+++ b/lib/screens/retro_achievements_screen/ra_content.dart
@@ -47,7 +47,12 @@ class _RAContentState extends State<RAContent>
   GamepadNavigation? _gamepadNav;
 
   @override
-  List<FocusNode?> get selectionSlots => [_usernameFocus, _apiKeyFocus, null];
+  List<FocusNode?> get selectionSlots => [
+    _usernameFocus,
+    _apiKeyFocus,
+    null,
+    null,
+  ];
 
   @override
   void initState() {
@@ -87,6 +92,10 @@ class _RAContentState extends State<RAContent>
       return;
     }
     if (focusSelectedField()) return;
+    if (selectedSlot == 2) {
+      _openRaControlPanel();
+      return;
+    }
     _connectToRA();
   }
 
@@ -160,6 +169,15 @@ class _RAContentState extends State<RAContent>
         raProvider.error!,
         type: NotificationType.error,
       );
+    }
+  }
+
+  Future<void> _openRaControlPanel() async {
+    final url = Uri.parse(
+      'https://retroachievements.org/settings?tab=applications',
+    );
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
     }
   }
 
@@ -507,6 +525,53 @@ class _RAContentState extends State<RAContent>
                   onFieldSubmitted: (_) => _connectToRA(),
                 ),
               ),
+            ),
+          ),
+          SizedBox(height: 6.r),
+
+          // Direct users to the page where RetroAchievements exposes their
+          // personal Web API key, without asking the app to handle passwords.
+          Container(
+            constraints: BoxConstraints(maxWidth: 320.r),
+            decoration: isSelected(2)
+                ? BoxDecoration(
+                    borderRadius: BorderRadius.circular(8.r),
+                    boxShadow: [
+                      BoxShadow(
+                        color: theme.colorScheme.primary.withValues(
+                          alpha: 0.35,
+                        ),
+                        blurRadius: 8.r,
+                        spreadRadius: 1.r,
+                      ),
+                    ],
+                  )
+                : null,
+            child: OutlinedButton.icon(
+              onPressed: _openRaControlPanel,
+              icon: Icon(Symbols.key_rounded, size: 14.r),
+              label: Text(
+                AppLocale.raGetApiKey.getString(context),
+                style: TextStyle(fontSize: 11.r, fontWeight: FontWeight.w600),
+              ),
+              style: OutlinedButton.styleFrom(
+                minimumSize: Size(double.infinity, 32.r),
+                side: BorderSide(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.6),
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8.r),
+                ),
+              ),
+            ),
+          ),
+          SizedBox(height: 4.r),
+          Text(
+            AppLocale.raApiKeyHelp.getString(context),
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.65),
+              fontSize: 8.r,
             ),
           ),
           SizedBox(height: 6.r),


### PR DESCRIPTION
## Summary
- add a controller-accessible Get API Key action to the RetroAchievements login form
- open RetroAchievements Settings > Applications, where users manage their Web API key
- add localized guidance explaining how to obtain the key

## Why
The existing username and API-key form gave users no direct path to the required credential, making sign-in unnecessarily difficult.

## Validation
- flutter analyze
- flutter test test/retro_achievements_service_test.dart test/retro_achievements_credentials_test.dart test/retro_achievements_resolver_test.dart
- manually built and verified the Android debug build on an AYN Thor