### PR TITLE
fix: handle unavailable SMB ROM shares

### DIFF
--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -18,6 +18,11 @@ import '../../repositories/system_repository.dart';
 class SqliteConfigService {
   static final _log = LoggerService.instance;
 
+  // Directory operations against an unavailable SMB/UNC share can wait
+  // indefinitely on Windows. Keep discovery responsive and let the scan
+  // continue with any other configured ROM roots.
+  static const _fileSystemOperationTimeout = Duration(seconds: 15);
+
   /// Counts valid ROM files within a given directory.
   ///
   /// Filters files based on valid extensions retrieved from the database
@@ -45,7 +50,8 @@ class SqliteConfigService {
           .list(recursive: recursive, followLinks: false)
           .where((entity) => entity is File)
           .cast<File>()
-          .toList();
+          .toList()
+          .timeout(_fileSystemOperationTimeout);
 
       int count = 0;
       for (final file in files) {
@@ -342,7 +348,16 @@ class SqliteConfigService {
     final detectedSystemsMap = <String, SystemModel>{};
 
     for (final romFolder in romFolders) {
-      if (!Directory(romFolder).existsSync()) {
+      bool folderExists;
+      try {
+        folderExists = await Directory(
+          romFolder,
+        ).exists().timeout(_fileSystemOperationTimeout);
+      } catch (e) {
+        _log.w('Error checking ROM folder $romFolder: $e');
+        continue;
+      }
+      if (!folderExists) {
         _log.w('ROM folder does not exist: $romFolder');
         continue;
       }
@@ -350,7 +365,9 @@ class SqliteConfigService {
       final romDir = Directory(romFolder);
       List<FileSystemEntity> entities;
       try {
-        entities = await romDir.list().toList();
+        entities = await romDir.list().toList().timeout(
+          _fileSystemOperationTimeout,
+        );
       } catch (e) {
         _log.w('Error listing directory $romFolder: $e');
         continue;

--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -63,6 +63,38 @@ class RomEntry {
 class SqliteDatabaseService {
   static final _log = LoggerService.instance;
 
+  // Windows can block on an unavailable SMB/UNC share while resolving or
+  // listing a directory. A bounded operation prevents the entire scan from
+  // appearing stuck at 0%.
+  static const _fileSystemOperationTimeout = Duration(seconds: 15);
+
+  /// Probes Windows UNC roots by starting a directory listing and waiting for
+  /// the first result. This checks the actual SMB share rather than ICMP, which
+  /// is commonly disabled even when the share itself is reachable.
+  static Future<List<String>> findUnreachableNetworkFolders(
+    List<String> folders,
+  ) async {
+    if (!Platform.isWindows) return [];
+
+    final networkFolders = folders
+        .where((folder) => RegExp(r'^\\\\[^\\/]+[\\/]').hasMatch(folder))
+        .toList();
+    final results = await Future.wait(
+      networkFolders.map((folder) async {
+        try {
+          await Directory(
+            folder,
+          ).list().take(1).toList().timeout(_fileSystemOperationTimeout);
+          return null;
+        } catch (e) {
+          _log.w('Network ROM folder is unreachable: $folder ($e)');
+          return folder;
+        }
+      }),
+    );
+    return results.whereType<String>().toList();
+  }
+
   /// Retrieves the complete game database, grouped by system folder name.
   static Future<Map<String, List<DatabaseGameModel>>> loadDatabase() async {
     try {
@@ -1041,11 +1073,16 @@ class SqliteDatabaseService {
 
   /// Quickly identifies existing subdirectories within multiple ROM root folders.
   static Future<Map<String, Map<String, String>>> getExistingSubdirectories(
-    List<String> romFolders,
-  ) async {
+    List<String> romFolders, {
+    Set<String> skipFolders = const {},
+  }) async {
     final Map<String, Map<String, String>> result = {};
     for (final folder in romFolders) {
       final Map<String, String> subdirs = {};
+      if (skipFolders.contains(folder)) {
+        result[folder] = subdirs;
+        continue;
+      }
       try {
         if (Platform.isAndroid && folder.startsWith('content://')) {
           final children = await SafDirectoryService.listFiles(folder);
@@ -1057,8 +1094,10 @@ class SqliteDatabaseService {
           }
         } else {
           final dir = Directory(folder);
-          if (await dir.exists()) {
-            final entities = await dir.list().toList();
+          if (await dir.exists().timeout(_fileSystemOperationTimeout)) {
+            final entities = await dir.list().toList().timeout(
+              _fileSystemOperationTimeout,
+            );
             for (final entity in entities) {
               if (entity is Directory) {
                 subdirs[path.basename(entity.path).toLowerCase()] = entity.path;
@@ -1113,7 +1152,9 @@ class SqliteDatabaseService {
   }) async {
     if (useSaf) return dirPath;
     try {
-      return await Directory(dirPath).resolveSymbolicLinks();
+      return await Directory(
+        dirPath,
+      ).resolveSymbolicLinks().timeout(_fileSystemOperationTimeout);
     } catch (e) {
       // Unreadable, or gone between listing and resolving. Fall back to the
       // literal path so the directory is still walked exactly once.
@@ -1200,9 +1241,14 @@ class SqliteDatabaseService {
   }) async {
     try {
       final rootDir = Directory(romFolderPath);
-      if (!await rootDir.exists()) return null;
+      if (!await rootDir.exists().timeout(_fileSystemOperationTimeout)) {
+        return null;
+      }
       try {
-        final List<FileSystemEntity> children = await rootDir.list().toList();
+        final List<FileSystemEntity> children = await rootDir
+            .list()
+            .toList()
+            .timeout(_fileSystemOperationTimeout);
         for (final child in children) {
           if (await _shouldSkipStandardEntity(
             child,
@@ -1219,7 +1265,11 @@ class SqliteDatabaseService {
       } catch (e) {
         _log.e('Error listing standard directory $romFolderPath: $e');
         final directPath = path.join(romFolderPath, folderName);
-        if (await Directory(directPath).exists()) return directPath;
+        if (await Directory(
+          directPath,
+        ).exists().timeout(_fileSystemOperationTimeout)) {
+          return directPath;
+        }
       }
       return null;
     } catch (e) {
@@ -1239,9 +1289,10 @@ class SqliteDatabaseService {
   }) async {
     final entries = <RomEntry>[];
     try {
-      final entities = await Directory(
-        pathStr,
-      ).list(recursive: recursive, followLinks: false).toList();
+      final entities = await Directory(pathStr)
+          .list(recursive: recursive, followLinks: false)
+          .toList()
+          .timeout(_fileSystemOperationTimeout);
       for (final entity in entities) {
         if (await _shouldSkipStandardEntity(
           entity,

--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -26,11 +26,15 @@ class ScanSummary {
   /// Human-readable name of the system scanned.
   final String systemName;
 
+  /// True when a configured source was skipped because it was unreachable.
+  final bool sourceUnavailable;
+
   ScanSummary({
     required this.added,
     required this.removed,
     required this.total,
     required this.systemName,
+    this.sourceUnavailable = false,
   });
 
   /// Returns true if any files were added or removed during the scan.
@@ -62,38 +66,6 @@ class RomEntry {
 /// - Batch database operations with performance-tuned SQLite PRAGMAs.
 class SqliteDatabaseService {
   static final _log = LoggerService.instance;
-
-  // Windows can block on an unavailable SMB/UNC share while resolving or
-  // listing a directory. A bounded operation prevents the entire scan from
-  // appearing stuck at 0%.
-  static const _fileSystemOperationTimeout = Duration(seconds: 15);
-
-  /// Probes Windows UNC roots by starting a directory listing and waiting for
-  /// the first result. This checks the actual SMB share rather than ICMP, which
-  /// is commonly disabled even when the share itself is reachable.
-  static Future<List<String>> findUnreachableNetworkFolders(
-    List<String> folders,
-  ) async {
-    if (!Platform.isWindows) return [];
-
-    final networkFolders = folders
-        .where((folder) => RegExp(r'^\\\\[^\\/]+[\\/]').hasMatch(folder))
-        .toList();
-    final results = await Future.wait(
-      networkFolders.map((folder) async {
-        try {
-          await Directory(
-            folder,
-          ).list().take(1).toList().timeout(_fileSystemOperationTimeout);
-          return null;
-        } catch (e) {
-          _log.w('Network ROM folder is unreachable: $folder ($e)');
-          return folder;
-        }
-      }),
-    );
-    return results.whereType<String>().toList();
-  }
 
   /// Retrieves the complete game database, grouped by system folder name.
   static Future<Map<String, List<DatabaseGameModel>>> loadDatabase() async {
@@ -138,6 +110,7 @@ class SqliteDatabaseService {
     List<String> romFolders, {
     bool ignoreHiddenFiles = true,
     Map<String, Map<String, String>>? rootFoldersMap,
+    Set<String> skippedNetworkFolders = const {},
   }) async {
     if (system.id == null) {
       _log.e('System without ID: ${system.realName}');
@@ -159,6 +132,7 @@ class SqliteDatabaseService {
     // Support for metadata-only .steam files
     validExtensionsSet.add('steam');
 
+    final scanTimedOut = [false];
     return await Future.any([
       _performSystemScan(
         system,
@@ -166,8 +140,11 @@ class SqliteDatabaseService {
         validExtensionsSet,
         ignoreHiddenFiles: ignoreHiddenFiles,
         rootFoldersMap: rootFoldersMap,
+        skippedNetworkFolders: skippedNetworkFolders,
+        scanTimedOut: scanTimedOut,
       ),
       Future.delayed(const Duration(minutes: 10), () {
+        scanTimedOut[0] = true;
         throw Exception('Timeout scanning ${system.realName}');
       }),
     ]).catchError((error) {
@@ -188,6 +165,8 @@ class SqliteDatabaseService {
     Set<String> validExtensionsSet, {
     bool ignoreHiddenFiles = true,
     Map<String, Map<String, String>>? rootFoldersMap,
+    Set<String> skippedNetworkFolders = const {},
+    List<bool>? scanTimedOut,
   }) async {
     final initialCount = await SqliteService.getRomCountForSystem(system.id!);
 
@@ -307,11 +286,24 @@ class SqliteDatabaseService {
       ..addAll(deduplicatedEntries);
 
     // Clean orphaned entries (files deleted from disk)
+    final sourceUnavailable = romFolders.any(skippedNetworkFolders.contains);
     final cleanup = await _cleanupOrphanedRomsOptimized(
       system.id!,
       romEntries.map((e) => e.path).toSet(),
+      allowRemoval: !sourceUnavailable && !(scanTimedOut?[0] ?? false),
     );
     final removedCount = cleanup.removed;
+
+    if (scanTimedOut?[0] ?? false) {
+      final finalCount = await SqliteService.getRomCountForSystem(system.id!);
+      return ScanSummary(
+        added: 0,
+        removed: 0,
+        total: finalCount,
+        systemName: system.realName,
+        sourceUnavailable: true,
+      );
+    }
 
     if (romEntries.isEmpty) {
       final finalCount = await SqliteService.getRomCountForSystem(system.id!);
@@ -320,6 +312,7 @@ class SqliteDatabaseService {
         removed: removedCount,
         total: finalCount,
         systemName: system.realName,
+        sourceUnavailable: sourceUnavailable || (scanTimedOut?[0] ?? false),
       );
     }
 
@@ -777,8 +770,9 @@ class SqliteDatabaseService {
   static Future<({int removed, Set<String> knownPaths})>
   _cleanupOrphanedRomsOptimized(
     String systemId,
-    Set<String> existingRomPaths,
-  ) async {
+    Set<String> existingRomPaths, {
+    bool allowRemoval = true,
+  }) async {
     try {
       final db = await SqliteService.getDatabase();
       final existingRoms = await db.rawQuery(
@@ -787,6 +781,16 @@ class SqliteDatabaseService {
       );
       if (existingRoms.isEmpty) {
         return (removed: 0, knownPaths: <String>{});
+      }
+
+      if (!allowRemoval) {
+        return (
+          removed: 0,
+          knownPaths: existingRoms
+              .map((row) => row['rom_path'].toString())
+              .where(existingRomPaths.contains)
+              .toSet(),
+        );
       }
 
       final knownPaths = <String>{};
@@ -1094,10 +1098,8 @@ class SqliteDatabaseService {
           }
         } else {
           final dir = Directory(folder);
-          if (await dir.exists().timeout(_fileSystemOperationTimeout)) {
-            final entities = await dir.list().toList().timeout(
-              _fileSystemOperationTimeout,
-            );
+          if (await dir.exists()) {
+            final entities = await dir.list().toList();
             for (final entity in entities) {
               if (entity is Directory) {
                 subdirs[path.basename(entity.path).toLowerCase()] = entity.path;
@@ -1152,9 +1154,7 @@ class SqliteDatabaseService {
   }) async {
     if (useSaf) return dirPath;
     try {
-      return await Directory(
-        dirPath,
-      ).resolveSymbolicLinks().timeout(_fileSystemOperationTimeout);
+      return await Directory(dirPath).resolveSymbolicLinks();
     } catch (e) {
       // Unreadable, or gone between listing and resolving. Fall back to the
       // literal path so the directory is still walked exactly once.
@@ -1241,14 +1241,11 @@ class SqliteDatabaseService {
   }) async {
     try {
       final rootDir = Directory(romFolderPath);
-      if (!await rootDir.exists().timeout(_fileSystemOperationTimeout)) {
+      if (!await rootDir.exists()) {
         return null;
       }
       try {
-        final List<FileSystemEntity> children = await rootDir
-            .list()
-            .toList()
-            .timeout(_fileSystemOperationTimeout);
+        final List<FileSystemEntity> children = await rootDir.list().toList();
         for (final child in children) {
           if (await _shouldSkipStandardEntity(
             child,
@@ -1265,9 +1262,7 @@ class SqliteDatabaseService {
       } catch (e) {
         _log.e('Error listing standard directory $romFolderPath: $e');
         final directPath = path.join(romFolderPath, folderName);
-        if (await Directory(
-          directPath,
-        ).exists().timeout(_fileSystemOperationTimeout)) {
+        if (await Directory(directPath).exists()) {
           return directPath;
         }
       }
@@ -1289,10 +1284,9 @@ class SqliteDatabaseService {
   }) async {
     final entries = <RomEntry>[];
     try {
-      final entities = await Directory(pathStr)
-          .list(recursive: recursive, followLinks: false)
-          .toList()
-          .timeout(_fileSystemOperationTimeout);
+      final entities = await Directory(
+        pathStr,
+      ).list(recursive: recursive, followLinks: false).toList();
       for (final entity in entities) {
         if (await _shouldSkipStandardEntity(
           entity,

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -26,6 +26,7 @@ mixin AppLocale {
   static const String cancel = 'cancel';
   static const String ok = 'ok';
   static const String retry = 'retry';
+  static const String openNetworkFolder = 'open_network_folder';
   static const String confirm = 'confirm';
   static const String apply = 'apply';
   static const String save = 'save';

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -27,6 +27,16 @@ mixin AppLocale {
   static const String ok = 'ok';
   static const String retry = 'retry';
   static const String openNetworkFolder = 'open_network_folder';
+  static const String checkingRomFolders = 'checking_rom_folders';
+  static const String networkRomFolderUnavailable =
+      'network_rom_folder_unavailable';
+  static const String waitingForRomStorage = 'waiting_for_rom_storage';
+  static const String updatingSystemsList = 'updating_systems_list';
+  static const String romsScanned = 'roms_scanned';
+  static const String romsScannedNetworkFoldersSkipped =
+      'roms_scanned_network_folders_skipped';
+  static const String errorScanningRoms = 'error_scanning_roms';
+  static const String romStorageNotReady = 'rom_storage_not_ready';
   static const String confirm = 'confirm';
   static const String apply = 'apply';
   static const String save = 'save';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.cancel: 'Abbrechen',
   AppLocale.ok: 'OK',
   AppLocale.retry: 'Wiederholen',
+  AppLocale.openNetworkFolder: 'Netzwerkordner öffnen',
   AppLocale.confirm: 'Bestätigen',
   AppLocale.apply: 'Anwenden',
   AppLocale.save: 'Speichern',

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.ok: 'OK',
   AppLocale.retry: 'Wiederholen',
   AppLocale.openNetworkFolder: 'Netzwerkordner öffnen',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: 'Bestätigen',
   AppLocale.apply: 'Anwenden',
   AppLocale.save: 'Speichern',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.cancel: 'Cancel',
   AppLocale.ok: 'OK',
   AppLocale.retry: 'Retry',
+  AppLocale.openNetworkFolder: 'Open Network Folder',
   AppLocale.confirm: 'Confirm',
   AppLocale.apply: 'Apply',
   AppLocale.save: 'Save',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.ok: 'OK',
   AppLocale.retry: 'Retry',
   AppLocale.openNetworkFolder: 'Open Network Folder',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: 'Confirm',
   AppLocale.apply: 'Apply',
   AppLocale.save: 'Save',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.cancel: 'Cancelar',
   AppLocale.ok: 'Aceptar',
   AppLocale.retry: 'Reintentar',
+  AppLocale.openNetworkFolder: 'Abrir carpeta de red',
   AppLocale.confirm: 'Confirmar',
   AppLocale.apply: 'Aplicar',
   AppLocale.save: 'Guardar',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.ok: 'Aceptar',
   AppLocale.retry: 'Reintentar',
   AppLocale.openNetworkFolder: 'Abrir carpeta de red',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: 'Confirmar',
   AppLocale.apply: 'Aplicar',
   AppLocale.save: 'Guardar',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.cancel: 'Annuler',
   AppLocale.ok: 'OK',
   AppLocale.retry: 'Réessayer',
+  AppLocale.openNetworkFolder: 'Ouvrir le dossier réseau',
   AppLocale.confirm: 'Confirmer',
   AppLocale.apply: 'Appliquer',
   AppLocale.save: 'Enregistrer',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.ok: 'OK',
   AppLocale.retry: 'Réessayer',
   AppLocale.openNetworkFolder: 'Ouvrir le dossier réseau',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: 'Confirmer',
   AppLocale.apply: 'Appliquer',
   AppLocale.save: 'Enregistrer',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.cancel: 'Batal',
   AppLocale.ok: 'Oke',
   AppLocale.retry: 'Coba Lagi',
+  AppLocale.openNetworkFolder: 'Buka Folder Jaringan',
   AppLocale.confirm: 'Konfirmasi',
   AppLocale.apply: 'Terapkan',
   AppLocale.save: 'Simpan',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.ok: 'Oke',
   AppLocale.retry: 'Coba Lagi',
   AppLocale.openNetworkFolder: 'Buka Folder Jaringan',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: 'Konfirmasi',
   AppLocale.apply: 'Terapkan',
   AppLocale.save: 'Simpan',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.ok: 'OK',
   AppLocale.retry: 'Riprova',
   AppLocale.openNetworkFolder: 'Apri cartella di rete',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: 'Conferma',
   AppLocale.apply: 'Applica',
   AppLocale.save: 'Salva',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.cancel: 'Annulla',
   AppLocale.ok: 'OK',
   AppLocale.retry: 'Riprova',
+  AppLocale.openNetworkFolder: 'Apri cartella di rete',
   AppLocale.confirm: 'Conferma',
   AppLocale.apply: 'Applica',
   AppLocale.save: 'Salva',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.ok: 'OK',
   AppLocale.retry: '再試行',
   AppLocale.openNetworkFolder: 'ネットワークフォルダーを開く',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: '確認',
   AppLocale.apply: '適用',
   AppLocale.save: '保存',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.cancel: 'キャンセル',
   AppLocale.ok: 'OK',
   AppLocale.retry: '再試行',
+  AppLocale.openNetworkFolder: 'ネットワークフォルダーを開く',
   AppLocale.confirm: '確認',
   AppLocale.apply: '適用',
   AppLocale.save: '保存',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.ok: '확인',
   AppLocale.retry: '재시도',
   AppLocale.openNetworkFolder: '네트워크 폴더 열기',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: '확인',
   AppLocale.apply: '적용',
   AppLocale.save: '저장',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.cancel: '취소',
   AppLocale.ok: '확인',
   AppLocale.retry: '재시도',
+  AppLocale.openNetworkFolder: '네트워크 폴더 열기',
   AppLocale.confirm: '확인',
   AppLocale.apply: '적용',
   AppLocale.save: '저장',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.cancel: 'Cancelar',
   AppLocale.ok: 'OK',
   AppLocale.retry: 'Tentar novamente',
+  AppLocale.openNetworkFolder: 'Abrir pasta de rede',
   AppLocale.confirm: 'Confirmar',
   AppLocale.apply: 'Aplicar',
   AppLocale.save: 'Salvar',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.ok: 'OK',
   AppLocale.retry: 'Tentar novamente',
   AppLocale.openNetworkFolder: 'Abrir pasta de rede',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: 'Confirmar',
   AppLocale.apply: 'Aplicar',
   AppLocale.save: 'Salvar',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.ok: 'ОК',
   AppLocale.retry: 'Повторить',
   AppLocale.openNetworkFolder: 'Открыть сетевую папку',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: 'Подтвердить',
   AppLocale.apply: 'Применить',
   AppLocale.save: 'Сохранить',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.cancel: 'Отмена',
   AppLocale.ok: 'ОК',
   AppLocale.retry: 'Повторить',
+  AppLocale.openNetworkFolder: 'Открыть сетевую папку',
   AppLocale.confirm: 'Подтвердить',
   AppLocale.apply: 'Применить',
   AppLocale.save: 'Сохранить',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.cancel: '取消',
   AppLocale.ok: '确定',
   AppLocale.retry: '重试',
+  AppLocale.openNetworkFolder: '打开网络文件夹',
   AppLocale.confirm: '确认',
   AppLocale.apply: '应用',
   AppLocale.save: '保存',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.ok: '确定',
   AppLocale.retry: '重试',
   AppLocale.openNetworkFolder: '打开网络文件夹',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: '确认',
   AppLocale.apply: '应用',
   AppLocale.save: '保存',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -9,6 +9,18 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.ok: '確定',
   AppLocale.retry: '重試',
   AppLocale.openNetworkFolder: '開啟網路資料夾',
+  AppLocale.checkingRomFolders: 'Checking ROM folders...',
+  AppLocale.networkRomFolderUnavailable:
+      'Network ROM folder unavailable: {folders}',
+  AppLocale.waitingForRomStorage:
+      'Waiting for ROM storage ({attempt}/{max})...',
+  AppLocale.updatingSystemsList: 'Updating systems list...',
+  AppLocale.romsScanned: 'ROMs scanned',
+  AppLocale.romsScannedNetworkFoldersSkipped:
+      'ROMs scanned; unavailable network folder(s) skipped: {folders}',
+  AppLocale.errorScanningRoms: 'Error scanning ROMs',
+  AppLocale.romStorageNotReady:
+      'ROM storage is not ready; existing games were kept.',
   AppLocale.confirm: '確認',
   AppLocale.apply: '套用',
   AppLocale.save: '儲存',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -8,6 +8,7 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.cancel: '取消',
   AppLocale.ok: '確定',
   AppLocale.retry: '重試',
+  AppLocale.openNetworkFolder: '開啟網路資料夾',
   AppLocale.confirm: '確認',
   AppLocale.apply: '套用',
   AppLocale.save: '儲存',

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -76,6 +76,9 @@ class SqliteConfigProvider extends ChangeNotifier with WidgetsBindingObserver {
   /// Human-readable status message for the current scanning phase.
   String _scanStatus = '';
 
+  /// Windows UNC roots that failed the SMB preflight for the current scan.
+  Set<String> _unreachableNetworkRomFolders = {};
+
   // Systems download progress
   final bool _isDownloadingSystems = false;
   final double _downloadProgress = 0.0;
@@ -157,6 +160,8 @@ class SqliteConfigProvider extends ChangeNotifier with WidgetsBindingObserver {
   int get scannedSystemsCount => _scannedSystemsCount;
   double get scanProgress => _scanProgress;
   String get scanStatus => _scanStatus;
+  List<String> get unreachableNetworkRomFolders =>
+      List.unmodifiable(_unreachableNetworkRomFolders);
 
   // Getters for systems download progress
   bool get isDownloadingSystems => _isDownloadingSystems;

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -26,6 +26,8 @@ import '../constants/system_folder_names.dart';
 import '../services/game_session_persistence.dart';
 import '../utils/nav_tabs.dart';
 import '../services/saf_directory_service.dart';
+import '../services/network_folder_service.dart';
+import '../l10n/app_locale.dart';
 
 part 'sqlite_config_provider/mutators.dart';
 part 'sqlite_config_provider/scanning.dart';

--- a/lib/providers/sqlite_config_provider/scanning.dart
+++ b/lib/providers/sqlite_config_provider/scanning.dart
@@ -12,20 +12,15 @@ extension SqliteConfigScanning on SqliteConfigProvider {
   /// Opens an unavailable UNC share in Windows Explorer so Windows can show
   /// its native credential prompt. Credentials never pass through NeoStation.
   Future<bool> openNetworkFolder(String folder) async {
-    if (!Platform.isWindows ||
-        !_unreachableNetworkRomFolders.contains(folder)) {
+    if (!_unreachableNetworkRomFolders.contains(folder)) {
       return false;
     }
+    return NetworkFolderService.openFolder(folder);
+  }
 
-    try {
-      await Process.start('explorer.exe', [
-        folder,
-      ], mode: ProcessStartMode.detached);
-      return true;
-    } catch (e) {
-      SqliteConfigProvider._log.e('Error opening network folder $folder: $e');
-      return false;
-    }
+  void clearUnreachableNetworkRomFolders() {
+    _unreachableNetworkRomFolders = {};
+    _notify();
   }
 
   /// Registers a new filesystem directory as a ROM source.
@@ -159,7 +154,7 @@ extension SqliteConfigScanning on SqliteConfigProvider {
       if (waitForAndroidStorage &&
           await _hasStoredRoms() &&
           !await _waitForAndroidRomFolders()) {
-        _scanStatus = 'ROM storage is not ready; existing games were kept.';
+        _scanStatus = AppLocale.romStorageNotReady;
         SqliteConfigProvider._log.w(
           'Startup scan skipped because Android ROM storage never became ready',
         );
@@ -173,16 +168,12 @@ extension SqliteConfigScanning on SqliteConfigProvider {
     _totalSystemsToScan = 0;
     _scannedSystemsCount = 0;
     _scanProgress = 0.0;
-    _scanStatus = 'Checking ROM folders...';
+    _scanStatus = AppLocale.checkingRomFolders;
     _unreachableNetworkRomFolders = {
-      ...await SqliteDatabaseService.findUnreachableNetworkFolders(
-        _config.romFolders,
-      ),
+      ...await NetworkFolderService.findUnreachableFolders(_config.romFolders),
     };
     if (_unreachableNetworkRomFolders.isNotEmpty) {
-      _scanStatus =
-          'Network ROM folder unavailable: '
-          '${_unreachableNetworkRomFolders.join(', ')}';
+      _scanStatus = AppLocale.networkRomFolderUnavailable;
       _notify();
     }
 
@@ -360,7 +351,7 @@ extension SqliteConfigScanning on SqliteConfigProvider {
         );
       } else {
         _totalSystemsToScan = _detectedSystems.length;
-        _scanStatus = 'Scanning ROMs...';
+        _scanStatus = AppLocale.scanningRoms;
         await _scanRomsInBackground();
       }
 
@@ -401,7 +392,9 @@ extension SqliteConfigScanning on SqliteConfigProvider {
       }
 
       if (attempt < maxAttempts) {
-        _scanStatus = 'Waiting for ROM storage ($attempt/$maxAttempts)...';
+        _scanStatus = AppLocale.waitingForRomStorage
+            .replaceFirst('{attempt}', '$attempt')
+            .replaceFirst('{max}', '$maxAttempts');
         _notify();
         await Future<void>.delayed(retryDelay);
       }
@@ -480,7 +473,7 @@ extension SqliteConfigScanning on SqliteConfigProvider {
       }
 
       // Phase 2: Update the systems list (0.95 - 1.0)
-      _scanStatus = 'Updating systems list...';
+      _scanStatus = AppLocale.updatingSystemsList;
       _scanProgress = scanPhaseWeight; // 95%
       _notify();
 
@@ -524,7 +517,14 @@ extension SqliteConfigScanning on SqliteConfigProvider {
         final bool isAndroidVirtual =
             (system.folderName == 'android' && Platform.isAndroid);
 
-        if (romCount > 0 || hasFolderWhenNonRecursive || isAndroidVirtual) {
+        final sourceUnavailable = _unreachableNetworkRomFolders.any(
+          _config.romFolders.contains,
+        );
+        if (romCount > 0 ||
+            hasFolderWhenNonRecursive ||
+            isAndroidVirtual ||
+            (sourceUnavailable &&
+                _detectedSystems.any((detected) => detected.id == system.id))) {
           systemsToKeep.add(system.copyWith(romCount: romCount));
 
           // Increment count for 'all' logic if it's a real emulator system with games
@@ -568,14 +568,16 @@ extension SqliteConfigScanning on SqliteConfigProvider {
 
       // Completar al 100%
       _scanStatus = _unreachableNetworkRomFolders.isEmpty
-          ? 'ROMs Scanned'
-          : 'ROMs scanned; unavailable network folder(s) skipped: '
-                '${_unreachableNetworkRomFolders.join(', ')}';
+          ? AppLocale.romsScanned
+          : AppLocale.romsScannedNetworkFoldersSkipped.replaceFirst(
+              '{folders}',
+              _unreachableNetworkRomFolders.join(', '),
+            );
       _scanProgress = 1.0;
       _notify();
     } catch (e) {
       SqliteConfigProvider._log.e('Error scanning ROMs: $e');
-      _scanStatus = 'Error scanning ROMs';
+      _scanStatus = AppLocale.errorScanningRoms;
       _notify();
     } finally {
       _isScanningRoms = false; // Liberar el lock
@@ -603,10 +605,13 @@ extension SqliteConfigScanning on SqliteConfigProvider {
         _config.romFolders,
         ignoreHiddenFiles: _config.ignoreHiddenFiles,
         rootFoldersMap: rootFoldersMap,
+        skippedNetworkFolders: _unreachableNetworkRomFolders,
       );
 
       // Update ROM count in system
-      await refreshSystem(system, rootFoldersMap: rootFoldersMap);
+      if (!summary.sourceUnavailable) {
+        await refreshSystem(system, rootFoldersMap: rootFoldersMap);
+      }
 
       // Trigger Steam scraper if it's the Steam system
       if (system.folderName == 'steam') {

--- a/lib/providers/sqlite_config_provider/scanning.dart
+++ b/lib/providers/sqlite_config_provider/scanning.dart
@@ -9,6 +9,25 @@ part of '../sqlite_config_provider.dart';
 /// `notifyListeners()` routes through the host's `_notify()` bridge and the
 /// static `_log` is host-qualified (both required from an extension).
 extension SqliteConfigScanning on SqliteConfigProvider {
+  /// Opens an unavailable UNC share in Windows Explorer so Windows can show
+  /// its native credential prompt. Credentials never pass through NeoStation.
+  Future<bool> openNetworkFolder(String folder) async {
+    if (!Platform.isWindows ||
+        !_unreachableNetworkRomFolders.contains(folder)) {
+      return false;
+    }
+
+    try {
+      await Process.start('explorer.exe', [
+        folder,
+      ], mode: ProcessStartMode.detached);
+      return true;
+    } catch (e) {
+      SqliteConfigProvider._log.e('Error opening network folder $folder: $e');
+      return false;
+    }
+  }
+
   /// Registers a new filesystem directory as a ROM source.
   ///
   /// Automatically triggers a system detection scan unless [scan] is set to false.
@@ -154,7 +173,18 @@ extension SqliteConfigScanning on SqliteConfigProvider {
     _totalSystemsToScan = 0;
     _scannedSystemsCount = 0;
     _scanProgress = 0.0;
-    _scanStatus = 'Please Wait...';
+    _scanStatus = 'Checking ROM folders...';
+    _unreachableNetworkRomFolders = {
+      ...await SqliteDatabaseService.findUnreachableNetworkFolders(
+        _config.romFolders,
+      ),
+    };
+    if (_unreachableNetworkRomFolders.isNotEmpty) {
+      _scanStatus =
+          'Network ROM folder unavailable: '
+          '${_unreachableNetworkRomFolders.join(', ')}';
+      _notify();
+    }
 
     try {
       // Reload from synchronized database during initialization
@@ -174,7 +204,11 @@ extension SqliteConfigScanning on SqliteConfigProvider {
       } else {
         // On Desktop, use File IO based detection
         detectedSystems = await SqliteConfigService.detectSystems(
-          romFolders: _config.romFolders,
+          romFolders: _config.romFolders
+              .where(
+                (folder) => !_unreachableNetworkRomFolders.contains(folder),
+              )
+              .toList(),
           availableSystems: _availableSystems,
         );
       }
@@ -397,6 +431,7 @@ extension SqliteConfigScanning on SqliteConfigProvider {
       final rootFoldersMap =
           await SqliteDatabaseService.getExistingSubdirectories(
             _config.romFolders,
+            skipFolders: _unreachableNetworkRomFolders,
           );
 
       const batchSize = 1; // Process 1 system at a time for better granularity
@@ -532,7 +567,10 @@ extension SqliteConfigScanning on SqliteConfigProvider {
       await _refreshDetectedSystemsFromDatabase();
 
       // Completar al 100%
-      _scanStatus = 'ROMs Scanned';
+      _scanStatus = _unreachableNetworkRomFolders.isEmpty
+          ? 'ROMs Scanned'
+          : 'ROMs scanned; unavailable network folder(s) skipped: '
+                '${_unreachableNetworkRomFolders.join(', ')}';
       _scanProgress = 1.0;
       _notify();
     } catch (e) {

--- a/lib/services/network_folder_service.dart
+++ b/lib/services/network_folder_service.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'logger_service.dart';
+
+/// Desktop filesystem helpers for ROM roots that may require network access.
+class NetworkFolderService {
+  static final _log = LoggerService.instance;
+  static const _probeTimeout = Duration(seconds: 15);
+
+  static bool looksLikeNetworkPath(String folder) {
+    return RegExp(
+      r'^(?:\\\\\?\\UNC\\|\\\\|//)[^\\/]+[\\/]|^[A-Za-z]:[\\/]|^/Volumes/|^/(?:mnt|media|run/media)/',
+    ).hasMatch(folder);
+  }
+
+  static Future<List<String>> findUnreachableFolders(
+    List<String> folders,
+  ) async {
+    if (Platform.isAndroid) return [];
+    final candidates = folders.where(looksLikeNetworkPath).toList();
+    final results = await Future.wait(
+      candidates.map((folder) async {
+        try {
+          await Directory(
+            folder,
+          ).list().take(1).toList().timeout(_probeTimeout);
+          return null;
+        } catch (error) {
+          _log.w('Network ROM folder is unreachable: $folder ($error)');
+          return folder;
+        }
+      }),
+    );
+    return results.whereType<String>().toList();
+  }
+
+  static Future<bool> openFolder(String folder) async {
+    final command = Platform.isWindows
+        ? ('explorer.exe', <String>[folder])
+        : Platform.isMacOS
+        ? ('open', <String>[folder])
+        : ('xdg-open', <String>[folder]);
+    try {
+      await Process.start(
+        command.$1,
+        command.$2,
+        mode: ProcessStartMode.detached,
+      );
+      return true;
+    } catch (error) {
+      _log.e('Error opening network folder $folder: $error');
+      return false;
+    }
+  }
+}

--- a/lib/widgets/system_scan_progress_widget.dart
+++ b/lib/widgets/system_scan_progress_widget.dart
@@ -12,7 +12,8 @@ class SystemScanProgressWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<SqliteConfigProvider>(
       builder: (context, configProvider, child) {
-        if (!configProvider.isScanning) {
+        if (!configProvider.isScanning &&
+            configProvider.unreachableNetworkRomFolders.isEmpty) {
           return SizedBox.shrink();
         }
 
@@ -119,6 +120,39 @@ class SystemScanProgressWidget extends StatelessWidget {
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Theme.of(context).colorScheme.onSurface,
                   ),
+                ),
+              ],
+              if (configProvider.unreachableNetworkRomFolders.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                for (final folder
+                    in configProvider.unreachableNetworkRomFolders) ...[
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          folder,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ),
+                      TextButton.icon(
+                        onPressed: () =>
+                            configProvider.openNetworkFolder(folder),
+                        icon: const Icon(Symbols.folder_open_rounded, size: 18),
+                        label: Text(
+                          AppLocale.openNetworkFolder.getString(context),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+                TextButton.icon(
+                  onPressed: configProvider.isScanning
+                      ? null
+                      : configProvider.scanSystems,
+                  icon: const Icon(Symbols.refresh_rounded, size: 18),
+                  label: Text(AppLocale.retry.getString(context)),
                 ),
               ],
             ],

--- a/lib/widgets/system_scan_progress_widget.dart
+++ b/lib/widgets/system_scan_progress_widget.dart
@@ -4,14 +4,76 @@ import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:provider/provider.dart';
 import '../providers/sqlite_config_provider.dart';
+import '../utils/gamepad_nav.dart';
+import '../services/game_service.dart' show GamepadNavigationManager;
 
-class SystemScanProgressWidget extends StatelessWidget {
+class SystemScanProgressWidget extends StatefulWidget {
   const SystemScanProgressWidget({super.key});
+
+  @override
+  State<SystemScanProgressWidget> createState() =>
+      _SystemScanProgressWidgetState();
+}
+
+class _SystemScanProgressWidgetState extends State<SystemScanProgressWidget> {
+  GamepadNavigation? _gamepadNavigation;
+  int _selectedRecoveryAction = 0;
+
+  void _syncGamepadNavigation(SqliteConfigProvider provider) {
+    final hasRecovery = provider.unreachableNetworkRomFolders.isNotEmpty;
+    if (!hasRecovery && _gamepadNavigation != null) {
+      GamepadNavigationManager.popLayer('system_scan_recovery');
+      _gamepadNavigation!.dispose();
+      _gamepadNavigation = null;
+    } else if (hasRecovery && _gamepadNavigation == null) {
+      _gamepadNavigation = GamepadNavigation(
+        onNavigateUp: () => _moveRecoveryAction(provider, -1),
+        onNavigateDown: () => _moveRecoveryAction(provider, 1),
+        onSelectItem: () => _activateRecoveryAction(provider),
+        onBack: provider.clearUnreachableNetworkRomFolders,
+      )..initialize();
+      _gamepadNavigation!.activate();
+      GamepadNavigationManager.pushLayer(
+        'system_scan_recovery',
+        onActivate: () => _gamepadNavigation?.activate(),
+        onDeactivate: () => _gamepadNavigation?.deactivate(),
+      );
+    }
+  }
+
+  void _moveRecoveryAction(SqliteConfigProvider provider, int delta) {
+    final actionCount = provider.unreachableNetworkRomFolders.length + 2;
+    setState(() {
+      _selectedRecoveryAction =
+          (_selectedRecoveryAction + delta + actionCount) % actionCount;
+    });
+  }
+
+  void _activateRecoveryAction(SqliteConfigProvider provider) {
+    final folders = provider.unreachableNetworkRomFolders;
+    if (_selectedRecoveryAction < folders.length) {
+      provider.openNetworkFolder(folders[_selectedRecoveryAction]);
+    } else if (_selectedRecoveryAction == folders.length) {
+      provider.scanSystems();
+    } else {
+      provider.clearUnreachableNetworkRomFolders();
+    }
+  }
+
+  @override
+  void dispose() {
+    GamepadNavigationManager.popLayer('system_scan_recovery');
+    _gamepadNavigation?.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Consumer<SqliteConfigProvider>(
       builder: (context, configProvider, child) {
+        WidgetsBinding.instance.addPostFrameCallback(
+          (_) => _syncGamepadNavigation(configProvider),
+        );
         if (!configProvider.isScanning &&
             configProvider.unreachableNetworkRomFolders.isEmpty) {
           return SizedBox.shrink();
@@ -51,7 +113,7 @@ class SystemScanProgressWidget extends StatelessWidget {
                   Expanded(
                     child: Text(
                       configProvider.scanStatus.isNotEmpty
-                          ? configProvider.scanStatus
+                          ? _localizedScanStatus(context, configProvider)
                           : AppLocale.scanningSystemsRoms.getString(context),
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         fontWeight: FontWeight.w500,
@@ -143,6 +205,17 @@ class SystemScanProgressWidget extends StatelessWidget {
                         label: Text(
                           AppLocale.openNetworkFolder.getString(context),
                         ),
+                        style: TextButton.styleFrom(
+                          backgroundColor:
+                              _selectedRecoveryAction ==
+                                  configProvider.unreachableNetworkRomFolders
+                                      .toList()
+                                      .indexOf(folder)
+                              ? Theme.of(
+                                  context,
+                                ).colorScheme.primary.withValues(alpha: 0.2)
+                              : null,
+                        ),
                       ),
                     ],
                   ),
@@ -153,6 +226,30 @@ class SystemScanProgressWidget extends StatelessWidget {
                       : configProvider.scanSystems,
                   icon: const Icon(Symbols.refresh_rounded, size: 18),
                   label: Text(AppLocale.retry.getString(context)),
+                  style: TextButton.styleFrom(
+                    backgroundColor:
+                        _selectedRecoveryAction ==
+                            configProvider.unreachableNetworkRomFolders.length
+                        ? Theme.of(
+                            context,
+                          ).colorScheme.primary.withValues(alpha: 0.2)
+                        : null,
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: configProvider.clearUnreachableNetworkRomFolders,
+                  icon: const Icon(Symbols.close_rounded, size: 18),
+                  label: Text(AppLocale.close.getString(context)),
+                  style: TextButton.styleFrom(
+                    backgroundColor:
+                        _selectedRecoveryAction ==
+                            configProvider.unreachableNetworkRomFolders.length +
+                                1
+                        ? Theme.of(
+                            context,
+                          ).colorScheme.primary.withValues(alpha: 0.2)
+                        : null,
+                  ),
                 ),
               ],
             ],
@@ -160,6 +257,20 @@ class SystemScanProgressWidget extends StatelessWidget {
         );
       },
     );
+  }
+
+  String _localizedScanStatus(
+    BuildContext context,
+    SqliteConfigProvider configProvider,
+  ) {
+    final status = configProvider.scanStatus;
+    var localized = status.getString(context);
+    localized = localized.replaceFirst(
+      '{folders}',
+      configProvider.unreachableNetworkRomFolders.join(', '),
+    );
+    if (localized != status) return localized;
+    return status;
   }
 }
 

--- a/test/network_folder_service_test.dart
+++ b/test/network_folder_service_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/network_folder_service.dart';
+
+void main() {
+  group('NetworkFolderService', () {
+    test('recognizes common desktop network path forms', () {
+      expect(
+        NetworkFolderService.looksLikeNetworkPath(r'\\server\share'),
+        isTrue,
+      );
+      expect(
+        NetworkFolderService.looksLikeNetworkPath(r'\\?\UNC\server\share'),
+        isTrue,
+      );
+      expect(
+        NetworkFolderService.looksLikeNetworkPath('//server/share'),
+        isTrue,
+      );
+      expect(NetworkFolderService.looksLikeNetworkPath(r'Z:\ROMs'), isTrue);
+      expect(
+        NetworkFolderService.looksLikeNetworkPath('/Volumes/ROMs'),
+        isTrue,
+      );
+    });
+
+    test('does not classify ordinary local paths as network paths', () {
+      expect(
+        NetworkFolderService.looksLikeNetworkPath('/home/user/roms'),
+        isFalse,
+      );
+      expect(
+        NetworkFolderService.looksLikeNetworkPath('/Users/user/roms'),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

Protect existing ROM libraries when a configured network source is unavailable or a filesystem scan times out. The scan now probes desktop network roots, skips unreachable roots without treating them as empty, preserves systems and ROM metadata, removes per-directory 15-second enumeration timeouts, localizes status messages, and provides a controller-reachable recovery UI with retry, open-folder, and dismiss actions.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [x] **Gamepad support verified** (recovery actions are included in the custom navigation layer).

## Screenshots (if applicable)

Not applicable.
