### PR TITLE
fix(secondary): match the main screen's wheel logo drop shadow

### DIFF
--- a/lib/screens/secondary_screen/background_builders.dart
+++ b/lib/screens/secondary_screen/background_builders.dart
@@ -40,6 +40,14 @@ Widget buildDefaultBackground() {
   return const SizedBox.shrink();
 }
 
+/// Offset of the wheel logo's drop shadow on the secondary display.
+///
+/// Derived from the main screen's treatment rather than picked by eye: it
+/// offsets by 6.r on a 280.r-wide logo, so the shadow sits at ~2.1% of the
+/// logo's width. This display renders the same logo at 600.r, so matching that
+/// proportion is what makes the two screens read alike.
+double get _wheelShadowOffset => 600.r * (6 / 280);
+
 /// Mirrors the main screen's game art as a fallback when no screenshot or
 /// video is available: fanart filling the screen (cover) with the game's
 /// wheel/logo centered on top. Either asset is optional — a logo-only game
@@ -69,19 +77,35 @@ Widget buildFanartWithLogo(SecondaryDisplayStateData value) {
             child: Stack(
               alignment: Alignment.center,
               children: [
-                // Drop shadow: black-tinted copy offset behind the logo,
-                // mirroring the main screen's wheel shadow treatment.
-                Transform.translate(
-                  offset: Offset(4.r, 4.r),
-                  child: Image.file(
-                    File(value.gameWheel!),
-                    fit: BoxFit.contain,
-                    width: 600.r,
-                    filterQuality: FilterQuality.low,
-                    cacheWidth: 32,
-                    color: Colors.black.withValues(alpha: 0.7),
-                    errorBuilder: (context, error, stackTrace) =>
-                        const SizedBox.shrink(),
+                // Drop shadow: tinted copy offset behind the logo, mirroring
+                // the main screen's wheel shadow treatment (see the general
+                // details tab) — same tint and the same offset *relative to
+                // the logo*. The offset has to be scaled, not copied: this
+                // logo renders at 600.r against the main screen's 280.r, so
+                // the main screen's 6.r would tuck under the artwork here
+                // instead of reading as a shadow.
+                //
+                // Decoded at the same cacheWidth as the logo below it. That is
+                // not just for fidelity — at 600.r a smaller decode is visibly
+                // blocky — but also cheaper: cacheWidth is part of the
+                // ResizeImage cache key, so matching it means both copies share
+                // one decode instead of each holding its own bitmap.
+                Builder(
+                  builder: (context) => Transform.translate(
+                    offset: Offset(_wheelShadowOffset, _wheelShadowOffset),
+                    child: Image.file(
+                      File(value.gameWheel!),
+                      fit: BoxFit.contain,
+                      width: 600.r,
+                      filterQuality: FilterQuality.low,
+                      isAntiAlias: false,
+                      cacheWidth: 640,
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.shadow.withValues(alpha: 0.5),
+                      errorBuilder: (context, error, stackTrace) =>
+                          const SizedBox.shrink(),
+                    ),
                   ),
                 ),
                 Image.file(


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). The analysis, code and testing were carried out by Claude under my direction, and I have reviewed the result on hardware.

# Description

The secondary display's wheel logo drop shadow looked noticeably worse than the main screen's. Investigating turned up three separate causes.

**1. The shadow was a 32-pixel bitmap stretched to `600.r`.** It decoded at `cacheWidth: 32` and rendered at `600.r` — roughly a 20× upscale, so what read as a bad blur was actually the source bitmap's texels, with blocky axis-aligned artefacts. The `32` appears to be copied from the Android app icon shadow in `game_details_general_tab.dart`, where it is proportionate because that icon renders at `60.r`.

It now decodes at `640`, matching the logo drawn directly beneath it. Worth noting this is **cheaper, not more expensive**: `cacheWidth` is part of the `ResizeImage` cache key (see the note in `lib/utils/artwork_cache.dart`), so copies at `32` and `640` decode and cache the same file twice, while matching them shares a single decode. That matters here because the secondary display runs in its own engine with its own image cache.

**2. The offset didn't scale with the logo.** The main screen offsets by `6.r` on a `280.r`-wide logo (~2.1% of its width); this offset by `4.r` on a `600.r`-wide one (~0.7%), so the shadow tucked behind the artwork rather than reading as a shadow. The offset is now derived from the main screen's proportion instead of being a hand-picked number.

**3. The tint was hardcoded.** It used `Colors.black` at 0.7 where the main screen uses `colorScheme.shadow` at 0.5 — both darker and unresponsive to the theme. Reading the theme needs a `BuildContext`, which `buildFanartWithLogo` doesn't take; I used a local `Builder` rather than changing the signature, since the file documents its functions as pure `SecondaryDisplayStateData` → `Widget` mappings.

Fixes # (no issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

`dart format`, `flutter analyze` and `flutter test` (520 tests) all pass. No tests added — this is a rendering-parameter change on the second display, which the widget tests don't cover.

## Screenshots (if applicable)

Verified on the AYN Thor's second display with the same game shown on both screens at once, so the two shadows could be compared directly.

Before: the shadow shows blocky rectangular texel artefacts and, at the larger render size, sits close enough to the logo to be largely hidden behind it.

After: the shadow is clean at full resolution, offset proportionally to the logo, and tinted from the theme — reading the same as the main screen's.
