### PR TITLE
fix: stop the games view mode from overwriting the systems view mode

### DIFF
--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -345,6 +345,9 @@ class SqliteMigrations {
       case 113:
         await _migrateToVersion113(db);
         break;
+      case 114:
+        await _migrateToVersion114(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -5358,6 +5361,43 @@ class SqliteMigrations {
       _log.i('Migration v113 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v113: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v114: Repairs `user_config.system_view_mode` values that the
+  /// games view used to write into it.
+  ///
+  /// Until the game view settings screen was removed, choosing a games layout
+  /// there wrote the games mode into `system_view_mode` as well — the two
+  /// columns were once one. They do not share a value domain: the systems view
+  /// understands only `grid` and `carousel`, so a user who picked the `list`
+  /// games layout was left with a systems mode nothing recognises. The systems
+  /// view falls back to the grid and neither option shows as selected in the
+  /// sort dropdown, and re-picking the layout by hand is the only way out.
+  ///
+  /// The writer is fixed, so this runs once to normalise the rows it already
+  /// wrote. `grid` matches both the column default and the fallback those users
+  /// are seeing, so the repair changes nothing they can observe except the
+  /// dropdown selection.
+  static Future<void> _migrateToVersion114(Database db) async {
+    _log.i('Migration v114: Normalising unrecognised system_view_mode values');
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_config)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+      if (!columns.contains('system_view_mode')) {
+        _log.i('Column system_view_mode absent, nothing to normalise');
+        return;
+      }
+      db.execute(
+        "UPDATE user_config SET system_view_mode = 'grid' "
+        "WHERE system_view_mode IS NULL "
+        "OR system_view_mode NOT IN ('grid', 'carousel')",
+      );
+      _log.i('Migration v114 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v114: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 113;
+  static const int _databaseVersion = 114;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -2589,10 +2589,7 @@ class SqliteService {
 
     // Update fields if provided
     if (lastScan != null) updates['last_scan'] = lastScan;
-    if (gameViewMode != null) {
-      updates['system_view_mode'] = gameViewMode; // Legacy mapping
-      updates['game_view_mode'] = gameViewMode;
-    }
+    if (gameViewMode != null) updates['game_view_mode'] = gameViewMode;
     if (systemViewMode != null) updates['system_view_mode'] = systemViewMode;
     if (themeName != null) updates['theme_name'] = themeName;
     if (videoSound != null) updates['video_sound'] = videoSound;
@@ -2742,17 +2739,6 @@ class SqliteService {
       'UPDATE user_detected_systems SET is_hidden = ? WHERE actual_folder_name = ?',
       [isHidden ? 1 : 0, folderName],
     );
-  }
-
-  /// Retrieves the game view mode (grid/list).
-  static Future<String> getGameViewMode() async {
-    final config = await getUserConfig();
-    return config?['game_view_mode']?.toString() ?? 'list';
-  }
-
-  /// Updates the game view mode.
-  static Future<void> updateGameViewMode(String mode) async {
-    await saveUserConfig(gameViewMode: mode);
   }
 
   /// Checks if recursive scan is enabled for a system.

--- a/lib/repositories/config_repository.dart
+++ b/lib/repositories/config_repository.dart
@@ -6,18 +6,6 @@ class ConfigRepository {
   static Future<List<String>> getUserRomFolders() =>
       SqliteService.getUserRomFolders();
 
-  /// Returns the current game view mode ('list', 'grid', etc.).
-  static Future<String> getGameViewMode() => SqliteService.getGameViewMode();
-
-  /// Persists the selected game view mode.
-  ///
-  /// UI should call `SqliteConfigProvider.updateGameViewMode` instead: writing
-  /// the column from here leaves the provider's in-memory [ConfigModel] holding
-  /// the old mode, and the next whole-config save writes that stale value back
-  /// over this one. The screen that did exactly that has been removed.
-  static Future<void> updateGameViewMode(String mode) =>
-      SqliteService.updateGameViewMode(mode);
-
   /// Returns the full user_config row, or null if not yet created.
   static Future<Map<String, dynamic>?> getUserConfig() =>
       SqliteService.getUserConfig();

--- a/test/config_repository_test.dart
+++ b/test/config_repository_test.dart
@@ -21,20 +21,6 @@ void main() {
     });
 
     test(
-      'getGameViewMode returns default "list" when no config exists',
-      () async {
-        final mode = await ConfigRepository.getGameViewMode();
-        expect(mode, 'list');
-      },
-    );
-
-    test('updateGameViewMode persists the mode', () async {
-      await ConfigRepository.updateGameViewMode('grid');
-      final mode = await ConfigRepository.getGameViewMode();
-      expect(mode, 'grid');
-    });
-
-    test(
       'getThemeName returns default "system" when no config exists',
       () async {
         final theme = await ConfigRepository.getThemeName();

--- a/test/game_view_mode_write_test.dart
+++ b/test/game_view_mode_write_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+
+import 'database_test_helper.dart';
+
+/// [SqliteService.saveUserConfig] used to mirror a `gameViewMode` write onto
+/// `system_view_mode` as well — a leftover from before the two were separate
+/// columns. The columns do not share a value domain: the games view also
+/// accepts `list`, which nothing on the systems side recognises, so writing
+/// the games view mode on its own silently dropped the systems view back to
+/// the grid with no option showing as selected.
+///
+/// Every production write currently names both modes, and the systems one is
+/// applied second, so the mapping was masked. These tests write the game mode
+/// alone, which is the only shape that shows it.
+void main() {
+  final dbHelper = DatabaseTestHelper();
+
+  setUp(() async => dbHelper.setUp());
+  tearDown(() async => dbHelper.tearDown());
+
+  group('game view mode writes', () {
+    test(
+      'writing the game view mode leaves the system view mode alone',
+      () async {
+        await SqliteService.saveUserConfig(systemViewMode: 'carousel');
+
+        await SqliteService.saveUserConfig(gameViewMode: 'list');
+
+        final stored = await SqliteService.getUserConfig();
+        expect(stored?['game_view_mode'].toString(), 'list');
+        expect(stored?['system_view_mode'].toString(), 'carousel');
+      },
+    );
+
+    test('both modes are still written when both are named', () async {
+      await SqliteService.saveUserConfig(
+        gameViewMode: 'carousel',
+        systemViewMode: 'grid',
+      );
+
+      final stored = await SqliteService.getUserConfig();
+      expect(stored?['game_view_mode'].toString(), 'carousel');
+      expect(stored?['system_view_mode'].toString(), 'grid');
+    });
+  });
+}

--- a/test/system_view_mode_repair_migration_test.dart
+++ b/test/system_view_mode_repair_migration_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+
+/// Tests for migration v114, which repairs `user_config.system_view_mode`
+/// values that the games view used to write into it.
+///
+/// The game view settings screen (removed in #317) saved the games layout
+/// through a writer that mirrored it onto `system_view_mode` as well. The
+/// systems view understands only `grid` and `carousel`, so anyone who picked
+/// the `list` games layout ended up with a systems mode nothing recognises:
+/// the view falls back to the grid and the sort dropdown shows no option as
+/// selected. The writer is fixed; this migration cleans up after it.
+void main() {
+  late Database db;
+
+  setUp(() {
+    db = sqlite3.openInMemory();
+    db.execute('''
+      CREATE TABLE user_config (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        system_view_mode TEXT DEFAULT 'grid',
+        game_view_mode TEXT DEFAULT 'list'
+      )
+    ''');
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  Future<void> runV114() => SqliteMigrations.migrateToVersion(db, 114);
+
+  void seed(String? systemViewMode, {String gameViewMode = 'list'}) {
+    db.execute(
+      'INSERT INTO user_config (id, system_view_mode, game_view_mode) '
+      'VALUES (1, ?, ?)',
+      [systemViewMode, gameViewMode],
+    );
+  }
+
+  String? storedSystemViewMode() {
+    final rows = db.select('SELECT system_view_mode FROM user_config');
+    return rows.first['system_view_mode'] as String?;
+  }
+
+  group('migration v114', () {
+    test(
+      'a games-view value written into the column is reset to grid',
+      () async {
+        seed('list');
+
+        await runV114();
+
+        expect(storedSystemViewMode(), 'grid');
+      },
+    );
+
+    test('a deliberate carousel choice is left alone', () async {
+      seed('carousel');
+
+      await runV114();
+
+      expect(storedSystemViewMode(), 'carousel');
+    });
+
+    test('an existing grid choice is left alone', () async {
+      seed('grid');
+
+      await runV114();
+
+      expect(storedSystemViewMode(), 'grid');
+    });
+
+    test('a null column is filled in with the default', () async {
+      seed(null);
+
+      await runV114();
+
+      expect(storedSystemViewMode(), 'grid');
+    });
+
+    test('the games view mode itself is untouched', () async {
+      seed('list', gameViewMode: 'list');
+
+      await runV114();
+
+      final rows = db.select('SELECT game_view_mode FROM user_config');
+      expect(rows.first['game_view_mode'], 'list');
+    });
+
+    test('an empty user_config is a no-op', () async {
+      await runV114();
+
+      final rows = db.select('SELECT COUNT(*) AS n FROM user_config');
+      expect(rows.first['n'], 0);
+    });
+
+    test('a database without the column does not throw', () async {
+      db.execute('DROP TABLE user_config');
+      db.execute('CREATE TABLE user_config (id INTEGER PRIMARY KEY)');
+
+      await expectLater(runV114(), completes);
+    });
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission.

# Description

Saving the **games** view layout also wrote the value into `system_view_mode`, so changing how games are listed silently changed how *systems* are displayed.

The two columns were a single column once, and `saveUserConfig` still carried the mapping:

```dart
if (gameViewMode != null) {
  updates['system_view_mode'] = gameViewMode; // Legacy mapping
  updates['game_view_mode'] = gameViewMode;
}
```

They do not share a value domain:

| Column | Accepted values | Read at |
|---|---|---|
| `game_view_mode` | `list`, `grid`, `carousel` | `game_view_mode_dropdown.dart` |
| `system_view_mode` | `grid`, `carousel` **only** | `my_systems_grid.dart:89`, `header_sort_dropdown.dart:281,500-502` |

So picking the **List** games layout wrote `system_view_mode = 'list'` — a value nothing recognises. `my_systems_grid.dart:89` tests only for `'carousel'`, so the systems view drops to the grid, and in `header_sort_dropdown.dart:500-502` **neither** option renders as selected. The user has no indication of what happened and no way back except re-picking a systems layout by hand.

`git log -S "Legacy mapping"` traces the line to the initial import (`b6148da1`), before the columns were split. Nothing has depended on it since.

### Why this still matters even though no caller remains

`GameViewSettingsScreen` was the live caller and #317 removed it, so the bug cannot fire on `main` today. But that screen shipped from the initial import until #317 and offered `list` as one of its two choices, so **affected databases already exist in the field** and do not self-heal.

Fixing the writer alone would prevent new cases and repair nobody, so this PR also adds **migration v114**, which normalises any `system_view_mode` outside `grid`/`carousel` back to `grid`. `grid` is both the column default and the fallback those users are already looking at, so nothing they can see changes except that the sort dropdown regains a selected option. The user's original systems choice is genuinely unrecoverable — the mapping overwrote it.

### Also removed

`get/updateGameViewMode` on `ConfigRepository` and `SqliteService`. They had no callers left after #317 and were the only entry point that could reach the mapping — a natural-looking API to wire back up to a screen. The UI path (`SqliteConfigProvider.updateGameViewMode` → `saveConfig`, which always writes both modes) is untouched.

Fixes # (no issue — found while following up on #317)

## Steps to Reproduce

**Preconditions**
- A build from before #317, so **Settings → Game View** still exists.
- Systems view set to **Carousel**, to make the change visible.

**Steps**
1. Systems screen → set the systems view to **Carousel**. Confirm the carousel renders.
2. Go to **Settings → Game View** and choose **List**.
3. Return to the systems screen.

**Actual:** the systems view is now a grid. Opening the sort dropdown shows *neither* Grid nor Carousel selected. `user_config.system_view_mode` reads `'list'`.

**Expected:** the systems view stays on Carousel. Changing the games layout should not touch it.

On `main` (post-#317) the screen is gone, so reproduce the writer directly:

```dart
await SqliteService.saveUserConfig(systemViewMode: 'carousel');
await SqliteService.saveUserConfig(gameViewMode: 'list');
// before: system_view_mode == 'list'   after: 'carousel'
```

That is `test/game_view_mode_write_test.dart`, which fails on `main` and passes here.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation. *(no doc covers this)*
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. *(no new assets)*
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable). *(no interactive surface changed; systems view driven by gamepad after the migration)*

### Tests

- `test/game_view_mode_write_test.dart` — the writer regression. **Confirmed failing before the fix** (`system_view_mode` read back `'list'`, expected `'carousel'`) and passing after. The existing suite did not cover this, which is how the mapping survived.
- `test/system_view_mode_repair_migration_test.dart` — 7 cases against v114: `list` → `grid`; `carousel` and `grid` left alone; NULL filled; `game_view_mode` untouched; empty table a no-op; missing column does not throw.
- Full suite: **619 passing**, `flutter analyze` clean, `dart format` clean.

### Device verification (AYN Thor, Android)

No affected row existed on my hardware — all three installed channels already read `grid` — so the repair was verified against a faithful synthetic case: a real v110 database (9,130 ROMs) poisoned exactly the way the removed screen would have, then launched under this build.

| | before | after |
|---|---|---|
| `user_version` | 110 | 111 → *renumbered to 114 after rebasing onto #318* |
| `system_view_mode` | `list` | **`grid`** — repaired |
| `game_view_mode` | `list` | `list` — untouched |
| `user_roms` | 9,130 | 9,130 — no data loss |

The systems view then rendered normally with the grid option selected. Note the device run predates the #318 rebase, so it exercised the migration as v111; only the version number changed afterwards, and the unit tests were re-run against v114.

> [!IMPORTANT]
> **Migration number.** This was authored as v111, then #318 merged and claimed 111–113, so it is now **v114** on top of `_databaseVersion = 113`. If anything else bumps the version before this merges, it needs renumbering again — a collision fails silently, since anyone already at that `user_version` would never run the repair.

## Screenshots (if applicable)

No visual change on a healthy database. For a repaired one, the systems view returns to the grid with the layout option correctly selected in the sort dropdown — the state it should have been in all along.
