### PR TITLE
perf: stop the notification bell pulsing while the app is idle

### DIFF
--- a/lib/widgets/notification_bell.dart
+++ b/lib/widgets/notification_bell.dart
@@ -26,6 +26,7 @@ class _NotificationBellState extends State<NotificationBell>
     with SingleTickerProviderStateMixin {
   late AnimationController _pulseController;
   late Animation<double> _pulseAnimation;
+  late ValueNotifier<List<GlobalNotificationData>> _notifications;
   OverlayEntry? _overlayEntry;
 
   /// Vertical gap between the bell icon and the top of the dropdown.
@@ -44,11 +45,35 @@ class _NotificationBellState extends State<NotificationBell>
     _pulseAnimation = Tween<double>(begin: 1.0, end: 0.4).animate(
       CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
     );
-    _pulseController.repeat(reverse: true);
+
+    // The pulse only runs while there is something to pulse about. Repeating
+    // unconditionally kept a ticker alive for the life of the app: the bell
+    // lives in the header on every screen, so a controller that never stops
+    // requested a frame every vsync forever, and the whole display re-rastered
+    // at 60 fps while the user sat still (~26% of a core in the raster thread).
+    _notifications = GlobalNotificationService().notifier;
+    _notifications.addListener(_syncPulse);
+    _syncPulse();
+  }
+
+  /// Starts the pulse when notifications appear and stops it when the last one
+  /// goes away, parking the controller at its opaque end.
+  void _syncPulse() {
+    final bool hasNotifications = _notifications.value.isNotEmpty;
+    if (hasNotifications) {
+      if (!_pulseController.isAnimating) {
+        _pulseController.repeat(reverse: true);
+      }
+    } else if (_pulseController.isAnimating) {
+      _pulseController.stop();
+      // Tween begin (1.0 = fully opaque) sits at controller value 0.
+      _pulseController.value = 0;
+    }
   }
 
   @override
   void dispose() {
+    _notifications.removeListener(_syncPulse);
     _closeDropdown();
     _pulseController.dispose();
     super.dispose();
@@ -65,14 +90,12 @@ class _NotificationBellState extends State<NotificationBell>
           child: Stack(
             alignment: Alignment.center,
             children: [
-              AnimatedBuilder(
-                animation: _pulseAnimation,
-                builder: (context, child) {
-                  return Opacity(
-                    opacity: hasNotifications ? _pulseAnimation.value : 1.0,
-                    child: child,
-                  );
-                },
+              // FadeTransition rather than AnimatedBuilder + Opacity: it drives
+              // the opacity layer directly, so a running pulse repaints without
+              // rebuilding this subtree every frame. Parked at 1.0 (opaque)
+              // whenever the controller is stopped.
+              FadeTransition(
+                opacity: _pulseAnimation,
                 child: Icon(
                   hasNotifications
                       ? Symbols.notifications_active_rounded

--- a/test/notification_bell_idle_test.dart
+++ b/test/notification_bell_idle_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/services/global_notification_service.dart';
+import 'package:neostation/widgets/notification_bell.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The bell's pulse used to `repeat()` unconditionally from initState, and the
+/// bell lives in the header on every screen. A ticker that never stops asks the
+/// engine for a frame every vsync, so the whole display re-rastered at 60 fps
+/// while the user sat still — measured at ~48% of a core on an idle AYN Thor,
+/// 26% of it in the raster thread alone.
+///
+/// transientCallbackCount is the assertion that catches it: a running ticker
+/// registers exactly one, so "no notifications" must mean zero.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await FlutterLocalization.instance.ensureInitialized();
+    FlutterLocalization.instance.init(
+      mapLocales: [MapLocale('en', AppLocale.en)],
+      initLanguageCode: 'en',
+    );
+  });
+
+  tearDown(() => GlobalNotificationService().dismiss());
+
+  Future<void> pumpBell(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(size: Size(1920, 1080)),
+        child: ScreenUtilInit(
+          designSize: const Size(1920, 1080),
+          builder: (context, child) => MaterialApp(
+            localizationsDelegates:
+                FlutterLocalization.instance.localizationsDelegates,
+            supportedLocales: FlutterLocalization.instance.supportedLocales,
+            home: const Scaffold(body: Center(child: NotificationBell())),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('idles without a ticker when there are no notifications', (
+    tester,
+  ) async {
+    await pumpBell(tester);
+
+    // pumpAndSettle times out rather than returning if an animation never
+    // finishes, so reaching the expect at all is half the assertion.
+    await tester.pumpAndSettle();
+
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('pulses while a notification is active', (tester) async {
+    await pumpBell(tester);
+    await tester.pumpAndSettle();
+
+    GlobalNotificationService().show(id: 'test', message: 'hello');
+    await tester.pump();
+
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+  });
+
+  testWidgets('stops the pulse again when the last notification clears', (
+    tester,
+  ) async {
+    await pumpBell(tester);
+    GlobalNotificationService().show(id: 'test', message: 'hello');
+    await tester.pump();
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+
+    GlobalNotificationService().dismiss('test');
+    await tester.pump();
+
+    expect(tester.binding.transientCallbackCount, 0);
+    // No stray scheduled work left behind either.
+    await tester.pumpAndSettle();
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission.

# Description

NeoStation burned roughly half a core while sitting completely still in the foreground. The cause is the notification bell.

`_pulseController.repeat(reverse: true)` runs unconditionally from `initState` and is never stopped, but the animated value is only *used* when there are notifications:

```dart
opacity: hasNotifications ? _pulseAnimation.value : 1.0,
```

So with an empty notification list — the normal state — the controller still ticks at 60 Hz to rebuild an `AnimatedBuilder` into `Opacity(opacity: 1.0)`, forever. A running ticker asks the engine for a frame every vsync, and the bell lives in the header on **every** screen, so the whole display re-rastered continuously while the user did nothing.

This is pre-existing on `main`, not a regression from any recent branch.

### Fix

- `_syncPulse()` drives the controller from `GlobalNotificationService().notifier`: it starts the repeat when a notification arrives, and stops it — parked at the opaque end of the tween — when the last one clears.
- `AnimatedBuilder` + `Opacity` becomes a `FadeTransition`, so a pulse that genuinely *is* running drives the opacity layer instead of rebuilding the subtree every frame.

### Measured

Idle on an AYN Thor, `featuretest` release build, systems grid, native 1920x1080, stock clocks, untouched for 25 s:

| | before | after |
|---|---|---|
| idle frames | 60.0 fps | **0.0 fps** |
| process CPU | 48.3% of one core | **1.7%** |
| `1.raster` | 26.1% | **0.2%** |
| `ion.<pkg>` | 7.8% | 0.3% |
| `IplrVkResMgr` | 7.5% | 0.0% |

While a notification *is* active, the pulse now costs ~2 rebuilds per 5 s window instead of ~300, because `FadeTransition` repaints via the opacity layer rather than rebuilding.

## Steps to Reproduce

**Preconditions:** any screen with the header visible (the systems grid is fine), no active notifications, screen awake, app in the foreground. A release build (`featuretest` or `production`) — the `dev` channel's gamepad logging adds its own CPU cost and muddies the reading.

1. Launch the app and let it settle on the systems grid.
2. Do not touch the device — no input at all.
3. Measure the process:
   ```
   adb shell top -H -p $(adb shell pidof <pkg>) -n 1
   ```
   or read per-thread ticks from `/proc/<pid>/task/*/stat`.

**Before:** the process sits at ~48% of one core, ~26% of it in `1.raster`, and an `atrace gfx view` shows 600 frames in 10 s (60.0 fps) with zero idle gaps.
**After:** ~1.7% of one core and no frames scheduled at all.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

### Tests

`test/notification_bell_idle_test.dart` asserts `transientCallbackCount`, which counts running tickers — so "no notifications" must mean zero:

- idles without a ticker when there are no notifications
- pulses while a notification is active
- stops the pulse again when the last notification clears

All three were confirmed to **fail** against the previous implementation (two time out in `pumpAndSettle`, the third reports `Expected: <0> Actual: <1>`).

Full suite: 650 passing. `flutter analyze` clean, `dart format` clean.

### How it was found

By asking the framework rather than bisecting suspects: `debugPrintScheduleFrameStacks` and `debugPrintMarkNeedsPaintStacks` name every frame requester, but at 60 fps the raw output is unreadable, so the events were bucketed and reported as a ranked summary. The first run showed `SCHEDULE: 300 events, 1 distinct` with the stack `Ticker._tick → Ticker.scheduleTick → scheduleFrame`, and the rebuild bucket identified the widget by its tween (`1.0 → 0.4`, `Cubic(0.42, 0, 0.58, 1)`). That instrumentation was temporary and is not part of this PR.

## Screenshots (if applicable)

Verified on device by raising a real notification and dismissing it again: the bell pulses (frames captured 1 s apart show it dim and bright, with the `notifications_active` glyph and badge), frame rate goes 0 → 60.0 fps while it is up, and returns to a sustained 0.0 fps across five consecutive 5 s windows once dismissed.
