### PR TITLE
fix(linux): reach ROM folders without an XDG portal in SteamOS Game Mode

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -821,6 +821,8 @@ mixin AppLocale {
   // TV directory picker
   // ---------------------------------------------------------------------------
   static const String selectStorage = 'select_storage';
+  static const String homeFolder = 'home_folder';
+  static const String filesystemRoot = 'filesystem_root';
   static const String internalStorage = 'internal_storage';
   static const String externalStorage = 'external_storage';
   static const String folderRestrictedAndroid = 'folder_restricted_android';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -824,6 +824,10 @@ const Map<String, dynamic> appLocaleDe = {
       'Drücke [ESC], [ENTER] oder [LEERTASTE] zum Schließen',
 
   AppLocale.selectStorage: 'Speicher auswählen',
+
+  AppLocale.homeFolder: 'Persönlicher Ordner',
+
+  AppLocale.filesystemRoot: 'Dateisystem',
   AppLocale.internalStorage: 'Interner Speicher',
   AppLocale.externalStorage: 'Externer Speicher ({name})',
   AppLocale.folderRestrictedAndroid: 'Von Android eingeschränkter Ordner',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -795,6 +795,10 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.pressToClose: 'Press [ESC], [ENTER] or [SPACE] to close',
 
   AppLocale.selectStorage: 'Select Storage',
+
+  AppLocale.homeFolder: 'Home',
+
+  AppLocale.filesystemRoot: 'Filesystem',
   AppLocale.internalStorage: 'Internal Storage',
   AppLocale.externalStorage: 'External Storage ({name})',
   AppLocale.folderRestrictedAndroid: 'Folder restricted by Android',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -821,6 +821,10 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.pressToClose: 'Presiona [ESC], [ENTER] o [ESPACIO] para cerrar',
 
   AppLocale.selectStorage: 'Seleccionar almacenamiento',
+
+  AppLocale.homeFolder: 'Carpeta personal',
+
+  AppLocale.filesystemRoot: 'Sistema de archivos',
   AppLocale.internalStorage: 'Almacenamiento interno',
   AppLocale.externalStorage: 'Almacenamiento externo ({name})',
   AppLocale.folderRestrictedAndroid: 'Carpeta restringida por Android',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -827,6 +827,10 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.pressToClose: 'Appuyez sur [ESC], [ENTER] ou [ESPACE] pour fermer',
 
   AppLocale.selectStorage: 'Sélectionner le Stockage',
+
+  AppLocale.homeFolder: 'Dossier personnel',
+
+  AppLocale.filesystemRoot: 'Système de fichiers',
   AppLocale.internalStorage: 'Stockage Interne',
   AppLocale.externalStorage: 'Stockage Externe ({name})',
   AppLocale.folderRestrictedAndroid: 'Dossier restreint par Android',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -800,6 +800,10 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.pressToClose: 'Tekan [ESC], [ENTER], atau [SPASI] untuk menutup',
 
   AppLocale.selectStorage: 'Pilih Penyimpanan',
+
+  AppLocale.homeFolder: 'Beranda',
+
+  AppLocale.filesystemRoot: 'Sistem berkas',
   AppLocale.internalStorage: 'Penyimpanan Internal',
   AppLocale.externalStorage: 'Penyimpanan Eksternal ({name})',
   AppLocale.folderRestrictedAndroid: 'Folder dibatasi oleh Android',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -819,6 +819,10 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.pressToClose: 'Premi [ESC], [ENTER] o [SPAZIO] per chiudere',
 
   AppLocale.selectStorage: 'Seleziona Archiviazione',
+
+  AppLocale.homeFolder: 'Cartella home',
+
+  AppLocale.filesystemRoot: 'File system',
   AppLocale.internalStorage: 'Archiviazione Interna',
   AppLocale.externalStorage: 'Archiviazione Esterna ({name})',
   AppLocale.folderRestrictedAndroid: 'Cartella limitata da Android',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -725,6 +725,10 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.pressToClose: ' [ESC], [ENTER], または [SPACE] を押して閉じる',
 
   AppLocale.selectStorage: 'ストレージを選択',
+
+  AppLocale.homeFolder: 'ホーム',
+
+  AppLocale.filesystemRoot: 'ファイルシステム',
   AppLocale.internalStorage: '内部ストレージ',
   AppLocale.externalStorage: '外部ストレージ ({name})',
   AppLocale.folderRestrictedAndroid: 'Androidによる制限付きフォルダ',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -732,6 +732,10 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.pressToClose: '닫으려면 [ESC], [ENTER] 또는 [SPACE]를 누르세요',
 
   AppLocale.selectStorage: '저장소 선택',
+
+  AppLocale.homeFolder: '홈',
+
+  AppLocale.filesystemRoot: '파일 시스템',
   AppLocale.internalStorage: '내부 저장소',
   AppLocale.externalStorage: '외부 저장소({name})',
   AppLocale.folderRestrictedAndroid: 'Android에서 제한된 폴더',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -807,6 +807,10 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.pressToClose: 'Pressione [ESC], [ENTER] ou [ESPAÇO] para fechar',
 
   AppLocale.selectStorage: 'Selecionar Armazenamento',
+
+  AppLocale.homeFolder: 'Pasta pessoal',
+
+  AppLocale.filesystemRoot: 'Sistema de ficheiros',
   AppLocale.internalStorage: 'Armazenamento Interno',
   AppLocale.externalStorage: 'Armazenamento Externo ({name})',
   AppLocale.folderRestrictedAndroid: 'Pasta restrita pelo Android',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -798,6 +798,10 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.pressToClose: 'Нажмите [ESC], [ENTER] или [ПРОБЕЛ], чтобы закрыть',
 
   AppLocale.selectStorage: 'Выбрать хранилище',
+
+  AppLocale.homeFolder: 'Домашняя папка',
+
+  AppLocale.filesystemRoot: 'Файловая система',
   AppLocale.internalStorage: 'Внутренняя память',
   AppLocale.externalStorage: 'Внешняя память ({name})',
   AppLocale.folderRestrictedAndroid: 'Папка ограничена Android',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -715,6 +715,10 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.pressToClose: '按 [ESC], [ENTER] 或 [空格] 关闭',
 
   AppLocale.selectStorage: '选择存储',
+
+  AppLocale.homeFolder: '主目录',
+
+  AppLocale.filesystemRoot: '文件系统',
   AppLocale.internalStorage: '内部存储',
   AppLocale.externalStorage: '外部存储 ({name})',
   AppLocale.folderRestrictedAndroid: '文件夹受 Android 限制',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -715,6 +715,10 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.pressToClose: '按 [ESC], [ENTER] 或 [空格] 關閉',
 
   AppLocale.selectStorage: '選擇儲存空間',
+
+  AppLocale.homeFolder: '主目錄',
+
+  AppLocale.filesystemRoot: '檔案系統',
   AppLocale.internalStorage: '內部儲存空間',
   AppLocale.externalStorage: '外部儲存空間 ({name})',
   AppLocale.folderRestrictedAndroid: '資料夾受 Android 限制',

--- a/lib/providers/sqlite_config_provider/scanning.dart
+++ b/lib/providers/sqlite_config_provider/scanning.dart
@@ -716,8 +716,15 @@ extension SqliteConfigScanning on SqliteConfigProvider {
             }
           }
         }
+      } else if (context != null && context.mounted) {
+        // Desktop: the platform picker, falling back to the in-app browser
+        // where no XDG portal backend exists (SteamOS Game Mode).
+        result = await TvDirectoryPicker.pickDirectory(
+          context,
+          dialogTitle: 'Select ROM Folder',
+        );
       } else {
-        // Desktop: Use standard file picker
+        // Desktop without a context to host the fallback browser.
         result = await FilePicker.getDirectoryPath(
           dialogTitle: 'Select ROM Folder',
         );

--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -11,6 +11,7 @@ import 'package:neostation/widgets/systems_update_dialog.dart';
 import 'package:neostation/services/logger_service.dart';
 import '../widgets/fixed_header.dart';
 import 'systems_screen/system_content.dart';
+import 'systems_screen/my_systems_section/initial_setup_widget.dart';
 import 'search_screen/search_screen.dart';
 import 'retro_achievements_screen/ra_content.dart';
 import 'settings_screen/new_settings_screen.dart';
@@ -442,7 +443,13 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
   }
 
   void _selectCurrentItem() async {
-    if (_selectedTabIndex == AppTabs.systems) return;
+    if (_selectedTabIndex == AppTabs.systems) {
+      // The systems grid owns A through its own navigation layer, which is why
+      // this returns. On first run that grid is replaced by the setup card,
+      // which has no layer — without this its one button is pad-unreachable.
+      InitialSetupWidget.selectCurrent();
+      return;
+    }
 
     if (_selectedTabIndex == AppTabs.scraper) {
       NewScraperOptionsScreen.selectCurrent();

--- a/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
@@ -4,7 +4,6 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:neostation/widgets/confirm_action_dialog.dart';
 import 'package:neostation/providers/file_provider.dart';
@@ -268,7 +267,8 @@ class DirectoriesSettingsContentState
           }
         }
       } else {
-        selected = await FilePicker.getDirectoryPath(
+        selected = await TvDirectoryPicker.pickDirectory(
+          context,
           dialogTitle: AppLocale.esdeSelectFolder.getString(context),
         );
       }
@@ -502,7 +502,8 @@ class DirectoriesSettingsContentState
           }
         }
       } else {
-        selected = await FilePicker.getDirectoryPath(
+        selected = await TvDirectoryPicker.pickDirectory(
+          context,
           dialogTitle: AppLocale.selectRomsFolder.getString(context),
         );
       }
@@ -581,7 +582,8 @@ class DirectoriesSettingsContentState
           }
         }
       } else {
-        selected = await FilePicker.getDirectoryPath(
+        selected = await TvDirectoryPicker.pickDirectory(
+          context,
           dialogTitle: AppLocale.selectUserDataFolder.getString(context),
           initialDirectory: _currentUserDataPath,
         );

--- a/lib/screens/systems_screen/my_systems_section/initial_setup_widget.dart
+++ b/lib/screens/systems_screen/my_systems_section/initial_setup_widget.dart
@@ -9,8 +9,50 @@ import '../../../providers/sqlite_config_provider.dart';
 ///
 /// Facilitates the initial filesystem handshake, allowing users to select
 /// their root ROM directory and initiate the first automated system scan.
-class InitialSetupWidget extends StatelessWidget {
+class InitialSetupWidget extends StatefulWidget {
   const InitialSetupWidget({super.key});
+
+  static _InitialSetupWidgetState? _currentInstance;
+
+  /// Runs the folder picker for whichever setup card is on screen, if any.
+  ///
+  /// This card replaces the systems grid on first run, and unlike the grid it
+  /// pushes no navigation layer — so AppScreen, which hands the Systems tab to
+  /// that layer, has nothing to hand A to and drops it. Selecting a ROM folder
+  /// was therefore reachable by touch only, which on a controller-driven
+  /// handheld means the first run cannot be completed at all.
+  ///
+  /// A layer of its own would have to re-serve every other binding the tab
+  /// relies on (bumpers, settings, back); registering the one action it owns
+  /// is the smaller contract. Mirrors `NewSettingsScreen.selectCurrent`.
+  static void selectCurrent() => _currentInstance?._selectFolder();
+
+  @override
+  State<InitialSetupWidget> createState() => _InitialSetupWidgetState();
+}
+
+class _InitialSetupWidgetState extends State<InitialSetupWidget> {
+  @override
+  void initState() {
+    super.initState();
+    InitialSetupWidget._currentInstance = this;
+  }
+
+  @override
+  void dispose() {
+    if (identical(InitialSetupWidget._currentInstance, this)) {
+      InitialSetupWidget._currentInstance = null;
+    }
+    super.dispose();
+  }
+
+  /// Opens the ROM folder picker. Inert while a scan is running, matching the
+  /// button, which shows a progress state instead of an action just then.
+  void _selectFolder() {
+    final configProvider = context.read<SqliteConfigProvider>();
+    if (configProvider.isLoading || configProvider.isScanning) return;
+    configProvider.selectRomFolder(context: context);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -200,35 +242,47 @@ class InitialSetupWidget extends StatelessWidget {
     final theme = Theme.of(context);
     final hasFolder = configProvider.hasRomFolder;
 
+    // Focus ring, in the app's usual 2px primary. It is always drawn rather
+    // than tracking a selection because this button is the only thing on the
+    // first-run card a controller can act on — it says "A does this here",
+    // which nothing on this screen said before. Kept outside the fill with a
+    // gap of surface, since the button is already filled with that primary.
     return Container(
-      width: double.infinity,
-      height: 64,
+      padding: const EdgeInsets.all(4),
       decoration: BoxDecoration(
-        color: theme.colorScheme.primary,
-        borderRadius: BorderRadius.circular(18),
-        boxShadow: [
-          BoxShadow(
-            color: theme.colorScheme.primary.withValues(alpha: 0.3),
-            blurRadius: 12,
-            offset: const Offset(0, 4),
-          ),
-        ],
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(color: theme.colorScheme.primary, width: 2),
       ),
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: () => configProvider.selectRomFolder(context: context),
+      child: Container(
+        width: double.infinity,
+        height: 64,
+        decoration: BoxDecoration(
+          color: theme.colorScheme.primary,
           borderRadius: BorderRadius.circular(18),
-          child: Center(
-            child: Text(
-              hasFolder
-                  ? AppLocale.changeFolder.getString(context)
-                  : AppLocale.selectRomFolderButton.getString(context),
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w800,
-                letterSpacing: 1.2,
-                color: theme.colorScheme.onPrimary,
+          boxShadow: [
+            BoxShadow(
+              color: theme.colorScheme.primary.withValues(alpha: 0.3),
+              blurRadius: 12,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: _selectFolder,
+            borderRadius: BorderRadius.circular(18),
+            child: Center(
+              child: Text(
+                hasFolder
+                    ? AppLocale.changeFolder.getString(context)
+                    : AppLocale.selectRomFolderButton.getString(context),
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 1.2,
+                  color: theme.colorScheme.onPrimary,
+                ),
               ),
             ),
           ),

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter/services.dart';
@@ -766,7 +765,8 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
           }
         }
       } else {
-        selected = await FilePicker.getDirectoryPath(
+        selected = await TvDirectoryPicker.pickDirectory(
+          context,
           dialogTitle: AppLocale.selectUserDataFolder.getString(context),
           initialDirectory: _selectedUserDataPath,
         );
@@ -1449,7 +1449,8 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
           }
         }
       } else {
-        selected = await FilePicker.getDirectoryPath(
+        selected = await TvDirectoryPicker.pickDirectory(
+          context,
           dialogTitle: AppLocale.esdeSelectFolder.getString(context),
         );
       }
@@ -1947,7 +1948,7 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
           await configProvider.addRomFolder(result, scan: false);
         }
       } else {
-        await configProvider.selectRomFolder(scan: false);
+        await configProvider.selectRomFolder(scan: false, context: context);
         // Provider already called addRomFolder internally; read back the path
         result = configProvider.config.romFolder;
       }

--- a/lib/widgets/tv_directory_picker.dart
+++ b/lib/widgets/tv_directory_picker.dart
@@ -1,12 +1,14 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import '../utils/gamepad_nav.dart';
 import '../services/game_service.dart';
+import '../services/logger_service.dart';
 import '../services/permission_service.dart';
 
 /// Full-screen directory/file browser for Android TV / Google TV.
@@ -45,6 +47,32 @@ class TvDirectoryPicker extends StatefulWidget {
       barrierDismissible: false,
       builder: (_) => TvDirectoryPicker(allowedExtensions: extensions),
     );
+  }
+
+  /// Picks a directory through the desktop picker, falling back to the in-app
+  /// browser when the platform cannot serve the request.
+  ///
+  /// On Linux the picker is the XDG portal, which exposes no `FileChooser`
+  /// interface in SteamOS Game Mode and **throws** rather than returning null.
+  /// That is what separates an unavailable picker from a user cancelling one:
+  /// a cancel yields null and must not reopen anything.
+  static Future<String?> pickDirectory(
+    BuildContext context, {
+    String? dialogTitle,
+    String? initialDirectory,
+  }) async {
+    try {
+      return await FilePicker.getDirectoryPath(
+        dialogTitle: dialogTitle,
+        initialDirectory: initialDirectory,
+      );
+    } catch (e) {
+      LoggerService.instance.w(
+        'Directory picker unavailable ($e); using the in-app browser',
+      );
+      if (!context.mounted) return null;
+      return show(context);
+    }
   }
 
   /// Portal-free executable picker for Linux and SteamOS Game Mode.
@@ -213,37 +241,94 @@ class _TvDirectoryPickerState extends State<TvDirectoryPicker> {
     Navigator.of(context).pop();
   }
 
+  /// Volume roots offered when browsing for a *directory* on Linux.
+  ///
+  /// The XDG portal exposes no `FileChooser` interface in SteamOS Game Mode —
+  /// `xdg-desktop-portal` selects a backend from `XDG_CURRENT_DESKTOP`, which
+  /// gamescope leaves unset — so this list is the only way to reach a ROM
+  /// folder there.
+  Future<List<_StorageVolume>> _linuxDirectoryVolumes(
+    BuildContext context,
+  ) async {
+    // Read localized labels before the first await: no context after a gap.
+    final homeLabel = AppLocale.homeFolder.getString(context);
+    final rootLabel = AppLocale.filesystemRoot.getString(context);
+    final home = Platform.environment['HOME'] ?? '';
+    final user = Platform.environment['USER'] ?? '';
+
+    final volumes = <_StorageVolume>[
+      if (home.isNotEmpty)
+        _StorageVolume(name: homeLabel, path: home, isInternal: true),
+    ];
+    final seen = <String>{for (final volume in volumes) volume.path};
+
+    // Removable and secondary media. SteamOS mounts the SD card and any USB
+    // drive at /run/media/<user>/<label>; older layouts omit the user segment
+    // and other distributions use /media or /mnt. The user-scoped roots are
+    // marked seen so the bare roots do not offer them a second time.
+    final userScoped = <String>[
+      if (user.isNotEmpty) '/run/media/$user',
+      if (user.isNotEmpty) '/media/$user',
+    ];
+    seen.addAll(userScoped);
+    for (final root in [...userScoped, '/run/media', '/media', '/mnt']) {
+      final dir = Directory(root);
+      if (!await dir.exists()) continue;
+      try {
+        for (final entry in await dir.list().toList()) {
+          if (entry is! Directory || !seen.add(entry.path)) continue;
+          volumes.add(
+            _StorageVolume(
+              name: entry.path.split('/').last,
+              path: entry.path,
+              isInternal: false,
+            ),
+          );
+        }
+      } on FileSystemException {
+        // An unreadable mount root is not fatal — keep the other volumes.
+      }
+    }
+
+    if (seen.add('/')) {
+      volumes.add(_StorageVolume(name: rootLabel, path: '/', isInternal: true));
+    }
+    return volumes;
+  }
+
   Future<void> _detectVolumes(BuildContext context) async {
     final volumes = <_StorageVolume>[];
 
-    if (Platform.isLinux && widget.executableMode) {
+    if (Platform.isLinux) {
       final home = Platform.environment['HOME'] ?? '';
-      final candidates = <_StorageVolume>[
-        if (home.isNotEmpty)
-          _StorageVolume(name: 'Home', path: home, isInternal: true),
-        if (home.isNotEmpty)
-          _StorageVolume(
-            name: 'Applications',
-            path: '$home/Applications',
-            isInternal: true,
-          ),
-        if (home.isNotEmpty)
-          _StorageVolume(
-            name: 'Local binaries',
-            path: '$home/.local/bin',
-            isInternal: true,
-          ),
-        const _StorageVolume(
-          name: 'System binaries',
-          path: '/usr/bin',
-          isInternal: true,
-        ),
-        const _StorageVolume(
-          name: 'Host system binaries',
-          path: '/run/host/usr/bin',
-          isInternal: true,
-        ),
-      ];
+      final candidates = widget.executableMode
+          ? <_StorageVolume>[
+              if (home.isNotEmpty)
+                _StorageVolume(name: 'Home', path: home, isInternal: true),
+              if (home.isNotEmpty)
+                _StorageVolume(
+                  name: 'Applications',
+                  path: '$home/Applications',
+                  isInternal: true,
+                ),
+              if (home.isNotEmpty)
+                _StorageVolume(
+                  name: 'Local binaries',
+                  path: '$home/.local/bin',
+                  isInternal: true,
+                ),
+              const _StorageVolume(
+                name: 'System binaries',
+                path: '/usr/bin',
+                isInternal: true,
+              ),
+              const _StorageVolume(
+                name: 'Host system binaries',
+                path: '/run/host/usr/bin',
+                isInternal: true,
+              ),
+            ]
+          : await _linuxDirectoryVolumes(context);
       for (final candidate in candidates) {
         if (await Directory(candidate.path).exists()) volumes.add(candidate);
       }

--- a/lib/widgets/tv_directory_picker.dart
+++ b/lib/widgets/tv_directory_picker.dart
@@ -123,8 +123,13 @@ class _TvDirectoryPickerState extends State<TvDirectoryPicker> {
   final ScrollController _scrollController = ScrollController();
   GamepadNavigation? _gamepadNav;
 
-  double get _itemHeight => widget.executableMode ? 60.0 : 44.0;
-  double get _volumeRowSpacing => widget.executableMode ? 8.0 : 0.0;
+  // Scaled like the text inside the rows. Left unscaled these were fixed
+  // pixels wrapping `.r`-sized labels, so anywhere `.r` is above 1 the two
+  // lines of a volume row overflowed the row and printed on top of each other
+  // (the Steam Deck is the worst case at exactly 2x — 640x480 design size
+  // against a 1280x800 logical screen).
+  double get _itemHeight => (widget.executableMode ? 60.0 : 44.0).r;
+  double get _volumeRowSpacing => (widget.executableMode ? 8.0 : 0.0).r;
 
   @override
   void initState() {
@@ -154,10 +159,16 @@ class _TvDirectoryPickerState extends State<TvDirectoryPicker> {
       onBack: _handleBack,
     );
     _gamepadNav?.initialize();
+    // Modal: this is a `showDialog` surface and must keep the controller until
+    // it is dismissed. Left non-modal, any widget mounting behind it pushes
+    // itself on top and takes the input, so the picker stops responding — or
+    // never appears to. It opens nothing on top of itself, so the manager's
+    // caveat about a modal's own children does not apply.
     GamepadNavigationManager.pushLayer(
       'tv_directory_picker',
       onActivate: () => _gamepadNav?.activate(),
       onDeactivate: () => _gamepadNav?.deactivate(),
+      modal: true,
     );
   }
 
@@ -238,6 +249,13 @@ class _TvDirectoryPickerState extends State<TvDirectoryPicker> {
   }
 
   void _handleBack() {
+    // B unwinds the browse before it cancels it: out of a subfolder, up to its
+    // parent, back to the volume list, and only then out of the picker. Going
+    // straight out from three levels deep loses the whole descent to one press.
+    if (!_showVolumePicker) {
+      _goUp();
+      return;
+    }
     Navigator.of(context).pop();
   }
 
@@ -276,11 +294,34 @@ class _TvDirectoryPickerState extends State<TvDirectoryPicker> {
       if (!await dir.exists()) continue;
       try {
         for (final entry in await dir.list().toList()) {
-          if (entry is! Directory || !seen.add(entry.path)) continue;
+          if (entry is! Directory) continue;
+
+          // SteamOS leaves /run/media/<label> as a symlink to the user-scoped
+          // /run/media/<user>/<label>, so the same card arrives twice under
+          // two different paths. Dedup on the target, and offer that rather
+          // than the link.
+          String resolved;
+          try {
+            resolved = await entry.resolveSymbolicLinks();
+          } on FileSystemException {
+            continue;
+          }
+          if (!seen.add(resolved)) continue;
+
+          // Something we cannot read is no use as a starting point: SteamOS
+          // keeps a root-owned /run/media/root that would otherwise be listed
+          // and then open empty. Taking one entry is enough to prove access,
+          // and an empty directory yields none without throwing.
+          try {
+            await Directory(resolved).list(followLinks: false).take(1).toList();
+          } on FileSystemException {
+            continue;
+          }
+
           volumes.add(
             _StorageVolume(
-              name: entry.path.split('/').last,
-              path: entry.path,
+              name: resolved.split('/').last,
+              path: resolved,
               isInternal: false,
             ),
           );
@@ -675,7 +716,7 @@ class _TvDirectoryPickerState extends State<TvDirectoryPicker> {
       controller: _scrollController,
       physics: const ClampingScrollPhysics(),
       itemCount: _volumes.length,
-      separatorBuilder: (_, _) => SizedBox(height: _volumeRowSpacing.r),
+      separatorBuilder: (_, _) => SizedBox(height: _volumeRowSpacing),
       itemBuilder: (context, index) {
         final vol = _volumes[index];
         final focused = _focusedIndex == index;
@@ -701,7 +742,12 @@ class _TvDirectoryPickerState extends State<TvDirectoryPicker> {
               children: [
                 Icon(
                   vol.isInternal
-                      ? Symbols.phone_android_rounded
+                      // A phone glyph for "Home" reads as wrong on a desktop
+                      // or a handheld PC, which is where this list is the
+                      // only way to reach a folder.
+                      ? (Platform.isAndroid
+                            ? Symbols.phone_android_rounded
+                            : Symbols.computer_rounded)
                       : Symbols.sd_card_rounded,
                   color: focused
                       ? theme.colorScheme.primary
@@ -1026,7 +1072,10 @@ class _TvDirectoryPickerState extends State<TvDirectoryPicker> {
               SizedBox(width: 12.r),
               _HintChip(
                 label: 'B',
-                description: AppLocale.cancel.getString(context),
+                // Inside a folder B is a level up, not a way out.
+                description: _showVolumePicker
+                    ? AppLocale.cancel.getString(context)
+                    : AppLocale.hintBack.getString(context),
               ),
             ],
           ),


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). The diagnosis, patch and on-device verification were produced in an agent session.

# Description

On SteamOS **Game Mode** a ROM folder cannot be added at all. Two separate faults stack up, and between them a first run cannot be completed on the gamepad.

**1. The portal picker throws.** gamescope leaves `XDG_CURRENT_DESKTOP` unset, so `xdg-desktop-portal` selects no backend; the desktop object answers on DBus but implements no `FileChooser` interface. Every pick throws:

```
org.freedesktop.DBus.Error.UnknownMethod: No such interface
"org.freedesktop.portal.FileChooser" on object at path /org/freedesktop/portal/desktop
```

The call sites caught that, logged it, and returned — which is why the button looked inert rather than broken. That covers "Add ROM folder", the ES-DE folder, the user-data folder and the setup wizard's ROM step.

Confirmed on a Steam Deck: the portal backends are installed (`gtk.portal`, `kde.portal`) and the `xdg-desktop-portal` frontend is running, but no backend process is. In Desktop Mode the same build picks folders fine, because Plasma starts `kde.portal`.

**2. The first-run button ignores the A button.** On first run the systems grid is replaced by `InitialSetupWidget`, whose single "Select ROM Folder" button is the only route to the picker. The grid owns A through its own navigation layer, so `AppScreen` hands the Systems tab to that layer and returns early — but the setup card pushes no layer, so A was dropped and the button answered to touch alone. This predates the branch; it is included because it *is* the first-run path in Game Mode, and fixing the portal without it still leaves a controller-only device unable to finish setup.

#271 already shipped a portal-free **executable** picker built on `TvDirectoryPicker` for exactly this scenario. The *directory* pickers never got the same treatment — this closes that gap rather than adding a new mechanism.

## Approach

### Reaching the picker

`TvDirectoryPicker.pickDirectory()` tries the platform picker and falls back to the in-app browser **only when it throws**. That distinction matters: a user cancelling the portal dialog returns `null`, which must not reopen anything. Only an unavailable picker raises.

`_detectVolumes` gains a Linux branch for directory mode (it previously handled Linux only under `executableMode` and otherwise fell through to the Android volume path, coming back empty). It offers Home, every mount under `/run/media/<user>`, `/run/media`, `/media/<user>`, `/media` and `/mnt`, and the filesystem root.

Call sites routed through the wrapper:

| File | Picker |
| --- | --- |
| `directories_settings_content.dart` | ROM folder, ES-DE folder, user-data folder |
| `setup_wizard.dart` | user-data folder, ES-DE folder |
| `sqlite_config_provider/scanning.dart` | ROM folder (desktop branch, when a context is available) |

`setup_wizard.dart` also now passes `context:` to `selectRomFolder()`; without it the provider had no context to host the fallback.

`InitialSetupWidget` registers the one action it owns and `AppScreen` calls it instead of returning blind, mirroring `NewSettingsScreen.selectCurrent`. Giving that card a navigation layer of its own was the alternative, and rejected: a layer would have to re-serve every other binding the tab relies on — bumpers, settings, back — or strand the user on the screen. Tap and pad now share one path, inert while a scan runs to match the button's own progress state. The button gains a focus ring in the app's usual 2px primary, since nothing on that screen previously indicated A would do anything; it sits outside the fill with a gap, the button being filled with that same primary.

### What Game Mode testing then found

The fallback browser had never run on a screen this size, and three things needed fixing before it was usable:

- **Overlapping text.** Row heights were fixed pixels wrapping `.r`-scaled labels, so the name and the path drew on top of each other anywhere `.r` exceeds 1 — exactly 2x on a Deck, where the 640x480 design size meets a 1280x800 logical screen. They now scale with their contents. The separator was the same bug inverted: `.r` at the call site, raw in the scroll-offset maths.
- **The SD card listed twice.** SteamOS leaves `/run/media/<label>` as a symlink to `/run/media/<user>/<label>`. Volumes now dedup on the resolved target and offer that rather than the link. A root-owned `/run/media/root` that the user cannot read (and that opens empty) is skipped along with anything else that cannot be listed.
- **B cancelled from any depth**, losing a whole descent to one press. It now goes up a level, then back to the volume list, and only cancels there. The hint chip follows, reading `Back` while browsing — reusing the existing `AppLocale.hintBack`, so no new keys for it.

The layer is also pushed `modal: true`. It is a `showDialog` surface, and the manager's own guidance is that a non-modal layer can be displaced by a widget mounting behind it.

Two new `AppLocale` keys (`homeFolder`, `filesystemRoot`) with values in all 12 locale files.

## Deliberately out of scope

- `lib/providers/config_provider.dart` makes the same portal call, but nothing imports the file anywhere in `lib/` — left untouched rather than modernising dead code.
- The `executableMode` volume labels from #271 are still hardcoded English (`Home`, `Applications`, …). Localising them means four more keys across twelve files for an unrelated mode; happy to do it here or in a follow-up if you'd prefer.

## Steps to Reproduce

Preconditions: a Steam Deck (or any SteamOS/gamescope session) running the AppImage **launched from Steam in Game Mode**. Desktop Mode will *not* reproduce either fault — Plasma provides a portal backend.

**Fault 1 — the picker never opens.** With a profile that already has a ROM folder:

1. Launch NeoStation from Steam in Game Mode.
2. Go to Settings → Directories → **Add ROM folder**.
3. Press A (or tap it).
4. Nothing happens — no picker, no error. Repeat presses do nothing.
5. `~/.neostation/user-data/app.log` shows one `ROM folder selection failed: … UnknownMethod … FileChooser` per press.

**Fault 2 — the first-run button cannot be reached.** With a profile that has no ROM folder configured:

1. Launch NeoStation from Steam in Game Mode. The Systems tab shows the "Setup Your Library" card.
2. Press A on **Select ROM Folder** with the gamepad.
3. Nothing happens, and nothing is logged — the press never reaches the button. Touching the same button works.

With this change, both open the in-app browser, and the ROM folder can be selected on the gamepad.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [ ] Android
- [x] **Gamepad support verified** (if applicable).

### Notes on the unchecked boxes

- **Tests.** No test added. The behaviour is gated on `Platform.isLinux` and on real mount points under `/run/media`, so a meaningful test needs the enumeration extracted behind an injectable filesystem probe. Happy to do that if you want it covered.
- **Documentation.** No user-facing doc covers folder selection, so there was nothing to amend; the reasoning lives in comments at each changed site.

### What was verified on device

On a Steam Deck, SteamOS, launched from Steam in Game Mode: both entry points open the in-app browser on the gamepad; the volume list shows Home, the SD card once (`/run/media/deck/Deck`) and the filesystem root, with the unreadable `/run/media/root` gone; rows render without overlapping text; B unwinds a folder at a time. The Android paths in the touched files are unchanged — only the desktop `else` branches moved — and were not retested.

`dart format`, `flutter analyze` (clean) and `flutter test` (566 passing) are green locally.

## Related

Independent of #311. That one stops a path the picker hands back from destroying the ROM library; this one makes the picker reachable. Neither depends on the other.
