### PR TITLE
fix(steam): store Steam box art in the folder the UI reads

### DIFF
--- a/lib/services/steam_scraper_service.dart
+++ b/lib/services/steam_scraper_service.dart
@@ -159,7 +159,7 @@ class SteamScraperService {
 
     // Steam API Mapping to NeoStation Media Convention:
     // - Static URL based on AppID -> fanarts/ (Background art)
-    // - Static URL based on AppID -> box2D/ (Box art)
+    // - Static URL based on AppID -> box2d/ (Box art)
     // - Static URL based on AppID -> wheels/ (Transparent Logo)
     // - screenshots[0] -> screenshots/ (In-game thumbnail)
 
@@ -179,7 +179,7 @@ class SteamScraperService {
 
     await _downloadFile(
       box2dUrl,
-      path.join(mediaDir, systemFolder, 'box2D', '$romBaseName.jpg'),
+      path.join(mediaDir, systemFolder, 'box2d', '$romBaseName.jpg'),
     );
 
     // Standardize logos to PNG format; perform cleanup of legacy JPG assets.
@@ -241,7 +241,7 @@ class SteamScraperService {
     // Define the core media requirements for a 'complete' entry.
     final imageConfigs = [
       {'folder': 'fanarts', 'ext': 'jpg'},
-      {'folder': 'box2D', 'ext': 'jpg'},
+      {'folder': 'box2d', 'ext': 'jpg'},
       {'folder': 'wheels', 'ext': 'png'},
       {'folder': 'screenshots', 'ext': 'jpg'},
     ];


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission.

# Description

Steam box art never appeared on Linux/SteamOS. The Steam scraper wrote it to `media/<system>/box2D/`, but every reader in the app resolves box art from `box2d/`.

`FileProvider.getMediaPath` uses the media-type string verbatim as a path segment, so on a case-sensitive filesystem those are two different directories: the file downloaded fine, it just landed somewhere nothing looks. Windows, macOS and Android are case-insensitive, which is why this only ever showed up on the Deck.

Three characters, one file (`lib/services/steam_scraper_service.dart`): the download target, the matching comment, and the `_needsImages` completeness check.

That last one is why the bug was silent. `_needsImages` probed the same wrong folder it had just written to, found the file, and marked the entry complete — so no retry, no warning, and nothing in the logs. The only symptom was a blank box in the UI.

### Scope

The other `box2D` strings in the codebase are deliberately left alone. Those are ScreenScraper **API media-type names**, which `MediaResolver.mapMediaTypeToFolder` already maps to the `box2d` folder. Only the Steam scraper bypassed that mapping and used the API-style name as a literal path.

Fixes # (no issue filed — found while testing Steam library support on the Deck)

## Steps to Reproduce

**Preconditions**

- A **case-sensitive** filesystem — Linux or SteamOS. The bug is invisible on Windows, macOS and Android.
- Steam scraping configured, with a `steam` system that has at least one entry (e.g. `roms/steam/Team Fortress 2.steam` containing the AppID).
- No previously scraped media for that entry (delete `~/.neostation/media/steam/` to start clean).

**Reproduce (before this PR)**

1. Launch NeoStation and run a scrape/rescan over the `steam` system.
2. Open the Steam system in the game list.
3. **Observed:** fanart, wheel and screenshot all render; the box art slot is empty. No error is shown and nothing is logged.
4. `ls ~/.neostation/media/steam/` shows a stray `box2D/` directory holding the image, alongside the `box2d/` the UI reads.
5. Rescanning does not fix it — `_needsImages` sees its own file in `box2D/` and reports the entry complete.

**After this PR**

Same steps: the image lands in `box2d/` and the box art renders.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. — the change is a path-literal correction with no seam to test against; `_downloadFile` writes to the real filesystem from a live Steam CDN URL. Verified on-device instead (below).
- [ ] I have updated the corresponding documentation. — no doc change needed.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. — no new assets.
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [ ] Android
- [x] **Gamepad support verified** (if applicable). — no input-path change; navigated the game list with the pad to confirm the art renders.

Full local gate green: `dart format` clean (443 files, 0 changed), `flutter analyze` → *No issues found*, `flutter test` → **629 passed**.

## Screenshots (if applicable)

Verified on a Steam Deck (SteamOS, Game Mode) with a `Team Fortress 2.steam` fixture. After a rescan, all four media types land in the folders the UI reads — note `box2d/`, lowercase, and no stray `box2D/` anywhere under `~/.neostation`:

```
~/.neostation/media/steam/box2d/Team Fortress 2.jpg          57,351
~/.neostation/media/steam/fanarts/Team Fortress 2.jpg       232,097
~/.neostation/media/steam/screenshots/Team Fortress 2.jpg    64,212
~/.neostation/media/steam/wheels/Team Fortress 2.png        277,674
```

Box art confirmed rendering in the game list on the device.
