### PR TITLE
Add Emucore V to the Vita System and ARMSX3 to the PS3 system

### DIFF
--- a/assets/systems/ds.json
+++ b/assets/systems/ds.json
@@ -236,6 +236,17 @@
       }
     },
     {
+      "name": "Standalone Seedless DS",
+      "unique_id": "ds.standalone.Seedless",
+      "is_retroachievements_compatible": false,
+      "description": "SeedlessDS emulator",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.seedlessds.app/com.seedlessds.app.LaunchGame -e rom_path \"{file.path}\""
+        }
+      }
+    },
+    {
       "name": "Standalone NooDS",
       "unique_id": "ds.standalone.noods",
       "is_retroachievements_compatible": false,

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -40,7 +40,19 @@
         }
       }
     },
-    {
+    [
+      "name": "Standalone ARMSX3",
+      "default_standalone": true,
+      "unique_id": "ps3.armsx3.",
+      "description": "Supported extensions: iso.",
+      "is_retroachievements_compatible": false,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.armsx3/com.armsx2.Main -e iso_uri \"{file.uri}\""
+        }
+      }
+    },
+    ]
       "name": "Standalone RPCS3",
       "unique_id": "ps3.rpcs3",
       "description": "Supported extensions: iso.",
@@ -59,6 +71,18 @@
         "macos": {
           "executable": "rpcs3",
           "args": "--no-gui \"{file.path}\""
+        }
+      }
+    },
+    ]
+      "name": "Standalone aPS3e",
+      "default_standalone": true,
+      "unique_id": "ps3.aenu.aps3e",
+      "description": "Supported extensions: iso.",
+      "is_retroachievements_compatible": false,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n aenu.aps3e/aenu.aps3e.EmulatorActivity -a aenu.intent.action.APS3E -e iso_uri \"{file.uri}\""
         }
       }
     }

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -33,7 +33,7 @@
       "name": "Standalone aPS3e",
       "default_standalone": true,
       "unique_id": "ps3.aenu.aps3e",
-      "description": "Supported extensions: iso.",
+      "description": "Supported extensions: iso, ps3folder.",
       "is_retroachievements_compatible": false,
       "platforms": {
         "android": {
@@ -45,7 +45,7 @@
       "name": "Standalone ARMSX3",
       "default_standalone": true,
       "unique_id": "ps3.armsx3.",
-      "description": "Supported extensions: iso.",
+      "description": "Supported extensions: iso, ps3folder.",
       "is_retroachievements_compatible": false,
       "platforms": {
         "android": {

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -48,7 +48,7 @@
       "is_retroachievements_compatible": false,
       "platforms": {
         "android": {
-          "launch_arguments": "-n com.armsx3/com.armsx2.Main -a android.intent.action.VIEW -e path \"{file.uri}\""
+          "launch_arguments": "-n com.armsx3/com.armsx2.Main -a android.intent.action.VIEW -e path \"{file.path}\""
         }
       }
     },

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -48,7 +48,7 @@
       "is_retroachievements_compatible": false,
       "platforms": {
         "android": {
-          "launch_arguments": "-n com.armsx3/com.armsx2.Main -e iso_uri \"{file.uri}\""
+          "launch_arguments": "-n com.armsx3/com.armsx2.Main android.intent.action.VIEW -e path_uri \"{file.uri}\""
         }
       }
     },

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -32,7 +32,7 @@
       "name": "Standalone aPS3e",
       "default_standalone": true,
       "unique_id": "ps3.aenu.aps3e",
-      "description": "Supported extensions: iso, ps3folder.",
+      "description": "Supported extensions: iso.",
       "is_retroachievements_compatible": false,
       "platforms": {
         "android": {
@@ -44,7 +44,7 @@
       "name": "Standalone ARMSX3",
       "default_standalone": true,
       "unique_id": "ps3.armsx3.",
-      "description": "Supported extensions: iso, ps3folder.",
+      "description": "Supported extensions: iso.",
       "is_retroachievements_compatible": false,
       "platforms": {
         "android": {

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -48,7 +48,7 @@
       "is_retroachievements_compatible": false,
       "platforms": {
         "android": {
-          "launch_arguments": "-n com.armsx3/com.armsx2.Main android.intent.action.VIEW -e path_uri \"{file.uri}\""
+          "launch_arguments": "-n com.armsx3/com.armsx2.Main android.intent.action.VIEW -d \"{file.uri}\""
         }
       }
     },

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -48,7 +48,7 @@
       "is_retroachievements_compatible": false,
       "platforms": {
         "android": {
-          "launch_arguments": "-n com.armsx3/com.armsx2.Main android.intent.action.VIEW -d \"{file.uri}\""
+          "launch_arguments": "-n com.armsx3/com.armsx2.Main -a android.intent.action.VIEW -e file_path \"{file.uri}\""
         }
       }
     },

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -24,8 +24,7 @@
       "#9e9e9e"
     ],
     "extensions": [
-      "iso",
-     "ps3folder"
+      "iso"
     ]
   },
   "emulators": [

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -24,7 +24,8 @@
       "#9e9e9e"
     ],
     "extensions": [
-      "iso"
+      "iso",
+     "ps3folder"
     ]
   },
   "emulators": [

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -48,7 +48,7 @@
       "is_retroachievements_compatible": false,
       "platforms": {
         "android": {
-          "launch_arguments": "-n com.armsx3/com.armsx2.Main -a android.intent.action.VIEW -e file_path \"{file.uri}\""
+          "launch_arguments": "-n com.armsx3/com.armsx2.Main -a android.intent.action.VIEW -e path \"{file.uri}\""
         }
       }
     },

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -40,7 +40,7 @@
         }
       }
     },
-    [
+    {
       "name": "Standalone ARMSX3",
       "default_standalone": true,
       "unique_id": "ps3.armsx3.",
@@ -52,7 +52,7 @@
         }
       }
     },
-    ]
+    {
       "name": "Standalone RPCS3",
       "unique_id": "ps3.rpcs3",
       "description": "Supported extensions: iso.",
@@ -71,19 +71,7 @@
         "macos": {
           "executable": "rpcs3",
           "args": "--no-gui \"{file.path}\""
-        }
       }
-    },
-    ]
-      "name": "Standalone aPS3e",
-      "default_standalone": true,
-      "unique_id": "ps3.aenu.aps3e",
-      "description": "Supported extensions: iso.",
-      "is_retroachievements_compatible": false,
-      "platforms": {
-        "android": {
-          "launch_arguments": "-n aenu.aps3e/aenu.aps3e.EmulatorActivity -a aenu.intent.action.APS3E -e iso_uri \"{file.uri}\""
-        }
       }
     }
   ],

--- a/assets/systems/vita.json
+++ b/assets/systems/vita.json
@@ -61,6 +61,17 @@
       "platforms": {
         "android": {
           "launch_arguments": "-n org.vita3k.emulator.ikhoeyZX/org.vita3k.emulator.Emulator --esa AppStartParameters \"-r,{tags.vita_game_id}\""
+          }
+      }
+    },
+	{
+      "name": "Standalone EmucoreV",
+      "unique_id": "vita.emucorev",
+      "description": "Supported extensions: dpt.",
+      "is_retroachievements_compatible": false,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.sbro.emucorev/.core.vita.Emulator --esa AppStartParameters \"-r,{tags.vita_game_id}\""
         }
       }
     }


### PR DESCRIPTION
Hey Devs,
Please add PS Vita emulator EmuCoreV and PS3 Emulator to ARMSX3 .

I have tested both on these 2 commits and both work as expected.



It took a bit of time to work out the launch commands for neostation for ARMSX3


The PS3 emulator supports the folder format so I will work on adding that in now.


Edit


I couldnt get the folder format to work with neostation.

Any chance you can add that in?




  
