### PR TITLE
fix(systems): one default standalone emulator for PS3

### DIFF
--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -42,8 +42,7 @@
     },
     {
       "name": "Standalone ARMSX3",
-      "default_standalone": true,
-      "unique_id": "ps3.armsx3.",
+      "unique_id": "ps3.com.armsx3",
       "description": "Supported extensions: iso.",
       "is_retroachievements_compatible": false,
       "platforms": {
@@ -71,7 +70,7 @@
         "macos": {
           "executable": "rpcs3",
           "args": "--no-gui \"{file.path}\""
-      }
+        }
       }
     }
   ],


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission.

# Description

`test/emulator_seed_default_test.dart` is red on `main`, and has been since #323:

```
every system ships at most one default_standalone emulator
  Expected: empty
    Actual: ['ps3.json: [ps3.aenu.aps3e, ps3.armsx3.]']

per (system, os) at most one default_standalone emulator is offered
  Expected: empty
    Actual: ['ps3.json [android]: [ps3.aenu.aps3e, ps3.armsx3.]']
```

#323 added ARMSX3 to `ps3.json` with `"default_standalone": true` while aPS3e already carried it, so PS3 ships **two designated defaults**. That is the data shape behind the duplicate `is_default = 1` rows for one `(system_id, os_id)` that migration v108 exists to repair.

It doesn't corrupt databases today, because the seeder's enforcement pass takes the JSON pick with `putIfAbsent` (array order wins → aPS3e) and then rewrites the whole group in a single `CASE WHEN` statement. The problem is what's left behind: `is_default_standalone` stays set on **both** rows, and the two fallbacks that read that column order by `name ASC`:

```sql
ORDER BY is_default_standalone DESC, name ASC LIMIT 1
```

…where `Standalone ARMSX3` sorts *ahead of* `Standalone aPS3e`. So the JSON's intent and the fallbacks disagree about which emulator a PS3 game launches with, and the answer depends on which path last touched the row. That ambiguity is exactly what the test rejects.

**The fix:** drop `default_standalone` from ARMSX3, leaving aPS3e as the PS3 default. That is already what the enforcement pass resolves to, so **no install changes behaviour** — the data just stops contradicting itself. aPS3e also predates ARMSX3 as the system's default, so this preserves the intent that was there before #323.

Two smaller fixes in the same entry/file:

* **`unique_id` was `ps3.armsx3.`** — trailing dot, matching no convention (siblings are `ps2.com.armsx2`, `ps1.com.nanodata.armsx`). Renamed to `ps3.com.armsx3`. It's a permanent key, so it's worth correcting now rather than living with; the sync path nulls `user_roms.app_emulator_unique_id` for ids it no longer sees, so an explicit ARMSX3 pick degrades to "inherit the system default" instead of dangling.
* **Restored the indentation** of the RPCS3 `macos` block, which #323 also shifted.

### Not addressed here

* `assets/manifest.json` is still `0.3.11` — #323 didn't bump it, so ARMSX3, EmucoreV and Seedless DS only reach fresh installs, not existing ones over the air. Same goes for this fix. Bumping it prompts every user to update their systems data, so it felt like a release-cadence call rather than something to slip into a test fix.
* ARMSX3's launch arguments are `-n com.armsx3/com.armsx2.Main` — a `com.armsx2` activity class inside a `com.armsx3` package. It looks wrong, but `ps1.json` does the same (`com.nanodata.armsx/com.armsx2.Main`), so the ARMSX family appears to genuinely reuse that class name. Left alone; it needs someone with the app installed to confirm.
* `vita.json` picked up a stray tab and an indent shuffle in #323. Cosmetic, left out of scope.

## Steps to Reproduce

**Preconditions:** a checkout of `main` at or after 8f51b29 (#323), Flutter toolchain installed.

1. `flutter test test/emulator_seed_default_test.dart`
2. Two tests fail, both naming `ps3.json: [ps3.aenu.aps3e, ps3.armsx3.]`.

Runtime symptom (harder to trigger, which is why the test exists): on Android, a PS3 game launched through a path that falls back to `ORDER BY is_default_standalone DESC, name ASC` — e.g. the RetroArch-orphan repair, or the seed applied to a group with no designated default — resolves to ARMSX3, while the systems JSON designates aPS3e.

**After this change:** all 5 tests in that file pass, and the full suite is green (987 passing).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works. *(The guard test already existed — from #260/#279 — and this restores it to green. No new test needed.)*
- [ ] I have updated the corresponding documentation. *(N/A — data fix.)*
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. *(N/A — no new assets.)*
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable). *(N/A — no UI change.)*

Verified by the test suite, and the resulting default is unchanged from what installs already resolve to. The ARMSX3 launch path itself is unverified — I don't have the app.

## Screenshots (if applicable)

N/A — data-only change.
