### PR TITLE
fix(systems): point four systems at the right RetroAchievements console

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.11"
+  "latest_version": "0.3.12"
 }

--- a/assets/systems/fds.json
+++ b/assets/systems/fds.json
@@ -12,7 +12,7 @@
     },
     "ids": {
       "screenscraper": 106,
-      "retroachievements": 7
+      "retroachievements": 81
     },
     "folders": [
       "fds",

--- a/assets/systems/jagcd.json
+++ b/assets/systems/jagcd.json
@@ -12,7 +12,7 @@
     },
     "ids": {
       "screenscraper": 171,
-      "retroachievements": null
+      "retroachievements": 77
     },
     "folders": [
       "jagcd",

--- a/assets/systems/vc4k.json
+++ b/assets/systems/vc4k.json
@@ -12,7 +12,7 @@
     },
     "ids": {
       "screenscraper": 281,
-      "retroachievements": null
+      "retroachievements": 74
     },
     "folders": [
       "vc4k",

--- a/assets/systems/wii.json
+++ b/assets/systems/wii.json
@@ -12,7 +12,7 @@
     },
     "ids": {
       "screenscraper": 16,
-      "retroachievements": null
+      "retroachievements": 19
     },
     "folders": [
       "wii",


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission. Commits carry an `AI-Assisted:` trailer.

# Description

RetroAchievements game ids are looked up by `(hash, console_id)`, so a system pointing at the wrong console can never match — however good the hash is. Four systems were pointing at the wrong console or at none at all.

| system | was | now | RA console |
|---|---|---|---|
| `fds` | 7 | **81** | Famicom Disk System |
| `jagcd` | `null` | **77** | Atari Jaguar CD |
| `vc4k` | `null` | **74** | Interton VC 4000 |
| `wii` | `null` | **19** | Wii |

`fds` is the actual bug: it was mapped to console 7, which is NES/Famicom. The Famicom Disk System is a separate console on RetroAchievements, so every FDS lookup searched the wrong console and returned nothing. The other three had no console at all, leaving those libraries unreachable.

Each id is confirmed against `console_name` in the bundled snapshot (`assets/data/ra_insert.sql`) rather than taken from documentation:

```
81 -> ('Famicom Disk System', 62 hashes)
77 -> ('Atari Jaguar CD',     20 hashes)
74 -> ('Interton VC 4000',    39 hashes)
19 -> ('Wii',                393 hashes)
```

**Expected impact is deliberately modest.** Measured on a 189-ROM FDS library: 0 matches under console 7, and the *same stored hashes* match under 81 — so the hashing was already correct and only the mapping was wrong. But RetroAchievements publishes just 62 FDS hashes in total, so this turns 0 matches into 2 on that library, not 189.

`jagcd` and `wii` are disc systems. RetroAchievements identifies a disc by its primary executable rather than by hashing the whole image, which NeoStation does not do yet, so no lookup can run for them regardless. The mapping is a prerequisite for that work, not a fix on its own.

Part of #346.

## Steps to Verify

**Preconditions:** signed in to RetroAchievements; an `fds` folder containing at least one `.fds` ROM that has a published set — *Electrician* (RA game 13713) is one, and matched on the test device.

1. Add the ROM folder and let the `fds` system be detected.
2. Open the FDS game → **Achievements**.
3. **Before:** "No achievements found". The hash *is* computed and stored in `user_roms.ra_hash`; the lookup runs against console 7 and finds nothing.
4. **After:** the achievement set loads.

Confirmed against the database rather than by eye — 0 rows before, matches after:

```sql
SELECT ur.filename, g.title, g.game_id
FROM user_roms ur
JOIN app_systems s ON ur.app_system_id = s.id
JOIN app_ra_game_list g ON g.hash = ur.ra_hash COLLATE NOCASE
WHERE s.folder_name = 'fds' AND g.console_id = 81;
```

Note for reviewers testing locally: the app prefers previously downloaded systems over the bundle, so the `assets/manifest.json` bump in this PR is also what makes a local build read these edits instead of its cache.

## Tested on

- [x] Android — device: AYN Thor (dev channel, 9,132-ROM library)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (987)
- [ ] Tests added or updated — *the change is four literals in `assets/systems/*.json`. The console ids are external facts about RetroAchievements, so a unit test would restate the diff rather than verify it; the verification that matters is the SQL above, run against a real library.*
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — no new assets

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

Only the `assets/systems/` section applies. No strings, no schema, no navigation, no path handling, no launch behaviour.

**`assets/systems/` or emulator launching**
- [x] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible — JSON only; no Kotlin touched
- [x] `assets/manifest.json` version bumped if this should reach existing installs OTA — `0.3.11` → `0.3.12`

</details>

## Screenshots / video

Not applicable — no visual change.
