### PR TITLE
fix(gamelist): make the grid/carousel footer legible on light themes

### DIFF
--- a/lib/widgets/game_view_footer.dart
+++ b/lib/widgets/game_view_footer.dart
@@ -52,6 +52,15 @@ class GameViewFooter extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Unlike the details-card footer this one mirrors, the grid and carousel
+    // footers sit on the flat scaffold surface, not on top of the game's
+    // artwork. The white-on-black-shadow treatment inherited from that footer
+    // therefore renders as near-invisible ghost text in the light theme
+    // (white fill on a light background, readable only via its own outline).
+    // Take the colours from the scheme and drop the shadows: there is no busy
+    // background here for them to lift the text off.
+    final scheme = Theme.of(context).colorScheme;
+
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 8.r),
       child: Row(
@@ -67,16 +76,9 @@ class GameViewFooter extends StatelessWidget {
                   text: GameUtils.formatGameName(game.name),
                   isActive: true,
                   style: TextStyle(
-                    color: Colors.white,
+                    color: scheme.onSurface,
                     fontSize: 18.r,
                     fontWeight: FontWeight.bold,
-                    shadows: [
-                      Shadow(
-                        blurRadius: 2.r,
-                        color: Colors.black,
-                        offset: const Offset(0, 0),
-                      ),
-                    ],
                   ),
                 ),
                 // Always reserve the ROM-filename subtitle's line height so the
@@ -93,16 +95,9 @@ class GameViewFooter extends StatelessWidget {
                     forceStrutHeight: true,
                   ),
                   style: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.72),
+                    color: scheme.onSurface.withValues(alpha: 0.72),
                     fontSize: 12.r,
                     fontWeight: FontWeight.w400,
-                    shadows: [
-                      Shadow(
-                        blurRadius: 2.r,
-                        color: Colors.black.withValues(alpha: 0.45),
-                        offset: const Offset(2, 2),
-                      ),
-                    ],
                   ),
                 ),
               ],
@@ -219,6 +214,36 @@ class GameViewFooter extends StatelessWidget {
   }
 }
 
+/// The one surface every status pill in this footer draws itself on.
+///
+/// [ChromeSurface] already unified the *fill*, but the rest of the pill
+/// treatment stayed copy-pasted, and the drop shadows had drifted apart: 0.5 on
+/// the rating and play-time pills, 0.1 on the achievements pill, none on the
+/// mute pill. Because the fill is translucent by design, a shadow underneath it
+/// bleeds through and darkens the body — so those three alphas rendered as
+/// three visibly different pills side by side, and at 0.5 the rating pill
+/// landed darker than the page background and read as pressed next to its
+/// raised neighbours.
+///
+/// Border, radius and elevation now live here alongside the token so they
+/// cannot drift again; 0.1 matches the PLAY button next to them.
+BoxDecoration _pillDecoration(BuildContext context) {
+  final theme = Theme.of(context);
+  final radii = theme.extension<CornerRadii>() ?? CornerRadii.m();
+  return BoxDecoration(
+    color: ChromeSurface.fill(context),
+    borderRadius: radii.radiusExternal,
+    border: Border.all(color: theme.colorScheme.outline, width: 1.r),
+    boxShadow: [
+      BoxShadow(
+        color: theme.colorScheme.shadow.withValues(alpha: 0.1),
+        blurRadius: 4.r,
+        offset: Offset(2.0.r, 2.0.r),
+      ),
+    ],
+  );
+}
+
 /// A Steam-inspired rating badge that interpolates color based on the score intensity.
 /// Compact pill showing accumulated play time as a clock (HH:MM:SS), sized to
 /// match the rating / achievements pills in this footer.
@@ -237,25 +262,10 @@ class _PlayTimePill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final radii = Theme.of(context).extension<CornerRadii>() ?? CornerRadii.m();
     return Container(
       height: 32.r,
       padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
-      decoration: BoxDecoration(
-        color: ChromeSurface.fill(context),
-        borderRadius: radii.radiusExternal,
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline,
-          width: 1.r,
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.5),
-            blurRadius: 3.r,
-            offset: Offset(2.0.r, 2.0.r),
-          ),
-        ],
-      ),
+      decoration: _pillDecoration(context),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
@@ -288,7 +298,6 @@ class _SteamStyleRating extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final radii = Theme.of(context).extension<CornerRadii>() ?? CornerRadii.m();
     final ratingValue = (game.rating / 2).clamp(0.0, 10.0);
     final colorRatio = (ratingValue - 1) / 9;
     final customColors = AppThemes.getCustomColors(context);
@@ -301,21 +310,7 @@ class _SteamStyleRating extends StatelessWidget {
     return Container(
       height: 32.r,
       padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
-      decoration: BoxDecoration(
-        color: ChromeSurface.fill(context),
-        borderRadius: radii.radiusExternal,
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline,
-          width: 1.r,
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.5),
-            blurRadius: 3.r,
-            offset: Offset(2.0.r, 2.0.r),
-          ),
-        ],
-      ),
+      decoration: _pillDecoration(context),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
@@ -402,22 +397,13 @@ class _CompactAchievementsIndicator extends StatelessWidget {
         hoverColor: Colors.transparent,
         highlightColor: Colors.transparent,
         splashColor: theme.colorScheme.onSurface.withValues(alpha: 0.1),
-        borderRadius: radii.radiusInternal,
+        // Clip the ripple to the pill's own outline rather than the tighter
+        // inner radius, so it doesn't square off against the rounded corners.
+        borderRadius: radii.radiusExternal,
         child: Container(
           width: 101.r,
           height: 32.r,
-          decoration: BoxDecoration(
-            color: ChromeSurface.fill(context),
-            borderRadius: radii.radiusExternal,
-            border: Border.all(color: theme.colorScheme.outline, width: 1.r),
-            boxShadow: [
-              BoxShadow(
-                color: theme.colorScheme.shadow.withValues(alpha: 0.1),
-                blurRadius: 4.r,
-                offset: Offset(2.0.r, 2.0.r),
-              ),
-            ],
-          ),
+          decoration: _pillDecoration(context),
           child: Padding(
             // Match the rating pill's 8.r horizontal inset so the trophy icon
             // doesn't hug the pill's left border (the pill's width above is
@@ -514,9 +500,10 @@ class _MuteHintPill extends StatelessWidget {
     return Selector<SqliteConfigProvider, bool>(
       selector: (_, provider) => !provider.config.videoSound,
       builder: (context, isMuted, _) {
+        // Structured like the achievements pill — transparent Material for the
+        // ink, decoration on the Container — so both resolve to the same fill.
         return Material(
-          color: ChromeSurface.fill(context),
-          borderRadius: radii.radiusExternal,
+          color: Colors.transparent,
           child: InkWell(
             onTap: () {
               SfxService().playNavSound();
@@ -527,10 +514,7 @@ class _MuteHintPill extends StatelessWidget {
             child: Container(
               height: 32.r,
               padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
-              decoration: BoxDecoration(
-                borderRadius: radii.radiusExternal,
-                border: Border.all(color: scheme.outline, width: 1.r),
-              ),
+              decoration: _pillDecoration(context),
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.center,


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). The analysis, code and testing were carried out by Claude under my direction, and I have reviewed the result on hardware.

# Description

Two problems in the grid/carousel footer, both most visible on the light theme.

**1. The title and ROM subtitle were near-invisible.** They inherited the details-card footer's white-fill-plus-black-shadow treatment. That is right *there*, where the footer is `Positioned` over the game's artwork — but `GameViewFooter` sits on the flat scaffold surface. `#298` floats the *list* view's chrome over the fanart; it did not touch `my_games_grid.dart` or `my_games_carousel.dart`, and both still render the footer on `scaffoldBackgroundColor`. So on a light theme the title was white on `#EEEEEE` — **1.06:1**, readable only via its own outline.

Both colours now come from the scheme, and the shadows are dropped: there is no busy background here for them to lift the text off. This is not Light-only — five of the built-in themes have a light surface and all had the same invisible title: **Light, Nord, Valentine, Retro, Cyberpunk**. The ten dark themes now take their own `onSurface` instead of hardcoded white, which is what the pill text beside them already used, so the footer finally agrees with itself.

**2. The status pills rendered as three different whites.** `#298` unified the *fill* via `ChromeSurface.fill()`, but the rest of the pill treatment stayed copy-pasted and the drop shadows had drifted: `0.5` on the rating and play-time pills, `0.1` on the achievements pill, none on the mute pill. Because the fill is translucent by design, a shadow underneath it bleeds *through* and darkens the body — so those three alphas rendered as three visibly different pills side by side. At `0.5` the rating pill landed **darker than the page background** and read as pressed next to its raised neighbours.

Border, radius and elevation now live in one `_pillDecoration()` alongside `ChromeSurface.fill()`, so they cannot drift again. `0.1` matches the PLAY button beside them.

Two smaller fixes came along: `_MuteHintPill` was the odd one out, putting its fill on the `Material` and only a border on the `Container` — it now matches the achievements pill; and that pill's ripple was clipped to `radiusInternal` while its box used `radiusExternal`, so the splash squared off against the rounded corners.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

Verified on an AYN Thor, on a build rebased onto `#298`, sampling the actual framebuffer in both the grid and the carousel:

| light theme | before | after |
|---|---|---|
| Title fill | `#FFFFFF` on `#EEEEEE` — **1.06:1** | `#18181B` — **15.27:1** |
| Subtitle | **~1.1:1** | `#535355` — **6.61:1** |
| Pill fills | `#DEDEDE` / `#F5F5F5` / `#FBFBFB` | all `#F5F5F5` |

Also checked on Horizon (dark) that the pills resolve to a single fill there too — the same bug existed in every theme, but with `shadow` and the background both near-black the bleed was only ~2 RGB levels, versus ~29 on a light theme.

No new tests: this is a rendering change with no logic to assert against, and the existing suite (538) passes.

## Screenshots (if applicable)

Light theme, carousel footer — before, the title reads only as an outline and the rating pill sinks into the background; after, both resolve against the scheme and the pills sit level.
