### PR TITLE
fix: rename MelonDualDS to WatermelonDS

### DIFF
--- a/assets/systems/ds.json
+++ b/assets/systems/ds.json
@@ -225,10 +225,10 @@
       }
     },
     {
-      "name": "Standalone MelonDualDS",
+      "name": "Standalone WatermelonDS",
       "unique_id": "ds.standalone.melonds.dual",
       "is_retroachievements_compatible": false,
-      "description": "MelonDS (Dual Screen Fork) build.",
+      "description": "WatermelonDS emulator",
       "platforms": {
         "android": {
           "launch_arguments": "-n me.magnum.melondualds/me.magnum.melonds.ui.emulator.EmulatorActivity -a me.magnum.melonds.dev.LAUNCH_ROM -d \"{file.uri}\""


### PR DESCRIPTION
# Description

Renames MelonDualDS to WatermelonDS in the user-facing UI.

Fixes # (not applicable — no issue linked)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [ ] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [ ] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Not applicable — this is a text-only rename.