### PR TITLE
docs(github): rework the PR template and automate PR labelling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,70 @@
+<!-- PR title must follow Conventional Commits — e.g. `fix(android): stop double launches`.
+     Release notes are generated from it. Type list: CONTRIBUTING.md.
+     If AI tooling wrote a significant part of this, say so below and add an
+     `AI-Assisted: NAME:VERSION` trailer to your commits. Never sign commits as an AI. -->
+
 # Description
 
-Briefly describe the changes you are introducing.
+<!-- What changes, and why. -->
 
-Fixes # (issue)
+Closes #
 
-## Type of Change
+## Steps to Verify
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds capability)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation improvement
-- [ ] Code refactoring
+<!-- Required for bug fixes. Preconditions first (which system, how many games,
+     which device), then numbered steps someone else can follow. -->
+
+**Preconditions:**
+
+1.
+
+## Tested on
+
+<!-- Name the device. Desktop-only testing does not catch Android SAF path bugs. -->
+
+- [ ] Android — device:
+- [ ] Linux — device:
+- [ ] Windows
+- [ ] macOS
+- [ ] Not runtime-tested — why:
 
 ## Checklist
 
-- [ ] I have run `flutter analyze` and there are no errors.
-- [ ] I have added tests demonstrating that my fix or feature works.
-- [ ] I have updated the corresponding documentation.
-- [ ] My changes do not introduce secrets, credentials, or sensitive data.
-- [ ] I have verified that any new assets have compatible licenses.
-- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
-- [ ] **Gamepad support verified** (if applicable).
+- [ ] `dart format .` — no diff
+- [ ] `flutter analyze` — clean (no errors *or* warnings)
+- [ ] `flutter test` — all passing
+- [ ] Tests added or updated
+- [ ] No secrets, credentials, or personal data in the diff (including tests and fixtures)
+- [ ] New assets have compatible licenses
 
-## Screenshots (if applicable)
+<details>
+<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>
 
-Add screenshots or GIFs showing the visual change.
+**User-facing text**
+- [ ] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
+- [ ] No hardcoded UI strings — everything goes through `AppLocale`
+
+**The database**
+- [ ] Column added to the versioned migration in `sqlite_migrations.dart` **and** the `CREATE TABLE` in `sqlite_service.dart`
+- [ ] Migration number is above every slot in use on any open branch, not just `main` + 1
+- [ ] Migration is idempotent (`PRAGMA table_info` guard) and has a test
+- [ ] `_databaseVersion` bumped; new column selected in *every* system-loading query
+
+**Navigation or a new screen**
+- [ ] Every interactive element is reachable by D-pad, not just touch/mouse
+- [ ] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()`
+- [ ] B cancels / goes back, including out of a focused text field
+
+**Android**
+- [ ] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths
+- [ ] Verified on a device, not only on desktop
+
+**`assets/systems/` or emulator launching**
+- [ ] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible
+- [ ] `assets/manifest.json` version bumped if this should reach existing installs OTA
+
+</details>
+
+## Screenshots / video
+
+<!-- Before and after for any visual change. Delete if not applicable. -->

--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -24,7 +24,8 @@
         "style",
         "ci",
         "perf",
-        "test"
+        "test",
+        "revert"
       ]
     },
     {
@@ -36,6 +37,20 @@
     {
       "title": "## Other",
       "labels": []
+    }
+  ],
+  "label_extractor": [
+    {
+      "pattern": "^(feat|fix|docs|style|refactor|perf|test|chore|ci|revert)(\\([^)]*\\))?(!)?:[\\s\\S]*$",
+      "target": "$1",
+      "on_property": "title",
+      "flags": "gu"
+    },
+    {
+      "pattern": "^build\\(deps[^)]*\\)(!)?:[\\s\\S]*$",
+      "target": "dependencies",
+      "on_property": "title",
+      "flags": "gu"
     }
   ],
   "sort": "ASC",

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,67 @@
+# Path-based triage labels, applied automatically by .github/workflows/labeler.yml.
+#
+# Contributors opening a PR from a fork cannot add labels themselves — that needs
+# write or triage permission on this repository. These rules apply the platform and
+# area labels on their behalf. Release-note categories are NOT set here: they come
+# from the Conventional Commits prefix in the PR title (see .github/changelog-config.json).
+
+android:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'android/**'
+
+linux:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'linux/**'
+          - 'build-utils/build-linux*.sh'
+
+windows:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'windows/**'
+          - 'build-utils/build-windows.ps1'
+
+macos:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'macos/**'
+          - 'build-utils/build-macos.sh'
+
+systems:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'assets/systems/**'
+          - 'assets/manifest.json'
+
+themes:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/themes/**'
+          - 'THEMES.md'
+
+RetroAchievements:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/screens/retro_achievements_screen/**'
+          - 'lib/services/retro_achievements_*.dart'
+          - 'lib/services/retroachievements_*.dart'
+          - 'lib/repositories/retro_achievements_repository.dart'
+
+screenscraper:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/screens/scraper_screen/**'
+          - 'lib/services/screenscraper/**'
+          - 'lib/services/screenscraper_service.dart'
+          - 'lib/repositories/scraper_repository.dart'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,30 @@
+name: Label PRs
+
+# `pull_request_target` rather than `pull_request` so PRs opened from a fork get a
+# token that can actually write labels — a fork's `pull_request` token is read-only,
+# which is why contributor PRs currently arrive unlabelled. This is only safe because
+# the job never checks out or executes the PR's code; it reads the changed-file list
+# and applies labels. Do not add a checkout of `github.event.pull_request.head` here.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply path labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          # Never strip a label a maintainer applied by hand.
+          sync-labels: false


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission.

# Description

Two problems, one cause: the PR template asks for things that don't help, and doesn't ask for the things that do.

### The template

The old one was generic Flutter boilerplate. It never asked for reproduction steps — yet every substantive PR grows them by hand anyway (#344, #348), because that is the section a reviewer actually reads. Meanwhile it asked for a "Type of Change" that just restates the commit title, and its `- [ ] **Tested on:** [ ] Windows | [ ] Linux` line never rendered as checkboxes at all (GitHub only renders the leading marker; the inline ones stay literal text).

It also carried none of the traps that are documented in `CLAUDE.md` and that keep costing real time — the 12-locale string requirement, migration numbering, gamepad navigation layers, SAF path handling. Those now live in a collapsed `<details>` block, so they are there when you need them and invisible when you don't.

The checklist now matches what `pr-checks.yml` actually gates on. It listed only `flutter analyze`; CI also runs `dart format --set-exit-if-changed` and `flutter test`.

**Net: one fewer checkbox than before** — 12 visible boxes down to 11 — because dropping "Type of Change" pays for the per-platform "Tested on" rows outright.

### The labels

Labelling a PR needs write or triage permission on this repo. **A contributor opening a PR from a fork cannot do it**, and never could.

That is not just a papercut, it is why the release notes are wrong: `changelog-config.json` buckets the changelog by label, so unlabelled PRs land in **Other**. #325 (`chore: remove three unreferenced screen/modal files`) and #336 (`feat(neosync): …`) both did, despite titles that say exactly where they belong.

So take the category from something a contributor *does* control — the title:

- **`label_extractor` in `changelog-config.json`** derives a virtual label from the Conventional Commits prefix. Real labels still win where a maintainer applies one; this only fills the gap. `build(deps)` maps to `dependencies` so Dependabot keeps its own section, and `revert` joins the Maintenance labels.
- **A `labeler` workflow** applies the platform and area labels (`android`, `linux`, `systems`, `themes`, `RetroAchievements`, `screenscraper`, `ci`, `documentation`) from the changed paths, so those need no contributor involvement either.

The workflow runs on `pull_request_target` because a fork's `pull_request` token is read-only and cannot write labels. That is only safe because the job never checks out or executes PR code — it reads the changed-file list and applies labels. There is a comment in the workflow saying so, and `sync-labels: false` means it can never strip a label applied by hand.

**No PR categorises worse than it does today:** a non-conventional title matches nothing and falls to "Other", exactly as now.

## Steps to Verify

**Preconditions:** none — this changes no app code.

1. **Template renders correctly.** Open the PR body you are reading. The "Tested on" rows are real checkboxes (the old inline `[ ]` markers were not), and the extra-checks block is collapsed rather than a wall of unticked boxes.
2. **Extractor categorises real titles.** Replay the last dozen merged PR titles through both extractors:

   | title | virtual label | section |
   |---|---|---|
   | `feat(games): hide games from the library…` (#348) | `feat` | Features |
   | `fix(systems): one default standalone emulator for PS3` (#347) | `fix` | Fixes |
   | `perf: stop the notification bell pulsing…` (#344) | `perf` | Maintenance |
   | `chore: remove three unreferenced screen/modal files` (#325) | `chore` | Maintenance ← was **Other** |
   | `feat(neosync): introduce the NeoSync v2 cloud path standard` (#336) | `feat` | Features ← was **Other** |
   | `build(deps): bump the pub-dependencies group…` (#338) | `dependencies` | Dependencies |
   | `Add Emucore V to the Vita System…` (#323) | *(none)* | Other (unchanged) |

   Note `fixture: not a real type` correctly extracts nothing — the prefix must be followed by `(`, `!` or `:`.
3. **Configs are valid.** `.github/changelog-config.json` parses as JSON; `.github/labeler.yml` and `.github/workflows/labeler.yml` parse as YAML.

### Two things that cannot be verified until this merges

- **The labeler will not run on this PR.** `pull_request_target` workflows execute from the *base* branch, which does not have the workflow yet. It takes effect for PRs opened after merge — so **this PR needs its labels applied by hand**, one last time.
- **The extractor takes effect at the next release build**, since the changelog is only built on a tag.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: changes only `.github/` metadata. No Dart, Kotlin, or asset code is touched, so there is nothing to run on a device.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [x] Tests added or updated — n/a, no code under test; verification is the title replay above
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — n/a, no new assets

<sub>`dart format` also reports `lib/utils/dev_credential_seeder.dart`, an untracked local dev helper that CI never checks out. All tracked files are clean.</sub>

## Screenshots / video

n/a — the rendered template is this PR body.
