### PR TITLE
fix: stop B from prompting to exit on the systems tab

### DIFF
--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -1,9 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_localization/flutter_localization.dart';
-import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
-import 'package:neostation/l10n/app_locale.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:neostation/utils/nav_tabs.dart';
 import 'package:neostation/models/config_model.dart';
@@ -24,7 +20,6 @@ import '../widgets/scraper_content.dart';
 import 'package:neostation/services/game_service.dart';
 import 'package:neostation/providers/theme_provider.dart';
 import 'package:neostation/repositories/emulator_repository.dart';
-import 'package:neostation/widgets/confirm_action_dialog.dart';
 import 'dart:async';
 import 'dart:io';
 
@@ -86,11 +81,6 @@ class AppNavigation {
   static void previousTab() {
     AppScreenState._navigateToPreviousTabStatic();
   }
-
-  /// Requests the root-level exit confirmation from the active home layout.
-  static void requestExit() {
-    AppScreenState._currentInstance?._handleBackNavigation();
-  }
 }
 
 class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
@@ -104,8 +94,6 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
 
   /// Input orchestration layer for gamepad and keyboard support.
   late GamepadNavigation _gamepadNav;
-
-  bool _exitConfirmationOpen = false;
 
   /// Static reference to the currently active instance for global access.
   static AppScreenState? _currentInstance;
@@ -448,32 +436,8 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
   }
 
   void _handleBackNavigation() {
-    if (_selectedTabIndex == AppTabs.systems && !Platform.isAndroid) {
-      unawaited(_confirmExitApplication());
-    } else if (_selectedTabIndex == AppTabs.scraper) {
+    if (_selectedTabIndex == AppTabs.scraper) {
       NewScraperOptionsScreen.backCurrent();
-    }
-  }
-
-  Future<void> _confirmExitApplication() async {
-    if (_exitConfirmationOpen || !mounted) return;
-    _exitConfirmationOpen = true;
-
-    final confirmed = await ConfirmActionDialog.show(
-      context,
-      title: AppLocale.exitApplication.getString(context),
-      body: AppLocale.exitConfirmation.getString(context),
-      confirmLabel: AppLocale.confirmExit.getString(context),
-      icon: Symbols.exit_to_app_rounded,
-    );
-
-    _exitConfirmationOpen = false;
-    if (!confirmed || !mounted) return;
-
-    if (Platform.isAndroid) {
-      SystemNavigator.pop();
-    } else {
-      exit(0);
     }
   }
 

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -180,7 +180,6 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
       onNavigateRight: _navigateNext,
       onSelectItem: _selectCurrentSystem,
       onSettings: _openSystemSettingsFromCarousel,
-      onBack: AppNavigation.requestExit,
       onXButton: () {
         HeaderSortDropdown.globalKey.currentState?.showDropdown();
       },

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid/gamepad_grid_nav.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid/gamepad_grid_nav.dart
@@ -38,7 +38,6 @@ extension _GamepadGridNav on _SystemCardGridViewState {
       },
       onSelectItem: () => widget.onEnterPressed?.call(),
       onSettings: () => widget.onEscapePressed?.call(),
-      onBack: AppNavigation.requestExit,
       onXButton: () {
         HeaderSortDropdown.globalKey.currentState?.showDropdown();
       },


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Pressing **B** on the Systems tab pops an "Exit Application" confirmation dialog on desktop platforms. Since the Systems tab is the first tab — where the app lands at startup — the very first back press offers to quit the app rather than doing nothing.

This was introduced by #271, which wired the systems grid and carousel's `onBack` to a new root-level `AppNavigation.requestExit()`. The handler is gated `!Platform.isAndroid`, which is why it only shows on Windows/Linux/macOS (very visible on the Steam Deck, where B is the natural "go back" reflex).

This PR restores the pre-#271 behaviour: B is unbound on the Systems tab.

- Removed `onBack: AppNavigation.requestExit` from `my_systems_grid/gamepad_grid_nav.dart` and `my_systems_carousel.dart`.
- Removed `AppNavigation.requestExit()`, `_confirmExitApplication()` and the `_exitConfirmationOpen` guard from `app_screen.dart`; `_handleBackNavigation()` again only handles the Scraper tab.
- Dropped the imports that became unused in `app_screen.dart`.

Exiting is unchanged everywhere it was already offered — **Settings → Exit** still shows the same confirmation dialog, so the `exit_application` / `exit_confirmation` / `confirm_exit` locale strings are all still in use and were left in place. Android was never affected.

Fixes # (issue) — no filed issue; reported on the Steam Deck.

## Steps to Reproduce

**Preconditions:** a desktop build (Linux/Windows/macOS — the code path is gated `!Platform.isAndroid`), at least one system in the library so the Systems tab renders the grid or carousel, and a connected gamepad.

1. Launch NeoStation on a desktop platform and let it settle on the **Systems** tab (the default first tab).
2. Move the selection with the D-pad so the systems grid/carousel owns gamepad focus.
3. Press **B** (or <kbd>Backspace</kbd>).

**Observed (before this PR):** an "Exit Application" / "Are you sure you want to exit NeoStation?" dialog appears; confirming quits the app.
**Expected (after this PR):** nothing happens — B is a back action, and there is nothing to go back to from the first tab. Quitting stays an explicit choice under Settings → Exit.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. — behavioural gamepad-nav wiring; verified on device instead (all 555 existing tests pass)
- [ ] I have updated the corresponding documentation. — no docs describe this binding
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. — no new assets
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [ ] Android
- [x] **Gamepad support verified** (if applicable).

Built and installed on a Steam Deck (Linux/SteamOS, Game Mode, physical gamepad) for verification: B on the Systems tab is inert, while tab switching with the bumpers, X for the sort dropdown, A to enter a system, and Settings → Exit are untouched by this change. The other gamepad bindings on those two views are unchanged — only the `onBack` entry was removed from each `GamepadNavigation`.

## Screenshots (if applicable)

N/A — the change removes a dialog; there is nothing new to show.
