### PR TITLE
fix(ui): keep the localized play label inside its button in the details footer

### DIFF
--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -208,6 +208,12 @@ class GameDetailsFooter extends StatelessWidget {
         final isFocused = Focus.of(context).hasFocus;
         return AnimatedContainer(
           duration: const Duration(milliseconds: 200),
+          // Deliberately a fixed width. The footer row has no slack — the
+          // achievements pill beside it is Expanded, so anything this button
+          // takes comes straight out of that pill (at 104.r it is already only
+          // ~97.r wide on a 640x480-design handheld, just enough for "0/9").
+          // Long labels are absorbed by scaling the text down, not by growing
+          // the button; see the FittedBox below.
           width: 104.r,
           height: 45.r,
           decoration: BoxDecoration(
@@ -255,14 +261,28 @@ class GameDetailsFooter extends StatelessWidget {
                       color: Theme.of(context).colorScheme.onPrimary,
                     ),
                     SizedBox(width: 8.r),
-                    Text(
-                      AppLocale.playButton.getString(context),
-                      style: TextStyle(
-                        color: Theme.of(context).colorScheme.onPrimary,
-                        fontWeight: FontWeight.w900,
-                        fontSize: 14.r,
-                        letterSpacing: 1.5,
-                        height: 1.0,
+                    // The label is localized and the button is a fixed width,
+                    // so only "PLAY" fits at the full 14.r: "SPIELEN",
+                    // "ИГРАТЬ" and "开始游戏" used to render past the pill's
+                    // right edge and off the screen. scaleDown shrinks just
+                    // those to fit — it never scales up, so every label that
+                    // already fit is untouched — and keeps the button's
+                    // footprint constant so the pills beside it don't move.
+                    Flexible(
+                      child: FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Text(
+                          AppLocale.playButton.getString(context),
+                          maxLines: 1,
+                          softWrap: false,
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.onPrimary,
+                            fontWeight: FontWeight.w900,
+                            fontSize: 14.r,
+                            letterSpacing: 1.5,
+                            height: 1.0,
+                          ),
+                        ),
                       ),
                     ),
                   ],


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

In the game list view, the details card's play button is a fixed `104.r` wide, a size that only fits the English "PLAY". Every longer translation made the button's inner `Row` wider than the box and, since the container does not clip, the label rendered straight past the pill's right edge and off the screen. Reported in German ("SPIELEN"); Russian ("ИГРАТЬ") and both Chinese variants ("开始游戏" / "開始遊戲") are affected the same way.

The label now scales down to fit instead of the button growing to fit the label: `Flexible` + `FittedBox(fit: BoxFit.scaleDown)`. `scaleDown` never scales up, so "PLAY" and every other label that already fitted renders byte-identically, and the button's footprint stays constant.

Growing the button was tried first and rejected: the footer row has no slack. The achievements pill next to it sits in an `Expanded`, so every pixel the button takes comes straight out of that pill. Measured on the device in the tight state (rating + achievements + play time + play button, legend shown, `.r` = 3.0 px):

| | before | grow the button (rejected) | this PR |
|---|---|---|---|
| play button | 104.r, label clipped off-screen | 127.r | 104.r, label fits |
| achievements pill | 97.r, reads `0/28` | 74.r, truncated to `0...` | 97.r, reads `0/28` |
| play-time pill | x 1371-1538 | shifted to 1302-1469 | x 1371-1538, unmoved |

German ends up at roughly 11.r, which is the size the grid and carousel footer already uses for the same label.

## Steps to Verify

**Preconditions:** app language set to a locale whose play label is longer than "PLAY" (Settings, Allgemein, Sprache, Deutsch), and a system with scraped games.

1. Open a system and switch to the list view, so the game details card is on the right.
2. Select any game.
3. Before this change the green button's label runs past its right edge and is cut off by the screen edge. After it, "SPIELEN" sits inside the button.
4. Now select a game that has both RetroAchievements data and accumulated play time, so the achievements pill and the clock pill are both shown. The achievements pill must still read its full count (for example `0/28`) with a full-width progress bar, and every pill must sit where it did in English.
5. Switch the language back to English and confirm the button and the pills are unchanged.

## Tested on

- [x] Android — device: AYN Thor (dev channel, release build), German and English
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (987)
- [ ] Tests added or updated — none: the change is a pure layout/paint adjustment inside one button, verified by on-device pixel measurement rather than by a widget test (a golden here would encode the substituted test font, not the real one)
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — no new assets

**User-facing text**

- No new `AppLocale` keys: this fixes how an existing localized string is laid out, so no `app_locale_<lang>.dart` changes are needed.

## Screenshots / video

Before and after were captured on device and measured pixel-exact; the numbers are in the table above. Happy to attach the images if useful.
