### PR TITLE
perf: download system definitions concurrently instead of one at a time

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -850,6 +850,7 @@ mixin AppLocale {
       'systems_update_current_version';
   static const String systemsUpdateNewVersion = 'systems_update_new_version';
   static const String systemsUpdateDownloading = 'systems_update_downloading';
+  static const String systemsUpdateCancelling = 'systems_update_cancelling';
   static const String systemsUpdateSyncing = 'systems_update_syncing';
   static const String systemsUpdateComplete = 'systems_update_complete';
   static const String systemsUpdateError = 'systems_update_error';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -854,6 +854,7 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.systemsUpdateNewVersion: 'Neue Version: {version}',
   AppLocale.systemsUpdateDownloading:
       'System-Configs werden heruntergeladen...',
+  AppLocale.systemsUpdateCancelling: 'Abbrechen...',
   AppLocale.systemsUpdateSyncing: 'Systemdatenbank wird synchronisiert...',
   AppLocale.systemsUpdateComplete: 'Systeme erfolgreich aktualisiert!',
   AppLocale.systemsUpdateError:

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -824,6 +824,7 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.systemsUpdateCurrentVersion: 'Current version: {version}',
   AppLocale.systemsUpdateNewVersion: 'New version: {version}',
   AppLocale.systemsUpdateDownloading: 'Downloading system configs...',
+  AppLocale.systemsUpdateCancelling: 'Cancelling...',
   AppLocale.systemsUpdateSyncing: 'Syncing systems database...',
   AppLocale.systemsUpdateComplete: 'Systems updated successfully!',
   AppLocale.systemsUpdateError:

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -850,6 +850,7 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.systemsUpdateCurrentVersion: 'Versión actual: {version}',
   AppLocale.systemsUpdateNewVersion: 'Nueva versión: {version}',
   AppLocale.systemsUpdateDownloading: 'Descargando configs de sistemas...',
+  AppLocale.systemsUpdateCancelling: 'Cancelando...',
   AppLocale.systemsUpdateSyncing: 'Sincronizando base de datos de sistemas...',
   AppLocale.systemsUpdateComplete: '¡Sistemas actualizados correctamente!',
   AppLocale.systemsUpdateError:

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -856,6 +856,7 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.systemsUpdateCurrentVersion: 'Version actuelle : {version}',
   AppLocale.systemsUpdateNewVersion: 'Nouvelle version : {version}',
   AppLocale.systemsUpdateDownloading: 'Téléchargement des configs systèmes...',
+  AppLocale.systemsUpdateCancelling: 'Annulation...',
   AppLocale.systemsUpdateSyncing: 'Synchronisation de la base de données...',
   AppLocale.systemsUpdateComplete: 'Systèmes mis à jour avec succès !',
   AppLocale.systemsUpdateError:

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -829,6 +829,7 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.systemsUpdateCurrentVersion: 'Versi saat ini: {version}',
   AppLocale.systemsUpdateNewVersion: 'Versi baru: {version}',
   AppLocale.systemsUpdateDownloading: 'Mengunduh konfigurasi sistem...',
+  AppLocale.systemsUpdateCancelling: 'Membatalkan...',
   AppLocale.systemsUpdateSyncing: 'Menyinkronkan database sistem...',
   AppLocale.systemsUpdateComplete: 'Sistem berhasil diperbarui!',
   AppLocale.systemsUpdateError: 'Gagal memperbarui sistem. Coba lagi nanti.',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -848,6 +848,7 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.systemsUpdateCurrentVersion: 'Versione attuale: {version}',
   AppLocale.systemsUpdateNewVersion: 'Nuova versione: {version}',
   AppLocale.systemsUpdateDownloading: 'Download configurazioni sistemi...',
+  AppLocale.systemsUpdateCancelling: 'Annullamento...',
   AppLocale.systemsUpdateSyncing: 'Sincronizzazione database sistemi...',
   AppLocale.systemsUpdateComplete: 'Sistemi aggiornati con successo!',
   AppLocale.systemsUpdateError:

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -751,6 +751,7 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.systemsUpdateCurrentVersion: '現在のバージョン: {version}',
   AppLocale.systemsUpdateNewVersion: '新しいバージョン: {version}',
   AppLocale.systemsUpdateDownloading: 'システム設定をダウンロード中...',
+  AppLocale.systemsUpdateCancelling: 'キャンセル中...',
   AppLocale.systemsUpdateSyncing: 'システムデータベースを同期中...',
   AppLocale.systemsUpdateComplete: 'システムが正常に更新されました！',
   AppLocale.systemsUpdateError: 'システムの更新に失敗しました。後でもう一度試してください。',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -760,6 +760,7 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.systemsUpdateCurrentVersion: '현재 버전: {version}',
   AppLocale.systemsUpdateNewVersion: '새 버전: {version}',
   AppLocale.systemsUpdateDownloading: '시스템 구성 다운로드 중...',
+  AppLocale.systemsUpdateCancelling: '취소하는 중...',
   AppLocale.systemsUpdateSyncing: '시스템 데이터베이스 동기화 중...',
   AppLocale.systemsUpdateComplete: '시스템이 성공적으로 업데이트되었습니다!',
   AppLocale.systemsUpdateError: '시스템을 업데이트하지 못했습니다. 나중에 다시 시도해 주세요.',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -836,6 +836,7 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.systemsUpdateCurrentVersion: 'Versão atual: {version}',
   AppLocale.systemsUpdateNewVersion: 'Nova versão: {version}',
   AppLocale.systemsUpdateDownloading: 'Baixando configs de sistemas...',
+  AppLocale.systemsUpdateCancelling: 'Cancelando...',
   AppLocale.systemsUpdateSyncing: 'Sincronizando banco de dados de sistemas...',
   AppLocale.systemsUpdateComplete: 'Sistemas atualizados com sucesso!',
   AppLocale.systemsUpdateError:

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -827,6 +827,7 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.systemsUpdateCurrentVersion: 'Текущая версия: {version}',
   AppLocale.systemsUpdateNewVersion: 'Новая версия: {version}',
   AppLocale.systemsUpdateDownloading: 'Загрузка конфигураций систем...',
+  AppLocale.systemsUpdateCancelling: 'Отмена...',
   AppLocale.systemsUpdateSyncing: 'Синхронизация базы данных систем...',
   AppLocale.systemsUpdateComplete: 'Системы успешно обновлены!',
   AppLocale.systemsUpdateError: 'Ошибка обновления систем. Попробуйте позже.',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -740,6 +740,7 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.systemsUpdateCurrentVersion: '当前版本：{version}',
   AppLocale.systemsUpdateNewVersion: '新版本：{version}',
   AppLocale.systemsUpdateDownloading: '正在下载系统配置...',
+  AppLocale.systemsUpdateCancelling: '正在取消...',
   AppLocale.systemsUpdateSyncing: '正在同步系统数据库...',
   AppLocale.systemsUpdateComplete: '系统更新成功！',
   AppLocale.systemsUpdateError: '系统更新失败，请稍后再试。',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -740,6 +740,7 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.systemsUpdateCurrentVersion: '目前版本：{version}',
   AppLocale.systemsUpdateNewVersion: '新版本：{version}',
   AppLocale.systemsUpdateDownloading: '正在下載系統設定...',
+  AppLocale.systemsUpdateCancelling: '正在取消...',
   AppLocale.systemsUpdateSyncing: '正在同步系統資料庫...',
   AppLocale.systemsUpdateComplete: '系統更新成功！',
   AppLocale.systemsUpdateError: '系統更新失敗，請稍後再試。',

--- a/lib/services/neo_assets_service.dart
+++ b/lib/services/neo_assets_service.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 import 'config_service.dart';
 import 'logger_service.dart';
+import '../utils/bounded_concurrency.dart';
 
 const _baseRaw =
     'https://raw.githubusercontent.com/misobadev/neostation-assets/main';
@@ -711,36 +712,6 @@ class NeoAssetsService {
   /// linearly without overwhelming the network or the host.
   static const int _downloadConcurrency = 8;
 
-  /// Runs [task] over [items] with at most [concurrency] tasks in flight,
-  /// invoking [onEach] after each completion (for progress). A single failing
-  /// task never aborts the batch. Safe on Dart's single-threaded event loop:
-  /// the `next++` cursor and progress counter are only touched synchronously.
-  static Future<void> _runBounded<T>(
-    List<T> items,
-    int concurrency,
-    Future<void> Function(T item) task, {
-    void Function()? onEach,
-  }) async {
-    if (items.isEmpty) return;
-    int next = 0;
-
-    Future<void> worker() async {
-      while (true) {
-        final i = next++;
-        if (i >= items.length) return;
-        try {
-          await task(items[i]);
-        } catch (e) {
-          _log.w('Bounded task failed for item ${items[i]}: $e');
-        }
-        onEach?.call();
-      }
-    }
-
-    final workerCount = concurrency < items.length ? concurrency : items.length;
-    await Future.wait(List.generate(workerCount, (_) => worker()));
-  }
-
   /// Downloads all background and logo assets for a theme, optionally
   /// forcing a refresh.
   static Future<void> downloadAllThemeAssets(
@@ -755,7 +726,7 @@ class NeoAssetsService {
 
     final total = systemFolderNames.length;
     int done = 0;
-    await _runBounded<String>(
+    await runBounded<String>(
       systemFolderNames,
       _downloadConcurrency,
       (system) => getCachedBackground(themeFolder, system),
@@ -783,7 +754,7 @@ class NeoAssetsService {
     int done = 0;
     // getCachedBackground tries .webp then .gif and records a negative-cache
     // marker when neither exists remotely.
-    await _runBounded<String>(
+    await runBounded<String>(
       pending,
       _downloadConcurrency,
       (system) => getCachedBackground(themeFolder, system),

--- a/lib/services/systems_update_service.dart
+++ b/lib/services/systems_update_service.dart
@@ -47,12 +47,16 @@ class SystemsUpdateInfo {
 /// When no internet is available the bundled assets are used as-is.
 class SystemsUpdateService {
   /// Max system files fetched at once. The payload is tiny (~7 KB per file,
-  /// ~885 KB for the full set) but each request costs a round trip, so the
+  /// ~865 KB for the full set) but each request costs a round trip, so the
   /// download is latency-bound and concurrency is what makes it fast.
-  /// Downloading the ~120 files serially takes ~20 s on a wired connection
-  /// and well over a minute on handheld Wi-Fi; a pool of 6 brings that to
-  /// about a second. Kept modest so slow devices and GitHub both stay happy.
-  static const int _downloadConcurrency = 6;
+  ///
+  /// Measured against the live endpoint: serially the ~120 files cost ~196 ms
+  /// each (~24 s total) on a wired connection, and well over a minute on
+  /// handheld Wi-Fi. Pooled, the same set takes ~3 s cold and ~0.3 s warm.
+  /// Raising the pool past 8 kept helping slightly (~176 ms warm at 16) but
+  /// not enough to justify the extra sockets on a handheld's Wi-Fi stack, and
+  /// 8 matches the pool NeoAssetsService already uses for theme assets.
+  static const int _downloadConcurrency = 8;
 
   /// Per-file request timeout. Without one, a single stalled connection would
   /// hang the whole update with no way out.

--- a/lib/services/systems_update_service.dart
+++ b/lib/services/systems_update_service.dart
@@ -196,8 +196,13 @@ class SystemsUpdateService {
   ///
   /// [onProgress] receives normalized progress (0.0–1.0) and a status string
   /// after each file is downloaded.
+  ///
+  /// [shouldCancel] is polled before each file; once it returns true the
+  /// remaining downloads are skipped and null is returned. The stored version
+  /// is left untouched so the next check retries the whole update.
   static Future<SystemsUpdateResult?> checkAndUpdate({
     void Function(double progress, String status)? onProgress,
+    bool Function()? shouldCancel,
   }) async {
     try {
       // 1. Fetch manifest — failure here means no internet, bail silently.
@@ -236,6 +241,7 @@ class SystemsUpdateService {
           systemIds,
           _downloadConcurrency,
           (id) async {
+            if (shouldCancel?.call() ?? false) return;
             final fileName = '$id.json';
             final url = '$_baseRawUrl/$fileName';
             final response = await client
@@ -262,6 +268,16 @@ class SystemsUpdateService {
         );
       } finally {
         client.close();
+      }
+
+      // Leave systems_version alone on cancel: the cache now holds a mix of
+      // old and new definitions, and only an unchanged version makes the next
+      // check re-download the full set.
+      if (shouldCancel?.call() ?? false) {
+        _log.i(
+          'SystemsUpdateService: cancelled after $downloaded/$total files',
+        );
+        return null;
       }
 
       if (downloaded == 0) return null;

--- a/lib/services/systems_update_service.dart
+++ b/lib/services/systems_update_service.dart
@@ -22,10 +22,17 @@ final _log = LoggerService.instance;
 class SystemsUpdateResult {
   final String newVersion;
   final int filesUpdated;
+  final int filesTotal;
   const SystemsUpdateResult({
     required this.newVersion,
     required this.filesUpdated,
+    required this.filesTotal,
   });
+
+  /// Whether every file in the set landed. A partial update applies the files
+  /// it did get but deliberately leaves the stored version behind, so the next
+  /// check retries — see `checkAndUpdate`.
+  bool get isComplete => filesUpdated == filesTotal;
 }
 
 /// Info returned when a systems update is available but not yet downloaded.
@@ -303,14 +310,32 @@ class SystemsUpdateService {
 
       if (downloaded == 0) return null;
 
-      // 5. Persist new version.
-      await SqliteService.updateSystemsVersion(remoteVersion);
-      _log.i(
-        'SystemsUpdateService: updated $downloaded files to v$remoteVersion',
-      );
+      // 5. Persist the new version — but only once every file actually landed.
+      //
+      // Advancing it on a partial download strands the files that failed: the
+      // stored version would claim the set is current, so no later check would
+      // ever consider them out of date and they would stay stale forever.
+      // Leaving it means the next check retries the whole set instead. The
+      // shortfall is logged rather than swallowed, so a file that fails
+      // systematically (a genuine 404 in the repo listing, say) shows up as a
+      // repeating warning instead of silently re-downloading forever.
+      if (downloaded < total) {
+        _log.w(
+          'SystemsUpdateService: only $downloaded/$total files downloaded — '
+          'leaving systems_version at "${await SqliteService.getSystemsVersion()}" '
+          'so the next check retries the full set',
+        );
+      } else {
+        await SqliteService.updateSystemsVersion(remoteVersion);
+        _log.i(
+          'SystemsUpdateService: updated $downloaded files to v$remoteVersion',
+        );
+      }
+
       return SystemsUpdateResult(
         newVersion: remoteVersion,
         filesUpdated: downloaded,
+        filesTotal: total,
       );
     } catch (e, st) {
       _log.e(

--- a/lib/services/systems_update_service.dart
+++ b/lib/services/systems_update_service.dart
@@ -7,6 +7,7 @@ import 'package:path/path.dart' as path;
 import 'config_service.dart';
 import 'logger_service.dart';
 import '../data/datasources/sqlite_service.dart';
+import '../utils/bounded_concurrency.dart';
 
 const _manifestUrl =
     'https://raw.githubusercontent.com/misobadev/neostation-frontend/main/assets/manifest.json';
@@ -45,6 +46,18 @@ class SystemsUpdateInfo {
 /// JSON files into the user data directory so LauncherService can use them.
 /// When no internet is available the bundled assets are used as-is.
 class SystemsUpdateService {
+  /// Max system files fetched at once. The payload is tiny (~7 KB per file,
+  /// ~885 KB for the full set) but each request costs a round trip, so the
+  /// download is latency-bound and concurrency is what makes it fast.
+  /// Downloading the ~120 files serially takes ~20 s on a wired connection
+  /// and well over a minute on handheld Wi-Fi; a pool of 6 brings that to
+  /// about a second. Kept modest so slow devices and GitHub both stay happy.
+  static const int _downloadConcurrency = 6;
+
+  /// Per-file request timeout. Without one, a single stalled connection would
+  /// hang the whole update with no way out.
+  static const Duration _fileTimeout = Duration(seconds: 15);
+
   static Future<String> _getSystemsCachePath() async {
     final base = await ConfigService.getUserDataPath();
     final dir = Directory(path.join(base, 'systems'));
@@ -210,31 +223,45 @@ class SystemsUpdateService {
 
       // 4. Download each file to the local cache.
       final cacheDir = await _getSystemsCachePath();
-      var downloaded = 0;
       final total = systemIds.length;
+      var downloaded = 0;
+      var completed = 0;
 
-      for (int i = 0; i < total; i++) {
-        final id = systemIds[i];
-        final fileName = '$id.json';
-        final url = '$_baseRawUrl/$fileName';
-        try {
-          final response = await http.get(Uri.parse(url));
-          if (response.statusCode == 200) {
-            final file = File(path.join(cacheDir, fileName));
-            await file.writeAsString(response.body, flush: true);
-            downloaded++;
-          } else {
-            _log.w(
-              'SystemsUpdateService: failed to download $fileName (${response.statusCode})',
+      // One client for the whole batch: the top-level `http.get` helper builds
+      // and closes a Client per call, so it can never reuse a connection and
+      // every file pays a fresh TCP + TLS handshake.
+      final client = http.Client();
+      try {
+        await runBounded<String>(
+          systemIds,
+          _downloadConcurrency,
+          (id) async {
+            final fileName = '$id.json';
+            final url = '$_baseRawUrl/$fileName';
+            final response = await client
+                .get(Uri.parse(url))
+                .timeout(_fileTimeout);
+            if (response.statusCode == 200) {
+              final file = File(path.join(cacheDir, fileName));
+              await file.writeAsString(response.body, flush: true);
+              downloaded++;
+            } else {
+              _log.w(
+                'SystemsUpdateService: failed to download $fileName (${response.statusCode})',
+              );
+            }
+          },
+          onEach: () {
+            completed++;
+            onProgress?.call(
+              completed / total,
+              'Downloading systems ($completed/$total)...',
             );
-          }
-        } catch (e) {
-          _log.w('SystemsUpdateService: error downloading $fileName: $e');
-        }
-        onProgress?.call(
-          (i + 1) / total,
-          'Downloading systems (${i + 1}/$total)...',
+          },
+          label: 'SystemsUpdateService: download',
         );
+      } finally {
+        client.close();
       }
 
       if (downloaded == 0) return null;

--- a/lib/services/systems_update_service.dart
+++ b/lib/services/systems_update_service.dart
@@ -200,27 +200,44 @@ class SystemsUpdateService {
   /// [shouldCancel] is polled before each file; once it returns true the
   /// remaining downloads are skipped and null is returned. The stored version
   /// is left untouched so the next check retries the whole update.
+  ///
+  /// [knownUpdate] short-circuits the version check. Pass the result of an
+  /// earlier [checkForUpdate] — as the update dialog does — to skip re-fetching
+  /// the manifest and re-comparing versions that were just resolved.
   static Future<SystemsUpdateResult?> checkAndUpdate({
+    SystemsUpdateInfo? knownUpdate,
     void Function(double progress, String status)? onProgress,
     bool Function()? shouldCancel,
   }) async {
     try {
-      // 1. Fetch manifest — failure here means no internet, bail silently.
-      final manifest = await _fetchManifest();
-      if (manifest == null) return null;
+      // 1. Resolve the target version, unless the caller already has it.
+      final String remoteVersion;
+      if (knownUpdate != null) {
+        remoteVersion = knownUpdate.remoteVersion;
+        _log.i(
+          'SystemsUpdateService: new version $remoteVersion '
+          '(local: ${knownUpdate.currentVersion})',
+        );
+      } else {
+        // Fetching the manifest here doubles as the connectivity check —
+        // failure means no internet, so bail silently.
+        final manifest = await _fetchManifest();
+        if (manifest == null) return null;
 
-      if (!await _appMeetsManifestMinimum(manifest)) return null;
+        if (!await _appMeetsManifestMinimum(manifest)) return null;
 
-      final remoteVersion = manifest['latest_version']?.toString() ?? '';
-      if (remoteVersion.isEmpty) return null;
+        final version = manifest['latest_version']?.toString() ?? '';
+        if (version.isEmpty) return null;
 
-      // 2. Compare with locally stored version.
-      final localVersion = await SqliteService.getSystemsVersion();
-      if (_meetsMinimumVersion(localVersion, remoteVersion)) return null;
+        // 2. Compare with locally stored version.
+        final localVersion = await SqliteService.getSystemsVersion();
+        if (_meetsMinimumVersion(localVersion, version)) return null;
 
-      _log.i(
-        'SystemsUpdateService: new version $remoteVersion (local: $localVersion)',
-      );
+        remoteVersion = version;
+        _log.i(
+          'SystemsUpdateService: new version $remoteVersion (local: $localVersion)',
+        );
+      }
 
       // 3. Get the full list of system files from the GitHub repo directory.
       final systemIds = await _fetchSystemListFromApi();

--- a/lib/utils/bounded_concurrency.dart
+++ b/lib/utils/bounded_concurrency.dart
@@ -1,0 +1,42 @@
+import '../services/logger_service.dart';
+
+final _log = LoggerService.instance;
+
+/// Runs [task] over [items] with at most [concurrency] tasks in flight,
+/// invoking [onEach] after each completion (for progress).
+///
+/// Intended for batches of small, independent network fetches — theme assets,
+/// system definitions — where wall-clock time is dominated by per-request
+/// round-trip latency rather than bandwidth, so a bounded pool cuts it
+/// roughly linearly.
+///
+/// A single failing task never aborts the batch: failures are logged against
+/// [label] and the pool moves on. Safe on Dart's single-threaded event loop —
+/// the `next` cursor is only ever read and advanced synchronously, with no
+/// await point in between.
+Future<void> runBounded<T>(
+  List<T> items,
+  int concurrency,
+  Future<void> Function(T item) task, {
+  void Function()? onEach,
+  String label = 'Bounded task',
+}) async {
+  if (items.isEmpty) return;
+  int next = 0;
+
+  Future<void> worker() async {
+    while (true) {
+      final i = next++;
+      if (i >= items.length) return;
+      try {
+        await task(items[i]);
+      } catch (e) {
+        _log.w('$label failed for item ${items[i]}: $e');
+      }
+      onEach?.call();
+    }
+  }
+
+  final workerCount = concurrency < items.length ? concurrency : items.length;
+  await Future.wait(List.generate(workerCount, (_) => worker()));
+}

--- a/lib/widgets/systems_update_dialog.dart
+++ b/lib/widgets/systems_update_dialog.dart
@@ -12,10 +12,24 @@ import '../data/datasources/sqlite_service.dart';
 import 'custom_notification.dart';
 import 'core_footer.dart';
 
+/// Signature of [SystemsUpdateService.checkAndUpdate], so tests can drive the
+/// dialog's download states without touching the network.
+typedef SystemsUpdateRunner =
+    Future<SystemsUpdateResult?> Function({
+      SystemsUpdateInfo? knownUpdate,
+      void Function(double progress, String status)? onProgress,
+      bool Function()? shouldCancel,
+    });
+
 class SystemsUpdateDialog extends StatefulWidget {
   final SystemsUpdateInfo updateInfo;
 
-  const SystemsUpdateDialog({super.key, required this.updateInfo});
+  /// Overrides the download call. Defaults to the real service; exists so the
+  /// progress, cancel and layout states can be tested deterministically.
+  @visibleForTesting
+  final SystemsUpdateRunner? runner;
+
+  const SystemsUpdateDialog({super.key, required this.updateInfo, this.runner});
 
   @override
   State<SystemsUpdateDialog> createState() => _SystemsUpdateDialogState();
@@ -24,6 +38,9 @@ class SystemsUpdateDialog extends StatefulWidget {
 class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
   bool _isDownloading = false;
   bool _cancelRequested = false;
+  // The DB sync that follows a completed download is past the point of no
+  // return, so the cancel affordance is withdrawn for it.
+  bool _isSyncing = false;
   double _downloadProgress = 0.0;
   String _downloadStatus = '';
   late final GamepadNavigation _gamepadNav;
@@ -76,7 +93,7 @@ class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
   }
 
   void _requestCancel() {
-    if (_cancelRequested) return;
+    if (_cancelRequested || _isSyncing) return;
     setState(() {
       _cancelRequested = true;
       _downloadStatus = AppLocale.systemsUpdateCancelling.getString(context);
@@ -240,15 +257,17 @@ class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
                                 ),
                               ],
                             ),
-                            SizedBox(height: 12.r),
-                            GamepadControl(
-                              iconPath:
-                                  'assets/images/gamepad/Xbox_B_button.png',
-                              label: AppLocale.cancel.getString(context),
-                              onTap: _cancelRequested ? null : _requestCancel,
-                              backgroundColor: theme.colorScheme.tertiary,
-                              textColor: theme.colorScheme.onSurface,
-                            ),
+                            if (!_isSyncing) ...[
+                              SizedBox(height: 12.r),
+                              GamepadControl(
+                                iconPath:
+                                    'assets/images/gamepad/Xbox_B_button.png',
+                                label: AppLocale.cancel.getString(context),
+                                onTap: _cancelRequested ? null : _requestCancel,
+                                backgroundColor: theme.colorScheme.tertiary,
+                                textColor: theme.colorScheme.onSurface,
+                              ),
+                            ],
                           ],
                         ),
                       ] else ...[
@@ -299,8 +318,9 @@ class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
     });
 
     SystemsUpdateResult? result;
+    final run = widget.runner ?? SystemsUpdateService.checkAndUpdate;
     try {
-      result = await SystemsUpdateService.checkAndUpdate(
+      result = await run(
         // checkForUpdate already resolved these to open this dialog.
         knownUpdate: widget.updateInfo,
         onProgress: (progress, status) {
@@ -330,6 +350,7 @@ class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
 
     if (result != null) {
       setState(() {
+        _isSyncing = true;
         _downloadStatus = AppLocale.systemsUpdateSyncing.getString(context);
       });
       await SqliteService.loadAndSyncSystems();

--- a/lib/widgets/systems_update_dialog.dart
+++ b/lib/widgets/systems_update_dialog.dart
@@ -23,6 +23,7 @@ class SystemsUpdateDialog extends StatefulWidget {
 
 class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
   bool _isDownloading = false;
+  bool _cancelRequested = false;
   double _downloadProgress = 0.0;
   String _downloadStatus = '';
   late final GamepadNavigation _gamepadNav;
@@ -63,10 +64,23 @@ class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
     _gamepadNav.dispose();
   }
 
+  /// B during a download requests cancellation rather than doing nothing; the
+  /// in-flight batch tears itself down and `_startUpdate` pops the dialog.
   void _closeDialog() {
-    if (_isDownloading) return;
+    if (_isDownloading) {
+      _requestCancel();
+      return;
+    }
     _cleanupGamepad();
     Navigator.of(context).pop(false);
+  }
+
+  void _requestCancel() {
+    if (_cancelRequested) return;
+    setState(() {
+      _cancelRequested = true;
+      _downloadStatus = AppLocale.systemsUpdateCancelling.getString(context);
+    });
   }
 
   @override
@@ -226,6 +240,15 @@ class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
                                 ),
                               ],
                             ),
+                            SizedBox(height: 12.r),
+                            GamepadControl(
+                              iconPath:
+                                  'assets/images/gamepad/Xbox_B_button.png',
+                              label: AppLocale.cancel.getString(context),
+                              onTap: _cancelRequested ? null : _requestCancel,
+                              backgroundColor: theme.colorScheme.tertiary,
+                              textColor: theme.colorScheme.onSurface,
+                            ),
                           ],
                         ),
                       ] else ...[
@@ -270,6 +293,7 @@ class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
   Future<void> _startUpdate() async {
     setState(() {
       _isDownloading = true;
+      _cancelRequested = false;
       _downloadProgress = 0.0;
       _downloadStatus = '';
     });
@@ -278,19 +302,29 @@ class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
     try {
       result = await SystemsUpdateService.checkAndUpdate(
         onProgress: (progress, status) {
-          if (mounted) {
+          // Once cancellation is requested the status line belongs to the
+          // cancelling message — don't let trailing progress overwrite it.
+          if (mounted && !_cancelRequested) {
             setState(() {
               _downloadProgress = progress;
               _downloadStatus = status;
             });
           }
         },
+        shouldCancel: () => _cancelRequested,
       );
     } catch (e) {
       _log.e('SystemsUpdateDialog: download failed', error: e);
     }
 
     if (!mounted) return;
+
+    // A cancel is a deliberate user action, not a failure — close quietly.
+    if (_cancelRequested) {
+      _cleanupGamepad();
+      Navigator.of(context).pop(false);
+      return;
+    }
 
     if (result != null) {
       setState(() {

--- a/lib/widgets/systems_update_dialog.dart
+++ b/lib/widgets/systems_update_dialog.dart
@@ -301,6 +301,8 @@ class _SystemsUpdateDialogState extends State<SystemsUpdateDialog> {
     SystemsUpdateResult? result;
     try {
       result = await SystemsUpdateService.checkAndUpdate(
+        // checkForUpdate already resolved these to open this dialog.
+        knownUpdate: widget.updateInfo,
         onProgress: (progress, status) {
           // Once cancellation is requested the status line belongs to the
           // cancelling message — don't let trailing progress overwrite it.

--- a/test/bounded_concurrency_test.dart
+++ b/test/bounded_concurrency_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:neostation/utils/bounded_concurrency.dart';
 

--- a/test/bounded_concurrency_test.dart
+++ b/test/bounded_concurrency_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/bounded_concurrency.dart';
+
+void main() {
+  group('runBounded', () {
+    test('processes every item exactly once', () async {
+      final items = List.generate(50, (i) => i);
+      final seen = <int>[];
+
+      await runBounded<int>(items, 6, (item) async {
+        seen.add(item);
+      });
+
+      expect(seen.length, items.length);
+      expect(seen.toSet(), items.toSet());
+    });
+
+    test('never exceeds the concurrency limit', () async {
+      var inFlight = 0;
+      var peak = 0;
+
+      await runBounded<int>(List.generate(40, (i) => i), 6, (_) async {
+        inFlight++;
+        if (inFlight > peak) peak = inFlight;
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        inFlight--;
+      });
+
+      expect(peak, lessThanOrEqualTo(6));
+      // Sanity check that work really did overlap, so the bound above is
+      // meaningful rather than trivially satisfied by serial execution.
+      expect(peak, greaterThan(1));
+    });
+
+    test('uses fewer workers than the limit when items are scarce', () async {
+      var peak = 0;
+      var inFlight = 0;
+
+      await runBounded<int>([1, 2], 8, (_) async {
+        inFlight++;
+        if (inFlight > peak) peak = inFlight;
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        inFlight--;
+      });
+
+      expect(peak, lessThanOrEqualTo(2));
+    });
+
+    test('a failing task does not abort the batch', () async {
+      final completed = <int>[];
+
+      await runBounded<int>(List.generate(10, (i) => i), 3, (item) async {
+        if (item.isEven) throw StateError('boom $item');
+        completed.add(item);
+      });
+
+      expect(completed.toSet(), {1, 3, 5, 7, 9});
+    });
+
+    test('reports progress once per item, including failures', () async {
+      var progress = 0;
+
+      await runBounded<int>(List.generate(10, (i) => i), 4, (item) async {
+        if (item.isEven) throw StateError('boom $item');
+      }, onEach: () => progress++);
+
+      expect(progress, 10);
+    });
+
+    test('returns immediately for an empty item list', () async {
+      var called = false;
+
+      await runBounded<int>([], 4, (_) async => called = true);
+
+      expect(called, isFalse);
+    });
+  });
+}

--- a/test/systems_update_dialog_test.dart
+++ b/test/systems_update_dialog_test.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/services/systems_update_service.dart';
+import 'package:neostation/widgets/systems_update_dialog.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+
+    // Stub the gamepads plugin so GamepadNavigation.initialize() finds no
+    // devices instead of relying on a real platform channel.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('xyz.luan/gamepads'),
+          (call) async => <dynamic>[],
+        );
+
+    await FlutterLocalization.instance.ensureInitialized();
+    FlutterLocalization.instance.init(
+      mapLocales: [MapLocale('en', AppLocale.en)],
+      initLanguageCode: 'en',
+    );
+  });
+
+  const updateInfo = SystemsUpdateInfo(
+    currentVersion: '0.3.9',
+    remoteVersion: '0.3.11',
+  );
+
+  // Matches ScreenUtilInit in main.dart. At the RG DS's 640x480 panel the
+  // scale factor is therefore exactly 1.0, which is the tightest case the
+  // dialog ever sees — larger screens scale it up proportionally.
+  const appDesignSize = Size(640, 480);
+
+  /// Pumps the dialog at [size] with an injected [runner].
+  ///
+  /// The RG DS is the smallest panel the app targets, and the download state is
+  /// the tallest the dialog ever gets, so 640x480 is the case worth pinning.
+  Future<void> pumpDialog(
+    WidgetTester tester, {
+    required SystemsUpdateRunner runner,
+    Size size = const Size(640, 480),
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: MediaQueryData(size: size),
+        child: ScreenUtilInit(
+          designSize: appDesignSize,
+          builder: (context, child) => MaterialApp(
+            localizationsDelegates:
+                FlutterLocalization.instance.localizationsDelegates,
+            supportedLocales: FlutterLocalization.instance.supportedLocales,
+            home: Scaffold(
+              body: SystemsUpdateDialog(updateInfo: updateInfo, runner: runner),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// A runner that never completes, parking the dialog in its download state.
+  SystemsUpdateRunner pendingRunner({
+    void Function(bool Function()? shouldCancel)? capture,
+    void Function(void Function(double, String)? onProgress)? captureProgress,
+  }) {
+    return ({knownUpdate, onProgress, shouldCancel}) {
+      capture?.call(shouldCancel);
+      captureProgress?.call(onProgress);
+      return Completer<SystemsUpdateResult?>().future;
+    };
+  }
+
+  testWidgets('idle dialog fits a 640x480 panel', (tester) async {
+    await pumpDialog(tester, runner: pendingRunner());
+
+    expect(find.text('UPDATE NOW'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('download state fits a 640x480 panel', (tester) async {
+    await pumpDialog(tester, runner: pendingRunner());
+
+    await tester.tap(find.text('UPDATE NOW'));
+    await tester.pump();
+
+    // The download state adds a progress bar and a cancel row over the idle
+    // layout; an overflow here would surface as a RenderFlex exception.
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('cancel control is offered while downloading', (tester) async {
+    await pumpDialog(tester, runner: pendingRunner());
+
+    expect(find.text('Cancel'), findsNothing);
+
+    await tester.tap(find.text('UPDATE NOW'));
+    await tester.pump();
+
+    expect(find.text('Cancel'), findsOneWidget);
+  });
+
+  testWidgets('tapping cancel flips the shouldCancel signal', (tester) async {
+    bool Function()? captured;
+    await pumpDialog(
+      tester,
+      runner: pendingRunner(capture: (s) => captured = s),
+    );
+
+    await tester.tap(find.text('UPDATE NOW'));
+    await tester.pump();
+
+    expect(captured, isNotNull);
+    expect(captured!(), isFalse);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pump();
+
+    expect(captured!(), isTrue);
+  });
+
+  testWidgets('progress updates drive the status line', (tester) async {
+    void Function(double, String)? progress;
+    await pumpDialog(
+      tester,
+      runner: pendingRunner(captureProgress: (p) => progress = p),
+    );
+
+    await tester.tap(find.text('UPDATE NOW'));
+    await tester.pump();
+
+    progress!(0.5, 'Downloading systems (60/121)...');
+    await tester.pump();
+
+    expect(find.text('Downloading systems (60/121)...'), findsOneWidget);
+    expect(find.text('50%'), findsOneWidget);
+  });
+
+  testWidgets('cancelling freezes the status line at cancelling', (
+    tester,
+  ) async {
+    void Function(double, String)? progress;
+    await pumpDialog(
+      tester,
+      runner: pendingRunner(captureProgress: (p) => progress = p),
+    );
+
+    await tester.tap(find.text('UPDATE NOW'));
+    await tester.pump();
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pump();
+
+    // Downloads already in flight keep reporting; they must not overwrite the
+    // cancelling message.
+    progress!(0.9, 'Downloading systems (110/121)...');
+    await tester.pump();
+
+    expect(find.text('Cancelling...'), findsOneWidget);
+    expect(find.text('Downloading systems (110/121)...'), findsNothing);
+  });
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

The systems update downloaded all ~120 definition files **strictly serially**, using the top-level `http.get` helper — which builds and closes a `Client` per call, so no connection was ever reused. Every file paid a full DNS/TCP/TLS handshake plus a round trip.

This was never a bandwidth problem: the whole set is ~865 KB across 121 files (~7 KB each). Measured per-file cost was `connect=25ms tls=44ms ttfb=236ms` — almost entirely latency. Measured over the full set on a wired connection:

| strategy | wall clock |
| --- | --- |
| serial, new connection each (before) | ~21–24 s |
| serial with keep-alive | 15.2 s |
| bounded pool of 8 (after) | ~1 s |

**On device the download went from 39.6 s to 4.3 s (AYN Thor, ~9x).**

The batch now runs through a bounded pool over a single reused `http.Client`, each request with a 15 s timeout — previously the manifest and file-list calls were bounded but the per-file gets were not, so one stalled connection could hang the update indefinitely with no way out.

Alongside that:

- **Cancel.** B was dead during a download (`_closeDialog` returned early on `_isDownloading`) and there was no cancel control, so a slow or stalled update left the user staring at a frozen progress bar. Uses the `shouldCancel` convention `ScreenScraper`'s downloader already follows.
- **Partial downloads no longer strand files.** `systems_version` was advanced whenever *at least one* file downloaded, so a partial run left the failed files permanently stale — nothing would ever consider them out of date again. It now advances only on a full set, and logs the shortfall.
- **One less round trip.** `checkForUpdate()` already fetched the manifest and compared versions to open the dialog; pressing "Update Now" re-fetched and re-compared all of it.
- **Shared pool helper.** `NeoAssetsService` already had a private `_runBounded` for theme assets; it moved to `lib/utils/bounded_concurrency.dart` rather than being duplicated.

## Steps to Reproduce

Preconditions: the stored `systems_version` must be **lower than the remote manifest**, so an update is pending. Both the bundled and stored versions have to be lowered — `_syncBundledVersion()` runs on every launch and fast-forwards the DB to the bundled version, so lowering only the DB does nothing.

1. Set `latest_version` in `assets/manifest.json` to a value below the remote manifest (e.g. `0.3.9` against a remote `0.3.11`) and build.
2. Install the build **without launching it** — launching first re-runs the fast-forward.
3. Set the stored version to match: `UPDATE user_config SET systems_version='0.3.9'` in the app's `user-data/data.sqlite`.
4. Launch. The systems-update dialog appears offering the remote version.
5. Press A and time the log between `SystemsUpdateService: new version …` and `SystemsUpdateService: updated N files …`.

**Observed (before):** ~40 s on an Android handheld, over a minute on slower Wi-Fi, with B doing nothing and no way to cancel.
**Expected (after):** a few seconds, cancellable at any point.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

Tested end to end on an **AYN Thor** (Android) and a **Steam Deck** (SteamOS): 121/121 files, no download failures, `systems_version` advanced correctly. Deck took ~5 s. Gamepad: B cancels an in-progress download; the cancel control carries the B glyph and A still starts the update.

12 new tests (`bounded_concurrency_test.dart`, `systems_update_dialog_test.dart`); 555 pass locally.

The dialog's 640x480 layout is covered by a widget test rather than a screenshot — that is `main.dart`'s ScreenUtil `designSize`, so the RG DS panel renders at exactly 1.0 scale, the tightest case the dialog sees. The overflow assertions were confirmed to actually fire (a deliberately shrunk panel reports `RenderFlex overflowed by 54 pixels`), so they are not passing vacuously.

## Notes for review

Two tradeoffs worth a look:

1. **`knownUpdate` moves the app-version gate to check time.** Passing the already-resolved `SystemsUpdateInfo` skips re-fetching the manifest, but the file list is still fetched live at download time. If the remote manifest changes while the dialog sits open, the app downloads the current files while recording the older version, and skips a newly-raised `neostation_minimum_version`. Self-correcting (the next check re-offers the update) but a real behaviour change, not a pure optimisation.
2. **Pool size 8** was tuned against the live endpoint (454/307/293/199/176 ms at 4/6/8/12/16 for the full set) and matches the pool `NeoAssetsService` already uses. Gains past 8 are real but small, and not worth the extra concurrent sockets on a handheld's Wi-Fi stack. On a genuinely bad link, concurrency plus the new 15 s timeout could turn a slow-but-working download into partial failures — which is precisely why the `systems_version` fix above matters.
