### PR TITLE
feat(games): hide games from the library, unhide per system

### DIFF
--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -472,6 +472,9 @@ class SqliteMigrations {
       case 119:
         await _migrateToVersion119(db);
         break;
+      case 122:
+        await _migrateToVersion122(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -5371,6 +5374,42 @@ class SqliteMigrations {
       _log.i('Migration v119 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v119: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v122: Adds `user_roms.is_hidden`, the per-game hide flag.
+  ///
+  /// Hiding is a view filter, not a deletion: the row keeps its favorite flag,
+  /// play time, emulator override and cloud-sync state, and the ROM file is
+  /// untouched. Games hidden here are restored from the system settings dialog.
+  /// Defaults to `0`, so nobody's library changes on upgrade.
+  ///
+  /// Numbered above every slot in use anywhere — main is at v119 and
+  /// `feat/ra-improvements` claims v121 — rather than at main + 1. A device
+  /// that migrated on that branch is already past 120, so it would skip a
+  /// `case 120` forever and every game query would then fail on the missing
+  /// column. Taking the highest number keeps this step reachable whatever
+  /// order the branches merge in.
+  static Future<void> _migrateToVersion122(Database db) async {
+    _log.i('Migration v122: Adding is_hidden to user_roms');
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_roms)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+
+      if (!columns.contains('is_hidden')) {
+        db.execute(
+          'ALTER TABLE user_roms ADD COLUMN is_hidden INTEGER DEFAULT 0',
+        );
+        _log.i('Column is_hidden added via v122');
+      } else {
+        _log.i('Column is_hidden already exists');
+      }
+
+      _log.i('Migration v122 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v122: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -422,7 +422,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 119;
+  static const int _databaseVersion = 122;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -463,7 +463,7 @@ class SqliteService {
     // Retrieve base systems with user settings and calculated ROM counts
     final systemsResults = await db.rawQuery('''
       SELECT s.*,
-             (SELECT COUNT(*) FROM user_roms ur WHERE ur.app_system_id = s.id) as rom_count,
+             (SELECT COUNT(*) FROM user_roms ur WHERE ur.app_system_id = s.id AND ur.is_hidden = 0) as rom_count,
              ss.recursive_scan,
              ss.custom_background_path,
              ss.custom_logo_path,
@@ -1890,6 +1890,7 @@ class SqliteService {
         ss_hash TEXT,
         id_ra INTEGER,
         is_favorite INTEGER DEFAULT 0,
+        is_hidden INTEGER DEFAULT 0,
         play_time INTEGER DEFAULT 0,
         last_played TEXT,
         cloud_sync_enabled INTEGER DEFAULT 1,
@@ -3047,7 +3048,7 @@ class SqliteService {
 
     final results = await db.rawQuery('''
       SELECT s.*, uds.actual_folder_name,
-             (SELECT COUNT(*) FROM user_roms ur WHERE ur.app_system_id = s.id) as rom_count,
+             (SELECT COUNT(*) FROM user_roms ur WHERE ur.app_system_id = s.id AND ur.is_hidden = 0) as rom_count,
              ss.recursive_scan,
              ss.hide_extension,
              ss.hide_parentheses,
@@ -3207,8 +3208,11 @@ class SqliteService {
         return false;
       });
 
-      // Synchronize exact ROM count from persistent storage.
-      final romCount = await getRomCountForSystem(system.id!);
+      // Synchronize exact ROM count from persistent storage. Hidden games are
+      // left out so the count always matches the list the user can see; the
+      // callers that decide whether a system still exists ask for the raw count
+      // instead ([getRomCountForSystem]).
+      final romCount = await getVisibleRomCountForSystem(system.id!);
       system = system.copyWith(romCount: romCount);
 
       // Enrich with user-specific system overrides.
@@ -3271,6 +3275,23 @@ class SqliteService {
     final db = await instance.database;
     final results = await db.rawQuery(
       'SELECT COUNT(*) as count FROM user_roms WHERE app_system_id = ?',
+      [systemId],
+    );
+    if (results.isEmpty) return 0;
+    return int.tryParse(results.first['count']?.toString() ?? '0') ?? 0;
+  }
+
+  /// Calculates the number of ROMs a system shows in its game list — the total
+  /// minus the ones the user hid.
+  ///
+  /// Never use this to decide whether a system still exists: a library whose
+  /// games are all hidden would prune the system and take the unhide UI with
+  /// it. Gate existence on [getRomCountForSystem].
+  static Future<int> getVisibleRomCountForSystem(String systemId) async {
+    final db = await instance.database;
+    final results = await db.rawQuery(
+      'SELECT COUNT(*) as count FROM user_roms '
+      'WHERE app_system_id = ? AND is_hidden = 0',
       [systemId],
     );
     if (results.isEmpty) return 0;
@@ -3529,7 +3550,7 @@ class SqliteService {
     // Fetch systems with comprehensive metadata and game statistics.
     final results = await db.rawQuery('''
       SELECT s.*,
-             (SELECT COUNT(*) FROM user_roms ur WHERE ur.app_system_id = s.id) as rom_count,
+             (SELECT COUNT(*) FROM user_roms ur WHERE ur.app_system_id = s.id AND ur.is_hidden = 0) as rom_count,
              ss.recursive_scan,
              ss.custom_background_path,
              ss.custom_logo_path,
@@ -4133,7 +4154,7 @@ class SqliteService {
     final results = await db.rawQuery(
       '''
       SELECT
-        ur.filename, ur.rom_path, ur.is_favorite, ur.play_time, ur.last_played,
+        ur.filename, ur.rom_path, ur.is_favorite, ur.is_hidden, ur.play_time, ur.last_played,
         ur.cloud_sync_enabled, ur.title_id, ur.title_name,
         ur.app_emulator_unique_id as emulator_name,
         s.id as system_id, s.real_name as system_real_name, s.folder_name as system_folder_name,
@@ -4176,7 +4197,7 @@ class SqliteService {
     final db = await instance.database;
     final results = await db.rawQuery('''
       SELECT
-        ur.filename, ur.rom_path, ur.is_favorite, ur.play_time, ur.last_played,
+        ur.filename, ur.rom_path, ur.is_favorite, ur.is_hidden, ur.play_time, ur.last_played,
         ur.cloud_sync_enabled, ur.title_id, ur.title_name,
         ur.app_emulator_unique_id as emulator_name,
         s.id as system_id, s.real_name as system_real_name, s.folder_name as system_folder_name,
@@ -4208,7 +4229,7 @@ class SqliteService {
     final db = await instance.database;
     final results = await db.rawQuery('''
       SELECT
-        ur.filename, ur.rom_path, ur.is_favorite, ur.play_time, ur.last_played,
+        ur.filename, ur.rom_path, ur.is_favorite, ur.is_hidden, ur.play_time, ur.last_played,
         ur.cloud_sync_enabled, ur.title_id, ur.title_name,
         ur.app_emulator_unique_id as emulator_name,
         s.id as system_id, s.real_name as system_real_name, s.folder_name as system_folder_name,
@@ -4244,7 +4265,7 @@ class SqliteService {
     final results = await db.rawQuery(
       '''
       SELECT
-        ur.filename, ur.rom_path, ur.is_favorite, ur.play_time, ur.last_played,
+        ur.filename, ur.rom_path, ur.is_favorite, ur.is_hidden, ur.play_time, ur.last_played,
         ur.cloud_sync_enabled, ur.title_id, ur.title_name,
         ur.app_emulator_unique_id as emulator_name,
         s.id as system_id, s.real_name as system_real_name, s.folder_name as system_folder_name,
@@ -4444,6 +4465,93 @@ class SqliteService {
       where: 'app_system_id = ? AND filename = ?',
       whereArgs: [system.id, filename],
     );
+  }
+
+  /// Hides or unhides a single game.
+  ///
+  /// Hidden ROMs stay in the database (favorites, play time, saves and cloud
+  /// sync are all preserved) — they are only filtered out of the game lists.
+  /// The user restores them from the system's settings dialog.
+  static Future<void> setRomHidden(
+    String systemFolderName,
+    String filename,
+    bool hidden,
+  ) async {
+    final db = await instance.database;
+    final system = await getSystemByFolderName(systemFolderName);
+    await db.update(
+      'user_roms',
+      {'is_hidden': hidden ? 1 : 0},
+      where: 'app_system_id = ? AND filename = ?',
+      whereArgs: [system.id, filename],
+    );
+  }
+
+  /// Restores every hidden game of [systemId] in one shot.
+  static Future<void> unhideAllRomsForSystem(String systemId) async {
+    final db = await instance.database;
+    await db.update(
+      'user_roms',
+      {'is_hidden': 0},
+      where: 'app_system_id = ? AND is_hidden = 1',
+      whereArgs: [systemId],
+    );
+  }
+
+  /// Restores every hidden game across all systems.
+  static Future<void> unhideAllRoms() async {
+    final db = await instance.database;
+    await db.update('user_roms', {'is_hidden': 0}, where: 'is_hidden = 1');
+  }
+
+  /// Retrieves the games hidden by the user.
+  ///
+  /// Pass [systemId] to scope the result to a single system; omit it (or pass
+  /// the virtual `all` system) to list the hidden games of the whole library.
+  static Future<List<DatabaseGameModel>> getHiddenGames({
+    String? systemId,
+  }) async {
+    final db = await instance.database;
+    final results = await db.rawQuery(
+      '''
+      SELECT
+        ur.filename, ur.rom_path, ur.is_favorite, ur.is_hidden, ur.play_time, ur.last_played,
+        ur.cloud_sync_enabled, ur.title_id, ur.title_name,
+        ur.app_emulator_unique_id as emulator_name,
+        s.id as system_id, s.real_name as system_real_name, s.folder_name as system_folder_name,
+        s.short_name as system_short_name,
+        COALESCE(usm.real_name, CASE WHEN s.folder_name IN ('android') THEN ur.title_name END, ur.filename) as game_display_name,
+        usm.real_name as ss_real_name,
+        usm.rating,
+        ur.box2d_aspect_ratio
+      FROM user_roms ur
+      JOIN app_systems s ON ur.app_system_id = s.id
+      LEFT JOIN user_screenscraper_metadata usm ON ur.app_system_id = usm.app_system_id AND ur.filename = usm.filename
+      WHERE ur.is_hidden = 1
+        ${systemId == null ? '' : 'AND ur.app_system_id = ?'}
+      ORDER BY LOWER(system_real_name) ASC, LOWER(game_display_name) ASC
+    ''',
+      [?systemId],
+    );
+
+    return results.map((row) => DatabaseGameModel.fromJson(row)).toList();
+  }
+
+  /// Returns how many games are hidden, keyed by system id.
+  ///
+  /// One query for the whole library: the scan loop subtracts these from the
+  /// raw ROM counts so a system card never advertises games the list won't show.
+  static Future<Map<String, int>> getHiddenRomCountsBySystem() async {
+    final db = await instance.database;
+    final results = await db.rawQuery(
+      'SELECT app_system_id, COUNT(*) as count FROM user_roms '
+      'WHERE is_hidden = 1 GROUP BY app_system_id',
+    );
+    return {
+      for (final row in results)
+        row['app_system_id'].toString():
+            int.tryParse(row['count']?.toString() ?? '0') ?? 0,
+    };
   }
 
   /// Resets a game's play statistics (time and last played) to zero.

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -973,6 +973,21 @@ mixin AppLocale {
   static const String deleteGameConfirm = 'delete_game_confirm';
   static const String deleteGameConfirmBody = 'delete_game_confirm_body';
   static const String deleteGameSubtitle = 'delete_game_subtitle';
+
+  // ---------------------------------------------------------------------------
+  // Hide / unhide games
+  // ---------------------------------------------------------------------------
+  static const String hideGame = 'hide_game';
+  static const String hideGameSubtitle = 'hide_game_subtitle';
+  static const String hide = 'hide';
+  static const String unhide = 'unhide';
+  static const String unhideAll = 'unhide_all';
+  static const String gameHidden = 'game_hidden';
+  static const String gameUnhidden = 'game_unhidden';
+  static const String allGamesUnhidden = 'all_games_unhidden';
+  static const String hiddenGames = 'hidden_games';
+  static const String noHiddenGames = 'no_hidden_games';
+  static const String noHiddenGamesSubtitle = 'no_hidden_games_subtitle';
   static const String restartRequired = 'restart_required';
   static const String restartRequiredBody = 'restart_required_body';
   static const String userDataLocationUpdated = 'user_data_location_updated';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -1163,4 +1163,20 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.wizardArtPackUnavailable:
       'Das Artwork-Paket ist derzeit nicht erreichbar. Du kannst es später in '
       'den Einstellungen installieren, sobald du online bist.',
+
+  // Hide / unhide games
+  AppLocale.hideGame: 'Spiel ausblenden',
+  AppLocale.hideGameSubtitle:
+      'Blendet es aus deinen Spielelisten aus. Es wird nichts gelöscht.',
+  AppLocale.hide: 'Ausblenden',
+  AppLocale.unhide: 'Einblenden',
+  AppLocale.unhideAll: 'Alle einblenden',
+  AppLocale.gameHidden: '{name} ausgeblendet',
+  AppLocale.gameUnhidden: '{name} wiederhergestellt',
+  AppLocale.allGamesUnhidden:
+      'Alle ausgeblendeten Spiele wurden wiederhergestellt',
+  AppLocale.hiddenGames: 'Ausgeblendet',
+  AppLocale.noHiddenGames: 'Keine ausgeblendeten Spiele',
+  AppLocale.noHiddenGamesSubtitle:
+      'Blende ein Spiel in seinen Einstellungen aus, dann erscheint es hier.',
 };

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -1117,4 +1117,19 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.wizardArtPackUnavailable:
       'The art pack couldn\'t be reached right now. You can install it later '
       'from Settings once you\'re online.',
+
+  // Hide / unhide games
+  AppLocale.hideGame: 'Hide Game',
+  AppLocale.hideGameSubtitle:
+      'Hides it from your game lists. Nothing is deleted.',
+  AppLocale.hide: 'Hide',
+  AppLocale.unhide: 'Unhide',
+  AppLocale.unhideAll: 'Unhide All',
+  AppLocale.gameHidden: '{name} hidden',
+  AppLocale.gameUnhidden: '{name} restored',
+  AppLocale.allGamesUnhidden: 'All hidden games restored',
+  AppLocale.hiddenGames: 'Hidden',
+  AppLocale.noHiddenGames: 'No hidden games',
+  AppLocale.noHiddenGamesSubtitle:
+      'Hide a game from its own settings and it appears here.',
 };

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -1156,4 +1156,19 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.wizardArtPackUnavailable:
       'No se pudo acceder al paquete de arte en este momento. Puedes instalarlo '
       'más tarde desde Ajustes cuando estés en línea.',
+
+  // Hide / unhide games
+  AppLocale.hideGame: 'Ocultar juego',
+  AppLocale.hideGameSubtitle:
+      'Lo oculta de tus listas de juegos. No se elimina nada.',
+  AppLocale.hide: 'Ocultar',
+  AppLocale.unhide: 'Mostrar',
+  AppLocale.unhideAll: 'Mostrar todos',
+  AppLocale.gameHidden: '{name} oculto',
+  AppLocale.gameUnhidden: '{name} restaurado',
+  AppLocale.allGamesUnhidden: 'Se han restaurado todos los juegos ocultos',
+  AppLocale.hiddenGames: 'Ocultos',
+  AppLocale.noHiddenGames: 'No hay juegos ocultos',
+  AppLocale.noHiddenGamesSubtitle:
+      'Oculta un juego desde sus ajustes y aparecerá aquí.',
 };

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -1166,4 +1166,19 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.wizardArtPackUnavailable:
       'Le pack visuel est actuellement inaccessible. Vous pourrez l\'installer '
       'plus tard depuis les Paramètres une fois en ligne.',
+
+  // Hide / unhide games
+  AppLocale.hideGame: 'Masquer le jeu',
+  AppLocale.hideGameSubtitle:
+      'Le retire de vos listes de jeux. Rien n\'est supprimé.',
+  AppLocale.hide: 'Masquer',
+  AppLocale.unhide: 'Afficher',
+  AppLocale.unhideAll: 'Tout afficher',
+  AppLocale.gameHidden: '{name} masqué',
+  AppLocale.gameUnhidden: '{name} restauré',
+  AppLocale.allGamesUnhidden: 'Tous les jeux masqués ont été restaurés',
+  AppLocale.hiddenGames: 'Masqués',
+  AppLocale.noHiddenGames: 'Aucun jeu masqué',
+  AppLocale.noHiddenGamesSubtitle:
+      'Masquez un jeu depuis ses paramètres pour le retrouver ici.',
 };

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -1130,4 +1130,19 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.wizardArtPackUnavailable:
       'Paket gambar tidak dapat dijangkau saat ini. Anda dapat memasangnya '
       'nanti dari Pengaturan setelah online.',
+
+  // Hide / unhide games
+  AppLocale.hideGame: 'Sembunyikan Game',
+  AppLocale.hideGameSubtitle:
+      'Menyembunyikannya dari daftar game. Tidak ada yang dihapus.',
+  AppLocale.hide: 'Sembunyikan',
+  AppLocale.unhide: 'Tampilkan',
+  AppLocale.unhideAll: 'Tampilkan Semua',
+  AppLocale.gameHidden: '{name} disembunyikan',
+  AppLocale.gameUnhidden: '{name} dipulihkan',
+  AppLocale.allGamesUnhidden: 'Semua game tersembunyi telah dipulihkan',
+  AppLocale.hiddenGames: 'Tersembunyi',
+  AppLocale.noHiddenGames: 'Tidak ada game tersembunyi',
+  AppLocale.noHiddenGamesSubtitle:
+      'Sembunyikan game dari pengaturannya dan game itu akan muncul di sini.',
 };

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -1154,4 +1154,19 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.wizardArtPackUnavailable:
       'Al momento non è stato possibile raggiungere il pacchetto grafico. Puoi '
       'installarlo in seguito dalle Impostazioni una volta online.',
+
+  // Hide / unhide games
+  AppLocale.hideGame: 'Nascondi gioco',
+  AppLocale.hideGameSubtitle:
+      'Lo nasconde dalle liste dei giochi. Non viene eliminato nulla.',
+  AppLocale.hide: 'Nascondi',
+  AppLocale.unhide: 'Mostra',
+  AppLocale.unhideAll: 'Mostra tutti',
+  AppLocale.gameHidden: '{name} nascosto',
+  AppLocale.gameUnhidden: '{name} ripristinato',
+  AppLocale.allGamesUnhidden: 'Tutti i giochi nascosti sono stati ripristinati',
+  AppLocale.hiddenGames: 'Nascosti',
+  AppLocale.noHiddenGames: 'Nessun gioco nascosto',
+  AppLocale.noHiddenGamesSubtitle:
+      'Nascondi un gioco dalle sue impostazioni e comparirà qui.',
 };

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -1027,4 +1027,17 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.wizardArtPackUnavailable:
       '現在アートパックにアクセスできませんでした。オンラインになったら、後で'
       '設定からインストールできます。',
+
+  // Hide / unhide games
+  AppLocale.hideGame: 'ゲームを非表示',
+  AppLocale.hideGameSubtitle: 'ゲーム一覧から隠します。削除はされません。',
+  AppLocale.hide: '非表示',
+  AppLocale.unhide: '再表示',
+  AppLocale.unhideAll: 'すべて再表示',
+  AppLocale.gameHidden: '{name} を非表示にしました',
+  AppLocale.gameUnhidden: '{name} を再表示しました',
+  AppLocale.allGamesUnhidden: '非表示のゲームをすべて再表示しました',
+  AppLocale.hiddenGames: '非表示',
+  AppLocale.noHiddenGames: '非表示のゲームはありません',
+  AppLocale.noHiddenGamesSubtitle: 'ゲーム設定から非表示にすると、ここに表示されます。',
 };

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -1037,4 +1037,17 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.sourceLocal: '이 기기',
   AppLocale.searchRatingLocalOnly: '평점 필터는 로컬 게임에만 적용됩니다',
   AppLocale.searchNoRommEquivalent: 'RomM에 ‘{value}’로 분류된 항목이 없습니다',
+
+  // Hide / unhide games
+  AppLocale.hideGame: '게임 숨기기',
+  AppLocale.hideGameSubtitle: '게임 목록에서 숨깁니다. 삭제되지 않습니다.',
+  AppLocale.hide: '숨기기',
+  AppLocale.unhide: '숨김 해제',
+  AppLocale.unhideAll: '모두 숨김 해제',
+  AppLocale.gameHidden: '{name} 숨김',
+  AppLocale.gameUnhidden: '{name} 복원됨',
+  AppLocale.allGamesUnhidden: '숨긴 게임을 모두 복원했습니다',
+  AppLocale.hiddenGames: '숨김',
+  AppLocale.noHiddenGames: '숨긴 게임 없음',
+  AppLocale.noHiddenGamesSubtitle: '게임 설정에서 게임을 숨기면 여기에 표시됩니다.',
 };

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -1138,4 +1138,19 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.wizardArtPackUnavailable:
       'Não foi possível acessar o pacote de arte agora. Você pode instalá-lo '
       'mais tarde nas Configurações quando estiver online.',
+
+  // Hide / unhide games
+  AppLocale.hideGame: 'Ocultar jogo',
+  AppLocale.hideGameSubtitle:
+      'Oculta-o das suas listas de jogos. Nada é excluído.',
+  AppLocale.hide: 'Ocultar',
+  AppLocale.unhide: 'Mostrar',
+  AppLocale.unhideAll: 'Mostrar todos',
+  AppLocale.gameHidden: '{name} ocultado',
+  AppLocale.gameUnhidden: '{name} restaurado',
+  AppLocale.allGamesUnhidden: 'Todos os jogos ocultos foram restaurados',
+  AppLocale.hiddenGames: 'Ocultos',
+  AppLocale.noHiddenGames: 'Nenhum jogo oculto',
+  AppLocale.noHiddenGamesSubtitle:
+      'Oculte um jogo nas configurações dele e ele aparecerá aqui.',
 };

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -1128,4 +1128,18 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.wizardArtPackUnavailable:
       'Сейчас не удалось получить набор обложек. Вы можете установить его позже '
       'в Настройках, когда будете онлайн.',
+
+  // Hide / unhide games
+  AppLocale.hideGame: 'Скрыть игру',
+  AppLocale.hideGameSubtitle: 'Игра исчезнет из списков. Ничего не удаляется.',
+  AppLocale.hide: 'Скрыть',
+  AppLocale.unhide: 'Показать',
+  AppLocale.unhideAll: 'Показать все',
+  AppLocale.gameHidden: '{name} скрыта',
+  AppLocale.gameUnhidden: '{name} восстановлена',
+  AppLocale.allGamesUnhidden: 'Все скрытые игры восстановлены',
+  AppLocale.hiddenGames: 'Скрытые',
+  AppLocale.noHiddenGames: 'Нет скрытых игр',
+  AppLocale.noHiddenGamesSubtitle:
+      'Скройте игру в её настройках, и она появится здесь.',
 };

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -1004,4 +1004,17 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.wizardDownloadArtPack: '下载美术包',
   AppLocale.wizardArtPackInstalled: '美术包已安装！你之后可以在“设置”中探索更多主题。',
   AppLocale.wizardArtPackUnavailable: '目前无法访问美术包。联网后，你可以稍后在“设置”中安装它。',
+
+  // Hide / unhide games
+  AppLocale.hideGame: '隐藏游戏',
+  AppLocale.hideGameSubtitle: '将其从游戏列表中隐藏，不会删除任何文件。',
+  AppLocale.hide: '隐藏',
+  AppLocale.unhide: '取消隐藏',
+  AppLocale.unhideAll: '全部取消隐藏',
+  AppLocale.gameHidden: '已隐藏 {name}',
+  AppLocale.gameUnhidden: '已恢复 {name}',
+  AppLocale.allGamesUnhidden: '已恢复所有隐藏的游戏',
+  AppLocale.hiddenGames: '已隐藏',
+  AppLocale.noHiddenGames: '没有隐藏的游戏',
+  AppLocale.noHiddenGamesSubtitle: '在游戏设置中隐藏游戏后，它会显示在这里。',
 };

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -1005,4 +1005,17 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.wizardDownloadArtPack: '下載美術包',
   AppLocale.wizardArtPackInstalled: '美術包已安裝！你之後可以在「設定」中探索更多主題。',
   AppLocale.wizardArtPackUnavailable: '目前無法存取美術包。連上網路後，你可以稍後在「設定」中安裝它。',
+
+  // Hide / unhide games
+  AppLocale.hideGame: '隱藏遊戲',
+  AppLocale.hideGameSubtitle: '將其從遊戲清單中隱藏，不會刪除任何檔案。',
+  AppLocale.hide: '隱藏',
+  AppLocale.unhide: '取消隱藏',
+  AppLocale.unhideAll: '全部取消隱藏',
+  AppLocale.gameHidden: '已隱藏 {name}',
+  AppLocale.gameUnhidden: '已恢復 {name}',
+  AppLocale.allGamesUnhidden: '已恢復所有隱藏的遊戲',
+  AppLocale.hiddenGames: '已隱藏',
+  AppLocale.noHiddenGames: '沒有隱藏的遊戲',
+  AppLocale.noHiddenGamesSubtitle: '在遊戲設定中隱藏遊戲後，它會顯示在這裡。',
 };

--- a/lib/models/database_game_model.dart
+++ b/lib/models/database_game_model.dart
@@ -16,6 +16,10 @@ class DatabaseGameModel {
   /// Whether the user has marked this game as a favorite.
   final bool isFavorite;
 
+  /// Whether the user hid this game from the game lists. Hidden games stay in
+  /// the database and are restored from the system settings dialog.
+  final bool isHidden;
+
   /// Unique identifier on RetroAchievements.org.
   final int? idRa;
 
@@ -96,6 +100,7 @@ class DatabaseGameModel {
     required this.filename,
     required this.romPath,
     this.isFavorite = false,
+    this.isHidden = false,
     this.idRa,
     this.emulatorName,
     this.emulatorPath,
@@ -165,6 +170,12 @@ class DatabaseGameModel {
                   .toLowerCase() ==
               'true' ||
           (json['is_favorite'] ?? json['isFavorite'] ?? 0).toString() == '1',
+      isHidden:
+          (json['is_hidden'] ?? json['isHidden'] ?? 0)
+                  .toString()
+                  .toLowerCase() ==
+              'true' ||
+          (json['is_hidden'] ?? json['isHidden'] ?? 0).toString() == '1',
       idRa: int.tryParse((json['id_ra'] ?? json['idRa'] ?? '').toString()),
       emulatorName: (json['emulator_name'] ?? json['emulatorName'])?.toString(),
       emulatorPath: (json['emulator_path'] ?? json['emulatorPath'])?.toString(),
@@ -229,6 +240,7 @@ class DatabaseGameModel {
       'filename': filename,
       'romPath': romPath,
       'isFavorite': isFavorite,
+      'isHidden': isHidden,
       'idRa': idRa,
       'emulatorName': emulatorName,
       'emulatorPath': emulatorPath,
@@ -264,6 +276,7 @@ class DatabaseGameModel {
     String? filename,
     String? romPath,
     bool? isFavorite,
+    bool? isHidden,
     int? idRa,
     String? emulatorName,
     String? emulatorPath,
@@ -295,6 +308,7 @@ class DatabaseGameModel {
       filename: filename ?? this.filename,
       romPath: romPath ?? this.romPath,
       isFavorite: isFavorite ?? this.isFavorite,
+      isHidden: isHidden ?? this.isHidden,
       idRa: idRa ?? this.idRa,
       emulatorName: emulatorName ?? this.emulatorName,
       emulatorPath: emulatorPath ?? this.emulatorPath,

--- a/lib/models/game_model.dart
+++ b/lib/models/game_model.dart
@@ -41,6 +41,10 @@ class GameModel {
   /// Whether the user has marked this game as a favorite.
   final bool? isFavorite;
 
+  /// Whether the user hid this game from the game lists. Hidden games are
+  /// filtered out of every list; the row and the ROM file are left untouched.
+  final bool isHidden;
+
   /// Timestamp of the last time the game was launched.
   final DateTime? lastPlayed;
 
@@ -101,6 +105,7 @@ class GameModel {
     required this.players,
     required this.rating,
     this.isFavorite,
+    this.isHidden = false,
     this.lastPlayed,
     this.playTime,
     this.romPath,
@@ -163,6 +168,7 @@ class GameModel {
       players: db.players ?? '',
       rating: db.rating ?? 0.0,
       isFavorite: db.isFavorite,
+      isHidden: db.isHidden,
       lastPlayed: db.lastPlayed,
       playTime: db.playTime,
       romPath: db.romPath,
@@ -212,6 +218,7 @@ class GameModel {
     String? players,
     double? rating,
     bool? isFavorite,
+    bool? isHidden,
     DateTime? lastPlayed,
     int? playTime,
     String? romPath,
@@ -241,6 +248,7 @@ class GameModel {
       players: players ?? this.players,
       rating: rating ?? this.rating,
       isFavorite: isFavorite ?? this.isFavorite,
+      isHidden: isHidden ?? this.isHidden,
       lastPlayed: lastPlayed ?? this.lastPlayed,
       playTime: playTime ?? this.playTime,
       romPath: romPath ?? this.romPath,

--- a/lib/providers/sqlite_config_provider/scanning.dart
+++ b/lib/providers/sqlite_config_provider/scanning.dart
@@ -555,6 +555,13 @@ extension SqliteConfigScanning on SqliteConfigProvider {
           .expand((m) => m.keys.map((k) => k.toLowerCase()))
           .toSet();
 
+      // Hidden games per system, in a single query. They stay in the ROM count
+      // that decides whether a system is kept (otherwise a system whose games
+      // are all hidden would vanish, taking the unhide UI with it) but are
+      // subtracted from the count shown on the system card, which has to match
+      // the list the user actually sees.
+      final hiddenBySystem = await GameRepository.getHiddenRomCountsBySystem();
+
       // First pass: collect all systems except 'all'
       for (final system in allSystems) {
         if (system.folderName == 'all') continue;
@@ -582,7 +589,8 @@ extension SqliteConfigScanning on SqliteConfigProvider {
             (system.folderName == 'android' && Platform.isAndroid);
 
         if (romCount > 0 || hasFolderWhenNonRecursive || isAndroidVirtual) {
-          systemsToKeep.add(system.copyWith(romCount: romCount));
+          final visibleRomCount = romCount - (hiddenBySystem[system.id!] ?? 0);
+          systemsToKeep.add(system.copyWith(romCount: visibleRomCount));
 
           // Increment count for 'all' logic if it's a real emulator system with games
           if (romCount > 0 && !virtualSystems.contains(system.folderName)) {
@@ -729,11 +737,19 @@ extension SqliteConfigScanning on SqliteConfigProvider {
         }
       }
 
+      // Raw ROM count, hidden games included. [updatedSystem.romCount] is the
+      // visible one (what the card shows), and pruning on it would make a
+      // system whose games are all hidden disappear — along with the only place
+      // to unhide them.
+      final totalRomCount = await SystemRepository.getRomCountForSystem(
+        updatedSystem.id!,
+      );
+
       // INCREMENTAL PERSISTENCE: Keep a system when it has ROMs, when its
       // folder exists and recursive scan is explicitly OFF (user can re-enable),
       // or when it is a virtual system (android / all).
       final bool shouldKeep =
-          updatedSystem.romCount > 0 ||
+          totalRomCount > 0 ||
           hasFolderWhenNonRecursive ||
           (updatedSystem.folderName == 'android' && Platform.isAndroid) ||
           updatedSystem.folderName == 'all' ||

--- a/lib/providers/sqlite_database_provider.dart
+++ b/lib/providers/sqlite_database_provider.dart
@@ -81,7 +81,12 @@ class SqliteDatabaseProvider extends ChangeNotifier {
     _error = null;
 
     try {
-      _database = await GameRepository.loadDatabase();
+      // The cache feeds the recent / most-played / favorites rows, so the games
+      // the user hid are dropped on the way in rather than at each reader.
+      _database = {
+        for (final entry in (await GameRepository.loadDatabase()).entries)
+          entry.key: entry.value.where((game) => !game.isHidden).toList(),
+      };
       _lastUpdate = DateTime.now();
       _log.i('Database loaded: ${_database.length} systems with games');
       notifyListeners();
@@ -103,7 +108,9 @@ class SqliteDatabaseProvider extends ChangeNotifier {
     String systemFolderName,
   ) async {
     try {
-      final games = await GameRepository.loadGamesForSystem(systemFolderName);
+      final games = (await GameRepository.loadGamesForSystem(
+        systemFolderName,
+      )).where((game) => !game.isHidden).toList();
       _database[systemFolderName] = games;
       notifyListeners();
       return games;

--- a/lib/repositories/game_repository.dart
+++ b/lib/repositories/game_repository.dart
@@ -354,6 +354,30 @@ class GameRepository {
     enabled,
   );
 
+  /// Hides or unhides a ROM. Hidden games stay in the database — only the
+  /// game lists filter them out.
+  static Future<void> setGameHidden(
+    String systemFolderName,
+    String romname,
+    bool hidden,
+  ) => SqliteService.setRomHidden(systemFolderName, romname, hidden);
+
+  /// Returns the hidden games of [systemId], or of the whole library when
+  /// [systemId] is null.
+  static Future<List<DatabaseGameModel>> getHiddenGames({String? systemId}) =>
+      SqliteService.getHiddenGames(systemId: systemId);
+
+  /// Restores every hidden game of [systemId].
+  static Future<void> unhideAllGamesForSystem(String systemId) =>
+      SqliteService.unhideAllRomsForSystem(systemId);
+
+  /// Restores every hidden game across all systems.
+  static Future<void> unhideAllGames() => SqliteService.unhideAllRoms();
+
+  /// Returns the number of hidden games per system id.
+  static Future<Map<String, int>> getHiddenRomCountsBySystem() =>
+      SqliteService.getHiddenRomCountsBySystem();
+
   /// Resets play time and last played timestamp for a ROM.
   static Future<void> resetPlayTime(String systemFolderName, String romname) =>
       SqliteService.resetRomPlayTime(systemFolderName, romname);

--- a/lib/screens/game_screen/game_settings_dialog/game_settings_dialog.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_dialog.dart
@@ -23,7 +23,7 @@ import 'game_settings_scrapping_tab.dart';
 /// tab strip, a content area, and a gamepad-hint footer. Tabs:
 ///  * Emulator  — per-game emulator override.
 ///  * Scrapping — force rescrape plus manual metadata/artwork editing.
-///  * Manage    — view mode, play-time reset, and game deletion.
+///  * Manage    — view mode, play-time reset, hiding, and game deletion.
 class GameSettingsDialog extends StatefulWidget {
   final GameModel game;
   final SystemModel system;
@@ -45,6 +45,11 @@ class GameSettingsDialog extends StatefulWidget {
   /// right after invoking this.
   final void Function(String romname)? onGameDeleted;
 
+  /// Called after the game is hidden from the game lists; the dialog closes
+  /// itself right after invoking this, exactly like [onGameDeleted]. The row
+  /// stays in the database — only the lists stop showing it.
+  final void Function(String romname)? onGameHidden;
+
   const GameSettingsDialog({
     super.key,
     required this.game,
@@ -54,6 +59,7 @@ class GameSettingsDialog extends StatefulWidget {
     this.isAllMode = false,
     this.onGameUpdated,
     this.onGameDeleted,
+    this.onGameHidden,
   });
 
   @override
@@ -177,6 +183,11 @@ class _GameSettingsDialogState extends State<GameSettingsDialog> {
     if (mounted) Navigator.of(context).pop();
   }
 
+  void _handleGameHidden(String romname) {
+    widget.onGameHidden?.call(romname);
+    if (mounted) Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -236,6 +247,7 @@ class _GameSettingsDialogState extends State<GameSettingsDialog> {
                     isAllMode: widget.isAllMode,
                     onGameUpdated: widget.onGameUpdated,
                     onGameDeleted: _handleGameDeleted,
+                    onGameHidden: _handleGameHidden,
                   ),
                 ],
               ),

--- a/lib/screens/game_screen/game_settings_dialog/game_settings_manage_tab.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_manage_tab.dart
@@ -8,7 +8,10 @@ import 'package:neostation/models/system_model.dart';
 import 'package:neostation/providers/file_provider.dart';
 import 'package:neostation/providers/neo_sync_provider.dart';
 import 'package:neostation/providers/romm_provider.dart';
+import 'package:neostation/providers/sqlite_config_provider.dart';
+import 'package:neostation/providers/sqlite_database_provider.dart';
 import 'package:neostation/repositories/game_repository.dart';
+import 'package:neostation/repositories/system_repository.dart';
 import 'package:neostation/utils/enabled_index_nav.dart';
 import 'package:neostation/screens/settings_screen/new_settings_options/widgets/setting_row.dart';
 import 'package:neostation/services/logger_service.dart';
@@ -22,8 +25,8 @@ import 'package:neostation/widgets/delete_game_dialog.dart';
 import 'package:provider/provider.dart';
 
 /// Manage tab for [GameSettingsDialog]: cloud sync, grid size/style,
-/// play-time reset, and permanent game deletion. View mode is selected from the
-/// game view itself (X button), not here.
+/// play-time reset, hiding the game, and permanent game deletion. View mode is
+/// selected from the game view itself (X button), not here.
 class GameSettingsManageTab extends StatefulWidget {
   final GameModel game;
   final SystemModel system;
@@ -32,6 +35,7 @@ class GameSettingsManageTab extends StatefulWidget {
   final bool isAllMode;
   final VoidCallback? onGameUpdated;
   final void Function(String romname)? onGameDeleted;
+  final void Function(String romname)? onGameHidden;
 
   const GameSettingsManageTab({
     super.key,
@@ -42,6 +46,7 @@ class GameSettingsManageTab extends StatefulWidget {
     required this.isAllMode,
     this.onGameUpdated,
     this.onGameDeleted,
+    this.onGameHidden,
   });
 
   @override
@@ -55,6 +60,7 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
   late bool _cloudSyncEnabled;
   bool _isUpdatingCloudSync = false;
   bool _isResettingPlayTime = false;
+  bool _isHiding = false;
   bool _isDeleting = false;
 
   final ScrollController _scrollController = ScrollController();
@@ -67,8 +73,9 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
   // cloud sync visibility or the grid options change.
   int get _cloudSyncIdx => 0;
   int get _playTimeIdx => 1;
-  int get _deleteIdx => 2;
-  int get _totalItems => 3;
+  int get _hideIdx => 2;
+  int get _deleteIdx => 3;
+  int get _totalItems => 4;
 
   bool get _showCloudSync => widget.syncProvider?.isAuthenticated == true;
 
@@ -127,6 +134,8 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
       if ((widget.game.playTime ?? 0) > 0 && !_isResettingPlayTime) {
         _confirmResetPlayTime();
       }
+    } else if (idx == _hideIdx) {
+      if (!_isHiding) _hideGame();
     } else if (idx == _deleteIdx) {
       _confirmDeleteGame();
     }
@@ -224,6 +233,59 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
     } finally {
       if (mounted) setState(() => _isResettingPlayTime = false);
     }
+  }
+
+  // ── Hide ────────────────────────────────────────────────────────────────
+
+  /// Hides the game from every game list.
+  ///
+  /// Deliberately unconfirmed: nothing is deleted and the game is one visit to
+  /// the system's settings dialog away from coming back, so a confirmation
+  /// would only get in the way.
+  Future<void> _hideGame() async {
+    if (_isHiding) return;
+    setState(() => _isHiding = true);
+
+    final hiddenRomname = widget.game.romname;
+    final displayName = widget.game.name.isNotEmpty
+        ? widget.game.name
+        : hiddenRomname;
+    // Read before the awaits: the dialog is popped as soon as this finishes.
+    final databaseProvider = context.read<SqliteDatabaseProvider>();
+    final configProvider = context.read<SqliteConfigProvider>();
+
+    try {
+      await GameRepository.setGameHidden(
+        _targetSystemFolder,
+        hiddenRomname,
+        true,
+      );
+      // The systems screen keeps its own cached copies — the recent-games row
+      // and the ROM count on the system card — so both are re-read here rather
+      // than left showing a game that no longer appears in any list.
+      await databaseProvider.loadGamesForSystem(_targetSystemFolder);
+      final system = await SystemRepository.getSystemByFolderName(
+        _targetSystemFolder,
+      );
+      if (system != null) await configProvider.refreshSystem(system);
+    } catch (e) {
+      _log.e('Hiding game failed: $e');
+      if (mounted) setState(() => _isHiding = false);
+      return;
+    }
+
+    if (!mounted) return;
+    setState(() => _isHiding = false);
+
+    AppNotification.showNotification(
+      context,
+      AppLocale.gameHidden
+          .getString(context)
+          .replaceFirst('{name}', displayName),
+      type: NotificationType.info,
+    );
+
+    widget.onGameHidden?.call(hiddenRomname);
   }
 
   // ── Delete ──────────────────────────────────────────────────────────────
@@ -390,6 +452,58 @@ class GameSettingsManageTabState extends State<GameSettingsManageTab> {
                               : theme.colorScheme.onSurface.withValues(
                                   alpha: 0.3,
                                 ),
+                        ),
+                      ),
+                    ),
+            ),
+          ),
+
+          SizedBox(height: 12.r),
+
+          // Hide game.
+          GestureDetector(
+            onTap: () {
+              SfxService().playNavSound();
+              setState(() => _selectedIndex = _hideIdx);
+              if (!_isHiding) _hideGame();
+            },
+            child: SettingRow(
+              key: _itemKey(_hideIdx),
+              focused: _selectedIndex == _hideIdx,
+              title: AppLocale.hideGame.getString(context),
+              subtitle: AppLocale.hideGameSubtitle.getString(context),
+              trailing: _isHiding
+                  ? SizedBox(
+                      width: 20.r,
+                      height: 20.r,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: theme.colorScheme.onSurface,
+                      ),
+                    )
+                  : Container(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 8.r,
+                        vertical: 3.r,
+                      ),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primary.withValues(
+                          alpha: 0.15,
+                        ),
+                        borderRadius: BorderRadius.circular(4.r),
+                        border: Border.all(
+                          color: theme.colorScheme.primary.withValues(
+                            alpha: 0.4,
+                          ),
+                          width: 1.r,
+                        ),
+                      ),
+                      child: Text(
+                        AppLocale.hide.getString(context),
+                        style: TextStyle(
+                          fontSize: 11.r,
+                          fontWeight: FontWeight.w600,
+                          color: theme.colorScheme.primary,
                         ),
                       ),
                     ),

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -507,6 +507,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
             widget.system.folderName == SystemFolderNames.favorites,
         onGameUpdated: _handleGameUpdated,
         onGameDeleted: _handleGameDeleted,
+        onGameHidden: _handleGameHidden,
       ),
     );
   }
@@ -1770,6 +1771,11 @@ class _SystemGamesListState extends State<SystemGamesList> {
     });
     _reorderGamesListKeepingVisualPosition();
   }
+
+  /// Called after a game is hidden. Hiding only takes the game out of the
+  /// lists, and this list is one of them — so it drops out exactly the way a
+  /// deleted game does.
+  void _handleGameHidden(String romname) => _handleGameDeleted(romname);
 
   /// Called after a game is permanently deleted. Removes it from the list and
   /// selects the previous game (or the next one if at the start).

--- a/lib/screens/search_screen/search_screen.dart
+++ b/lib/screens/search_screen/search_screen.dart
@@ -278,7 +278,11 @@ class _SearchScreenState extends State<SearchScreen> {
   }
 
   Future<void> _loadGames() async {
-    final games = await GameRepository.getAllGames();
+    // Games the user hid are dropped here: search is a game list like any
+    // other, so a hidden game must not surface through it either.
+    final games = (await GameRepository.getAllGames())
+        .where((g) => !g.isHidden)
+        .toList();
     if (!mounted) return;
 
     // Phase 1: make the data available and show the loaded UI instantly

--- a/lib/services/game/game_list_service.dart
+++ b/lib/services/game/game_list_service.dart
@@ -132,6 +132,7 @@ class GameListService {
         final databaseGames = (await GameRepository.getAllGames())
             .where(
               (dbGame) =>
+                  !dbGame.isHidden &&
                   dbGame.systemFolderName != 'android' &&
                   dbGame.systemFolderName != 'music',
             )
@@ -201,7 +202,9 @@ class GameListService {
         return [];
       }
 
-      final databaseGames = await GameRepository.getGamesBySystem(system.id!);
+      final databaseGames = (await GameRepository.getGamesBySystem(
+        system.id!,
+      )).where((dbGame) => !dbGame.isHidden).toList();
       final validExtensions = await SystemRepository.getExtensionsForSystem(
         system.id!,
       );
@@ -261,7 +264,9 @@ class GameListService {
   }
 
   static Future<List<GameModel>> _loadFavoriteGames() async {
-    final databaseGames = await GameRepository.getFavoriteGames();
+    final databaseGames = (await GameRepository.getFavoriteGames())
+        .where((dbGame) => !dbGame.isHidden)
+        .toList();
 
     final systemIds = databaseGames
         .map((g) => g.appSystemId)

--- a/lib/widgets/system_emulator_settings_dialog.dart
+++ b/lib/widgets/system_emulator_settings_dialog.dart
@@ -8,7 +8,9 @@ import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/themes/app_themes.dart';
 import 'package:provider/provider.dart';
+import '../constants/system_folder_names.dart';
 import '../models/core_emulator_model.dart';
+import '../models/database_game_model.dart';
 import '../models/standalone_emulator_model.dart';
 import '../themes/corner_radii.dart';
 import 'system_emulator_settings_dialog/models/emulator_list_item.dart';
@@ -17,6 +19,7 @@ import '../providers/sqlite_config_provider.dart';
 import '../providers/sqlite_database_provider.dart';
 import '../repositories/system_repository.dart';
 import '../repositories/emulator_repository.dart';
+import '../repositories/game_repository.dart';
 import '../services/config_service.dart';
 import 'package:neostation/services/logger_service.dart';
 import '../utils/gamepad_nav.dart';
@@ -65,6 +68,13 @@ class _SystemEmulatorSettingsDialogState
   int _currentTab = 0; // Default to General tab
   int _generalIndex = 0; // Index for General tab items
   int _appearanceIndex = 0; // Index for Appearance tab items
+  // Hidden-games tab: the games this system (or the whole library, for the
+  // virtual ones) has hidden, plus the row that restores them all at once.
+  List<DatabaseGameModel> _hiddenGames = [];
+  bool _isLoadingHiddenGames = true;
+  int _hiddenIndex = 0;
+  final Map<int, GlobalKey> _hiddenItemKeys = {};
+  late ScrollController _hiddenScrollController;
   // Emulators tab: 0 = default/core action, 1 = executable picker.
   int _emulatorActionIndex = 0;
   // 0: Prefer filename, 1: Hide ext, 2: (), 3: [], 4: Recursive?,
@@ -109,6 +119,7 @@ class _SystemEmulatorSettingsDialogState
         : 6;
 
     _generalScrollController = ScrollController();
+    _hiddenScrollController = ScrollController();
     _generalItemKeys = List.generate(
       _totalGeneralItems,
       (index) => GlobalKey(
@@ -126,6 +137,7 @@ class _SystemEmulatorSettingsDialogState
     );
 
     _loadCores();
+    _loadHiddenGames();
     _initializeGamepad();
   }
 
@@ -134,6 +146,7 @@ class _SystemEmulatorSettingsDialogState
     _cleanupGamepad();
     _centeredScrollController.dispose();
     _generalScrollController.dispose();
+    _hiddenScrollController.dispose();
     // Dispose focus nodes
     _headerCloseButtonFocusNode.dispose();
     _footerCloseButtonFocusNode.dispose();
@@ -311,6 +324,136 @@ class _SystemEmulatorSettingsDialogState
           context,
         ),
         type: NotificationType.info,
+      );
+    }
+  }
+
+  // ── Hidden games ──────────────────────────────────────────────────────────
+
+  /// True for the virtual libraries ('all' / 'favorites'), which aggregate
+  /// other systems and therefore list every hidden game rather than their own.
+  bool get _isVirtualLibrarySystem =>
+      _system.folderName == 'all' ||
+      _system.folderName == SystemFolderNames.favorites;
+
+  /// System to scope the hidden list to, or null for the whole library.
+  String? get _hiddenScopeSystemId =>
+      _isVirtualLibrarySystem ? null : _system.id;
+
+  /// Rows in the Hidden tab: one per hidden game, plus a final "unhide all"
+  /// row once there is more than one game to restore.
+  int get _totalHiddenItems =>
+      _hiddenGames.length + (_hiddenGames.length > 1 ? 1 : 0);
+
+  bool get _hasUnhideAllRow => _hiddenGames.length > 1;
+
+  Future<void> _loadHiddenGames() async {
+    try {
+      final games = await GameRepository.getHiddenGames(
+        systemId: _hiddenScopeSystemId,
+      );
+      if (!mounted) return;
+      setState(() {
+        _hiddenGames = games;
+        _isLoadingHiddenGames = false;
+        if (_hiddenIndex >= _totalHiddenItems) {
+          _hiddenIndex = _totalHiddenItems > 0 ? _totalHiddenItems - 1 : 0;
+        }
+      });
+    } catch (e) {
+      _log.e('Error loading hidden games: $e');
+      if (mounted) setState(() => _isLoadingHiddenGames = false);
+    }
+  }
+
+  /// Restores a single game to its system's list.
+  Future<void> _unhideGame(DatabaseGameModel game) async {
+    final folderName = game.systemFolderName ?? _system.folderName;
+    final displayName = game.realName ?? game.filename;
+    try {
+      await GameRepository.setGameHidden(folderName, game.filename, false);
+    } catch (e) {
+      _log.e('Error unhiding ${game.filename}: $e');
+      return;
+    }
+
+    await _loadHiddenGames();
+    if (!mounted) return;
+    await _refreshSystemAfterHiddenChange({folderName});
+    if (!mounted) return;
+
+    AppNotification.showNotification(
+      context,
+      AppLocale.gameUnhidden
+          .getString(context)
+          .replaceFirst('{name}', displayName),
+      type: NotificationType.success,
+    );
+  }
+
+  /// Restores every game listed in the tab.
+  Future<void> _unhideAllGames() async {
+    final affectedFolders = _hiddenGames
+        .map((g) => g.systemFolderName ?? _system.folderName)
+        .toSet();
+    try {
+      final scopeId = _hiddenScopeSystemId;
+      if (scopeId == null) {
+        await GameRepository.unhideAllGames();
+      } else {
+        await GameRepository.unhideAllGamesForSystem(scopeId);
+      }
+    } catch (e) {
+      _log.e('Error unhiding all games: $e');
+      return;
+    }
+
+    await _loadHiddenGames();
+    if (!mounted) return;
+    await _refreshSystemAfterHiddenChange(affectedFolders);
+    if (!mounted) return;
+
+    AppNotification.showNotification(
+      context,
+      AppLocale.allGamesUnhidden.getString(context),
+      type: NotificationType.success,
+    );
+  }
+
+  /// Re-reads the systems whose libraries just changed size so their ROM count
+  /// and game list catch up with the restored games.
+  Future<void> _refreshSystemAfterHiddenChange(
+    Set<String> affectedFolders,
+  ) async {
+    if (!mounted) return;
+    final configProvider = context.read<SqliteConfigProvider>();
+    final databaseProvider = context.read<SqliteDatabaseProvider>();
+
+    for (final folderName in affectedFolders) {
+      SystemModel? system = folderName == _system.folderName ? _system : null;
+      if (system == null) {
+        try {
+          system = await SystemRepository.getSystemByFolderName(folderName);
+        } catch (e) {
+          _log.w('Hidden-games refresh: unknown system $folderName ($e)');
+        }
+      }
+      if (system != null) {
+        await configProvider.refreshSystem(system);
+      }
+      await databaseProvider.loadGamesForSystem(folderName);
+      if (!mounted) return;
+    }
+  }
+
+  void _scrollToHiddenSelected() {
+    final key = _hiddenItemKeys[_hiddenIndex];
+    if (key?.currentContext != null) {
+      Scrollable.ensureVisible(
+        key!.currentContext!,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
       );
     }
   }
@@ -874,7 +1017,9 @@ class _SystemEmulatorSettingsDialogState
                         : _errorMessage != null
                         ? _buildErrorState()
                         : _buildEmulatorsTab())
-                  : _buildAppearanceTab(),
+                  : _currentTab == 2
+                  ? _buildAppearanceTab()
+                  : _buildHiddenGamesTab(),
             ),
             _buildFooter(),
           ],

--- a/lib/widgets/system_emulator_settings_dialog.dart
+++ b/lib/widgets/system_emulator_settings_dialog.dart
@@ -340,6 +340,30 @@ class _SystemEmulatorSettingsDialogState
   String? get _hiddenScopeSystemId =>
       _isVirtualLibrarySystem ? null : _system.id;
 
+  /// Whether a game of this system can be hidden in the first place.
+  ///
+  /// The Android system is browsed through [AndroidAppsGrid], a separate screen
+  /// that binds no settings action, so an installed app has no "Hide Game" row
+  /// to reach — a Hidden tab there could only ever be empty. Everything else
+  /// (music included) goes through the games list, where START opens the game
+  /// settings dialog.
+  bool get _systemSupportsHiding => _system.folderName != 'android';
+
+  /// Whether the Hidden tab is offered. Kept visible whenever games *are*
+  /// hidden even if the system can't hide them, so a row can never end up with
+  /// no way back — and so this starts working on its own if hiding is later
+  /// wired into the Android apps grid.
+  bool get _showHiddenTab => _systemSupportsHiding || _hiddenGames.isNotEmpty;
+
+  /// Tab indices this system offers, in strip order. Single source of truth for
+  /// the strip, the LB/RB cycle and the body switch.
+  List<int> get _availableTabs => [
+    0,
+    if (_system.folderName != 'all' && _system.folderName != 'android') 1,
+    2,
+    if (_showHiddenTab) 3,
+  ];
+
   /// Rows in the Hidden tab: one per hidden game, plus a final "unhide all"
   /// row once there is more than one game to restore.
   int get _totalHiddenItems =>
@@ -359,6 +383,9 @@ class _SystemEmulatorSettingsDialogState
         if (_hiddenIndex >= _totalHiddenItems) {
           _hiddenIndex = _totalHiddenItems > 0 ? _totalHiddenItems - 1 : 0;
         }
+        // Restoring the last hidden game of a system that can't hide any takes
+        // the tab away underneath the user; step back to one that still exists.
+        if (_currentTab == 3 && !_showHiddenTab) _currentTab = 2;
       });
     } catch (e) {
       _log.e('Error loading hidden games: $e');
@@ -1017,7 +1044,7 @@ class _SystemEmulatorSettingsDialogState
                         : _errorMessage != null
                         ? _buildErrorState()
                         : _buildEmulatorsTab())
-                  : _currentTab == 2
+                  : _currentTab == 2 || !_showHiddenTab
                   ? _buildAppearanceTab()
                   : _buildHiddenGamesTab(),
             ),

--- a/lib/widgets/system_emulator_settings_dialog/chrome.dart
+++ b/lib/widgets/system_emulator_settings_dialog/chrome.dart
@@ -168,6 +168,8 @@ extension _Chrome on _SystemEmulatorSettingsDialogState {
           ],
           SizedBox(width: 16.r),
           _buildTabItem(2, AppLocale.appearance.getString(context)),
+          SizedBox(width: 16.r),
+          _buildTabItem(3, AppLocale.hiddenGames.getString(context)),
           const Spacer(),
           // RB Icon
           Padding(

--- a/lib/widgets/system_emulator_settings_dialog/chrome.dart
+++ b/lib/widgets/system_emulator_settings_dialog/chrome.dart
@@ -161,15 +161,16 @@ extension _Chrome on _SystemEmulatorSettingsDialogState {
             ),
           ),
           _buildTabItem(0, AppLocale.general.getString(context)),
-          if (widget.system.folderName != 'all' &&
-              widget.system.folderName != 'android') ...[
+          if (_availableTabs.contains(1)) ...[
             SizedBox(width: 16.r),
             _buildTabItem(1, AppLocale.emulators.getString(context)),
           ],
           SizedBox(width: 16.r),
           _buildTabItem(2, AppLocale.appearance.getString(context)),
-          SizedBox(width: 16.r),
-          _buildTabItem(3, AppLocale.hiddenGames.getString(context)),
+          if (_availableTabs.contains(3)) ...[
+            SizedBox(width: 16.r),
+            _buildTabItem(3, AppLocale.hiddenGames.getString(context)),
+          ],
           const Spacer(),
           // RB Icon
           Padding(

--- a/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
+++ b/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
@@ -148,13 +148,9 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
   }
 
   void _previousTab() {
-    List<int> availableTabs = [0, 2, 3];
-    if (widget.system.folderName != 'all' &&
-        widget.system.folderName != 'android') {
-      availableTabs = [0, 1, 2, 3];
-    }
-
+    final availableTabs = _availableTabs;
     int currentIndex = availableTabs.indexOf(_currentTab);
+    if (currentIndex == -1) currentIndex = 0;
     int prevIndex =
         (currentIndex - 1 + availableTabs.length) % availableTabs.length;
     rebuild(() {
@@ -164,13 +160,9 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
   }
 
   void _nextTab() {
-    List<int> availableTabs = [0, 2, 3];
-    if (widget.system.folderName != 'all' &&
-        widget.system.folderName != 'android') {
-      availableTabs = [0, 1, 2, 3];
-    }
-
+    final availableTabs = _availableTabs;
     int currentIndex = availableTabs.indexOf(_currentTab);
+    if (currentIndex == -1) currentIndex = 0;
     int nextIndex = (currentIndex + 1) % availableTabs.length;
     rebuild(() {
       _currentTab = availableTabs[nextIndex];

--- a/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
+++ b/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
@@ -75,6 +75,13 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
         _appearanceIndex = (_appearanceIndex - 1 + 2) % 2;
       });
       _scrollToAppearanceSelected();
+    } else if (_currentTab == 3) {
+      if (_totalHiddenItems == 0) return;
+      rebuild(() {
+        _hiddenIndex =
+            (_hiddenIndex - 1 + _totalHiddenItems) % _totalHiddenItems;
+      });
+      _scrollToHiddenSelected();
     }
   }
 
@@ -117,6 +124,12 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
         _appearanceIndex = (_appearanceIndex + 1) % 2;
       });
       _scrollToAppearanceSelected();
+    } else if (_currentTab == 3) {
+      if (_totalHiddenItems == 0) return;
+      rebuild(() {
+        _hiddenIndex = (_hiddenIndex + 1) % _totalHiddenItems;
+      });
+      _scrollToHiddenSelected();
     }
   }
 
@@ -135,10 +148,10 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
   }
 
   void _previousTab() {
-    List<int> availableTabs = [0, 2];
+    List<int> availableTabs = [0, 2, 3];
     if (widget.system.folderName != 'all' &&
         widget.system.folderName != 'android') {
-      availableTabs = [0, 1, 2];
+      availableTabs = [0, 1, 2, 3];
     }
 
     int currentIndex = availableTabs.indexOf(_currentTab);
@@ -151,10 +164,10 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
   }
 
   void _nextTab() {
-    List<int> availableTabs = [0, 2];
+    List<int> availableTabs = [0, 2, 3];
     if (widget.system.folderName != 'all' &&
         widget.system.folderName != 'android') {
-      availableTabs = [0, 1, 2];
+      availableTabs = [0, 1, 2, 3];
     }
 
     int currentIndex = availableTabs.indexOf(_currentTab);
@@ -212,6 +225,13 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
         _pickAndSaveImage();
       } else if (_appearanceIndex == 1) {
         _pickAndSaveLogoImage();
+      }
+    } else if (_currentTab == 3) {
+      if (_hiddenIndex >= _totalHiddenItems) return;
+      if (_hasUnhideAllRow && _hiddenIndex == _totalHiddenItems - 1) {
+        _unhideAllGames();
+      } else {
+        _unhideGame(_hiddenGames[_hiddenIndex]);
       }
     }
   }

--- a/lib/widgets/system_emulator_settings_dialog/tabs.dart
+++ b/lib/widgets/system_emulator_settings_dialog/tabs.dart
@@ -616,6 +616,228 @@ extension _Tabs on _SystemEmulatorSettingsDialogState {
     );
   }
 
+  /// Hidden tab: the games the user took out of the game lists, each with the
+  /// action that puts it back. This is the only place a hidden game resurfaces,
+  /// so it stays reachable even when every game of the system is hidden.
+  Widget _buildHiddenGamesTab() {
+    final theme = Theme.of(context);
+
+    if (_isLoadingHiddenGames) {
+      return Center(
+        child: CircularProgressIndicator(
+          valueColor: AlwaysStoppedAnimation<Color>(theme.colorScheme.primary),
+        ),
+      );
+    }
+
+    if (_hiddenGames.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: EdgeInsets.all(24.r),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Symbols.visibility_off_rounded,
+                size: 28.r,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+              ),
+              SizedBox(height: 8.r),
+              Text(
+                AppLocale.noHiddenGames.getString(context),
+                style: TextStyle(
+                  fontSize: 12.r,
+                  fontWeight: FontWeight.w600,
+                  color: theme.colorScheme.onSurface,
+                ),
+              ),
+              SizedBox(height: 4.r),
+              Text(
+                AppLocale.noHiddenGamesSubtitle.getString(context),
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 10.r,
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return ListView.builder(
+      controller: _hiddenScrollController,
+      padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 6.r),
+      itemCount: _totalHiddenItems,
+      itemBuilder: (context, index) {
+        if (index >= _hiddenGames.length) return _buildUnhideAllItem(index);
+        return _buildHiddenGameItem(index, _hiddenGames[index]);
+      },
+    );
+  }
+
+  Widget _buildHiddenGameItem(int index, DatabaseGameModel game) {
+    final theme = Theme.of(context);
+    final isFocused = _hiddenIndex == index;
+    final key = _hiddenItemKeys.putIfAbsent(index, () => GlobalKey());
+    final displayName = game.realName ?? game.filename;
+    // In the aggregated libraries the same game name can come from several
+    // systems, so the row says which one it belongs to. Within one system the
+    // filename is the only extra detail worth showing, and only when the title
+    // above isn't already that same filename.
+    final subtitle = _isVirtualLibrarySystem
+        ? (game.systemRealName ?? game.systemFolderName ?? '')
+        : (displayName == game.filename ? '' : game.filename);
+
+    return Padding(
+      key: key,
+      padding: EdgeInsets.only(bottom: 4.r),
+      child: Container(
+        decoration: BoxDecoration(
+          color: isFocused
+              ? theme.colorScheme.primary.withValues(alpha: 0.2)
+              : Colors.transparent,
+          borderRadius:
+              Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
+              BorderRadius.circular(9.r),
+        ),
+        child: InkWell(
+          onTap: () {
+            SfxService().playNavSound();
+            rebuild(() => _hiddenIndex = index);
+            _unhideGame(game);
+          },
+          borderRadius:
+              Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
+              BorderRadius.circular(9.r),
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 6.r),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        displayName,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 10.r,
+                          fontWeight: FontWeight.w600,
+                          color: isFocused
+                              ? theme.colorScheme.primary
+                              : theme.colorScheme.onSurface,
+                        ),
+                      ),
+                      if (subtitle.isNotEmpty)
+                        Text(
+                          subtitle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 9.r,
+                            color: theme.colorScheme.onSurface.withValues(
+                              alpha: 0.6,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                SizedBox(width: 8.r),
+                _buildUnhidePill(AppLocale.unhide.getString(context)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUnhideAllItem(int index) {
+    final theme = Theme.of(context);
+    final isFocused = _hiddenIndex == index;
+    final key = _hiddenItemKeys.putIfAbsent(index, () => GlobalKey());
+
+    return Padding(
+      key: key,
+      padding: EdgeInsets.only(top: 4.r, bottom: 4.r),
+      child: Container(
+        decoration: BoxDecoration(
+          color: isFocused
+              ? theme.colorScheme.primary.withValues(alpha: 0.2)
+              : Colors.transparent,
+          borderRadius:
+              Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
+              BorderRadius.circular(9.r),
+        ),
+        child: InkWell(
+          onTap: () {
+            SfxService().playNavSound();
+            rebuild(() => _hiddenIndex = index);
+            _unhideAllGames();
+          },
+          borderRadius:
+              Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
+              BorderRadius.circular(9.r),
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 8.r),
+            child: Row(
+              children: [
+                Icon(
+                  Symbols.visibility_rounded,
+                  size: 14.r,
+                  color: isFocused
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.onSurface,
+                ),
+                SizedBox(width: 8.r),
+                Expanded(
+                  child: Text(
+                    AppLocale.unhideAll.getString(context),
+                    style: TextStyle(
+                      fontSize: 10.r,
+                      fontWeight: FontWeight.w600,
+                      color: isFocused
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurface,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUnhidePill(String label) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 3.r),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primary.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4.r),
+        border: Border.all(
+          color: theme.colorScheme.primary.withValues(alpha: 0.4),
+          width: 1.r,
+        ),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 9.r,
+          fontWeight: FontWeight.w600,
+          color: theme.colorScheme.primary,
+        ),
+      ),
+    );
+  }
+
   Widget _buildEmulatorsTab() {
     return _buildCoresList();
   }

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -79,6 +79,7 @@ class DatabaseTestHelper {
         ss_hash TEXT,
         id_ra INTEGER,
         is_favorite INTEGER DEFAULT 0,
+        is_hidden INTEGER DEFAULT 0,
         play_time INTEGER DEFAULT 0,
         last_played TEXT,
         cloud_sync_enabled INTEGER DEFAULT 0,

--- a/test/hidden_games_migration_test.dart
+++ b/test/hidden_games_migration_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+
+/// Tests for migration v122, which adds `user_roms.is_hidden` — the per-game
+/// hide flag behind "Hide Game" (per-game settings) and the Hidden tab of the
+/// system settings dialog.
+void main() {
+  late Database db;
+
+  setUp(() {
+    db = sqlite3.openInMemory();
+    // The pre-v122 shape of the table: no is_hidden column.
+    db.execute('''
+      CREATE TABLE user_roms (
+        app_system_id TEXT NOT NULL,
+        app_emulator_unique_id TEXT,
+        app_emulator_os_id INTEGER,
+        filename TEXT NOT NULL,
+        rom_path TEXT NOT NULL COLLATE NOCASE,
+        is_favorite INTEGER DEFAULT 0,
+        play_time INTEGER DEFAULT 0,
+        last_played TEXT,
+        cloud_sync_enabled INTEGER DEFAULT 1,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(rom_path)
+      )
+    ''');
+    db.execute(
+      "INSERT INTO user_roms (app_system_id, filename, rom_path, is_favorite, "
+      "play_time) VALUES ('nes', 'Game.zip', '/roms/nes/Game.zip', 1, 42)",
+    );
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  Future<void> runV122() => SqliteMigrations.migrateToVersion(db, 122);
+
+  List<String> romColumns() => db
+      .select('PRAGMA table_info(user_roms)')
+      .map((c) => c['name'].toString())
+      .toList();
+
+  group('migration v122', () {
+    test('adds is_hidden when the column is missing', () async {
+      expect(romColumns(), isNot(contains('is_hidden')));
+
+      await runV122();
+
+      expect(romColumns(), contains('is_hidden'));
+    });
+
+    test('defaults existing games to visible', () async {
+      await runV122();
+
+      final rows = db.select('SELECT is_hidden FROM user_roms');
+      expect(rows, hasLength(1));
+      expect(rows.first['is_hidden'], 0);
+    });
+
+    test('leaves the rest of the row untouched', () async {
+      await runV122();
+
+      final row = db.select('SELECT * FROM user_roms').first;
+      expect(row['filename'], 'Game.zip');
+      expect(row['is_favorite'], 1);
+      expect(row['play_time'], 42);
+    });
+
+    test('is a no-op when is_hidden already exists', () async {
+      db.execute(
+        'ALTER TABLE user_roms ADD COLUMN is_hidden INTEGER DEFAULT 0',
+      );
+      db.execute(
+        "UPDATE user_roms SET is_hidden = 1 WHERE filename = 'Game.zip'",
+      );
+
+      await runV122();
+
+      expect(romColumns(), contains('is_hidden'));
+      // Re-running must not reset what the user hid.
+      expect(
+        db.select('SELECT is_hidden FROM user_roms').first['is_hidden'],
+        1,
+      );
+    });
+  });
+}

--- a/test/hidden_games_test.dart
+++ b/test/hidden_games_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/system_model.dart';
+import 'package:neostation/repositories/game_repository.dart';
+import 'package:neostation/services/game/game_list_service.dart';
+
+import 'database_test_helper.dart';
+
+/// Behaviour of the per-game hide flag: hiding takes a game out of every list
+/// the user browses, leaves the row (favorite, play time, cloud sync) intact,
+/// and the hidden list in the system settings dialog is what puts it back.
+void main() {
+  final dbHelper = DatabaseTestHelper();
+  late dynamic db;
+
+  SystemModel system(String id, String folder, String realName) => SystemModel(
+    id: id,
+    folderName: folder,
+    realName: realName,
+    iconImage: 'assets/images/icons/heart-bulk.png',
+    color: '#ff006a',
+  );
+
+  setUp(() async {
+    db = await dbHelper.setUp();
+    await db.execute(
+      "INSERT INTO app_systems (id, real_name, folder_name) VALUES ('snes', 'Super Nintendo', 'snes')",
+    );
+    await db.execute(
+      "INSERT INTO app_systems (id, real_name, folder_name) VALUES ('nes', 'Nintendo', 'nes')",
+    );
+    await db.execute(
+      "INSERT INTO user_roms (filename, rom_path, app_system_id, is_favorite) VALUES ('zelda.smc', '/roms/snes/zelda.smc', 'snes', 1)",
+    );
+    await db.execute(
+      "INSERT INTO user_roms (filename, rom_path, app_system_id, is_favorite) VALUES ('mario.smc', '/roms/snes/mario.smc', 'snes', 0)",
+    );
+    await db.execute(
+      "INSERT INTO user_roms (filename, rom_path, app_system_id, is_favorite) VALUES ('metroid.nes', '/roms/nes/metroid.nes', 'nes', 0)",
+    );
+  });
+
+  tearDown(() async {
+    await dbHelper.tearDown();
+  });
+
+  group('hiding a game', () {
+    test('drops it from its system list', () async {
+      await GameRepository.setGameHidden('snes', 'zelda.smc', true);
+
+      final games = await GameListService.loadGamesForSystem(
+        system('snes', 'snes', 'Super Nintendo'),
+      );
+
+      expect(games.map((g) => g.romname), isNot(contains('zelda.smc')));
+      expect(games.map((g) => g.romname), contains('mario.smc'));
+    });
+
+    test(
+      'drops it from the favorites list without losing the favorite',
+      () async {
+        await GameRepository.setGameHidden('snes', 'zelda.smc', true);
+
+        final favorites = await GameListService.loadGamesForSystem(
+          system('favorites', 'favorites', 'Favorites'),
+        );
+        expect(favorites, isEmpty);
+
+        // The row keeps its favorite flag, so unhiding restores it as a favorite.
+        final row = await GameRepository.getSingleGame('snes', 'zelda.smc');
+        expect(row!.isFavorite, isTrue);
+        expect(row.isHidden, isTrue);
+      },
+    );
+
+    test('drops it from the aggregated "all" list', () async {
+      await GameRepository.setGameHidden('nes', 'metroid.nes', true);
+
+      final games = await GameListService.loadGamesForSystem(
+        system('all', 'all', 'All Games'),
+      );
+
+      expect(games.map((g) => g.romname), isNot(contains('metroid.nes')));
+      expect(games.map((g) => g.romname), contains('mario.smc'));
+    });
+
+    test('leaves the other systems alone', () async {
+      await GameRepository.setGameHidden('snes', 'zelda.smc', true);
+
+      final nesGames = await GameListService.loadGamesForSystem(
+        system('nes', 'nes', 'Nintendo'),
+      );
+      expect(nesGames.map((g) => g.romname), contains('metroid.nes'));
+    });
+  });
+
+  group('the hidden list', () {
+    test('lists only the hidden games of the requested system', () async {
+      await GameRepository.setGameHidden('snes', 'zelda.smc', true);
+      await GameRepository.setGameHidden('nes', 'metroid.nes', true);
+
+      final snesHidden = await GameRepository.getHiddenGames(systemId: 'snes');
+
+      expect(snesHidden.map((g) => g.filename), ['zelda.smc']);
+    });
+
+    test('lists every hidden game when no system is given', () async {
+      await GameRepository.setGameHidden('snes', 'zelda.smc', true);
+      await GameRepository.setGameHidden('nes', 'metroid.nes', true);
+
+      final allHidden = await GameRepository.getHiddenGames();
+
+      expect(allHidden.map((g) => g.filename).toSet(), {
+        'zelda.smc',
+        'metroid.nes',
+      });
+      // Rows carry their system so the aggregated view can label them.
+      expect(allHidden.map((g) => g.systemFolderName).toSet(), {'snes', 'nes'});
+    });
+
+    test('is empty until something is hidden', () async {
+      expect(await GameRepository.getHiddenGames(), isEmpty);
+    });
+  });
+
+  group('unhiding', () {
+    test('puts a single game back in its list', () async {
+      await GameRepository.setGameHidden('snes', 'zelda.smc', true);
+      await GameRepository.setGameHidden('snes', 'zelda.smc', false);
+
+      final games = await GameListService.loadGamesForSystem(
+        system('snes', 'snes', 'Super Nintendo'),
+      );
+
+      expect(games.map((g) => g.romname), contains('zelda.smc'));
+      expect(await GameRepository.getHiddenGames(), isEmpty);
+    });
+
+    test('unhideAllGamesForSystem restores only that system', () async {
+      await GameRepository.setGameHidden('snes', 'zelda.smc', true);
+      await GameRepository.setGameHidden('snes', 'mario.smc', true);
+      await GameRepository.setGameHidden('nes', 'metroid.nes', true);
+
+      await GameRepository.unhideAllGamesForSystem('snes');
+
+      final stillHidden = await GameRepository.getHiddenGames();
+      expect(stillHidden.map((g) => g.filename), ['metroid.nes']);
+    });
+
+    test('unhideAllGames restores the whole library', () async {
+      await GameRepository.setGameHidden('snes', 'zelda.smc', true);
+      await GameRepository.setGameHidden('nes', 'metroid.nes', true);
+
+      await GameRepository.unhideAllGames();
+
+      expect(await GameRepository.getHiddenGames(), isEmpty);
+    });
+  });
+
+  group('ROM counts', () {
+    test('hidden games are subtracted from the count a system shows', () async {
+      await GameRepository.setGameHidden('snes', 'zelda.smc', true);
+
+      final counts = await GameRepository.getHiddenRomCountsBySystem();
+      expect(counts['snes'], 1);
+      expect(counts.containsKey('nes'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission.

# Description

Closes #277.

Switch update NSPs, DLC, BIOS entries and duplicate dumps sit in the game lists with nothing to be done about them short of deleting the file. This adds a per-game **hide** that takes a game out of every list without touching the ROM, and a per-system list to bring it back — the "shown again through a setting" half of #277.

**Per-game settings** (START, or the gear in the action bar → **MANAGE**) gains a **Hide Game** row between Play Time and Delete Game:

```
Play Time      0s                                          [ Reset  ]
Hide Game      Hides it from your game lists.
               Nothing is deleted.                         [ Hide   ]
Delete Game    Permanently removes the ROM file from disk  [ Delete ]
```

It is deliberately **unconfirmed**. Nothing is destroyed and the game is one visit to the system's settings away from coming back, so a confirmation dialog would only be in the way — it shows a toast and the game drops out of the list exactly the way a deleted one does.

**System settings** gains a **HIDDEN** tab listing that system's hidden games, each with an *Unhide* action, plus an *Unhide All* row once there is more than one. On the aggregated libraries (`all` / `favorites`) it lists the whole library's hidden games, labelled by the system each belongs to. Empty state: *"No hidden games — Hide a game from its own settings and it appears here."*

The tab is **not** offered on the Android system: apps are browsed through `AndroidAppsGrid`, a separate screen that binds no settings action, so an app has no "Hide Game" row to reach and the tab could only ever be empty there. It still appears if that system somehow *has* hidden games, so a row can never end up with no way back — and it starts working on its own if hiding is later wired into the apps grid, which is arguably where users most want it. Music goes through the normal games list, where START still opens the dialog, so it keeps the tab.

### Hiding is a view filter, not a deletion

The row keeps its favorite flag, play time, emulator override and cloud-sync state, and a rescan leaves it hidden (the scan upsert only writes title fields). Hidden games are filtered out of:

* the per-system, `all` and favorites lists (`GameListService`),
* the search screen,
* the provider cache behind the systems screen's recent-games row.

They are deliberately **not** filtered out of RomM's downloaded-game matching or the save-sync lookups, so hiding a game never breaks its saves or its RomM link.

### ROM counts, and the trap avoided

The count on a system card now excludes hidden games, so the number matches the list. The counts that decide **whether a system still exists** deliberately keep counting them: a library with every game hidden would otherwise prune the system from the list and take the only unhide UI with it. `refreshSystem` therefore gates on the raw count while displaying the visible one — commented in place so it doesn't get "simplified" later.

### Schema

`user_roms.is_hidden`, added in **migration v122**, plus the column in the `CREATE TABLE` for fresh installs.

Numbered above every slot in use anywhere — `main` is at v119 and `feat/ra-improvements` claims v121 — rather than at main + 1. A device that migrated on that branch is already past 120, so it would skip a `case 120` forever and every game query would then fail on `no such column: ur.is_hidden`. Taking the highest number keeps the step reachable whatever order the branches merge in.

## Steps to Verify

**Preconditions:** any system with at least two games.

1. Focus a game → **START** (or the gear in the left action bar) → **MANAGE** tab.
2. Press **Hide**. The dialog closes, a toast confirms, and the game is gone from the list. The system card's game count drops by one.
3. Systems screen → focus that system → **Settings** → **HIDDEN** tab. The game is listed with its filename.
4. Press **Unhide**. It disappears from the tab, and the game and the count are back.
5. Confirm nothing was destroyed: the ROM file is still on disk, and a hidden favorite is still a favorite when restored.

Verified end to end on an AYN Thor at each of those steps, including the on-device DB (`is_hidden` flipping 1 → 0, ROM count returning to 381) and a clean 121 → 122 migration with no errors in logcat.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation. *(N/A — no doc covers per-game settings.)*
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. *(N/A — no new assets.)*
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable). *(Wired through the existing nav — the Manage tab's index list and a new tab in the system dialog's LB/RB strip with up/down + A. Touch-verified on device; the D-pad path through the Hidden tab has not been exercised with a physical pad yet, since injected key events don't reach the custom nav.)*

New tests: `test/hidden_games_test.dart` (11) covers hiding removing a game from each list while keeping the favorite, scoped vs global hidden lists, the three unhide paths, and the hidden-count query. `test/hidden_games_migration_test.dart` (4) follows the repo's migration pattern — adds the column to an old-shape table, defaults existing rows to visible, leaves the rest of the row alone, and no-ops on re-run without resetting what the user hid. Full suite: **987 passing**.

Localization: 11 new keys across all 12 languages.

## Screenshots (if applicable)

Captured on device during verification — will attach to the PR:

* Manage tab with the Hide Game row.
* System settings HIDDEN tab listing a hidden game with its Unhide action.
* The same tab's empty state.
