### PR TITLE
fix: await returned futures inside try blocks so their catch can see them

### DIFF
--- a/lib/providers/file_provider.dart
+++ b/lib/providers/file_provider.dart
@@ -343,7 +343,7 @@ class FileProvider extends ChangeNotifier {
     try {
       final directory = Directory(directoryPath);
       if (await directory.exists()) {
-        return directory.list().toList();
+        return await directory.list().toList();
       }
       return [];
     } catch (e) {

--- a/lib/providers/neosync/neosync_path_resolver.dart
+++ b/lib/providers/neosync/neosync_path_resolver.dart
@@ -488,7 +488,7 @@ extension NeoSyncPathResolver on NeoSyncProvider {
     if (!await dir.exists()) return [];
 
     try {
-      return dir
+      return await dir
           .list(recursive: true)
           .where((entity) => entity is File)
           .cast<File>()

--- a/lib/services/game/game_list_service.dart
+++ b/lib/services/game/game_list_service.dart
@@ -125,7 +125,7 @@ class GameListService {
   static Future<List<GameModel>> loadGamesForSystem(SystemModel system) async {
     try {
       if (system.folderName == SystemFolderNames.favorites) {
-        return _loadFavoriteGames();
+        return await _loadFavoriteGames();
       }
 
       if (system.folderName == 'all') {

--- a/lib/services/neo_assets_service.dart
+++ b/lib/services/neo_assets_service.dart
@@ -247,7 +247,7 @@ class NeoAssetsService {
           .cast<Map<String, dynamic>>()
           .map(NeoAssetsTheme.fromJson)
           .toList();
-      return Future.wait(
+      return await Future.wait(
         baseList.map((theme) async {
           final metadata = await _fetchThemeMetadata(theme.folder);
           if (metadata == null) return theme;


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission.

# Description

Four methods return a `Future` from inside a `try` without awaiting it. The future is handed back to the caller before it completes, so the `catch` that follows never runs — each of these blocks logs the error and returns an empty/null fallback, and none of that happens. The failure escapes to the caller as an unhandled async error instead.

| method | unawaited future | fails when |
|---|---|---|
| `FileProvider.getFilesInDirectory` | `directory.list().toList()` | missing dir, permission denied |
| `NeoSyncPathResolver._getSaveFiles` | `dir.list(recursive: true)…toList()` | missing dir, permission denied |
| `GameListService.loadGamesForSystem` | `_loadFavoriteGames()` | repository/DB error |
| `NeoAssetsService` theme fetch | `Future.wait(...)` over per-theme metadata | network error |

Each is a one-word fix — `return await …` — and the diff is 4 lines.

`FileProvider.getFilesInDirectory` is worth calling out: its immediate neighbour `getFileSize` already writes `return await file.length();` inside the same shape of try/catch, so this also brings two adjacent methods into agreement.

## Behaviour change

Deliberate, and the point of the change: errors from these futures are now **caught and logged**, and the caller receives the fallback (`[]` / `null`) instead of a thrown exception. That is what each method's signature and existing `catch` block already promised — the `await` just makes the promise true. Callers that somehow relied on the exception escaping would now see an empty list; none do, since every one of these already has to handle the documented fallback.

## How it was found

`unawaited_return_in_try_block`, a lint that ships with the analyzer in Flutter 3.47.0. CI is pinned to 3.44.9 (see the pin in #342), which predates the lint, so **CI here will not flag these** — green on this PR does not prove the lint is satisfied. It is satisfied by construction: the lint fires on `return <future>` inside `try`, and there is no longer one. Clearing these is what makes raising that pin safe.

## Steps to Reproduce

**Preconditions**

- Flutter 3.47.0 or newer (the version that carries the lint). CI and the pinned local toolchain are on 3.44.9, which does not report it.

**Steps**

1. `flutter analyze` on `main` with Flutter 3.47.0.
2. Four `unawaited_return_in_try_block` warnings are reported, and `flutter analyze` exits 1.

**Expected:** analyze is clean.

**Actual (before this PR):**

```
warning • Returning a 'Future' without 'await' inside a try block • lib/providers/file_provider.dart:346:9
warning • Returning a 'Future' without 'await' inside a try block • lib/providers/neosync/neosync_path_resolver.dart:491:7
warning • Returning a 'Future' without 'await' inside a try block • lib/services/game/game_list_service.dart:128:9
warning • Returning a 'Future' without 'await' inside a try block • lib/services/neo_assets_service.dart:250:7
```

For the runtime symptom rather than the lint: point a ROM directory at a path the app cannot read and call `getFilesInDirectory` — the intended `Error listing files in …` log line never appears and the exception surfaces at the caller instead.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [x] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

No tests added: each change is a single `await` on an existing call, and covering it would mean asserting that a filesystem/network failure is logged rather than thrown — a mock-heavy test for a one-word fix. Existing suite passes (629 tests), `flutter analyze` clean, `dart format` clean.

## Screenshots (if applicable)

Not applicable — no visual change.
