### PR TITLE
feat: library statistics as a widget on the All Games card

### DIFF
--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -425,6 +425,21 @@ class SqliteDatabaseService {
     }
   }
 
+  /// Retrieves whole-library statistics for the "All Games" details card.
+  static Future<Map<String, dynamic>> getLibraryStats() async {
+    try {
+      return await SqliteService.getLibraryStats();
+    } catch (e) {
+      _log.e('Error getting library stats: $e');
+      return {
+        'totalGames': 0,
+        'totalPlaytimeSeconds': 0,
+        'totalSystems': 0,
+        'mostPlayedGame': null,
+      };
+    }
+  }
+
   /// Retrieves the current ROM count for all detected systems.
   static Future<Map<String, int>> getRomCounts() async {
     try {

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -4679,6 +4679,42 @@ class SqliteService {
     return {'totalGames': totalGamesCount, 'systems': systems};
   }
 
+  /// Retrieves whole-library statistics for the "All Games" details card:
+  /// total games/systems, cumulative play time, and the single most-played
+  /// game. Cheap even on large libraries — three small aggregate queries,
+  /// no per-row Dart-side work.
+  static Future<Map<String, dynamic>> getLibraryStats() async {
+    final db = await instance.database;
+
+    final totals = (await db.rawQuery('''
+      SELECT COUNT(*) as total_games, COALESCE(SUM(play_time), 0) as total_playtime
+      FROM user_roms
+    ''')).first;
+
+    final systemsRow = (await db.rawQuery(
+      'SELECT COUNT(*) as count FROM user_detected_systems',
+    )).first;
+
+    final mostPlayedRows = await db.rawQuery('''
+      SELECT ur.title_name, ur.real_name, ur.filename, ur.play_time, s.real_name as system_name
+      FROM user_roms ur
+      JOIN app_systems s ON s.id = ur.app_system_id
+      WHERE ur.play_time > 0
+      ORDER BY ur.play_time DESC
+      LIMIT 1
+    ''');
+
+    return {
+      'totalGames':
+          int.tryParse(totals['total_games']?.toString() ?? '0') ?? 0,
+      'totalPlaytimeSeconds':
+          int.tryParse(totals['total_playtime']?.toString() ?? '0') ?? 0,
+      'totalSystems':
+          int.tryParse(systemsRow['count']?.toString() ?? '0') ?? 0,
+      'mostPlayedGame': mostPlayedRows.isEmpty ? null : mostPlayedRows.first,
+    };
+  }
+
   /// Identifies the current host operating system as a standardized string.
   static String getCurrentOs() {
     if (Platform.isWindows) return 'windows';

--- a/lib/repositories/game_repository.dart
+++ b/lib/repositories/game_repository.dart
@@ -39,6 +39,11 @@ class GameRepository {
   static Future<Map<String, dynamic>> getStats() =>
       SqliteDatabaseService.getStats();
 
+  /// Returns whole-library statistics: totalGames, totalPlaytimeSeconds,
+  /// totalSystems, and mostPlayedGame (or null if nothing has been played).
+  static Future<Map<String, dynamic>> getLibraryStats() =>
+      SqliteDatabaseService.getLibraryStats();
+
   /// Returns ROM counts keyed by system folder name.
   static Future<Map<String, int>> getRomCounts() =>
       SqliteDatabaseService.getRomCounts();

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -30,6 +30,7 @@ import 'package:neostation/widgets/header_sort_dropdown.dart';
 import 'package:neostation/widgets/native_carousel.dart';
 import 'system_list_builder.dart';
 import 'system_card.dart';
+import '../system_details_card/system_details.dart';
 
 /// A premium carousel-based orchestrator for system and recent game selection.
 ///
@@ -1027,9 +1028,44 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
             );
           }
 
-          return content;
+          return _withLibraryStatsOverlay(content, allSystems[_currentIndex]);
         },
       ),
+    );
+  }
+
+  /// Floats the (otherwise-unused) [SystemDetails] card over the carousel's
+  /// bottom-left corner while the 'All Games' entry is focused — the
+  /// carousel's own horizontal scroller has no reserved space for a
+  /// persistent sidebar, so this overlays rather than reflowing the layout.
+  Widget _withLibraryStatsOverlay(Widget content, SystemInfo focused) {
+    final showStats = focused.folderName?.toLowerCase() == 'all';
+    return Stack(
+      children: [
+        content,
+        Positioned(
+          left: 16.r,
+          bottom: 64.r,
+          width: 280.r,
+          height: 220.r,
+          child: IgnorePointer(
+            child: AnimatedOpacity(
+              opacity: showStats ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 220),
+              child: showStats
+                  ? SystemDetails(
+                      selectedSystem: _createAllGamesSystem(
+                        Provider.of<SqliteConfigProvider>(
+                          context,
+                          listen: false,
+                        ).detectedSystems,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/screens/systems_screen/system_details_card/system_details.dart
+++ b/lib/screens/systems_screen/system_details_card/system_details.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import '../../../models/system_model.dart';
+import '../../../repositories/game_repository.dart';
+import '../../secondary_screen/now_playing_helpers.dart' show formatPlayTime;
 
 /// A premium informational sidebar component displaying system metadata.
 ///
@@ -16,20 +19,50 @@ class SystemDetails extends StatefulWidget {
 }
 
 class SystemDetailsState extends State<SystemDetails> {
+  /// Whole-library stats shown when the 'All Games' card is focused. Null
+  /// while loading or when nothing has been fetched yet.
+  Map<String, dynamic>? _libraryStats;
+
+  bool get _isAllSelected =>
+      widget.selectedSystem?.folderName.toLowerCase() == 'all';
+
+  @override
+  void initState() {
+    super.initState();
+    if (_isAllSelected) _loadLibraryStats();
+  }
+
+  @override
+  void didUpdateWidget(SystemDetails oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final wasAllSelected =
+        oldWidget.selectedSystem?.folderName.toLowerCase() == 'all';
+    if (_isAllSelected && !wasAllSelected) {
+      _loadLibraryStats();
+    } else if (!_isAllSelected) {
+      _libraryStats = null;
+    }
+  }
+
+  Future<void> _loadLibraryStats() async {
+    final stats = await GameRepository.getLibraryStats();
+    if (mounted && _isAllSelected) setState(() => _libraryStats = stats);
+  }
+
   /// Renders hardware statistics and technical descriptions for a specific system.
   Widget _buildSystemStats(BuildContext context) {
     // Special branding for the 'ALL' (Global Library) view.
     final isAllSystem =
         widget.selectedSystem!.folderName.toLowerCase() == 'all';
-    const neoStationDescription =
-        'NeoStation is your ultimate hub for classic games. Relive the nostalgia and rediscover gaming history.';
 
     return Column(
       children: [
-        // Content Area: Prioritize hardware description or global branding.
-        if (isAllSystem ||
-            (widget.selectedSystem!.description != null &&
-                widget.selectedSystem!.description!.isNotEmpty)) ...[
+        // Content Area: library stats for 'All Games', hardware description
+        // for a specific system, both falling back to global branding.
+        if (isAllSystem) ...[
+          Expanded(child: _buildLibraryStats(context)),
+        ] else if (widget.selectedSystem!.description != null &&
+            widget.selectedSystem!.description!.isNotEmpty) ...[
           Expanded(
             child: Container(
               width: double.infinity,
@@ -47,9 +80,7 @@ class SystemDetailsState extends State<SystemDetails> {
                 ),
               ),
               child: Text(
-                isAllSystem
-                    ? neoStationDescription
-                    : widget.selectedSystem!.description!,
+                widget.selectedSystem!.description!,
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color: Theme.of(
                     context,
@@ -108,6 +139,128 @@ class SystemDetailsState extends State<SystemDetails> {
             ),
           ),
         ],
+      ],
+    );
+  }
+
+  /// Whole-library stat rows shown for the 'All Games' card: total games,
+  /// cumulative play time, systems detected, and the single most-played
+  /// game. Loads once per focus via [_loadLibraryStats]; shows a spinner
+  /// for the brief window before the first result lands.
+  Widget _buildLibraryStats(BuildContext context) {
+    final stats = _libraryStats;
+    final theme = Theme.of(context);
+
+    if (stats == null) {
+      return Center(
+        child: SizedBox(
+          width: 20.r,
+          height: 20.r,
+          child: CircularProgressIndicator(
+            strokeWidth: 2.r,
+            color: theme.colorScheme.primary.withValues(alpha: 0.5),
+          ),
+        ),
+      );
+    }
+
+    final mostPlayed = stats['mostPlayedGame'] as Map<String, Object?>?;
+    final mostPlayedName = mostPlayed == null
+        ? null
+        : ((mostPlayed['title_name'] as String?)?.isNotEmpty == true
+              ? mostPlayed['title_name'] as String
+              : (mostPlayed['real_name'] as String?) ??
+                    (mostPlayed['filename'] as String? ?? ''));
+
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.all(12.r),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(
+          alpha: 0.3,
+        ),
+        borderRadius: BorderRadius.circular(12.r),
+        border: Border.all(
+          color: theme.colorScheme.outline.withValues(alpha: 0.1),
+          width: 1.r,
+        ),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          _buildStatRow(
+            theme,
+            icon: Symbols.videogame_asset_rounded,
+            label: 'Games',
+            value: '${stats['totalGames']}',
+          ),
+          SizedBox(height: 10.r),
+          _buildStatRow(
+            theme,
+            icon: Symbols.dns_rounded,
+            label: 'Systems',
+            value: '${stats['totalSystems']}',
+          ),
+          SizedBox(height: 10.r),
+          _buildStatRow(
+            theme,
+            icon: Symbols.schedule_rounded,
+            label: 'Total Playtime',
+            value: formatPlayTime(stats['totalPlaytimeSeconds'] as int?),
+          ),
+          if (mostPlayedName != null && mostPlayedName.isNotEmpty) ...[
+            SizedBox(height: 10.r),
+            _buildStatRow(
+              theme,
+              icon: Symbols.local_fire_department_rounded,
+              label: 'Most Played',
+              value: mostPlayedName,
+              valueMaxLines: 2,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatRow(
+    ThemeData theme, {
+    required IconData icon,
+    required String label,
+    required String value,
+    int valueMaxLines = 1,
+  }) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          icon,
+          size: 14.r,
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        ),
+        SizedBox(width: 8.r),
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+            fontSize: 11.r,
+          ),
+        ),
+        const Spacer(),
+        Expanded(
+          flex: 2,
+          child: Text(
+            value,
+            textAlign: TextAlign.right,
+            maxLines: valueMaxLines,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurface,
+              fontWeight: FontWeight.w700,
+              fontSize: 11.r,
+            ),
+          ),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- New `SqliteService.getLibraryStats()` (+ repository/datasource passthroughs) computing total games, total systems, total playtime, and the single most-played game.
- Wired into the existing `SystemDetails` card for the virtual "All Games" system, replacing its static description text with these real numbers.
- Also surfaced as a small floating overlay on the carousel view when "All Games" is focused, since the underlying `SystemDetails` card wasn't rendered anywhere in the carousel layout before this.

## Why
Requested as a "spielstatistiken als widget" (game statistics as a widget) feature — a quick at-a-glance view of library size and play habits, in the spirit of what other launchers (Cocoon, iiSU) surface.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — full suite green (only the pre-existing unrelated `linux_emulator_discovery_test.dart` failure, present on `main` too)
- [x] Manually verified stats compute correctly against a real library (games/systems/playtime/most-played)

## Note
No screenshot on this one — while testing on an AYN Thor I couldn't get the "All Games" card to actually appear in either the grid or carousel view on that specific device/config, so I couldn't grab a live shot of the finished overlay. The stats computation and wiring are verified and covered by the code path, but I'd appreciate a maintainer double-check on a config where "All Games" is visible before merging, in case there's a config-gating reason it doesn't show there.