### PR TITLE
fix: paint startup and the secondary panel in the user's theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:neostation/services/steam_scraper_service.dart';
 import 'package:neostation/providers/system_background_provider.dart';
 import 'package:neostation/providers/neo_assets_provider.dart';
 import 'package:neostation/widgets/app_lifecycle_handler.dart';
+import 'package:neostation/services/startup_theme_cache.dart';
 import 'package:neostation/widgets/shimmering_logo.dart';
 import 'package:neostation/widgets/permission_check_wrapper.dart';
 import 'package:neostation/utils/custom_scroll_behavior.dart';
@@ -352,6 +353,12 @@ void main() async {
     }
   }
 
+  // Resolve the saved theme before the first themed frame. Created lazily,
+  // ThemeProvider would paint its platform-brightness fallback until the
+  // database read returned — a white flash on any platform that reports a
+  // light brightness (the Steam Deck does) for a user on a dark theme.
+  final themeProvider = await ThemeProvider.create();
+
   // Build NeoSync provider graph before runApp so SyncManager can register it.
   final neoSyncService = NeoSyncService();
   final neoSyncProvider = NeoSyncProvider(neoSyncService);
@@ -374,6 +381,7 @@ void main() async {
       sqliteDatabaseProvider: sqliteDatabaseProvider,
       neoSyncService: neoSyncService,
       neoSyncProvider: neoSyncProvider,
+      themeProvider: themeProvider,
     ),
   );
 
@@ -423,14 +431,20 @@ String _startupString(String key) {
 
 /// Shared chrome for the pre-initialization screens: logo, wordmark and a
 /// caller-supplied status area.
-class _StartupScaffold extends StatelessWidget {
+///
+/// These screens run before the database is readable, so they cannot ask
+/// [ThemeProvider] for the selected theme. They read the palette mirrored into
+/// [StartupThemeCache] on the last theme change instead, which keeps the whole
+/// intro in the user's theme rather than always-dark chrome.
+class _StartupScaffold extends StatefulWidget {
   const _StartupScaffold({
-    required this.children,
+    required this.childrenBuilder,
     this.onKeyEvent,
     this.animatedLogo = false,
   });
 
-  final List<Widget> children;
+  /// Builds the status area, given the resolved startup palette.
+  final List<Widget> Function(StartupThemeColors colors) childrenBuilder;
 
   /// Show the shimmering logo instead of the static one. Used by the loading
   /// screen, where the shine doubles as the activity indicator; the error
@@ -443,24 +457,45 @@ class _StartupScaffold extends StatelessWidget {
   final KeyEventResult Function(KeyEvent)? onKeyEvent;
 
   @override
+  State<_StartupScaffold> createState() => _StartupScaffoldState();
+}
+
+class _StartupScaffoldState extends State<_StartupScaffold> {
+  /// Starts on the dark chrome — the same color the Android splash hands over
+  /// — and is replaced once the cache read returns. That read is a fast
+  /// preferences lookup, so on a light theme the handoff lands within the
+  /// first frames rather than being visible as a change of screen.
+  StartupThemeColors _colors = StartupThemeColors.fallback;
+
+  @override
+  void initState() {
+    super.initState();
+    StartupThemeCache.load().then((colors) {
+      if (mounted) setState(() => _colors = colors);
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final children = widget.childrenBuilder(_colors);
     return MaterialApp(
       debugShowCheckedModeBanner: false,
+      theme: _colors.themeData,
       home: Scaffold(
-        // Matches the dark theme's scaffold color so the handoff into the
+        // Matches the selected theme's scaffold color so the handoff into the
         // themed splash doesn't read as a background jump.
-        backgroundColor: const Color(0xFF15191e),
+        backgroundColor: _colors.background,
         body: Focus(
-          autofocus: onKeyEvent != null,
-          onKeyEvent: onKeyEvent == null
+          autofocus: widget.onKeyEvent != null,
+          onKeyEvent: widget.onKeyEvent == null
               ? null
-              : (_, event) => onKeyEvent!(event),
+              : (_, event) => widget.onKeyEvent!(event),
           // Animated mode pins the logo at the exact screen centre — the same
           // spot the Android 12+ splash icon occupies — with the status text
           // hung below centre, so the native→Flutter handoff and the later
           // screens never move the logo. The error screen keeps the simpler
           // centred column with the wordmark.
-          child: animatedLogo
+          child: widget.animatedLogo
               ? Stack(
                   children: [
                     const Center(child: ShimmeringLogo()),
@@ -490,10 +525,10 @@ class _StartupScaffold extends StatelessWidget {
                           height: 112,
                         ),
                         const SizedBox(height: 24),
-                        const Text(
+                        Text(
                           'NeoStation',
                           style: TextStyle(
-                            color: Colors.white,
+                            color: _colors.foreground,
                             fontSize: 28,
                             fontWeight: FontWeight.w600,
                             letterSpacing: 1.2,
@@ -547,7 +582,7 @@ class _StartupLoadingAppState extends State<StartupLoadingApp> {
   Widget build(BuildContext context) {
     return _StartupScaffold(
       animatedLogo: true,
-      children: [
+      childrenBuilder: (colors) => [
         AnimatedOpacity(
           opacity: _showText ? 1.0 : 0.0,
           duration: const Duration(milliseconds: 400),
@@ -560,7 +595,7 @@ class _StartupLoadingAppState extends State<StartupLoadingApp> {
               // small and dimmed. GoogleFonts falls back gracefully for the
               // first frames if the font isn't warmed up yet.
               style: GoogleFonts.anta(
-                color: Colors.white.withValues(alpha: 0.6),
+                color: colors.foreground.withValues(alpha: 0.6),
                 fontSize: 17,
                 letterSpacing: 0.3,
               ),
@@ -609,7 +644,7 @@ class StartupStorageErrorApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return _StartupScaffold(
       onKeyEvent: _handleKey,
-      children: [
+      childrenBuilder: (colors) => [
         ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 520),
           child: Column(
@@ -618,15 +653,18 @@ class StartupStorageErrorApp extends StatelessWidget {
               Text(
                 _startupString(AppLocale.startupStorageUnavailable),
                 textAlign: TextAlign.center,
-                style: const TextStyle(color: Color(0xFFC4CBD6), fontSize: 16),
+                style: TextStyle(
+                  color: colors.foreground.withValues(alpha: 0.8),
+                  fontSize: 16,
+                ),
               ),
               if (storagePath != null && storagePath!.isNotEmpty) ...[
                 const SizedBox(height: 12),
                 Text(
                   storagePath!,
                   textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: Color(0xFF8A93A3),
+                  style: TextStyle(
+                    color: colors.foreground.withValues(alpha: 0.55),
                     fontSize: 13,
                   ),
                 ),
@@ -698,13 +736,18 @@ Future<void> subDisplay() async {
   // localization independently — otherwise AppLocale.getString() falls back to
   // raw keys here. Mirror the persisted-language init done in main().
   String initLang = 'en';
+  // The main engine only pushes the theme name once it has state to share, so
+  // without this the display would open on the brightness fallback (black)
+  // even for a user on a light theme. Read it from the same config row.
+  String? initThemeName;
   try {
     final rawConfig = await ConfigRepository.getUserConfig();
     if (rawConfig != null && rawConfig['app_language'] != null) {
       initLang = rawConfig['app_language'].toString();
     }
+    initThemeName = rawConfig?['theme_name']?.toString();
   } catch (e) {
-    debugPrint('Secondary display could not load saved language: $e');
+    debugPrint('Secondary display could not load saved config: $e');
   }
   await FlutterLocalization.instance.ensureInitialized();
   FlutterLocalization.instance.init(
@@ -725,7 +768,7 @@ Future<void> subDisplay() async {
     initLanguageCode: initLang.isNotEmpty ? initLang : 'en',
   );
 
-  runApp(const SecondaryScreen());
+  runApp(SecondaryScreen(initialThemeName: initThemeName));
 }
 
 /// Provides MaterialLocalizations as a fallback for locales that Flutter's
@@ -757,6 +800,10 @@ class MyApp extends StatefulWidget {
   final NeoSyncService neoSyncService;
   final NeoSyncProvider neoSyncProvider;
 
+  /// Built in `main()` with the saved theme already resolved, so the first
+  /// frame paints in the user's theme rather than the brightness fallback.
+  final ThemeProvider themeProvider;
+
   const MyApp({
     super.key,
     required this.fileProvider,
@@ -765,6 +812,7 @@ class MyApp extends StatefulWidget {
     required this.sqliteDatabaseProvider,
     required this.neoSyncService,
     required this.neoSyncProvider,
+    required this.themeProvider,
   });
 
   @override
@@ -803,7 +851,7 @@ class _MyAppState extends State<MyApp> {
         ChangeNotifierProvider.value(value: SyncManager.instance),
         ChangeNotifierProvider(create: (context) => BillingService()),
         ChangeNotifierProvider(create: (context) => NotificationService()),
-        ChangeNotifierProvider(create: (context) => ThemeProvider()),
+        ChangeNotifierProvider.value(value: widget.themeProvider),
         ChangeNotifierProvider(create: (context) => ScrapingProvider()),
         ChangeNotifierProvider(
           // Eager (not lazy): auto-login must run at startup so RA is connected

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -4,6 +4,7 @@ import 'package:neostation/services/logger_service.dart';
 import 'package:flutter/material.dart';
 import 'package:neostation/themes/app_themes.dart';
 import 'package:neostation/services/custom_theme_service.dart';
+import 'package:neostation/services/startup_theme_cache.dart';
 import 'package:neostation/repositories/config_repository.dart';
 
 /// Provider responsible for managing the application's visual theme.
@@ -82,9 +83,22 @@ class ThemeProvider extends ChangeNotifier with WidgetsBindingObserver {
     'horizon': 'Horizon',
   };
 
-  ThemeProvider() {
-    _loadSavedTheme();
+  ThemeProvider._() {
     WidgetsBinding.instance.addObserver(this);
+  }
+
+  /// Builds a provider whose saved theme is already resolved.
+  ///
+  /// Deliberately the only way to construct one: resolving the theme after
+  /// construction leaves the first frames on the platform-brightness fallback,
+  /// and on a device whose OS reports a light brightness (the Steam Deck does)
+  /// that fallback is the light theme — a white flash for anyone on a dark
+  /// theme. Awaiting this before `runApp` means the very first painted frame
+  /// already uses the user's theme.
+  static Future<ThemeProvider> create() async {
+    final provider = ThemeProvider._();
+    await provider._loadSavedTheme();
+    return provider;
   }
 
   @override
@@ -99,8 +113,16 @@ class ThemeProvider extends ChangeNotifier with WidgetsBindingObserver {
     if (_currentThemeName == 'system') {
       _log.i('Platform brightness changed, updating system theme...');
       _updateSystemTheme();
-      notifyListeners();
+      _notifyThemeChanged();
     }
+  }
+
+  /// Notifies listeners and mirrors the resolved palette for the startup
+  /// screens. Every theme change goes through here, so those screens are never
+  /// a launch behind the user's choice.
+  void _notifyThemeChanged() {
+    StartupThemeCache.save(currentTheme);
+    notifyListeners();
   }
 
   /// Internal logic to resolve the appropriate theme based on system brightness.
@@ -136,15 +158,15 @@ class ThemeProvider extends ChangeNotifier with WidgetsBindingObserver {
       if (savedThemeName == 'system') {
         _currentThemeName = 'system';
         _updateSystemTheme();
-        notifyListeners();
+        _notifyThemeChanged();
       } else if (availableThemes.containsKey(savedThemeName)) {
         _currentTheme = availableThemes[savedThemeName]!;
         _currentThemeName = savedThemeName;
-        notifyListeners();
+        _notifyThemeChanged();
       } else if (AppThemes.customThemes.containsKey(savedThemeName)) {
         _currentTheme = AppThemes.customThemes[savedThemeName]!.themeData;
         _currentThemeName = savedThemeName;
-        notifyListeners();
+        _notifyThemeChanged();
       } else {
         // The previously selected theme is no longer available (e.g. removed
         // in an update). Fall back to the system theme and persist it.
@@ -154,7 +176,7 @@ class ThemeProvider extends ChangeNotifier with WidgetsBindingObserver {
         _currentThemeName = 'system';
         _updateSystemTheme();
         await ConfigRepository.updateThemeName('system');
-        notifyListeners();
+        _notifyThemeChanged();
       }
     } catch (e) {
       _log.e('Error loading saved theme: $e');
@@ -175,7 +197,7 @@ class ThemeProvider extends ChangeNotifier with WidgetsBindingObserver {
         _log.e('Error saving theme: $e');
       }
 
-      notifyListeners();
+      _notifyThemeChanged();
       return;
     }
 
@@ -192,7 +214,7 @@ class ThemeProvider extends ChangeNotifier with WidgetsBindingObserver {
         _log.e('Error saving theme: $e');
       }
 
-      notifyListeners();
+      _notifyThemeChanged();
     }
   }
 

--- a/lib/screens/secondary_screen/background_builders.dart
+++ b/lib/screens/secondary_screen/background_builders.dart
@@ -216,9 +216,16 @@ Widget _withFanartDim(Widget art, SecondaryDisplayStateData value) {
 }
 
 Widget buildShaderFallback(SecondaryDisplayStateData value) {
-  return Container(
-    color: value.backgroundColor != null
-        ? Color(value.backgroundColor!)
-        : Colors.black,
+  if (value.backgroundColor != null) {
+    return Container(color: Color(value.backgroundColor!));
+  }
+  // No background pushed yet — the WELCOME screen during startup, before the
+  // main engine has sent one. Falling back to the theme rather than a hardcoded
+  // black keeps the panel in the user's theme instead of showing a dark screen
+  // for the whole of the boot. OLED resolves to black here anyway, so the
+  // empty-case OLED look described above is preserved.
+  return Builder(
+    builder: (context) =>
+        Container(color: Theme.of(context).scaffoldBackgroundColor),
   );
 }

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -24,7 +24,12 @@ import 'widgets/app_dock.dart';
 import 'widgets/now_playing_panel.dart';
 
 class SecondaryScreen extends StatefulWidget {
-  const SecondaryScreen({super.key});
+  const SecondaryScreen({super.key, this.initialThemeName});
+
+  /// Theme name read from the database by this engine's entrypoint, used until
+  /// the main engine pushes its state. Without it the display would open on
+  /// the platform-brightness fallback — black on a light theme.
+  final String? initialThemeName;
 
   @override
   State<SecondaryScreen> createState() => _SecondaryScreenState();
@@ -734,7 +739,9 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
       builder: (_, child) => ValueListenableBuilder<SecondaryDisplayStateData?>(
         valueListenable: _secondaryDisplayState ?? ValueNotifier(null),
         builder: (context, value, child) {
-          final theme = resolveTheme(value?.themeName);
+          final theme = resolveTheme(
+            value?.themeName ?? widget.initialThemeName,
+          );
           return MaterialApp(
             debugShowCheckedModeBanner: false,
             localizationsDelegates:
@@ -758,9 +765,12 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                 // so the _buildXxx helpers can resolve AppLocale strings.
                 _l10nContext = context;
                 return Scaffold(
+                  // Falls back to the resolved theme rather than black: before
+                  // the main engine pushes a background, a light-theme user
+                  // would otherwise get a black panel on startup.
                   backgroundColor: value?.backgroundColor != null
                       ? Color(value!.backgroundColor!)
-                      : Colors.black,
+                      : theme.scaffoldBackgroundColor,
                   body: value == null
                       ? _buildDefaultStaticUI()
                       : Stack(

--- a/lib/services/startup_theme_cache.dart
+++ b/lib/services/startup_theme_cache.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The few colors the pre-database startup screens paint with.
+///
+/// The selected theme lives in SQLite, which on a cold boot may sit on storage
+/// that has not mounted yet — that is precisely what the startup screens are
+/// waiting for. So the resolved palette is mirrored into SharedPreferences
+/// (always-available internal storage) whenever the theme changes, and read
+/// back from there on the next launch.
+@immutable
+class StartupThemeColors {
+  const StartupThemeColors({
+    required this.background,
+    required this.foreground,
+    required this.primary,
+  });
+
+  /// Surface the startup screens fill.
+  final Color background;
+
+  /// Text/icon color used on [background].
+  final Color foreground;
+
+  /// Accent used for the error screen's buttons.
+  final Color primary;
+
+  /// Dark neostation chrome — what a first launch (empty cache) paints, and
+  /// the fallback whenever the cache cannot be read. Values mirror
+  /// `dark_theme.dart` so a default install shows no handoff at all.
+  static const fallback = StartupThemeColors(
+    background: Color(0xFF15191e),
+    foreground: Color(0xFFecf9ff),
+    primary: Color(0xFF605dff),
+  );
+
+  /// Derived from the painted background rather than the theme's own
+  /// brightness flag: custom (imported) themes can pair either one, and it is
+  /// the background that decides whether Material's defaults will be legible.
+  Brightness get brightness =>
+      background.computeLuminance() > 0.5 ? Brightness.light : Brightness.dark;
+
+  /// Minimal theme for the startup screens, so the storage-error screen's
+  /// buttons pick up the user's accent instead of Material's stock purple.
+  ThemeData get themeData => ThemeData(
+    brightness: brightness,
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: primary,
+      brightness: brightness,
+    ),
+  );
+}
+
+/// Persists [StartupThemeColors] across launches.
+class StartupThemeCache {
+  const StartupThemeCache._();
+
+  static const _backgroundKey = 'startup_theme_background';
+  static const _foregroundKey = 'startup_theme_foreground';
+  static const _primaryKey = 'startup_theme_primary';
+
+  /// Reads the cached palette, falling back to the dark chrome when nothing
+  /// has been cached yet (first launch) or the read fails.
+  static Future<StartupThemeColors> load() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final background = prefs.getInt(_backgroundKey);
+      final foreground = prefs.getInt(_foregroundKey);
+      final primary = prefs.getInt(_primaryKey);
+      if (background == null || foreground == null || primary == null) {
+        return StartupThemeColors.fallback;
+      }
+      return StartupThemeColors(
+        background: Color(background),
+        foreground: Color(foreground),
+        primary: Color(primary),
+      );
+    } catch (_) {
+      return StartupThemeColors.fallback;
+    }
+  }
+
+  /// Mirrors [theme]'s startup-relevant colors for the next launch. Failures
+  /// are swallowed: a stale cache only costs a brief mismatched startup
+  /// screen, and this runs on the theme-change path where nothing should throw.
+  static Future<void> save(ThemeData theme) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(
+        _backgroundKey,
+        theme.scaffoldBackgroundColor.toARGB32(),
+      );
+      await prefs.setInt(
+        _foregroundKey,
+        theme.colorScheme.onSurface.toARGB32(),
+      );
+      await prefs.setInt(_primaryKey, theme.colorScheme.primary.toARGB32());
+    } catch (_) {
+      // Ignored — see doc comment.
+    }
+  }
+}

--- a/test/secondary_background_fallback_test.dart
+++ b/test/secondary_background_fallback_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/secondary_display_state.dart';
+import 'package:neostation/screens/secondary_screen/background_builders.dart';
+import 'package:neostation/themes/app_themes.dart';
+
+/// Pumps [child] under a MaterialApp themed with [theme] and reports the
+/// colour the resulting Container paints.
+Future<Color?> _paintedColor(
+  WidgetTester tester,
+  ThemeData theme,
+  Widget child,
+) async {
+  await tester.pumpWidget(MaterialApp(theme: theme, home: child));
+  final container = tester.widget<Container>(find.byType(Container));
+  final decoration = container.decoration;
+  if (decoration is BoxDecoration) return decoration.color;
+  return container.color;
+}
+
+void main() {
+  group('buildShaderFallback', () {
+    // The state the secondary display holds during startup: the main engine
+    // has pushed nothing yet, so there is no background colour to use.
+    final welcome = SecondaryDisplayStateData(systemName: 'WELCOME');
+
+    testWidgets('uses the theme background when none has been pushed', (
+      tester,
+    ) async {
+      // The regression: this used to be a hardcoded Colors.black, which left
+      // a light-theme user staring at a dark panel for the whole boot.
+      final color = await _paintedColor(
+        tester,
+        AppThemes.lightTheme,
+        buildShaderFallback(welcome),
+      );
+
+      expect(color, AppThemes.lightTheme.scaffoldBackgroundColor);
+      expect(color, isNot(Colors.black));
+    });
+
+    testWidgets('still resolves to black under the OLED theme', (tester) async {
+      // buildSystemBackground documents that the empty case preserves the OLED
+      // look; OLED's scaffold colour is pure black, so that holds without a
+      // special case here.
+      final color = await _paintedColor(
+        tester,
+        AppThemes.oledTheme,
+        buildShaderFallback(welcome),
+      );
+
+      expect(color, const Color(0xFF000000));
+    });
+
+    testWidgets('a pushed background colour still wins over the theme', (
+      tester,
+    ) async {
+      const pushed = 0xFF123456;
+      final withBackground = SecondaryDisplayStateData(
+        systemName: 'snes',
+        backgroundColor: pushed,
+      );
+
+      final color = await _paintedColor(
+        tester,
+        AppThemes.lightTheme,
+        buildShaderFallback(withBackground),
+      );
+
+      expect(color, const Color(pushed));
+    });
+  });
+}

--- a/test/startup_theme_cache_test.dart
+++ b/test/startup_theme_cache_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/providers/theme_provider.dart';
+import 'package:neostation/repositories/config_repository.dart';
+import 'package:neostation/services/startup_theme_cache.dart';
+import 'package:neostation/themes/app_themes.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'database_test_helper.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final dbHelper = DatabaseTestHelper();
+
+  setUp(() async {
+    await dbHelper.setUp();
+  });
+
+  tearDown(() async {
+    await dbHelper.tearDown();
+  });
+
+  group('StartupThemeCache', () {
+    test('load falls back to the dark chrome when nothing is cached', () async {
+      final colors = await StartupThemeCache.load();
+
+      expect(colors.background, StartupThemeColors.fallback.background);
+      expect(colors.foreground, StartupThemeColors.fallback.foreground);
+      expect(colors.primary, StartupThemeColors.fallback.primary);
+    });
+
+    test('save then load round-trips the theme palette', () async {
+      await StartupThemeCache.save(AppThemes.lightTheme);
+
+      final colors = await StartupThemeCache.load();
+
+      expect(colors.background, AppThemes.lightTheme.scaffoldBackgroundColor);
+      expect(colors.foreground, AppThemes.lightTheme.colorScheme.onSurface);
+      expect(colors.primary, AppThemes.lightTheme.colorScheme.primary);
+    });
+
+    test('reads a palette written by a previous launch', () async {
+      SharedPreferences.setMockInitialValues({
+        'flutter.startup_theme_background': 0xFFEEEEEE,
+        'flutter.startup_theme_foreground': 0xFF14161A,
+        'flutter.startup_theme_primary': 0xFF605DFF,
+      });
+
+      final colors = await StartupThemeCache.load();
+
+      expect(colors.background, const Color(0xFFEEEEEE));
+      expect(colors.foreground, const Color(0xFF14161A));
+      expect(colors.primary, const Color(0xFF605DFF));
+    });
+
+    test(
+      'a partially written cache falls back rather than half-applying',
+      () async {
+        // Only the background survived. Pairing a cached background with
+        // fallback text is how an illegible startup screen happens, so the
+        // whole palette is discarded instead.
+        SharedPreferences.setMockInitialValues({
+          'flutter.startup_theme_background': 0xFFEEEEEE,
+        });
+
+        final colors = await StartupThemeCache.load();
+
+        expect(colors.background, StartupThemeColors.fallback.background);
+      },
+    );
+
+    test(
+      'brightness follows the cached background, not the theme flag',
+      () async {
+        await StartupThemeCache.save(AppThemes.lightTheme);
+        expect((await StartupThemeCache.load()).brightness, Brightness.light);
+
+        await StartupThemeCache.save(AppThemes.darkTheme);
+        expect((await StartupThemeCache.load()).brightness, Brightness.dark);
+      },
+    );
+  });
+
+  group('ThemeProvider.create', () {
+    test('resolves the saved theme before it is ever read', () async {
+      // The regression this guards: resolving asynchronously left the first
+      // frames on the platform-brightness fallback, which is the *light*
+      // theme on platforms that report a light brightness (the Steam Deck) —
+      // a white flash for anyone on a dark theme.
+      await ConfigRepository.updateThemeName('dark');
+
+      final provider = await ThemeProvider.create();
+
+      expect(provider.currentThemeName, 'dark');
+      expect(
+        provider.currentTheme.scaffoldBackgroundColor,
+        AppThemes.darkTheme.scaffoldBackgroundColor,
+      );
+    });
+
+    test('mirrors the resolved theme into the startup cache', () async {
+      await ConfigRepository.updateThemeName('light');
+
+      await ThemeProvider.create();
+      // The cache write is deliberately not awaited on the startup path.
+      await Future<void>.delayed(Duration.zero);
+
+      final colors = await StartupThemeCache.load();
+      expect(colors.background, AppThemes.lightTheme.scaffoldBackgroundColor);
+    });
+
+    test('falls back to system mode when the saved theme is gone', () async {
+      await ConfigRepository.updateThemeName('a-theme-that-was-removed');
+
+      final provider = await ThemeProvider.create();
+
+      expect(provider.currentThemeName, 'system');
+      // The stale name is rewritten so the warning isn't logged every launch.
+      expect(await ConfigRepository.getThemeName(), 'system');
+    });
+  });
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Three related theme-at-startup bugs, all with the same root shape: something painted before the selected theme was known, and picked a hardcoded or brightness-derived colour instead.

**1. White flash on the Steam Deck.** `ThemeProvider` resolved the saved theme *asynchronously*, so until that database read returned it painted a fallback chosen from the platform brightness (`dark ? darkTheme : lightTheme`). The Deck reports a **light** brightness, so for anyone on a dark theme every frame before the read landed was the light theme — a white flash between the "waiting for storage" screen and the ROM scan. Visible on the Deck specifically because Android handhelds report a dark brightness and the fallback happened to be right there.

`ThemeProvider.create()` now resolves the theme before `runApp`, and is the **only** constructor, so the async path cannot be reintroduced by accident. As a side effect this also fixes custom-theme users, whose theme could not resolve at all until the themes directory had been read off disk.

**2. The startup screens ignored the theme.** They deliberately run before the database is readable — the theme selection lives in SQLite, which on a cold boot may sit on storage that has not mounted yet, which is precisely what those screens are waiting for. So they cannot ask `ThemeProvider`.

New `StartupThemeCache` mirrors the resolved palette (background / foreground / primary) into SharedPreferences — always-available internal storage — on every theme change, and the startup and storage-error screens read it back on the next launch. A fresh install still shows the existing dark chrome, since nothing is cached yet.

**3. The secondary display painted black for the whole boot.** On the dual-screen handhelds the bottom panel stayed dark regardless of theme, from two independent causes:

- `subDisplay()` runs in its own engine and had no theme name until the main engine pushed one, so `resolveTheme(null)` fell through to the platform brightness. It now seeds the name from the same config row that entrypoint already reads for the app language.
- `buildShaderFallback` hardcoded `Colors.black` whenever no background colour had been pushed — which is exactly the WELCOME state during startup. It now falls back to the theme's scaffold colour.

OLED's scaffold colour is `#000000`, so the empty-case OLED look documented on `buildSystemBackground` is preserved unchanged.

### Behaviour change worth flagging to reviewers

`buildShaderFallback` is the fallback for **any** system with no artwork, not just WELCOME. Dark-theme users browsing an artwork-less system will now see the theme's scaffold colour (`#15191e`) rather than pure black. That is the intent of the change, but it is a visible difference outside the reported bug.

## Steps to Reproduce

**Precondition:** a theme whose brightness differs from what the OS reports — on the Steam Deck, any dark theme (SteamOS reports a light platform brightness); on a dual-screen Android handheld, any light theme.

*White flash (Steam Deck):*
1. Set a dark theme in Settings → Themes. Fully quit the app.
2. Launch from Game Mode and watch the moment the "Preparing NeoStation…" screen hands over to the ROM scan.
3. **Before:** a white flash of roughly one to a few frames. **After:** no flash.

*Startup screen theme (any platform):*
1. Set a light theme, quit, relaunch.
2. **Before:** the "Preparing NeoStation…" screen is always dark chrome. **After:** it paints in the selected theme (from the second launch after setting it, once the palette has been cached).

*Secondary display (AYN Thor / dual-screen handhelds):*
1. Set a light theme, force-stop the app, relaunch.
2. Watch the bottom panel during the WELCOME phase, before the main engine pushes a background.
3. **Before:** solid black for the whole boot. **After:** the theme's background.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. *(no new assets)*
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable). *(no navigation changes; the storage-error screen's existing raw-key A/B handling is untouched)*

### Tests

Eleven new tests in `test/startup_theme_cache_test.dart` and `test/secondary_background_fallback_test.dart`, on the existing in-memory-SQLite + mock-preferences harness. Both regressions were **verified to fail against the previous behaviour**, not just to pass against the new one:

- Un-awaiting the resolve inside `ThemeProvider.create()` fails all three tests in that group — the saved `dark` theme comes back as `system`/light, exactly the flash.
- Restoring the hardcoded `Colors.black` in `buildShaderFallback` fails the theme-background test, while the OLED and pushed-colour tests keep passing. That is the useful part: OLED still resolves to black *through the theme*, so the documented empty-case behaviour is covered rather than special-cased.

`StartupThemeCache` is covered for the round-trip, the empty cache, a partially written one (falls back whole rather than pairing a cached background with fallback text), and the background-derived brightness.

Full suite: 566 tests pass. `dart format` and `flutter analyze` clean.

## Screenshots (if applicable)

Secondary panel measured through a cold boot on the AYN Thor with a **light** theme selected, sampling the panel every ~350 ms:

| phase | before | after |
| --- | --- | --- |
| WELCOME (before the main engine pushes a background) | `#000000` for ~14 consecutive frames | `#EEEEEE` — the light theme's scaffold colour |
| handoff into the game screen | black → light snap | fades straight in, no jump |

## Verification notes

- **Steam Deck:** white flash gone, confirmed on-device.
- **AYN Thor:** WELCOME phase now light, confirmed by screen capture of display 1 across a full cold boot.
- One thing left alone: on a light theme the WELCOME pill is a translucent-black chip with `white70` text — legible but muddy. That widget is shared with the system-name pill drawn over console artwork, where dark-on-art is correct, so making it theme-aware needs a way to distinguish those two cases. Left for a follow-up rather than risking the over-artwork case here.

## Performance note

`ThemeProvider.create()` puts a directory listing, a JSON parse per custom theme and one database read in front of `runApp` — all previously off the critical path. It runs behind the existing startup screen so nothing goes blank, but on low-spec hardware, where startup is already the bottleneck, it is the part of this change most worth a second look. If that is a concern I would rather add a timeout on the resolve — so a locked database can't stall the first frame — than move the work back off the critical path, since being off it is what caused the flash.
