### PR TITLE
feat: add ARMSX1 PS1 emulator

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.10"
+  "latest_version": "0.3.11"
 }

--- a/assets/systems/ps1.json
+++ b/assets/systems/ps1.json
@@ -115,6 +115,17 @@
       }
     },
     {
+      "name": "Standalone ARMSX1",
+      "unique_id": "ps1.com.nanodata.armsx",
+      "description": "Supported extensions: bin, chd, cue, ecm, exe, img, iso, m3u, mds, pbp, psexe, psf.",
+      "is_retroachievements_compatible": false,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.nanodata.armsx/com.armsx2.Main -a android.intent.action.VIEW -d \"{file.uri}\""
+        }
+      }
+    },
+    {
       "name": "RetroArch64 Beetle PSX HW",
       "default_core": true,
       "unique_id": "ps1.ra64.mednafen_psx_hw",


### PR DESCRIPTION
## Summary

- Add standalone ARMSX1 as a PS1 emulator option on Android.
- Launch games through ARMSX1's `com.armsx2.Main` activity.
- Bump the bundled systems manifest so clients refresh their cached definitions.

## Root cause

ARMSX1's Android app uses `com.armsx2.Main` for `content://` and `file://` game intents. NeoStation was initially configured to launch `.EmulatorActivity`, which only handles the custom `armsx://` scheme and crashed when a game was launched from NeoStation.

## Validation

- Deployed to an AYN Thor running Android 13.
- Confirmed a PS1 game boots successfully through NeoStation with Standalone ARMSX1 selected.
- `flutter test test/emulator_seed_default_test.dart`
