### PR TITLE
fix(gamelist): only show the footer mute pill when the game has a video

### DIFF
--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -274,6 +274,10 @@ class _GamesCarouselState extends State<GamesCarousel> {
     if (widget.artworkVersion != oldWidget.artworkVersion) {
       _fileExistsCache.clear();
       _lastBgIndex = -1;
+      // A scrape can add a preview video to the settled game, which changes
+      // whether the footer's mute pill applies — the cache above no longer
+      // answers it, so let the chrome rebuild against the new media too.
+      _chromeSig = null;
       WidgetsBinding.instance.addPostFrameCallback((_) => _updateBackground());
     }
   }
@@ -434,6 +438,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
       currentGameInfo: _currentGameInfo,
       onShowAchievements: _showAchievementsDialog,
       onToggleMute: _toggleVideoMute,
+      hasVideo: _hasVideoFor(settledGame),
     );
     // Positioning/visibility is applied at the Stack level (AnimatedPositioned)
     // so Select + B can slide it without invalidating this memoized subtree.
@@ -667,6 +672,23 @@ class _GamesCarouselState extends State<GamesCarousel> {
       return game.systemFolderName!;
     }
     return widget.system.primaryFolderName;
+  }
+
+  /// Whether the game has a preview video, so the footer knows whether a mute
+  /// control is worth showing.
+  ///
+  /// Scraped media lives on the plain filesystem (unlike SAF ROM paths), so a
+  /// sync stat is safe, and this only runs when the selection settles — not
+  /// per frame. Cached alongside the background lookups.
+  bool _hasVideoFor(GameModel game) {
+    final videoPath = game.getVideoPath(
+      _folderForGame(game),
+      widget.fileProvider,
+    );
+    return _fileExistsCache.putIfAbsent(
+      videoPath,
+      () => File(videoPath).existsSync(),
+    );
   }
 
   String _resolveImagePath(GameModel game, String imageType) {

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -111,6 +111,9 @@ class _GamesGridState extends State<GamesGrid> {
   Widget? _chromeFooter;
   Widget? _chromeLegend;
 
+  // Preview-video existence per resolved media path — see _hasVideoFor.
+  final Map<String, bool> _videoExistsCache = {};
+
   // Memoized grid rows. buildRow→_buildCard is a pure function of layout
   // (`_layoutGen`), `targetWidth`, `theme`, and per-card favorite/scrape state —
   // it never reads `_selectedIndex` (selection is drawn by the Positioned cursor
@@ -247,6 +250,24 @@ class _GamesGridState extends State<GamesGrid> {
       return game.systemFolderName!;
     }
     return widget.system.primaryFolderName;
+  }
+
+  /// Whether the game has a preview video, so the footer knows whether a mute
+  /// control is worth showing.
+  ///
+  /// Scraped media lives on the plain filesystem (unlike SAF ROM paths), so a
+  /// sync stat is safe, and this only runs when the selection settles — not
+  /// per frame. Memoized because a back-and-forth between two games would
+  /// otherwise re-stat both every time.
+  bool _hasVideoFor(GameModel game) {
+    final videoPath = game.getVideoPath(
+      _folderForGame(game),
+      widget.fileProvider,
+    );
+    return _videoExistsCache.putIfAbsent(
+      videoPath,
+      () => File(videoPath).existsSync(),
+    );
   }
 
   String _box2dPath(int index) {
@@ -629,6 +650,13 @@ class _GamesGridState extends State<GamesGrid> {
         widget.scrapingGameRomnames != oldWidget.scrapingGameRomnames ||
         widget.scrapeProgress != oldWidget.scrapeProgress) {
       _rowCache.clear();
+    }
+    // A scrape can add a preview video to the settled game, which changes
+    // whether the footer's mute pill applies. Drop the stat cache and the
+    // chrome signature so the footer is rebuilt against the new media.
+    if (widget.artworkVersion != oldWidget.artworkVersion) {
+      _videoExistsCache.clear();
+      _chromeSig = null;
     }
     if (widget.selectedIndex != oldWidget.selectedIndex) {
       _selectedIndex = widget.selectedIndex.clamp(
@@ -1263,6 +1291,7 @@ class _GamesGridState extends State<GamesGrid> {
       currentGameInfo: _currentGameInfo,
       onShowAchievements: _showAchievementsDialog,
       onToggleMute: _toggleVideoMute,
+      hasVideo: _hasVideoFor(settledGame),
     );
     // Positioning/visibility is applied at the Stack level (AnimatedPositioned)
     // so Select + B can animate it without invalidating this memoized subtree.

--- a/lib/widgets/game_view_footer.dart
+++ b/lib/widgets/game_view_footer.dart
@@ -33,6 +33,11 @@ class GameViewFooter extends StatelessWidget {
   /// Omit it to hide the pill.
   final VoidCallback? onToggleMute;
 
+  /// Whether the selected game actually has a preview video. There is nothing
+  /// to mute without one, so the pill stays hidden rather than offering a
+  /// control that does nothing for this game.
+  final bool hasVideo;
+
   const GameViewFooter({
     super.key,
     required this.game,
@@ -42,6 +47,7 @@ class GameViewFooter extends StatelessWidget {
     this.currentGameInfo,
     this.onShowAchievements,
     this.onToggleMute,
+    this.hasVideo = false,
   });
 
   @override
@@ -109,7 +115,7 @@ class GameViewFooter extends StatelessWidget {
           ExcludeFocus(
             child: Row(
               children: [
-                if (onToggleMute != null) ...[
+                if (onToggleMute != null && hasVideo) ...[
                   _MuteHintPill(onToggleMute: onToggleMute!),
                   SizedBox(width: 6.r),
                 ],


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). The analysis, code and testing were carried out by Claude under my direction, and I have reviewed the result on hardware.

# Description

The grid and carousel footers showed the Select/mute pill for every game. It toggles the preview video's sound, so on a game with no scraped video it is a control that does nothing — and it occupied a slot next to the rating and achievements pills on every single selection.

It is now gated on the selected game actually having a preview video.

**Where the check runs.** Both views resolve it in `_buildSettledChrome()`, which is already debounced by the settle timer, so it costs one `existsSync` per *settled* selection rather than one per frame. Scraped media lives on the plain filesystem (unlike SAF ROM paths, which are `content://` URIs), so a sync stat is safe here — it is the same check the carousel already does for fanart in `_updateBackground()`.

**Caching and invalidation.** The result is cached per resolved media path — the carousel reuses its existing `_fileExistsCache`, the grid gets a small `_videoExistsCache`. Both are cleared on `artworkVersion`, and that same branch now also nulls `_chromeSig`: a scrape that adds a video has to invalidate the *memoized footer* as well, or the pill would not appear until you navigated away and came back.

`hasVideo` defaults to `false`, so a future caller that forgets to pass it gets no pill rather than a dead one.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

Verified on an AYN Thor. Instrumented run confirming the resolution, on a build carrying a temporary debug line:

```
"Astro Warrior & Pit Pot.zip" -> .../media/sms/videos/Astro Warrior & Pit Pot.mp4 = true
"10-Pin Bowling.zip"          -> .../media/gbc/videos/10-Pin Bowling.mp4          = false
```

and the footer matched both: pill shown for the first, hidden for the second, with the remaining pills closing up cleanly. The debug line is not in this branch.

Existing suite passes (538 tests); no new tests — the change is a UI gate over a filesystem stat, which the current harness has no fixture for.

## Screenshots (if applicable)

Footer with a video present (mute pill leftmost), and without:

| has video | no video |
|---|---|
| `Astro Warrior & Pit Pot` — mute · rating · achievements · playtime · PLAY | `10-Pin Bowling` — achievements · PLAY |
