### PR TITLE
fix(android): stop the game-session flag expiring 30s into a session

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
@@ -41,7 +41,16 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
     private val LAUNCHER_CHANNEL = "com.neogamelab.neostation/launcher"
     var keyListener: ((KeyEvent) -> Boolean)? = null
     var motionListener: ((MotionEvent) -> Boolean)? = null
-    private var isGameActive = false // Flag para saber si hay un juego activo
+    // A launched game still owns the foreground: set when Flutter starts a
+    // session and cleared only when the user actually comes back (onResume) or
+    // Flutter ends the session. Drives the session bookkeeping below — it must
+    // NOT expire on its own, or a session outlives the flag that describes it.
+    private var isGameActive = false
+    // Gamepad input is swallowed so a stray press during the handoff to the
+    // emulator can't leak into the UI behind it. Unlike [isGameActive] this is
+    // deliberately short-lived and self-expiring, so a launch that never hands
+    // off can't strand the pad.
+    private var gamepadBlocked = false
     private var gamepadBlockTimeout: Handler? = null // Timeout para desbloquear automáticamente
     private var methodChannel: MethodChannel? = null // Canal para comunicación con Flutter
     private var launcherMethodChannel: MethodChannel? = null // Canal para launcher
@@ -253,7 +262,9 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
                     setGamepadBlock(block, result)
                 }
                 "getGamepadBlockStatus" -> {
-                    result.success(isGameActive)
+                    // Reports the pad block, as the name says — not whether a
+                    // game session is open (the two now expire independently).
+                    result.success(gamepadBlocked)
                 }
                 "getGameLaunchTimestamp" -> {
                     result.success(gameLaunchTimestamp)
@@ -786,13 +797,36 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
         result.success(true)
     }
 
-    private fun setGamepadBlockInternal(block: Boolean, autoUnlockDelay: Long = 30000) {
-        isGameActive = block
+    /**
+     * Blocks or releases gamepad input, and — for a real game launch
+     * ([markGameActive]) — opens or closes the session the bookkeeping in
+     * [onPause]/[onResume] hangs off.
+     *
+     * The two are separate on purpose. The pad block auto-expires after
+     * [autoUnlockDelay] so a launch that never hands off to an emulator can't
+     * leave the pad dead, but a session routinely outlasts that timeout by
+     * hours — expiring both together left every session longer than the timeout
+     * with no "game active" flag, so the return path below silently did
+     * nothing (including never clearing [gameLaunchTimestamp], which then
+     * inflated the next session's elapsed time).
+     *
+     * App launches that only want the pad quiet during the handoff — the dock
+     * and [launchPackage] — pass `markGameActive = false`.
+     */
+    private fun setGamepadBlockInternal(
+        block: Boolean,
+        autoUnlockDelay: Long = 30000,
+        markGameActive: Boolean = true
+    ) {
+        gamepadBlocked = block
+        if (markGameActive) isGameActive = block
         if (block && autoUnlockDelay > 0) {
             gamepadBlockTimeout?.removeCallbacksAndMessages(null)
             gamepadBlockTimeout = Handler(Looper.getMainLooper()).apply {
                 postDelayed(Runnable {
-                    if (isGameActive) setGamepadBlockInternal(false, 0)
+                    // Release the pad only: the game is still running, and the
+                    // session ends when the user returns, not on a timer.
+                    gamepadBlocked = false
                 }, autoUnlockDelay)
             }
         } else {
@@ -841,7 +875,7 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
 
     // Gamepad event forwarding / blocking
     override fun dispatchGenericMotionEvent(motionEvent: MotionEvent): Boolean {
-        if (isGameActive) return true
+        if (gamepadBlocked) return true
         val handled = motionListener?.invoke(motionEvent) ?: false
         return if (handled) true else super.dispatchGenericMotionEvent(motionEvent)
     }
@@ -851,8 +885,8 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
         if (keyEvent.keyCode == KeyEvent.KEYCODE_BACK) {
             return true // Consumir completamente, no pasar a ningún lado
         }
-        
-        if (isGameActive) return true
+
+        if (gamepadBlocked) return true
         val handled = keyListener?.invoke(keyEvent) ?: false
         return if (handled) true else super.dispatchKeyEvent(keyEvent)
     }
@@ -984,9 +1018,10 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
             val intent = packageManager.getLaunchIntentForPackage(packageName)
             if (intent != null) {
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                // Block gamepad for a short duration to prevent accidental inputs on return
-                setGamepadBlockInternal(true, 2000) 
-                
+                // Block gamepad for a short duration to prevent accidental inputs on return.
+                // Not a game session: the caller owns that state, so leave isGameActive alone.
+                setGamepadBlockInternal(true, 2000, markGameActive = false)
+
                 startActivity(intent)
                 result.success(true)
             } else {
@@ -1010,8 +1045,9 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
                 return
             }
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            // Block gamepad briefly to avoid accidental inputs on return.
-            setGamepadBlockInternal(true, 2000)
+            // Block gamepad briefly to avoid accidental inputs on return. A dock
+            // app is not a game session, so this must not set isGameActive.
+            setGamepadBlockInternal(true, 2000, markGameActive = false)
 
             val dm = getSystemService(android.content.Context.DISPLAY_SERVICE) as android.hardware.display.DisplayManager
             val secondaryDisplay = dm.displays.firstOrNull { it.displayId != Display.DEFAULT_DISPLAY }


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission.

# Description

`isGameActive` in `MainActivity` carried two unrelated meanings: *"the pad is blocked during the handoff to the emulator"* and *"a game session is open"*. The pad block auto-expires 30 seconds after launch — and because both meanings shared one field, the session flag expired with it. Every session longer than 30 seconds therefore ran with no flag describing it.

`onResume`'s return handling hangs off that flag:

```kotlin
if (isGameActive) {
    // …compute elapsedSeconds…
    methodChannel?.invokeMethod("onGameReturned", …)
    setGamepadBlockInternal(false, 0)
    gameLaunchTimestamp = 0        // never reached for a real session
}
```

So for any session past 30 seconds the whole block was skipped: no `onGameReturned` reached Flutter, and `gameLaunchTimestamp` was never cleared — the stale value then inflated the *next* session's reported elapsed time by the gap between the two.

Nothing is visibly broken on `main` today, because `GameLaunchManager` also closes the session from Flutter's `AppLifecycleState.resumed` observer, which leaves the native path as dead redundancy costing ~830 ms of extra close latency. It stops being harmless the moment a launch doesn't pause `MainActivity` — a game started on a secondary display, for instance — because then the native signal is the only one there is, and a session that outlives the pad block can never be closed at all.

## The fix

Split the two concerns:

- **`gamepadBlocked`** — keeps the existing self-expiring timeout so a launch that never hands off can't strand the pad. This is what `dispatchKeyEvent` / `dispatchGenericMotionEvent` now read, so input behaviour is unchanged.
- **`isGameActive`** — now genuinely means "a session is open": set when Flutter starts one, cleared when the user returns or Flutter ends it. No timer touches it.

Dock and app launches (`launchPackage`, `launchPackageOnSecondaryDisplay`) only ever wanted the pad quiet for 2 s during the handoff, so they pass `markGameActive = false` rather than opening a session they don't own. `getGamepadBlockStatus` now reports the pad block, matching its name — it has no Dart callers, so nothing observes the change.

## Steps to Reproduce

**Preconditions:** Android device, a working emulator (RetroArch here), `adb logcat` attached. The two log lines that matter are `[GameLaunchManager] Android: user returned — canDismiss=true.` (the Flutter lifecycle fallback, fires 800 ms after return) and `[GameLaunchManager] Close triggered — entering syncing phase.` (the close itself, reached by either path). The lifecycle line appears **only** when the native path failed to fire.

1. Launch any game and quit the emulator after ~10 seconds (under the 30 s pad-block timeout).
2. Launch the same game, play for 60+ seconds, quit.
3. Compare the two closes in logcat.

**Before:** run 1 closes in ~4 ms with no `canDismiss` line (native path). Run 2 shows `canDismiss=true` ~800 ms after `performResumeActivity`, then the close — the native path was silent.

**After:** both runs close in ~4 ms off the native path, with no `canDismiss` line.

Measured on an AYN Thor (Android 13), release channel vs this branch:

| Build | Session | Emulator died | `performResumeActivity` | Session closed | Path | Latency |
|---|---|---|---|---|---|---|
| release | ~9 s | `12:27:04.368` | `.373` | `.372` | native | 4 ms |
| release | ~120 s | `12:30:14.372` | `.378` | `12:30:15.215` | lifecycle fallback | 836 ms |
| this branch | ~78 s | `12:36:38.898` | `.903` | `.902` | native | 4 ms |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works — the change is Android activity-lifecycle behaviour with no Dart surface, so it is verified on-device (see the table above) rather than by unit test. `flutter test` (629 tests) passes unchanged.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses (none added).
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** — input blocking is unchanged by construction (it moved to `gamepadBlocked`, which keeps the same 30 s / 2 s timeouts); verified across game launches and dock app launches on the Thor.

## Notes

Found while reviewing #321, which launches games on a secondary display: nothing pauses `MainActivity` in that case, so the accessibility-driven native signal is the only way that session can ever close — and it lands on exactly this expired flag. This PR is deliberately independent of that one and changes nothing about the second-screen feature.
