### PR TITLE
fix(splash): keep the status block off the logo on short panels

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          # Pinned, not `channel: stable`. An unpinned stable silently moves
+          # under CI: 3.47.0 shipped a `dart format` that relaid out a file
+          # nobody had touched and an `unawaited_return_in_try_block` lint that
+          # fires in four existing files, so main went red without a commit.
+          # Bump this deliberately, in its own PR, with the fallout fixed.
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -80,13 +86,14 @@ jobs:
         if: matrix.target != 'linux-arm'
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
       - name: Setup Flutter (ARM64 Manual)
         if: matrix.target == 'linux-arm'
         run: |
-          git clone -b stable --depth 1 https://github.com/flutter/flutter.git $HOME/flutter
+          git clone -b 3.44.9 --depth 1 https://github.com/flutter/flutter.git $HOME/flutter
           echo "$HOME/flutter/bin" >> $GITHUB_PATH
           export PATH="$HOME/flutter/bin:$PATH"
           flutter config --no-analytics

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          # Pinned, not `channel: stable`. An unpinned stable silently moves
+          # under CI: 3.47.0 shipped a `dart format` that relaid out a file
+          # nobody had touched and an `unawaited_return_in_try_block` lint that
+          # fires in four existing files, so main went red without a commit.
+          # Bump this deliberately, in its own PR, with the fallout fixed.
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:neostation/services/startup_theme_cache.dart';
 import 'package:neostation/widgets/splash_status_layout.dart';
 import 'package:neostation/widgets/permission_check_wrapper.dart';
 import 'package:neostation/utils/custom_scroll_behavior.dart';
+import 'package:neostation/utils/display_metrics_log.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:neostation/services/config_service.dart';
@@ -865,7 +866,8 @@ class _MyAppState extends State<MyApp> {
             designSize: const Size(640, 480),
             minTextAdapt: true,
             splitScreenMode: true,
-            builder: (_, child) {
+            builder: (screenUtilContext, child) {
+              logDisplayMetrics(screenUtilContext, 'main');
               return FocusTraversalGroup(
                 policy: NoFocusTraversalPolicy(),
                 child: Shortcuts(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,7 @@ import 'package:neostation/providers/system_background_provider.dart';
 import 'package:neostation/providers/neo_assets_provider.dart';
 import 'package:neostation/widgets/app_lifecycle_handler.dart';
 import 'package:neostation/services/startup_theme_cache.dart';
-import 'package:neostation/widgets/shimmering_logo.dart';
+import 'package:neostation/widgets/splash_status_layout.dart';
 import 'package:neostation/widgets/permission_check_wrapper.dart';
 import 'package:neostation/utils/custom_scroll_behavior.dart';
 import 'package:flutter_localization/flutter_localization.dart';
@@ -492,27 +492,12 @@ class _StartupScaffoldState extends State<_StartupScaffold> {
               : (_, event) => widget.onKeyEvent!(event),
           // Animated mode pins the logo at the exact screen centre — the same
           // spot the Android 12+ splash icon occupies — with the status text
-          // hung below centre, so the native→Flutter handoff and the later
-          // screens never move the logo. The error screen keeps the simpler
-          // centred column with the wordmark.
+          // hung below it, so the native→Flutter handoff and the later screens
+          // never move the logo. Shared with the scan splash so the
+          // text/progress zone is one fixed place all intro. The error screen
+          // keeps the simpler centred column with the wordmark.
           child: widget.animatedLogo
-              ? Stack(
-                  children: [
-                    const Center(child: ShimmeringLogo()),
-                    Align(
-                      // Same offset as the scan splash's progress detail so
-                      // the text/progress zone is one fixed place all intro.
-                      alignment: const Alignment(0, 0.55),
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 32),
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: children,
-                        ),
-                      ),
-                    ),
-                  ],
-                )
+              ? SplashStatusLayout(children: children)
               : Center(
                   child: Padding(
                     padding: const EdgeInsets.all(32),

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -15,6 +15,7 @@ import '../../models/secondary_display_state.dart';
 import '../../models/retro_achievement_comment.dart';
 import '../../repositories/retro_achievements_repository.dart';
 import '../../services/retro_achievements_service.dart';
+import '../../utils/display_metrics_log.dart';
 import '../../utils/no_glow_scroll_behavior.dart';
 import 'background_builders.dart';
 import 'now_playing_helpers.dart';
@@ -739,6 +740,9 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
       builder: (_, child) => ValueListenableBuilder<SecondaryDisplayStateData?>(
         valueListenable: _secondaryDisplayState ?? ValueNotifier(null),
         builder: (context, value, child) {
+          // Inside ScreenUtilInit, so this reports the secondary panel's own
+          // metrics. Self-throttling: only re-logs when the numbers change.
+          logDisplayMetrics(context, 'secondary');
           final theme = resolveTheme(
             value?.themeName ?? widget.initialThemeName,
           );

--- a/lib/screens/systems_screen/system_content.dart
+++ b/lib/screens/systems_screen/system_content.dart
@@ -5,7 +5,7 @@ import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:provider/provider.dart';
 import 'package:neostation/providers/theme_provider.dart';
-import 'package:neostation/widgets/shimmering_logo.dart';
+import 'package:neostation/widgets/splash_status_layout.dart';
 import '../../../providers/sqlite_config_provider.dart';
 import 'my_systems_section/my_systems_grid.dart';
 import 'my_systems_section/initial_setup_widget.dart';
@@ -127,66 +127,48 @@ class _SystemContentState extends State<SystemContent> {
   ) {
     // The logo sits at the exact screen centre — the same spot it occupies on
     // the native splash and the startup screens — with the progress detail
-    // hung below centre, so nothing shifts across the whole intro sequence.
-    return Stack(
+    // hung below it, so nothing shifts across the whole intro sequence.
+    return SplashStatusLayout(
+      // Track the scan only once it is actually progressing. During the
+      // waiting-for-storage phase progress sits at 0, which would park the
+      // glint off-screen and leave the logo frozen for up to 30s — keep the
+      // ambient sweep running until there's real movement.
+      progress: configProvider.isScanning && configProvider.scanProgress > 0
+          ? configProvider.scanProgress
+          : null,
       children: [
-        Center(
-          child: ShimmeringLogo(
-            // Track the scan only once it is actually progressing. During the
-            // waiting-for-storage phase progress sits at 0, which would park
-            // the glint off-screen and leave the logo frozen for up to 30s —
-            // keep the ambient sweep running until there's real movement.
-            progress:
-                configProvider.isScanning && configProvider.scanProgress > 0
-                ? configProvider.scanProgress
-                : null,
-          ),
-        ),
-        if (configProvider.isScanning)
-          Align(
-            // 0.55 clears the 280-wide logo's bottom edge (~0.40 on the Thor's
-            // ~467dp-tall logical screen) with comfortable breathing room.
-            alignment: const Alignment(0, 0.55),
-            child: Container(
-              constraints: const BoxConstraints(maxWidth: 480),
-              padding: const EdgeInsets.symmetric(horizontal: 32),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  SizedBox(
-                    width: 220,
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(2),
-                      child: LinearProgressIndicator(
-                        value: configProvider.scanProgress,
-                        minHeight: 3,
-                        backgroundColor: Theme.of(
-                          context,
-                        ).colorScheme.onSurface.withValues(alpha: 0.12),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    configProvider.scanStatus.isNotEmpty
-                        ? configProvider.scanStatus
-                        : AppLocale.scanningSystemsRoms.getString(context),
-                    // 17 to match the startup screen's status line — the
-                    // theme's bodySmall (12) reads too small at couch distance.
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      fontSize: 17,
-                      color: Theme.of(
-                        context,
-                      ).colorScheme.onSurface.withValues(alpha: 0.6),
-                    ),
-                    textAlign: TextAlign.center,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
+        if (configProvider.isScanning) ...[
+          SizedBox(
+            width: 220,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(2),
+              child: LinearProgressIndicator(
+                value: configProvider.scanProgress,
+                minHeight: 3,
+                backgroundColor: Theme.of(
+                  context,
+                ).colorScheme.onSurface.withValues(alpha: 0.12),
               ),
             ),
           ),
+          const SizedBox(height: 16),
+          Text(
+            configProvider.scanStatus.isNotEmpty
+                ? configProvider.scanStatus
+                : AppLocale.scanningSystemsRoms.getString(context),
+            // 17 to match the startup screen's status line — the theme's
+            // bodySmall (12) reads too small at couch distance.
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              fontSize: 17,
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
       ],
     );
   }

--- a/lib/services/logger_service.dart
+++ b/lib/services/logger_service.dart
@@ -18,6 +18,17 @@ class LoggerService {
   Logger _logger;
   bool _initialized = false;
 
+  /// Whether [init] has run and log output is reaching the file as well as the
+  /// console.
+  ///
+  /// False in the secondary display's engine: it is a separate isolate with its
+  /// own copy of this singleton, and its entry point ([subDisplay] in main.dart)
+  /// deliberately does not call [init] — two isolates holding a FileOutput on
+  /// the same path would interleave writes and race the rotation rename. Code
+  /// that must not lose a line in that isolate should check this and fall back
+  /// to `debugPrint`.
+  bool get isFileBacked => _initialized;
+
   LoggerService._internal()
     : _logger = Logger(
         printer: RedactingPrinter(SimplePrinter(colors: true)),

--- a/lib/utils/display_metrics_log.dart
+++ b/lib/utils/display_metrics_log.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/services/logger_service.dart';
@@ -32,6 +34,23 @@ void logDisplayMetrics(BuildContext context, String display) {
     final dpr = view?.devicePixelRatio;
     final physical = view?.physicalSize;
 
+    // Android's density bucket. Flutter's devicePixelRatio *is*
+    // DisplayMetrics.density and density == densityDpi / 160, so this is the
+    // exact figure `wm density` reports and `./sim-rgds.sh` takes as its
+    // argument — a report that quotes it is a one-command repro.
+    //
+    // It is derived, not new information: at the 4dp the line prints, dpr does
+    // multiply back cleanly. It is logged anyway so nobody reading a support
+    // log has to do the arithmetic or decide how to round. (At the 2dp this
+    // line used to print, 2.31 x 160 = 369.6 and the figure really was
+    // unrecoverable — hence the precision bump alongside it.)
+    //
+    // Android-only: elsewhere dpr is not a density bucket, and the Deck's 1.0
+    // would report a meaningless 160.
+    final densityDpi = Platform.isAndroid && dpr != null
+        ? (dpr * 160).round()
+        : null;
+
     final sw = u.scaleWidth;
     final sh = u.scaleHeight;
     final r = u.radius(1);
@@ -52,7 +71,8 @@ void logDisplayMetrics(BuildContext context, String display) {
       '$tag physical='
           '${physical == null ? '?' : '${physical.width.toStringAsFixed(0)}x'
                     '${physical.height.toStringAsFixed(0)}'}'
-          ' dpr=${f(dpr, 2)}'
+          ' dpr=${f(dpr, 4)}'
+          '${densityDpi == null ? '' : ' densityDpi=$densityDpi'}'
           ' logical=${f(u.screenWidth, 1)}x${f(u.screenHeight, 1)}'
           ' orientation=${u.orientation.name}',
       '$tag design=640x480'

--- a/lib/utils/display_metrics_log.dart
+++ b/lib/utils/display_metrics_log.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:neostation/services/logger_service.dart';
+
+/// The last signature logged per display, so a rotation, a density override or
+/// a resized desktop window re-logs, while an ordinary rebuild does not.
+final Map<String, String> _lastSignature = {};
+
+/// Logs the display metrics ScreenUtil resolved for [display] (`main` or
+/// `secondary`).
+///
+/// Every `.r`, `.sp` and `.w` in the UI is derived from these numbers, so a
+/// layout report from a device we do not own is close to unactionable without
+/// them — asking a user to describe how big the text looks is not a
+/// measurement. This puts the actual factors in the log they already send.
+///
+/// Call from inside a `ScreenUtilInit` builder: that runs after `configure()`,
+/// and [ScreenUtil] reads the `MediaQueryData` belonging to *this* engine, so
+/// the secondary display reports itself rather than the primary view.
+///
+/// Both scale factors are logged because they are not interchangeable. `.sp`
+/// is `scaleWidth` — `ScreenUtilInit` installs a non-nullable
+/// `fontSizeResolver` defaulting to `FontSizeResolvers.width`, which bypasses
+/// `scaleText` and makes `minTextAdapt` unreachable. `.r` is
+/// `min(scaleWidth, scaleHeight)` and is what the app sizes the overwhelming
+/// majority of its fonts with. The two agree whenever `scaleWidth <=
+/// scaleHeight` and diverge on wide-and-short panels such as the Steam Deck.
+void logDisplayMetrics(BuildContext context, String display) {
+  try {
+    final u = ScreenUtil();
+    final view = View.maybeOf(context);
+    final dpr = view?.devicePixelRatio;
+    final physical = view?.physicalSize;
+
+    final sw = u.scaleWidth;
+    final sh = u.scaleHeight;
+    final r = u.radius(1);
+    final sp = u.setSp(1);
+
+    String f(double? v, [int p = 3]) => v == null ? '?' : v.toStringAsFixed(p);
+
+    final signature =
+        '${f(sw)}|${f(sh)}|${f(r)}|${f(sp)}|'
+        '${f(u.screenWidth, 1)}x${f(u.screenHeight, 1)}|${u.orientation}';
+    if (_lastSignature[display] == signature) return;
+    final changed = _lastSignature.containsKey(display);
+    _lastSignature[display] = signature;
+
+    final log = LoggerService.instance;
+    final tag = '[display:$display]${changed ? ' (changed)' : ''}';
+    final lines = [
+      '$tag physical='
+          '${physical == null ? '?' : '${physical.width.toStringAsFixed(0)}x'
+                    '${physical.height.toStringAsFixed(0)}'}'
+          ' dpr=${f(dpr, 2)}'
+          ' logical=${f(u.screenWidth, 1)}x${f(u.screenHeight, 1)}'
+          ' orientation=${u.orientation.name}',
+      '$tag design=640x480'
+          ' scaleWidth=${f(sw)} scaleHeight=${f(sh)}'
+          ' .r=${f(r)} .sp=${f(sp)}'
+          ' osTextScale=${f(u.textScaleFactor, 2)}',
+    ];
+
+    for (final line in lines) {
+      log.i(line);
+      // The secondary display's isolate has no file-backed logger, so a plain
+      // log.i() there reaches only the console and never app.log — the file a
+      // user actually sends with a bug report. Mirror to debugPrint so the
+      // numbers survive in logcat / stdout at least.
+      if (!log.isFileBacked) debugPrint(line);
+    }
+  } catch (e) {
+    // Diagnostics must never take the app down on an unfamiliar device — the
+    // one place this would run is exactly where something is already odd.
+    LoggerService.instance.w('[display:$display] metrics unavailable: $e');
+  }
+}

--- a/lib/widgets/splash_status_layout.dart
+++ b/lib/widgets/splash_status_layout.dart
@@ -1,0 +1,117 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import 'shimmering_logo.dart';
+
+/// Shared chrome for the intro screens: the shimmering logo pinned at the
+/// screen centre with a status block hung directly underneath it.
+///
+/// The logo stays at the exact centre — the same spot the native splash icon
+/// occupies — so it never moves across the native → startup → scan handoff.
+///
+/// The status block is placed from the logo's *rendered* bottom edge rather
+/// than at a fixed fraction of the screen height. A fraction only clears the
+/// logo on a screen tall enough for it: on short panels half the fixed-size
+/// logo is taller than the offset, which is how the loading text and the scan
+/// progress bar ended up printed across the glyph. For the same reason the
+/// logo is scaled down once it would take more than [_maxLogoHeightFraction]
+/// of the screen, which is what guarantees room for the status block below it.
+class SplashStatusLayout extends StatelessWidget {
+  const SplashStatusLayout({super.key, required this.children, this.progress});
+
+  /// Status widgets stacked under the logo (progress bar, status line, …).
+  final List<Widget> children;
+
+  /// Forwarded to [ShimmeringLogo]. Null keeps the ambient sweep.
+  final double? progress;
+
+  /// Rendered logo width on a screen with room for it. Matches what the
+  /// startup and scan splashes used before the layout was made responsive,
+  /// so nothing moves on the devices that were already laying out correctly.
+  static const double _maxLogoWidth = 280;
+
+  /// Aspect ratio of `assets/images/logo_transparent.png` (772×510).
+  static const double _logoAspect = 772 / 510;
+
+  /// Share of the screen width the logo may take, so it stays a logo rather
+  /// than a wall on narrow panels.
+  static const double _maxLogoWidthFraction = 0.55;
+
+  /// Share of the screen height the logo may take before it is scaled down.
+  /// Chosen so the Thor's ~467dp-tall screen still renders the logo at its
+  /// full [_maxLogoWidth] — only panels shorter than that scale it back.
+  static const double _maxLogoHeightFraction = 0.40;
+
+  /// Clear space between the logo's bottom edge and the status block.
+  static const double _gap = 16;
+
+  /// Keeps the status text off the very bottom edge of the panel.
+  static const double _bottomInset = 12;
+
+  /// Horizontal breathing room, and the width past which centred status text
+  /// starts reading as a paragraph instead of a caption.
+  static const double _horizontalPadding = 32;
+  static const double _maxStatusWidth = 480;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Fall back to the design size when handed an unbounded axis; the
+        // splash is always full-screen in practice, but an infinite extent
+        // would otherwise produce a NaN offset.
+        final width = constraints.maxWidth.isFinite
+            ? constraints.maxWidth
+            : _maxLogoWidth / _maxLogoWidthFraction;
+        final height = constraints.maxHeight.isFinite
+            ? constraints.maxHeight
+            : _maxLogoWidth / _logoAspect / _maxLogoHeightFraction;
+
+        final logoWidth = math.min(
+          _maxLogoWidth,
+          math.min(
+            width * _maxLogoWidthFraction,
+            height * _maxLogoHeightFraction * _logoAspect,
+          ),
+        );
+        final logoHeight = logoWidth / _logoAspect;
+
+        final statusWidth = math.max(
+          0.0,
+          math.min(_maxStatusWidth, width) - _horizontalPadding * 2,
+        );
+
+        return Stack(
+          children: [
+            Center(
+              child: ShimmeringLogo(width: logoWidth, progress: progress),
+            ),
+            Positioned(
+              top: height / 2 + logoHeight / 2 + _gap,
+              left: 0,
+              right: 0,
+              bottom: _bottomInset,
+              // The status text is laid out at its natural size and only
+              // scaled down when the panel is too short to hold it — a long
+              // status that wraps to three lines shrinks to fit rather than
+              // running off the bottom edge. On a panel with room the scale
+              // is 1 and nothing changes.
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: Alignment.topCenter,
+                child: SizedBox(
+                  width: statusWidth,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: children,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/test/splash_status_layout_test.dart
+++ b/test/splash_status_layout_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/widgets/shimmering_logo.dart';
+import 'package:neostation/widgets/splash_status_layout.dart';
+
+/// The intro splashes place their status block under a logo that is pinned at
+/// the screen centre. The offset used to be a fixed fraction of the screen
+/// height, which only cleared the fixed-size logo on a tall enough panel — on
+/// short handheld screens the loading text and the scan progress bar were
+/// drawn across the glyph. These sizes cover the panels the app ships on, from
+/// a 4:3 handheld up to a desktop window.
+void main() {
+  const sizes = <String, Size>{
+    'tiny 4:3 handheld': Size(320, 240),
+    // Konkr Pocket Advance: a 3.5" 960x640 3:2 panel (~333ppi). The reported
+    // regression came from this device — at xhdpi it is 480x320dp, the
+    // shortest panel the app is known to run on, and the old fixed 0.55
+    // offset put the status block inside the logo there.
+    'Konkr Pocket Advance (xhdpi)': Size(480, 320),
+    'Konkr Pocket Advance (hdpi)': Size(640, 427),
+    'wide handheld': Size(480, 272),
+    // Retroid Nova, 1280x960 at ~356dpi — the geometry sim-nova.sh reproduces.
+    'Retroid Nova': Size(575, 431),
+    'Thor': Size(831, 467),
+    'Steam Deck': Size(1280, 800),
+    'desktop': Size(1920, 1080),
+  };
+
+  Future<void> pumpAt(
+    WidgetTester tester,
+    Size size,
+    List<Widget> children,
+  ) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: SplashStatusLayout(children: children)),
+      ),
+    );
+  }
+
+  group('SplashStatusLayout', () {
+    for (final entry in sizes.entries) {
+      testWidgets('${entry.key}: status clears the logo', (tester) async {
+        await pumpAt(tester, entry.value, [
+          const SizedBox(
+            width: 220,
+            child: LinearProgressIndicator(value: 0.4, minHeight: 3),
+          ),
+          const SizedBox(height: 16),
+          const Text('Nintendo 64...', textAlign: TextAlign.center),
+        ]);
+
+        final logo = tester.getRect(find.byType(ShimmeringLogo));
+        final status = tester.getRect(find.byType(LinearProgressIndicator));
+        expect(
+          status.top,
+          greaterThanOrEqualTo(logo.bottom),
+          reason: 'the progress bar must not overlap the logo',
+        );
+        expect(
+          status.bottom,
+          lessThanOrEqualTo(entry.value.height),
+          reason: 'the status block must stay on screen',
+        );
+      });
+
+      testWidgets('${entry.key}: two-line status fits below the logo', (
+        tester,
+      ) async {
+        // The startup screen's longest status line: on the narrowest panels it
+        // wraps, and the wrapped block still has to fit under the logo.
+        await pumpAt(tester, entry.value, [
+          const Text(
+            'Preparing NeoStation. Waiting for storage and services...',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 17),
+          ),
+        ]);
+
+        final logo = tester.getRect(find.byType(ShimmeringLogo));
+        final text = tester.getRect(find.byType(Text));
+        expect(text.top, greaterThanOrEqualTo(logo.bottom));
+        expect(text.bottom, lessThanOrEqualTo(entry.value.height));
+      });
+    }
+
+    testWidgets('the logo stays centred on every panel', (tester) async {
+      for (final size in sizes.values) {
+        await pumpAt(tester, size, const [Text('x')]);
+        final logo = tester.getRect(find.byType(ShimmeringLogo));
+        expect(logo.center.dx, moreOrLessEquals(size.width / 2, epsilon: 0.5));
+        expect(logo.center.dy, moreOrLessEquals(size.height / 2, epsilon: 0.5));
+      }
+    });
+
+    testWidgets('a tall panel renders the logo at its full width', (
+      tester,
+    ) async {
+      await pumpAt(tester, const Size(831, 467), const [Text('x')]);
+      expect(tester.getRect(find.byType(ShimmeringLogo)).width, 280);
+    });
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission.

# Description

On a small handheld panel the splash screen's status block was drawn **on top of the logo** — the ROM-scan progress bar cut straight across the glyph's lower legs, and the startup "Preparing NeoStation…" text was printed over it. Reported on a Konkr Pocket Advance (960x640 3:2, 3.5").

Both intro splashes — `_StartupScaffold` in `main.dart` and the scan splash in `system_content.dart` — pinned the logo at the exact screen centre and then hung their status block at `Alignment(0, 0.55)`, a fixed fraction of the *screen height*. The logo is a fixed 280dp wide (185dp tall), so that fraction only clears it on a panel tall enough for it:

| panel | half-height x 0.55 | logo's half-height | result |
|---|---|---|---|
| AYN Thor, 467dp | 128dp | 92.5dp | clears the logo |
| Konkr, 394dp | 108dp | 92.5dp | status block lands **on the glyph** |

The status block is now positioned from the logo's *rendered bottom edge* + a 16dp gap, in a new `SplashStatusLayout` shared by both splashes so the two can't drift apart again. Two supporting rules make that safe on any panel:

- the logo scales down once it would take more than 40% of the screen height (tuned so the Thor still renders it at the full 280dp — nothing moves on panels that were already correct);
- the status block scales to fit whatever space that leaves, so a status line that wraps to three lines shrinks instead of running off the bottom edge.

Also folds in two diagnostics commits from `feat/log-display-metrics`, which log `physical`, `dpr`, `densityDpi` and `logical` size on startup. They are what makes the *next* small-panel report actionable: this one needed the device's geometry reverse-engineered from a photo, because no log carried it.

## Steps to Reproduce

**Preconditions**

- A short-panel Android device — the real report was a Konkr Pocket Advance (960x640, density 260, so 591x394dp logical). Reproducible on an AYN Thor with `wm size 640x960 -d 0`, `wm user-rotation -d 0 lock 1`, `wm density 260 -d 0`.
- A ROM library large enough that the startup scan is visible for a second or two (the reproduction used ~9,100 games).

**Steps**

1. Cold-start NeoStation on that panel (force-stop, then relaunch).
2. Watch the splash while the ROM scan runs.

**Expected:** the progress bar and the scanning status line sit below the logo.

**Actual (before this PR):** the progress bar is drawn across the logo's lower legs and the status text overlaps the glyph.

Measured as how far down the logo the bar sits — scale-invariant, since the logo was a fixed 280dp:

| | bar position down the glyph |
|---|---|
| Real device photo | 98.0% (+/- 2%, angled photo) |
| Thor @ density 260, before | 98.9% |
| Thor @ density 260, after | clear below the glyph |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

`test/splash_status_layout_test.dart` asserts the status block never overlaps the logo and always stays on screen, at six geometries: 320x240, 480x320 and 640x427 (the Konkr at each plausible density), 480x272, 831x467 (Thor), 1280x800 (Steam Deck) and 1920x1080. The two-line-status cases fail without the scale-to-fit rule, so the tests do catch the regression rather than merely documenting it. Full suite: 647 passing.

Verified on hardware by forcing an AYN Thor's main display to the Konkr's geometry and screen-recording a cold start of the production build (reproduces) and this branch (fixed).

## Screenshots (if applicable)

Before / after, both at 960x640 density 260. The "after" capture is on the dev channel, which runs a light theme — that colour difference is not part of this change, and the "before" frame is mid-crossfade so the systems grid ghosts through it.

