### PR TITLE
fix(linux): stop a dead desktop-portal path silently emptying the ROM library

### DIFF
--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -23,6 +23,7 @@ import '../models/secondary_display_state.dart';
 import 'package:flutter/services.dart';
 import '../widgets/tv_directory_picker.dart';
 import '../constants/system_folder_names.dart';
+import '../utils/rom_folder_path.dart';
 import '../services/game_session_persistence.dart';
 import '../utils/nav_tabs.dart';
 import '../services/saf_directory_service.dart';

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -24,6 +24,7 @@ import 'package:flutter/services.dart';
 import '../widgets/tv_directory_picker.dart';
 import '../constants/system_folder_names.dart';
 import '../utils/rom_folder_path.dart';
+import '../services/global_notification_service.dart';
 import '../services/game_session_persistence.dart';
 import '../utils/nav_tabs.dart';
 import '../services/saf_directory_service.dart';

--- a/lib/providers/sqlite_config_provider/scanning.dart
+++ b/lib/providers/sqlite_config_provider/scanning.dart
@@ -17,6 +17,21 @@ extension SqliteConfigScanning on SqliteConfigProvider {
     if (_config.romFolders.contains(folderPath)) return;
     if (_config.romFolders.length >= 5) return;
 
+    // A desktop-portal document path outlives neither the reboot nor the grant
+    // that produced it, so storing one hands the user a library that silently
+    // empties later. Refuse it at the door and say why.
+    if (isTransientPortalPath(folderPath)) {
+      _error =
+          'That folder came from a temporary desktop-portal path '
+          '($folderPath) and would stop working after a restart. '
+          'Pick it again with the built-in folder browser.';
+      SqliteConfigProvider._log.w(
+        'Rejected transient portal ROM folder: $folderPath',
+      );
+      _notify();
+      return;
+    }
+
     try {
       _setLoading(true);
       final newList = [..._config.romFolders, folderPath];
@@ -147,6 +162,46 @@ extension SqliteConfigScanning on SqliteConfigProvider {
         _setScanning(false);
         _notify();
         return;
+      }
+    }
+
+    // A configured ROM root can stop resolving between scans: an unmounted
+    // drive, a deleted folder, or a desktop-portal document path whose grant
+    // expired. Off Android nothing verified that until now, so the walk found
+    // nothing and the prune phase deleted every ROM row — indistinguishable
+    // from data loss to the user. Keep the library and explain instead.
+    if (!Platform.isAndroid && _config.romFolders.isNotEmpty) {
+      final unreachable = <String>[];
+      for (final folder in _config.romFolders) {
+        if (!await Directory(folder).exists()) unreachable.add(folder);
+      }
+      if (unreachable.isNotEmpty && await _hasStoredRoms()) {
+        // A portal grant cannot be restored by plugging anything back in, so
+        // that case needs different advice from a missing drive.
+        final advice = unreachable.any(isTransientPortalPath)
+            ? 'That path came from a temporary desktop-portal grant and '
+                  'cannot come back — remove it in Settings > Directories '
+                  'and add the folder again.'
+            : 'Reconnect the drive, or remove the folder in '
+                  'Settings > Directories.';
+        final plural = unreachable.length == 1 ? '' : 's';
+        _error =
+            'Cannot reach ROM folder$plural: ${unreachable.join(', ')}. '
+            'Existing games were kept. $advice';
+        SqliteConfigProvider._log.e(
+          'Scan aborted, ${unreachable.length} unreachable ROM folder(s); '
+          'library preserved: ${unreachable.join(', ')}',
+        );
+        _setScanning(false);
+        _notify();
+        return;
+      }
+      if (unreachable.isNotEmpty) {
+        // No library at risk, so scanning on is safe — but still say so.
+        SqliteConfigProvider._log.w(
+          'Unreachable ROM folder(s) ignored (no stored ROMs): '
+          '${unreachable.join(', ')}',
+        );
       }
     }
 

--- a/lib/providers/sqlite_config_provider/scanning.dart
+++ b/lib/providers/sqlite_config_provider/scanning.dart
@@ -8,6 +8,13 @@ part of '../sqlite_config_provider.dart';
 /// class declaration, all state, lifecycle wiring, and secondary-display logic.
 /// `notifyListeners()` routes through the host's `_notify()` bridge and the
 /// static `_log` is host-qualified (both required from an extension).
+/// Bell entry for ROM roots that stopped resolving. A fixed id so consecutive
+/// scans replace the warning in place rather than stacking one per launch.
+const String _unreachableRomFoldersNotificationId = 'rom-folders-unreachable';
+
+/// Bell entry for a ROM folder refused because its path was transient.
+const String _transientRomFolderNotificationId = 'rom-folder-transient';
+
 extension SqliteConfigScanning on SqliteConfigProvider {
   /// Registers a new filesystem directory as a ROM source.
   ///
@@ -27,6 +34,15 @@ extension SqliteConfigScanning on SqliteConfigProvider {
           'Pick it again with the built-in folder browser.';
       SqliteConfigProvider._log.w(
         'Rejected transient portal ROM folder: $folderPath',
+      );
+      // Settings > Directories, the screen this is normally reached from,
+      // never reads `_error` — without the bell the pick would simply appear
+      // to do nothing, which is no better than the silent failure being fixed.
+      GlobalNotificationService().show(
+        id: _transientRomFolderNotificationId,
+        title: 'ROM folder not added',
+        message: _error!,
+        type: GlobalNotificationType.error,
       );
       _notify();
       return;
@@ -192,6 +208,22 @@ extension SqliteConfigScanning on SqliteConfigProvider {
           'Scan aborted, ${unreachable.length} unreachable ROM folder(s); '
           'library preserved: ${unreachable.join(', ')}',
         );
+        // The preserved library is worth nothing if the screen behind this
+        // stays blank. `_scanCompleted` is only set at the far end of a
+        // successful scan, and the systems screen renders neither the library
+        // nor the setup prompt until it flips — an early return without it
+        // leaves an empty page, which is the very symptom being fixed.
+        _scanCompleted = true;
+        // `_error` reaches only the initial-setup widget, which is shown when
+        // no systems are detected — impossible here, since this branch needs
+        // stored ROMs. The bell is the one surface that both survives the scan
+        // ending and does not need a BuildContext from this layer.
+        GlobalNotificationService().show(
+          id: _unreachableRomFoldersNotificationId,
+          title: 'ROM folder$plural unavailable',
+          message: _error!,
+          type: GlobalNotificationType.error,
+        );
         _setScanning(false);
         _notify();
         return;
@@ -204,6 +236,11 @@ extension SqliteConfigScanning on SqliteConfigProvider {
         );
       }
     }
+
+    // Getting this far means nothing blocked the scan, so retire a warning
+    // left by an earlier one instead of leaving the user chasing a folder they
+    // have already reconnected or removed.
+    GlobalNotificationService().dismiss(_unreachableRomFoldersNotificationId);
 
     // Initialize progress
     _totalSystemsToScan = 0;

--- a/lib/utils/rom_folder_path.dart
+++ b/lib/utils/rom_folder_path.dart
@@ -1,0 +1,27 @@
+/// Classification of ROM-folder paths whose lifetime is shorter than the
+/// configuration that stores them.
+library;
+
+/// The XDG document portal's FUSE mount, e.g.
+/// `/run/user/1000/doc/d4efb740/roms`.
+///
+/// The desktop file-chooser portal hands a sandboxed client a path under this
+/// mount instead of the real location. The `<handle>` segment is minted per
+/// grant and the mount is torn down with the user session, so a path captured
+/// from it is dead after a reboot: it resolves to an empty directory rather
+/// than failing loudly, and a scan that trusts it finds no ROMs.
+final RegExp _documentPortalPath = RegExp(r'^/run/user/\d+/doc(/|$)');
+
+/// The same mount as seen from inside a Flatpak sandbox on some runtimes.
+final RegExp _flatpakDocumentPath = RegExp(r'^/run/flatpak/doc(/|$)');
+
+/// Whether [path] lives on a desktop-portal document mount and will therefore
+/// stop resolving once the granting session ends.
+///
+/// Such a path must never be persisted as a ROM directory: the library it
+/// describes silently empties on the next boot.
+bool isTransientPortalPath(String path) {
+  if (path.isEmpty) return false;
+  return _documentPortalPath.hasMatch(path) ||
+      _flatpakDocumentPath.hasMatch(path);
+}

--- a/lib/widgets/notification_bell.dart
+++ b/lib/widgets/notification_bell.dart
@@ -310,7 +310,12 @@ class _NotificationDropdownItem extends StatelessWidget {
                     ).colorScheme.onSurface.withValues(alpha: 0.8),
                     fontSize: 10.r,
                   ),
-                  maxLines: 3,
+                  // Enough room for a message that names a path and then says
+                  // what to do about it. At three lines the ROM-folder warnings
+                  // were cut off mid-advice ("…came from a temporary deskt"),
+                  // leaving the one actionable half of the message unread.
+                  // Short notifications are unaffected: this is a maximum.
+                  maxLines: 6,
                   overflow: TextOverflow.ellipsis,
                 ),
                 if (data.progress != null) ...[

--- a/test/rom_folder_path_test.dart
+++ b/test/rom_folder_path_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/rom_folder_path.dart';
+
+void main() {
+  group('isTransientPortalPath — the observed Steam Deck data loss', () {
+    test('flags the document-portal path that emptied a 398-ROM library', () {
+      // Exact shape read out of user_rom_folders on the Deck: the file-chooser
+      // portal handed back a doc mount, it was stored, and after a reboot the
+      // handle directory was empty — every rom_path under it pointed nowhere.
+      expect(isTransientPortalPath('/run/user/1000/doc/d4efb740/roms'), isTrue);
+    });
+
+    test('flags the mount root itself, with or without a trailing segment', () {
+      expect(isTransientPortalPath('/run/user/1000/doc'), isTrue);
+      expect(isTransientPortalPath('/run/user/1000/doc/'), isTrue);
+    });
+
+    test('flags any uid, not just 1000', () {
+      expect(isTransientPortalPath('/run/user/1/doc/abc/roms'), isTrue);
+      expect(isTransientPortalPath('/run/user/65534/doc/abc'), isTrue);
+    });
+
+    test('flags the Flatpak-sandbox view of the same mount', () {
+      expect(isTransientPortalPath('/run/flatpak/doc/beef/roms'), isTrue);
+    });
+
+    test('accepts the real Deck library root', () {
+      // What the fix steers users to instead.
+      expect(
+        isTransientPortalPath('/run/media/deck/Deck/Emulation/roms'),
+        isFalse,
+      );
+    });
+
+    test('accepts ordinary desktop and Android roots', () {
+      expect(isTransientPortalPath('/home/deck/roms'), isFalse);
+      expect(isTransientPortalPath('/media/user/SD/roms'), isFalse);
+      expect(isTransientPortalPath('/mnt/games/roms'), isFalse);
+      expect(isTransientPortalPath('/storage/emulated/0/emu/roms'), isFalse);
+      expect(isTransientPortalPath(r'C:\Games\roms'), isFalse);
+    });
+
+    test('accepts an Android SAF content URI untouched', () {
+      // Android folders are content:// URIs and must not be caught here.
+      expect(
+        isTransientPortalPath(
+          'content://com.android.externalstorage.documents/tree/primary%3Aemu',
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not flag look-alike paths outside the doc mount', () {
+      // /run/user/<uid> is legitimate for sockets etc; only the doc mount is
+      // transient in the way that matters here.
+      expect(isTransientPortalPath('/run/user/1000/roms'), isFalse);
+      expect(isTransientPortalPath('/run/user/1000/documents/roms'), isFalse);
+      expect(isTransientPortalPath('/run/media/doc/roms'), isFalse);
+      expect(isTransientPortalPath('/home/deck/run/user/1000/doc'), isFalse);
+    });
+
+    test('does not flag a non-numeric uid segment', () {
+      expect(isTransientPortalPath('/run/user/deck/doc/roms'), isFalse);
+    });
+
+    test('treats an empty path as ordinary', () {
+      expect(isTransientPortalPath(''), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
> Written with [Claude Code](https://claude.com/claude-code). Diagnosis came from a live Steam Deck database; the fix is unit-tested and passes the local gate, with on-device verification noted as pending below.

# Description

A ROM library can silently empty itself on Linux, with no error shown and nothing in the UI to explain where the games went.

The desktop file-chooser portal hands sandboxed clients a path on its **document mount** — `/run/user/<uid>/doc/<handle>/roms` — instead of the real location. The `<handle>` segment is minted per grant and the mount is torn down with the user session, so a path captured from it does not fail loudly on the next boot: it resolves to an **empty directory**.

Nothing off Android verified that a configured ROM root still resolved. The walk therefore found no files, and the prune phase in `_scanRomsInBackground` deleted every `user_roms` row. Android has had a guard for this since the SD-card-not-ready work (`canAccessDirectory` + `_hasStoredRoms()`); desktop never got one.

Observed on a Steam Deck. Read straight out of `user_rom_folders` on the device:

```
{'id': 24, 'path': '/run/user/1000/doc/d4efb740/roms'}
```

398 ROMs and 370 scraped-metadata rows hung off that single root. After a reboot `/run/user/1000/doc/d4efb740/` was an existing but empty directory, so every `rom_path` beneath it pointed nowhere. The library was scrap and nothing said so.

> **Correction, on re-inspecting the Deck:** the rows in that database were never actually pruned — see *On-device state* at the end. The stored dead path and the prune mechanism are both real, but the claim that this particular library was deleted in place does not hold up; it was superseded by the user-data relocation. Read the reproduction as the mechanism it demonstrates, not as a post-mortem.

This is not a regression — the behaviour predates the current release. It is reachable by anyone who picked a ROM folder while running under Flatpak, which is how NeoStation shipped on Linux before the AppImage.

## Approach

Two guards, at the two points where the damage is done.

**1. Refuse the path at the door.** `addRomFolder` rejects a document-portal path and tells the user to pick the folder again with the built-in browser, which returns a real path. Storing one was never going to work; failing immediately beats failing after the next reboot.

**2. Never prune against an unreachable root.** `scanSystems` now checks every configured root off Android. When any is unreachable *and* stored ROMs exist, it aborts before the prune phase and keeps the library. The message distinguishes the two causes, because the remedies differ:

| cause | advice given |
| --- | --- |
| missing drive / deleted folder | reconnect it, or remove the folder in Settings > Directories |
| expired portal grant | cannot come back — remove it and add the folder again |

When no ROMs are stored there is nothing to lose, so the scan continues and just logs the unreachable roots.

**3. Actually put the library back on screen, and the reason in front of the user.** Tracing where the guard's state lands in the UI turned up two gaps in the above, both fixed in the second commit:

- **The abort left the Systems tab blank.** `_scanCompleted` is only set at the far end of a successful scan, and `system_content.dart` draws the library only once it flips — an early return left `showSplash`, `showInitialSetup` and `showContent` all false, i.e. `SizedBox.shrink()`. The rows survived in the database, but the user still saw an empty screen: the exact symptom the guard exists to prevent. (The same shape is already documented in `app_screen.dart`'s `_performUpdateSequence` — *"left the Systems tab completely blank"*.) It now sets `_scanCompleted` before returning, so the preserved library is drawn.
- **Neither message could reach the user.** `_error` is rendered in exactly one place, `InitialSetupWidget`, which shows only when *no* systems are detected — unreachable from the abort branch, which requires stored ROMs. And `addRomFolder` is normally reached from Settings > Directories, which never reads `_error` at all, so a refused folder simply appeared to do nothing. Both now also post to the notification bell through `GlobalNotificationService`: a context-free singleton (so it is reachable from this layer), rendered in the header dropdown rather than a floating overlay, and it does not auto-dismiss. A later scan that completes retires the warning, so a reconnected drive clears it.

## Trade-off worth reviewing

Failing safe means a **permanently** removed folder now blocks scanning until the user removes it in Settings > Directories. I took that deliberately: refusing to scan is recoverable, pruning the library is not, and the message names the exact folder and the exact fix.

The narrower alternative — protect only the unreachable root's rows and let the reachable ones scan on — needs per-folder prune scoping inside `_scanRomsInBackground`, which is a materially bigger change. I've left it as a follow-up rather than half-implement it. Happy to go that way instead if you'd prefer the smaller behavioural change.

## Notes

- Messages are plain English, matching every other `_error` / `_scanStatus` in this provider — `scanStatus` is already rendered untranslated on the systems screen, the settings screen and the setup wizard. The layer has no `BuildContext`, so `AppLocale` is not reachable from it; localising these means routing them through the UI layer, which is its own change.
- The same early-return-without-`_scanCompleted` shape exists in the pre-existing Android guards above this one (storage permission, folder access, SD-not-ready). Left alone here — it predates this PR and changing it risks Android regressions — but it looks like the same latent blank-screen bug and is worth a follow-up.
- `isTransientPortalPath` is a pure function in `lib/utils/`, deliberately so it could be tested — see below.
- Independent of #310. That PR makes the picker *reachable* in SteamOS Game Mode; this one stops a path the picker hands back from destroying the library. Neither depends on the other.

## Steps to Reproduce

Preconditions: Linux with a working desktop portal (any Flatpak build, or a KDE/GNOME desktop session), and a ROM folder picked through the portal dialog rather than the in-app browser.

1. Add a ROM folder via the portal file chooser. It is stored as `/run/user/<uid>/doc/<handle>/<name>`.
2. Confirm the library scans and the games appear.
3. Reboot, or restart the user session so the document portal remints its handles.
4. Launch NeoStation and let it scan.
5. The library is now empty. No error, no notification. `user_roms` has been pruned to zero, and `user_rom_folders` still points at the dead handle.

With this change, step 1 is refused with an explanation, and an already-stored dead path makes step 4 abort with the library intact instead of pruning it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

### On the boxes

- **Tests:** 10 new cases in `test/rom_folder_path_test.dart` covering the exact Deck path, arbitrary uids, the mount root, the Flatpak view, and the look-alikes that must *not* be caught (`/run/user/1000/roms`, `/run/media/doc/roms`, a non-numeric uid, Android `content://` URIs, Windows paths). Rebased on current `main`; full suite **629 passing**, `flutter analyze` clean, `dart format` clean.
  The classifier is unit-tested, but the scan-abort branch is not: nothing in `test/` constructs a `SqliteConfigProvider`, so covering it means building a provider harness (database, config service, repositories) from nothing. That is a materially bigger change than the fix, so it is flagged rather than half-built.
- **Documentation:** the reasoning lives in dartdoc on `rom_folder_path.dart` and in comments at all three guards; no user-facing docs describe ROM-folder storage, so there was nothing else to update.
- **Tested on / gamepad:** Linux ticked — exercised on a Steam Deck in Game Mode, see below. Gamepad box left unticked: nothing gamepad-facing changed, and the one new surface (the notification bell) already existed.

### Verified on device (Steam Deck, SteamOS Game Mode)

A dead portal root was injected into the live configuration alongside the real one, against a stored library of 1024 ROMs:

```
user_rom_folders: [(3, '/run/media/deck/Deck/Emulation/roms'),
                   (4, '/run/user/1000/doc/deadbeef/roms')]   ← unreachable
```

- **The library survives and is drawn.** The systems grid renders normally, footer reading *"All Systems | 1024 Games"*. Without the `_scanCompleted` fix this is the blank tab described above. `user_roms` still holds all 1024 rows — nothing was pruned.
- **The guard fires on the right branch.** `[E] Scan aborted, 1 unreachable ROM folder(s); library preserved: /run/user/1000/doc/deadbeef/roms`, and the bell shows the *portal* advice rather than the reconnect-the-drive one, so `isTransientPortalPath` selects correctly at runtime and not just in the unit tests.
- **The message is readable end to end.** First run it arrived clipped — *"…came from a temporary **deskt**"* — because the bell clamped every message to three lines, cutting off precisely the half that says what to do. Hence the third commit; it now reads to the end in six lines with no overflow.
- **The warning retires itself.** Removing the dead root and relaunching, the scan runs through (`scanSystems starting (romFolders=1)` with no abort) and the bell reads *"No active notifications"* — so a reconnected drive clears the warning without the user dismissing anything by hand.

The Deck's configuration and all 1024 rows were restored afterwards; the injected root existed only for this run.

### On-device state (Steam Deck, read-only inspection)

Worth recording, because it qualifies the reproduction rather than confirming it. Read live from the Deck:

- The **active** database, `~/.neostation/user-data/data.sqlite`, holds a healthy config: one root at `/run/media/deck/Deck/Emulation/roms`, 1024 ROMs. A plain launch therefore exercises the no-regression path, not the guard.
- The database quoted in the diagnosis, `~/user-data/data.sqlite`, is the **superseded** one from before the user-data relocation. It still holds its dead root (`/run/user/1000/doc/d4efb740/roms`) *and* its 398 ROM rows — so those rows were never actually pruned; that library was left behind by the relocation rather than destroyed in place.
- The portal handle `d4efb740` is **currently live**: `/run/user/1000/doc/d4efb740/roms` resolves to the real 181-entry directory in this session. The dead-handle state only appears after the session that minted it ends, which is what makes the failure so quiet.

So the mechanism stands and the stored path is real, but the "398 ROMs pruned" wording overstates what this specific database shows. Exercising the guard therefore needed a deliberately unreachable root in the active config — which is what the on-device run above did.

