### PR TITLE
fix: stop a blanket config save from wiping the ROM folders

### DIFF
--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -2447,14 +2447,37 @@ class SqliteService {
   }
 
   /// Persists a complete list of ROM directories, replacing existing ones.
+  ///
+  /// An empty list is ignored while folders are already configured. No caller
+  /// legitimately clears the table this way — removing a folder has its own
+  /// targeted API ([removeRomFolder]) — so an empty list means the config
+  /// object never carried the folders, not that the user removed them. Acting
+  /// on it is silently destructive: the next scan runs as a fast scan, which
+  /// prunes every system and ROM row, which in turn leaves
+  /// [recoverRomFoldersFromStoredRoms] nothing to derive a root from.
   static Future<void> saveUserRomFolders(List<String> folders) async {
     final db = await instance.database;
+    final paths = folders.where((folder) => folder.isNotEmpty).toList();
+
+    if (paths.isEmpty) {
+      final rows = await db.rawQuery(
+        'SELECT COUNT(*) AS count FROM user_rom_folders',
+      );
+      final existing = rows.isEmpty ? 0 : (rows.first['count'] as int?) ?? 0;
+      if (existing > 0) {
+        _log.w(
+          'saveUserRomFolders called with an empty list while $existing ROM '
+          'folder(s) are configured - keeping them. Use removeRomFolder() to '
+          'remove one.',
+        );
+        return;
+      }
+    }
+
     await db.transaction((txn) async {
       await txn.delete('user_rom_folders');
-      for (final folder in folders) {
-        if (folder.isNotEmpty) {
-          await txn.insert('user_rom_folders', {'path': folder});
-        }
+      for (final folder in paths) {
+        await txn.insert('user_rom_folders', {'path': folder});
       }
     });
   }

--- a/test/rom_folders_empty_guard_test.dart
+++ b/test/rom_folders_empty_guard_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+
+import 'database_test_helper.dart';
+
+/// A blanket config save must never be able to wipe the configured ROM
+/// folders. `saveConfig` hands `saveUserRomFolders` whatever `romFolders` its
+/// config object carries, and an empty list there means "this object never had
+/// them" rather than "the user removed them" - removal has its own API.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final helper = DatabaseTestHelper();
+
+  setUp(() async {
+    await helper.setUp();
+  });
+
+  tearDown(() async {
+    await helper.tearDown();
+  });
+
+  Future<List<String>> storedFolders() async {
+    return SqliteService.getUserRomFolders();
+  }
+
+  test('saving an empty list keeps the configured folders', () async {
+    await SqliteService.saveUserRomFolders(['/roms', '/sdcard/roms']);
+    expect(await storedFolders(), ['/roms', '/sdcard/roms']);
+
+    await SqliteService.saveUserRomFolders([]);
+
+    expect(await storedFolders(), ['/roms', '/sdcard/roms']);
+  });
+
+  test('a list of only empty paths keeps the configured folders', () async {
+    await SqliteService.saveUserRomFolders(['/roms']);
+
+    await SqliteService.saveUserRomFolders(['', '']);
+
+    expect(await storedFolders(), ['/roms']);
+  });
+
+  test('an empty list is a no-op when nothing is configured', () async {
+    await SqliteService.saveUserRomFolders([]);
+
+    expect(await storedFolders(), isEmpty);
+  });
+
+  test('a non-empty list still replaces the existing folders', () async {
+    await SqliteService.saveUserRomFolders(['/old', '/also-old']);
+
+    await SqliteService.saveUserRomFolders(['/new']);
+
+    expect(await storedFolders(), ['/new']);
+  });
+
+  test('empty entries are dropped from a non-empty list', () async {
+    await SqliteService.saveUserRomFolders(['/roms', '', '/more-roms']);
+
+    expect(await storedFolders(), ['/roms', '/more-roms']);
+  });
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and covered by unit tests before posting. The underlying bug was observed on a real device; the fix itself is verified by tests, not by reproducing the field failure again.

# Description

`SqliteService.saveUserRomFolders` replaces the ROM-folder list by `DELETE`ing the whole `user_rom_folders` table and reinserting. `SqliteConfigService.saveConfig` calls it with whatever `romFolders` the `ConfigModel` it was handed happens to carry — so **any config save carrying an empty list erases every configured ROM folder.**

The damage is silent and self-reinforcing:

1. `user_rom_folders` is emptied by an unrelated config save.
2. The next scan therefore runs as a **fast scan**, which prunes every system and ROM row.
3. `recoverRomFoldersFromStoredRoms` — the safety net that rebuilds roots from stored games — now has nothing left to derive a root from (only Android app rows survive).

The library cannot heal itself, and nothing surfaces an error. Hit on an AYN Thor on 2026-08-02; the only repair was inserting the folder row into the device database by hand.

**The fix:** when the incoming list has no non-empty entries and the table currently has rows, log loudly and return without touching it.

It can be this blunt because **no caller legitimately clears the table this way** — deliberate removal has its own targeted API (`removeRomFolder(path)`, a scoped `DELETE`) that never reaches this function. There are only two callers:

- `sqlite_config_service.dart:95` — already guarded by `recoveredFolders.isNotEmpty`.
- `sqlite_config_service.dart:297` — the blanket `saveConfig` write. This is the problem one: an empty list there means *"this config object never had them"*, not *"the user removed them"*, and a bulk save cannot tell those apart — so it should not act on the difference.

Two small widenings over the narrowest possible fix: the guard triggers when there are no *non-empty* entries (a `['']` wipes the table just as thoroughly as `[]`), and the filtered list is reused for the insert loop so the empty-string skip isn't expressed twice.

This is a pre-existing `main` bug, found while working on an unrelated feature branch. No linked issue.

## Steps to Reproduce

**Preconditions:** an installed app with at least one configured ROM folder and a scanned library (`user_rom_folders` non-empty, `user_roms` populated).

1. Trigger any `SqliteConfigService.saveConfig` call with a `ConfigModel` whose `romFolders` is empty — e.g. a code path that builds a config object without populating them.
2. Observe `user_rom_folders` is now empty.
3. Trigger a library scan. It runs as a fast scan and prunes the system and ROM rows.
4. Restart. The library is empty, no ROM folder is configured, and recovery cannot restore it — the app reports `romFolders=0, fastScan=true`.

The deterministic repro of the destructive step alone is the first new test: save an empty list over a populated table and observe the rows disappear on `main`, survive on this branch.

**Note on what triggers step 1 in the field:** the specific caller that emptied the list on the affected device was never identified, which is part of why the guard is worth having — the failure is silent and the trigger is not obvious from the symptom.

**Not every empty library is this bug.** A build from a branch with a lower `_databaseVersion` drops every table via `_onDowngrade` and looks identical from outside. The tell: in that case the rest of the config is gone too, not just the folders.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation. — no user-facing or documented behaviour changes.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. — no new assets.
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [ ] Android — full suite green on Linux (571 existing + 5 new). The code path is platform-agnostic; the original field failure was on Android.
- [ ] **Gamepad support verified** (if applicable). — not applicable, no UI change.

### Tests

Five cases in `test/rom_folders_empty_guard_test.dart`, covering the guard and the behaviour it must not change:

- an empty list over a populated table keeps the folders
- a list of only empty strings over a populated table keeps the folders
- an empty list over an empty table is a no-op, not an error
- a non-empty list still replaces the existing folders
- empty entries are still dropped from an otherwise-populated list

## Screenshots (if applicable)

Not applicable — no visual change.
