### PR TITLE
feat(systems): add Mandarine-Neo emulator for 3DS

### DIFF
--- a/assets/systems/3ds.json
+++ b/assets/systems/3ds.json
@@ -294,6 +294,17 @@
       }
     },
     {
+      "name": "Standalone Mandarine-Neo",
+      "unique_id": "3ds.mandarine.neo",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n io.github.ptyfyre.mandarine.neo/io.github.mandarine3ds.mandarine.activities.EmulationActivity\n  -a android.intent.action.VIEW\n  -d {file.uri}\n  --activity-clear-task\n  --activity-clear-top\n"
+        }
+      }
+    },
+    {
       "name": "Standalone Citra Emu (Antutu)",
       "unique_id": "3ds.citraemu_antutu",
       "is_retroachievements_compatible": false,


### PR DESCRIPTION
# Description

Adds **Mandarine-Neo** as a standalone emulator option for the Nintendo 3DS system.

Mandarine-Neo (`ptyfyre/mandarine-neo`) is the active continuation of the Mandarine 3DS emulator, which is already listed here as `3ds.mandarine`. It ships as a separate Android package, so it needs its own entry rather than replacing the existing one.

**Launch component**

```
io.github.ptyfyre.mandarine.neo/io.github.mandarine3ds.mandarine.activities.EmulationActivity
```

Unlike the other Citra forks in this file, Mandarine-Neo's `applicationId` (`io.github.ptyfyre.mandarine.neo`) differs from its `namespace` (`io.github.mandarine3ds.mandarine`), so the usual `.activities.EmulationActivity` shorthand would resolve to the wrong class and the launch would fail.

The `applicationId` is still `io.github.lime3ds.android`, which would have collided with the existing `3ds.lime3ds` and `3ds.azahar.googleplay` entries. The `neo` branch is the correct source.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [ ] I have run `flutter analyze` and there are no errors. <!-- N/A: JSON-only change, no Dart touched -->
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. <!-- no new assets -->
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

N/A — configuration-only change.
