### PR TITLE
feat: prefer banner+logo over screenshot in second-screen library preview

### DIFF
--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -536,7 +536,9 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
 
   void _startVideoTimer(String path) {
     _videoTimer?.cancel();
-    _videoTimer = Timer(const Duration(milliseconds: 500), () {
+    // Give the banner + logo a moment on screen before the video takes over,
+    // rather than flashing straight to video on every hover.
+    _videoTimer = Timer(const Duration(seconds: 3), () {
       _initializeVideo(path);
     });
   }
@@ -834,7 +836,19 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                                 value.gameWheel != null)
                                               buildFanartWithLogo(value),
                                           ] else ...[
-                                            if (value.gameImageBytes != null)
+                                            // Library browsing (not actively
+                                            // launching): banner + logo reads
+                                            // better at a glance than a raw
+                                            // screenshot, and is what the
+                                            // video (below, after a few
+                                            // seconds) fades in from. Falls
+                                            // back to the screenshot only when
+                                            // there's no fanart/wheel at all.
+                                            if (value.gameFanart != null ||
+                                                value.gameWheel != null)
+                                              buildFanartWithLogo(value)
+                                            else if (value.gameImageBytes !=
+                                                null)
                                               buildBackgroundBytes(
                                                 value.gameImageBytes!,
                                                 fit: BoxFit
@@ -846,10 +860,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                                 value.gameScreenshot!,
                                                 fit: BoxFit
                                                     .contain, // "se debe ver completo"
-                                              )
-                                            else if (value.gameFanart != null ||
-                                                value.gameWheel != null)
-                                              buildFanartWithLogo(value),
+                                              ),
                                           ],
                                         ],
                                       ],


### PR DESCRIPTION
## Summary
- While browsing the library (not actively launching a game), the secondary-display preview now shows the banner + logo first, falling back to a raw screenshot only when there's no fanart/wheel art at all.
- The preview video now waits 3 seconds before starting (was 500ms), so quickly scrolling through the list doesn't just flash video after video — you get a moment on the banner/logo first.

## Why
A raw gameplay screenshot reads worse at a glance while browsing than clean banner + logo art, and starting the preview video almost immediately made fast scrolling feel noisy. This only touches the library-browsing preview path — the actively-launching path (which already prioritizes fanart+logo) is untouched.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — full suite green (only the pre-existing unrelated `linux_emulator_discovery_test.dart` failure, present on `main` too)
- [x] Manually verified on an AYN Thor with a second screen attached: browsing the library shows banner+logo, video kicks in after ~3s of hovering on a game

No screenshot on this one — it only shows up on an external/secondary display, which wasn't attached during this PR round. Happy to add one if useful.