### PR TITLE
fix: keep update dialogs in controller focus while the library mounts

### DIFF
--- a/lib/services/gamepad/gamepad_navigation_manager.dart
+++ b/lib/services/gamepad/gamepad_navigation_manager.dart
@@ -6,10 +6,15 @@ class NavLayer {
   final void Function() onActivate;
   final void Function() onDeactivate;
 
+  /// Whether this layer belongs to a modal surface that must keep input focus
+  /// until it is dismissed. See [GamepadNavigationManager.pushLayer].
+  final bool modal;
+
   NavLayer({
     required this.id,
     required this.onActivate,
     required this.onDeactivate,
+    this.modal = false,
   });
 }
 
@@ -24,12 +29,48 @@ class GamepadNavigationManager {
   /// Pushes a new navigation layer to the top of the stack and activates it.
   ///
   /// Automatically deactivates the previously active layer.
+  ///
+  /// Set [modal] for layers owned by a modal surface (dialogs). A modal layer
+  /// cannot be displaced by a later non-modal push: background widgets that
+  /// mount while the dialog is open are inserted *beneath* it instead, keeping
+  /// their registration without taking input focus. Without this, a widget that
+  /// appears late — e.g. the systems grid mounting when the startup ROM scan
+  /// finishes behind the systems-update dialog — pushed itself on top and stole
+  /// the controller, so A opened a system behind the dialog.
+  ///
+  /// CAVEAT: anything a modal opens *on top of itself* (a dropdown, an option
+  /// picker) must be pushed with [modal] too, or it lands underneath its own
+  /// parent and never receives input. Only mark self-contained dialogs modal.
   static void pushLayer(
     String id, {
     required void Function() onActivate,
     required void Function() onDeactivate,
+    bool modal = false,
   }) {
-    _log.i('[GamepadNavigationManager] Pushing layer: $id');
+    _log.i('[GamepadNavigationManager] Pushing layer: $id (modal: $modal)');
+
+    // A non-modal layer never displaces an open modal. Slot it below the
+    // lowest modal so the dialogs above it stay ordered, and so it becomes the
+    // active layer once they are all dismissed.
+    final firstModal = _stack.indexWhere((layer) => layer.modal);
+    if (!modal && firstModal != -1) {
+      _log.i(
+        '[GamepadNavigationManager] Modal ${_stack[firstModal].id} holds focus; '
+        'inserting $id beneath it',
+      );
+      _stack.insert(
+        firstModal,
+        NavLayer(
+          id: id,
+          onActivate: onActivate,
+          onDeactivate: onDeactivate,
+          modal: modal,
+        ),
+      );
+      // Not activated: the modal above keeps focus. The new layer starts
+      // inactive, which is the state a freshly built navigator is already in.
+      return;
+    }
 
     if (_stack.isNotEmpty) {
       _log.d(
@@ -46,6 +87,7 @@ class GamepadNavigationManager {
       id: id,
       onActivate: onActivate,
       onDeactivate: onDeactivate,
+      modal: modal,
     );
     _stack.add(newLayer);
 

--- a/lib/widgets/systems_update_dialog.dart
+++ b/lib/widgets/systems_update_dialog.dart
@@ -40,10 +40,15 @@ class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
     );
     _gamepadNav.initialize();
     _gamepadNav.activate();
+    // Modal: this dialog is shown during startup, while the initial ROM scan
+    // is still running. The systems grid mounts when that scan finishes and
+    // would otherwise push its layer on top of this one, so A would open a
+    // system behind the dialog instead of starting the update.
     GamepadNavigationManager.pushLayer(
       'systems_update_dialog',
       onActivate: () => _gamepadNav.activate(),
       onDeactivate: () => _gamepadNav.deactivate(),
+      modal: true,
     );
   }
 

--- a/lib/widgets/update_dialog.dart
+++ b/lib/widgets/update_dialog.dart
@@ -37,10 +37,14 @@ class _UpdateDialogState extends State<UpdateDialog> {
     );
     _gamepadNav.initialize();
     _gamepadNav.activate();
+    // Modal for the same reason as the systems update dialog: it opens during
+    // startup and must keep controller focus while the ROM scan finishes and
+    // the library widgets mount behind it.
     GamepadNavigationManager.pushLayer(
       'update_dialog',
       onActivate: () => _gamepadNav.activate(),
       onDeactivate: () => _gamepadNav.deactivate(),
+      modal: true,
     );
   }
 

--- a/test/gamepad_navigation_manager_test.dart
+++ b/test/gamepad_navigation_manager_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/gamepad/gamepad_navigation_manager.dart';
+
+/// Records which layer the manager considers active, in push/activation order.
+class _Recorder {
+  final List<String> events = [];
+
+  void push(String id, {bool modal = false}) {
+    GamepadNavigationManager.pushLayer(
+      id,
+      onActivate: () => events.add('+$id'),
+      onDeactivate: () => events.add('-$id'),
+      modal: modal,
+    );
+  }
+
+  void pop(String id) => GamepadNavigationManager.popLayer(id);
+}
+
+void main() {
+  group('GamepadNavigationManager modal layers', () {
+    test('a non-modal push does not steal focus from an open modal', () {
+      final r = _Recorder();
+      r.push('app_screen');
+      r.push('systems_update_dialog', modal: true);
+      r.events.clear();
+
+      // The systems grid mounts when the startup scan finishes, behind the
+      // dialog. It must not take the controller.
+      r.push('my_systems_list');
+
+      expect(r.events, isEmpty);
+
+      r.pop('my_systems_list');
+      r.pop('systems_update_dialog');
+      r.pop('app_screen');
+    });
+
+    test(
+      'the layer pushed under a modal becomes active once it is dismissed',
+      () {
+        final r = _Recorder();
+        r.push('app_screen');
+        r.push('systems_update_dialog', modal: true);
+        r.push('my_systems_list');
+        r.events.clear();
+
+        r.pop('systems_update_dialog');
+
+        expect(r.events, ['-systems_update_dialog', '+my_systems_list']);
+
+        r.pop('my_systems_list');
+        r.pop('app_screen');
+      },
+    );
+
+    test('a modal still stacks on top of another modal', () {
+      final r = _Recorder();
+      r.push('app_screen');
+      r.push('update_dialog', modal: true);
+      r.events.clear();
+
+      r.push('systems_update_dialog', modal: true);
+
+      expect(r.events, ['-update_dialog', '+systems_update_dialog']);
+
+      r.pop('systems_update_dialog');
+      r.pop('update_dialog');
+      r.pop('app_screen');
+    });
+
+    test(
+      'non-modal pushes slot below the lowest modal, keeping dialog order',
+      () {
+        final r = _Recorder();
+        r.push('app_screen');
+        r.push('update_dialog', modal: true);
+        r.push('systems_update_dialog', modal: true);
+        r.push('my_systems_list');
+        r.events.clear();
+
+        // Dismissing the top dialog must return focus to the one underneath it,
+        // not to the background layer that mounted late.
+        r.pop('systems_update_dialog');
+        expect(r.events, ['-systems_update_dialog', '+update_dialog']);
+
+        r.events.clear();
+        r.pop('update_dialog');
+        expect(r.events, ['-update_dialog', '+my_systems_list']);
+
+        r.pop('my_systems_list');
+        r.pop('app_screen');
+      },
+    );
+
+    test('ordinary stacking is unchanged when no modal is open', () {
+      final r = _Recorder();
+      r.push('app_screen');
+      r.events.clear();
+
+      r.push('my_systems_list');
+      expect(r.events, ['-app_screen', '+my_systems_list']);
+
+      r.events.clear();
+      r.pop('my_systems_list');
+      expect(r.events, ['-my_systems_list', '+app_screen']);
+
+      r.pop('app_screen');
+    });
+  });
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

The gamepad layer stack had no notion of a modal, so whichever widget pushed last took input regardless of what was actually on screen. A dialog could therefore be silently displaced by a background widget that mounted while it was open.

This is what happens on startup. `AppScreen._performUpdateSequence` deliberately runs the ROM scan and the network update checks **concurrently** (so a slow network can't leave the Systems tab blank). While the scan runs, `system_content.dart` shows the splash and `MySystems` is not mounted. The systems-update dialog appears and correctly pushes its layer — then the scan finishes, `MySystems` mounts, and `my_systems_grid` pushes `my_systems_list` **on top of the open dialog**, deactivating it. Pressing A then hit the grid's `onEnterPressed` and opened a system behind the dialog instead of starting the update.

The consequence is worse than a stray navigation. The systems grid can start a recently-played title directly (`deactivateAll()` → `game_launch_dialog` in `my_systems_grid.dart`), so an A press meant for the update dialog can **boot an emulator** rather than merely opening a system behind it. Both outcomes were observed on device.

It surfaces on the Steam Deck because the scan there outlasts the update check. On a fast or empty library the grid mounts *before* the dialog, the ordering happens to be correct, and nothing looks wrong.

**Fix.** `GamepadNavigationManager.pushLayer` takes a `modal` flag. A non-modal push made while a modal is open is inserted **beneath the lowest modal** rather than appended on top, and is not activated. It stays registered, so it becomes the active layer naturally once the modals above it are dismissed. Inserting at the *lowest* modal (rather than just below the top one) keeps stacked dialogs correctly ordered, so dismissing the top dialog returns focus to the dialog underneath it, not to a background widget.

Both startup update dialogs push with `modal: true`. Modal-on-modal stacking and the ordinary no-modal path are unchanged, and `popLayer` already handled removal of a non-top layer correctly, so it needed no changes.

Only these two dialogs are marked modal. Anything a modal opens *on top of itself* (a dropdown, an option picker) would have to be modal too, or it would land under its own parent — the flag suits self-contained dialogs, which is noted in the doc comment.

**Relationship to #299.** That PR targets the same symptom and is complementary, not overlapping: it guards a navigator being deactivated *during* async gamepad device detection, and changes *when* the dialogs register their layer. This one handles a *newer layer landing on top* of an open dialog, which neither of those can catch. The changes are independent — this branch is cut from `main` and does not include #299's commits — but both touch the `pushLayer` call in `update_dialog.dart` and `systems_update_dialog.dart`, so whichever merges second will need a one-line conflict resolution there (keep the merged structure, add `modal: true`).

## Steps to Reproduce

Preconditions: a device whose ROM scan takes longer than the update check (a real library — reproduced on Steam Deck and AYN Thor), and a pending systems update.

1. Make a systems update pending: ensure the device DB's `user_config.systems_version` is **lower** than `latest_version` in the remote `assets/manifest.json` on `main`. Locally you can force this by lowering `latest_version` in the bundled `assets/manifest.json` on a **fresh** install (an existing install compares against the value already stored in the DB).
2. Confirm `auto_update_systems` is enabled.
3. Cold-start the app so the startup ROM scan runs.
4. Wait for the "Systems update available" dialog, and keep waiting until the library finishes scanning behind it (the splash is replaced by the systems grid).
5. Press **A**.

**Before:** the dialog stays open and the press goes to the grid underneath — either a **system opens behind the dialog**, or, if the selection is on a recently-played title, **a game launches into its emulator**.
**After:** the press reaches the dialog and starts the update.

The whole thing is visible in `app.log`. Before, on an AYN Thor (note `my_systems_list` landing *after*, and therefore on top of, the dialog):

```
Pushing layer: app_screen
Pushing layer: systems_update_dialog
Pushing layer: my_systems_list          <- mounts ON TOP of the open dialog
[GamepadRaw] gamepad="10" type=button value=0.0000   <- the A press
Deactivating all layers
Pushing layer: game_launch_dialog       <- a game launched instead
```

After, same device and same dialog:

```
Pushing layer: app_screen (modal: false)
scanSystems starting (romFolders=1, fastScan=false)
Pushing layer: systems_update_dialog (modal: true)     <- dialog opens mid-scan
Pushing layer: my_systems_list (modal: false)          <- grid mounts when scan ends
Modal systems_update_dialog holds focus; inserting my_systems_list beneath it
SystemsUpdateService: updated 121 files to v0.3.11     <- A reached the DIALOG
Popping layer: my_systems_list                          <- re-scan unmounts grid
Pushing layer: my_systems_list (modal: false)
Modal systems_update_dialog holds focus; inserting my_systems_list beneath it
Popping layer: systems_update_dialog
Reactivating previous layer: my_systems_list            <- focus handed back
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

Five tests in `test/gamepad_navigation_manager_test.dart` cover focus retention under a modal, handoff on dismissal, dialog-over-dialog ordering, and the unchanged non-modal path. Full suite green (543 passing).

Device verification:
- **Steam Deck** (Linux, Game Mode) — the reported case; dialog keeps focus.
- **AYN Thor** (Android) — full lifecycle confirmed, including the grid remount caused by the post-update re-scan while the dialog is still open, and focus returning to the grid on dismissal.

## Screenshots (if applicable)

Not applicable — no visual change; the fix is in input routing.
