### PR TITLE
fix(secondary): keep the preview video off while the device sleeps

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
@@ -164,10 +164,12 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
                 when (intent?.action) {
                     android.content.Intent.ACTION_SCREEN_OFF -> {
                         pushDeviceScreenOn(false)
+                        notifySecondaryScreenState(false)
                         notifyFlutterScreenState(false)
                     }
                     android.content.Intent.ACTION_SCREEN_ON -> {
                         pushDeviceScreenOn(true)
+                        notifySecondaryScreenState(true)
                         notifyFlutterScreenState(true)
                     }
                 }
@@ -193,6 +195,23 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
             SharedStateManager.updateState(type, current)
         } catch (e: Exception) {
             android.util.Log.e("MainActivity", "pushDeviceScreenOn: ${e.message}")
+        }
+    }
+
+    /// Delivers the screen on/off edge straight to the secondary engine, on its
+    /// own channel. [pushDeviceScreenOn] mirrors the same fact into the shared
+    /// state, but that transport ships whole snapshots between two engines with
+    /// no ordering guarantee: a snapshot another producer built moments before
+    /// the screen went off can land after this write and resurrect
+    /// `deviceScreenOn: true`, leaving the bottom screen convinced the device is
+    /// awake — which is how a preview video's audio kept playing with the lid
+    /// shut. This edge cannot be clobbered, so the secondary engine treats it as
+    /// the authority and only ever plays when BOTH agree the screen is on.
+    private fun notifySecondaryScreenState(on: Boolean) {
+        try {
+            (subScreenPresentation as? SecondaryAppsPresentation)?.notifyScreenState(on)
+        } catch (e: Exception) {
+            android.util.Log.e("MainActivity", "notifySecondaryScreenState: ${e.message}")
         }
     }
 

--- a/android/app/src/main/kotlin/com/neogamelab/neostation/SecondaryAppsPresentation.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/SecondaryAppsPresentation.kt
@@ -70,9 +70,47 @@ class SecondaryAppsPresentation(
                         activity.openScreenshotAccessSettings()
                         result.success(null)
                     }
+                    "isDisplayOn" -> result.success(isDisplayOn())
                     else -> result.notImplemented()
                 }
             }
+        }
+    }
+
+    /**
+     * Live power state of the display this presentation renders on — the ground
+     * truth for "is the bottom screen actually lit". The secondary engine gets
+     * no Android lifecycle callbacks and its shared-state mirror of the screen
+     * flag travels on a transport that ships full snapshots with no ordering
+     * guarantee, so a stale snapshot can resurrect a `true` after the device has
+     * gone to sleep. Asking the display itself can't go stale.
+     *
+     * Fails open (true): a display we cannot read must not silently disable the
+     * preview while the device is awake.
+     */
+    private fun isDisplayOn(): Boolean {
+        return try {
+            getDisplay().state == Display.STATE_ON
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not read secondary display state: ${e.message}")
+            true
+        }
+    }
+
+    /**
+     * Pushes a device screen on/off edge straight to the secondary engine.
+     * Direct and ordered, unlike the shared-state snapshot mirror, so the engine
+     * can tear its preview video down on sleep and know the teardown sticks.
+     * Must be called on the main thread.
+     */
+    fun notifyScreenState(on: Boolean) {
+        try {
+            appsChannel?.invokeMethod(
+                if (on) "onDeviceScreenOn" else "onDeviceScreenOff",
+                null
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "notifyScreenState failed: ${e.message}")
         }
     }
 

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -360,10 +360,36 @@ class _SystemGamesListState extends State<SystemGamesList> {
 
     MusicPlayerService().addListener(_onMusicPlayerStateChanged);
 
+    GameService.deviceScreenOn.addListener(_onDeviceScreenPowerChanged);
+
     if (Platform.isAndroid) {
       _secondaryDisplayState = SecondaryDisplayState.instance;
       _secondaryDisplayState!.addListener(_onSecondaryDisplayChanged);
     }
+  }
+
+  /// Tears the preview video down when the device screen goes off, and brings
+  /// it back on wake.
+  ///
+  /// NeoStation runs as a HOME launcher, so the activity is never paused on
+  /// lock and nothing else stops this player: it would keep decoding — and,
+  /// with video sound on and no second screen to defer to, keep playing audio —
+  /// behind a dark screen for as long as the device slept.
+  void _onDeviceScreenPowerChanged() {
+    if (!mounted) return;
+    if (!GameService.deviceScreenOn.value) {
+      _stopVideoAndCleanup();
+      return;
+    }
+    // Back awake: re-arm the preview for whatever is still selected. Never
+    // while a game owns the foreground — the screen came back on for the
+    // emulator, not for us.
+    if (_selectedGame == null ||
+        _isGameLaunching ||
+        GameService.isGameLaunchInProgress) {
+      return;
+    }
+    _startVideoTimer();
   }
 
   @override
@@ -386,6 +412,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
     _scrapingProvider.removeListener(_onScrapingUpdated);
     MusicPlayerService().removeListener(_onMusicPlayerStateChanged);
     GameLegendVisibility.hidden.removeListener(_onLegendVisibilityChanged);
+    GameService.deviceScreenOn.removeListener(_onDeviceScreenPowerChanged);
 
     // Shared singleton — detach our listener, never dispose the instance.
     _secondaryDisplayState?.removeListener(_onSecondaryDisplayChanged);

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -151,6 +151,10 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     if (Platform.isAndroid) {
       _secondaryDisplayState = SecondaryDisplayState.instance;
       _secondaryDisplayState!.addListener(_onStateChanged);
+      // Direct, ordered screen on/off edges from the native presentation. See
+      // [_deviceAwake] for why the shared-state flag alone isn't trusted.
+      SecondaryAppsService.listenForScreenState();
+      SecondaryAppsService.deviceScreenOn.addListener(_onScreenPowerChanged);
       // Signal that the secondary screen is active — but only after the initial
       // state sync. Pushing it while the synced value is still null makes
       // updateState fall back to the WELCOME default and clobber the real
@@ -243,16 +247,22 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     _maybeStartCelebration(state);
     _syncDockMount(state);
 
-    if (state.isGameLaunching) {
+    // A launch is under way, or a game session is running and this screen is
+    // showing Now Playing: either way there is nothing for the preview to do.
+    // nowPlayingActive is checked as well as isGameLaunching because it stays
+    // true for the whole session, so a late or out-of-order snapshot arriving
+    // mid-game — the transport gives no ordering guarantee — can no longer
+    // start a trailer playing over the game the user is actually playing.
+    if (state.isGameLaunching || state.nowPlayingActive) {
       _stopVideo();
       return;
     }
 
     // Device asleep (lid closed / screen off): tear down the preview so its
     // audio output device stops and the CPU can deep-sleep. This engine never
-    // receives Android lifecycle callbacks, so deviceScreenOn (bridged from the
-    // native ACTION_SCREEN_ON/OFF receiver) is the only reliable signal.
-    if (!state.deviceScreenOn) {
+    // receives Android lifecycle callbacks, so the bridged screen state is the
+    // only "device is asleep" signal there is — see [_deviceAwake].
+    if (!_deviceAwake(state)) {
       _stopVideo();
       _currentVideoPath = null; // force a fresh start when the screen wakes
       return;
@@ -272,6 +282,40 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
         _videoController!.setVolume(state.isVideoMuted ? 0.0 : 1.0);
       }
     }
+  }
+
+  /// Whether the device screen is on, according to *both* signals that carry
+  /// that fact to this engine.
+  ///
+  /// [SecondaryDisplayStateData.deviceScreenOn] rides the cross-engine shared
+  /// state, which ships whole snapshots with no ordering guarantee: a snapshot
+  /// another producer built moments before the screen went off can land after
+  /// the screen-off write and flip the flag back to `true` — and nothing
+  /// corrects it until the next real screen event, so the preview video would
+  /// restart seconds after the lid closed and keep playing audio in the dark.
+  /// [SecondaryAppsService.deviceScreenOn] is fed by direct, ordered channel
+  /// calls from the native presentation and can't be clobbered, so requiring
+  /// both means one stale snapshot can no longer wake the preview.
+  bool _deviceAwake(SecondaryDisplayStateData state) =>
+      state.deviceScreenOn && SecondaryAppsService.deviceScreenOn.value;
+
+  /// Reacts to a native screen on/off edge. Off tears the preview down (and
+  /// freezes the session clock) immediately, without waiting for a shared-state
+  /// push that may never come; on re-runs the normal state handling so the
+  /// preview and the clock resume exactly as they do on any other update.
+  void _onScreenPowerChanged() {
+    final state = _secondaryDisplayState?.value;
+    debugPrint(
+      'SecondaryScreen: native screen edge — '
+      'on=${SecondaryAppsService.deviceScreenOn.value}',
+    );
+    if (SecondaryAppsService.deviceScreenOn.value) {
+      if (state != null) _onStateChanged();
+      return;
+    }
+    _stopVideo();
+    _currentVideoPath = null; // force a fresh start when the screen wakes
+    if (state != null) _applySessionPower(state);
   }
 
   /// Whether the app dock (and its all-apps launcher) belongs on screen: the
@@ -499,7 +543,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   /// native ACTION_SCREEN_ON/OFF receiver. Without this the [Stopwatch] keeps
   /// accruing wall-clock time while the device sleeps.
   void _applySessionPower(SecondaryDisplayStateData state) {
-    if (!state.deviceScreenOn) {
+    if (!_deviceAwake(state)) {
       // Screen off: freeze the counter where it is.
       if (_sessionWatch.isRunning) {
         _playTimeTicker?.cancel();
@@ -552,6 +596,23 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     try {
       controller = VideoPlayerController.file(File(path));
       await controller.initialize();
+      if (!mounted || gen != _videoGeneration) {
+        await controller.dispose();
+        return;
+      }
+
+      // Last line of defence before any audio comes out: ask the display itself
+      // whether it is lit. Every flag that got us here was pushed from another
+      // process and can be stale; this one cannot. Without it, a snapshot that
+      // resurrects "screen on" after the lid closed would start the trailer
+      // playing in the dark — audible, and burning an OLED panel nobody can see.
+      if (!await SecondaryAppsService.isDisplayOn()) {
+        debugPrint(
+          'SecondaryScreen: display is off — preview video start suppressed',
+        );
+        await controller.dispose();
+        return;
+      }
       if (!mounted || gen != _videoGeneration) {
         await controller.dispose();
         return;
@@ -610,6 +671,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   void dispose() {
     // Shared singleton — detach our listener, never dispose the instance.
     _secondaryDisplayState?.removeListener(_onStateChanged);
+    SecondaryAppsService.deviceScreenOn.removeListener(_onScreenPowerChanged);
     _celebrationTimer?.cancel();
     _playTimeTicker?.cancel();
     _dimTimer?.cancel();

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -48,6 +48,15 @@ class GameService {
   /// suspended while locked. `true` = screen on, `false` = screen off.
   static void Function(bool screenOn)? onScreenStateChanged;
 
+  /// Whether the device screen is on, mirrored from the same native bridge.
+  ///
+  /// A callback slot only serves one listener; this notifier serves the rest.
+  /// Screens that own media need it because NeoStation runs as a HOME launcher:
+  /// the activity is never paused on lock, so a preview video keeps decoding —
+  /// and, with video sound on, keeps playing audio — behind a dark screen until
+  /// something tears it down.
+  static final ValueNotifier<bool> deviceScreenOn = ValueNotifier<bool>(true);
+
   /// Initializes the platform-specific listener for Android game lifecycle events.
   static void initializeAndroidGameListener() {
     if (!Platform.isAndroid) return;
@@ -65,9 +74,14 @@ class GameService {
       } else if (call.method == 'onDeviceScreenOff') {
         // As a HOME launcher we are not paused on lock, so this is the only
         // reliable signal to release background resources while locked.
+        deviceScreenOn.value = false;
         MusicPlayerService().appPaused();
         onScreenStateChanged?.call(false);
       } else if (call.method == 'onDeviceScreenOn') {
+        // Published unconditionally: listeners that must not act behind a
+        // running game (the preview video) check that themselves, and leaving
+        // the notifier stuck on false would strand them after the game exits.
+        deviceScreenOn.value = true;
         // Skip restore while a game owns the foreground — the game-return
         // (lifecycle resumed) path re-opens everything. Restoring here would
         // reopen the audio engine (and restart music/websocket) behind the

--- a/lib/services/secondary_apps_service.dart
+++ b/lib/services/secondary_apps_service.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:neostation/services/logger_service.dart';
 
@@ -82,6 +85,68 @@ class SecondaryAppsService {
       _log.e(
         "Secondary: failed to open accessibility settings: '${e.message}'.",
       );
+    }
+  }
+
+  /// Whether the device screen is on, as pushed by the native presentation on
+  /// every ACTION_SCREEN_ON/OFF edge.
+  ///
+  /// The secondary engine also receives this fact through the shared display
+  /// state, but that transport ships full snapshots between engines with no
+  /// ordering guarantee: a snapshot built just before the screen went off can
+  /// land after the screen-off write and flip the flag back to `true` while the
+  /// device sleeps. This notifier is fed by a direct, ordered channel call, so
+  /// it cannot be clobbered — media on the bottom screen gates on both.
+  ///
+  /// Defaults to true so the preview plays normally until the first edge or the
+  /// [refreshScreenState] seed arrives.
+  static final ValueNotifier<bool> deviceScreenOn = ValueNotifier<bool>(true);
+
+  static bool _screenStateWired = false;
+
+  /// Subscribes to native screen on/off edges and seeds [deviceScreenOn] from
+  /// the display's live state. Idempotent — safe to call from every widget that
+  /// needs it. Only the secondary engine talks on this channel, so registering
+  /// the handler here cannot steal calls from the main engine.
+  static void listenForScreenState() {
+    if (_screenStateWired) return;
+    _screenStateWired = true;
+    _channel.setMethodCallHandler((call) async {
+      switch (call.method) {
+        case 'onDeviceScreenOn':
+          deviceScreenOn.value = true;
+          break;
+        case 'onDeviceScreenOff':
+          deviceScreenOn.value = false;
+          break;
+      }
+      return null;
+    });
+    // Edges alone would leave an engine that started while the device was
+    // already asleep stuck on the `true` default, so read the display up front.
+    unawaited(refreshScreenState());
+  }
+
+  /// Re-reads the bottom display's live power state into [deviceScreenOn].
+  static Future<void> refreshScreenState() async {
+    deviceScreenOn.value = await isDisplayOn();
+  }
+
+  /// Asks the native presentation whether the display it renders on is lit.
+  ///
+  /// Ground truth, unlike any pushed flag: used to double-check right before
+  /// starting the preview video, so a stale "screen is on" can never start
+  /// audio playing under a closed lid. Fails open (true) so a channel error
+  /// can't kill the preview on a healthy, awake device.
+  static Future<bool> isDisplayOn() async {
+    try {
+      final bool? on = await _channel.invokeMethod<bool>('isDisplayOn');
+      return on ?? true;
+    } on PlatformException catch (e) {
+      _log.e("Secondary: failed to read display state: '${e.message}'.");
+      return true;
+    } on MissingPluginException {
+      return true;
     }
   }
 }

--- a/test/secondary_screen_power_test.dart
+++ b/test/secondary_screen_power_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/secondary_apps_service.dart';
+
+/// Covers the bottom screen's power signal — the one that decides whether a
+/// game's preview video is allowed to play.
+///
+/// The secondary display runs in its own Flutter engine that never receives
+/// Android lifecycle callbacks, so "is the device awake" has to be told to it.
+/// It used to be told only through the cross-engine shared state, which ships
+/// whole snapshots with no ordering guarantee: a snapshot built moments before
+/// the screen went off could land after the screen-off write and flip the flag
+/// back to `true`, restarting the trailer — audio and all — under a closed lid,
+/// with nothing to correct it until the next real screen event.
+///
+/// These calls travel on the secondary engine's own channel instead: ordered
+/// edges that can't be clobbered, plus a live read of the display itself.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.neogamelab.neostation/secondary_apps');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  /// Delivers a native→Dart call the way the presentation does.
+  Future<void> pushFromNative(String method) {
+    return messenger.handlePlatformMessage(
+      channel.name,
+      const StandardMethodCodec().encodeMethodCall(MethodCall(method)),
+      (_) {},
+    );
+  }
+
+  bool? displayOnAnswer;
+
+  setUp(() {
+    displayOnAnswer = true;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'isDisplayOn') return displayOnAnswer;
+      return null;
+    });
+  });
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  test('seeds itself from the display when the listener is wired', () async {
+    displayOnAnswer = false;
+    SecondaryAppsService.listenForScreenState();
+    // An engine that started while the device was already asleep must not sit
+    // on the optimistic `true` default waiting for an edge that never comes.
+    await Future<void>.delayed(Duration.zero);
+    expect(SecondaryAppsService.deviceScreenOn.value, isFalse);
+  });
+
+  test('native edges drive the notifier', () async {
+    await pushFromNative('onDeviceScreenOn');
+    expect(SecondaryAppsService.deviceScreenOn.value, isTrue);
+
+    await pushFromNative('onDeviceScreenOff');
+    expect(SecondaryAppsService.deviceScreenOn.value, isFalse);
+
+    await pushFromNative('onDeviceScreenOn');
+    expect(SecondaryAppsService.deviceScreenOn.value, isTrue);
+  });
+
+  test('isDisplayOn reports what the display says', () async {
+    displayOnAnswer = false;
+    expect(await SecondaryAppsService.isDisplayOn(), isFalse);
+
+    displayOnAnswer = true;
+    expect(await SecondaryAppsService.isDisplayOn(), isTrue);
+  });
+
+  test('isDisplayOn fails open when the channel cannot answer', () async {
+    // A display we can't read must never disable the preview on a device that
+    // is plainly awake — the pushed flags still gate playback in that case.
+    displayOnAnswer = null;
+    expect(await SecondaryAppsService.isDisplayOn(), isTrue);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      throw PlatformException(code: 'ERROR');
+    });
+    expect(await SecondaryAppsService.isDisplayOn(), isTrue);
+
+    messenger.setMockMethodCallHandler(channel, null);
+    expect(await SecondaryAppsService.isDisplayOn(), isTrue);
+  });
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Reported on a dual-screen handheld (AYN Thor): with a game selected and its preview video playing on the bottom screen, closing the lid stops the audio, then 5 to 10 seconds later the video starts again and keeps playing with the device shut. The same trailer audio was then still playing over the game the user launched next.

The bottom screen runs in its own Flutter engine that never receives Android lifecycle callbacks, so "is the device awake" has to be told to it. Until now it was told only through the cross-engine shared state, and that transport ships **whole snapshots with no ordering guarantee** (the same hazard already documented in this file for `isGameLaunching` and the dock fields). A snapshot another producer built moments before the screen went off can land *after* the native screen-off write and resurrect `deviceScreenOn: true`. Nothing corrects it until the next real screen event, which is exactly the reported shape: audio stops, comes back a few seconds later, and then stays on, including over a launched game.

The fix stops the preview depending on that transport:

* `SecondaryAppsPresentation` gains `isDisplayOn` (reads `getDisplay().state`, ground truth that cannot go stale) and `notifyScreenState()`, which pushes ordered screen on/off edges straight to the secondary engine on its own channel.
* `MainActivity`'s screen receiver fires that direct edge alongside the existing shared-state mirror.
* `SecondaryScreen` plays only when **both** signals agree, re-checks the live display state immediately before the first frame of audio, and keeps the preview down for the whole Now Playing session rather than only the launch window (that is the "trailer over the running game" half).
* Everything fails open: a missing or broken channel degrades to the previous behaviour rather than killing the preview on a healthy device.

While in here, the main engine had the same class of bug with no race required. NeoStation runs as a HOME launcher, so its activity is never paused on lock and nothing stopped its own preview player: it kept decoding, and with video sound on and no second screen to defer to it kept playing audio, behind a dark screen for as long as the device slept. It now tears down on screen-off and re-arms on wake.

Reported by a user on Discord, no linked issue.

## Steps to Verify

**Preconditions:** a dual-screen Android handheld with the bottom screen enabled; a system containing a game that has a preview video in `user-data/media/<system>/videos/`; **Video Sound** enabled so the preview is audible.

1. Open that system's games list and select the game with a video. The preview plays on the bottom screen with sound.
2. Close the lid (or otherwise turn the screen off) and leave the device shut for a minute.
3. **Before:** the audio stops, then occasionally restarts a few seconds later and keeps playing with both screens dark, so the panel is lit and the video is decoding under a closed lid. **After:** the audio stops and stays stopped for as long as the device sleeps.
4. Open the lid. The preview resumes, exactly as before this change.
5. With the preview playing, launch the game. **Before:** if step 3 had gone wrong, the trailer audio was still playing over the game. **After:** the preview stays down for the whole session and the bottom screen shows Now Playing.

Single-screen path (same defect, no race needed): enable **Game Info** and **Video Sound** on a phone or single-screen handheld, select a game with a video so the preview plays in the list, then turn the screen off. Before this change the audio kept playing; after it, it stops and returns on wake.

Forced check that the new guard reads the display rather than a pushed flag: with the device asleep, restart the app from a shell (`am start` the main activity, which does not wake the device). The new engine seeds itself from the live display state, logs `SecondaryScreen: native screen edge — on=false`, and starts no audio.

## Tested on

- [x] Android — device: AYN Thor (dual screen, dev channel release build)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (991)
- [x] Tests added or updated — `test/secondary_screen_power_test.dart` covers the native screen-state channel: edges drive the notifier, an engine started while the device is asleep seeds itself from the display, and `isDisplayOn` fails open when the channel cannot answer
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses _(N/A — no new assets)_

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text** _(N/A — no user-facing strings added or changed)_

**The database** _(N/A — no schema change)_

**Navigation or a new screen** _(N/A — no new screen or navigation change; the bottom screen's existing touch controls are untouched)_

**Android**
- [x] Path logic handles SAF `content://` URIs — _(N/A — no path logic touched)_
- [x] Verified on a device, not only on desktop

**`assets/systems/` or emulator launching** _(N/A — no systems JSON or launcher change)_

</details>

## Screenshots / video

Not applicable: the change is that nothing plays while both screens are dark. Verified instead with `dumpsys audio`, which shows the `CONTENT_TYPE_MOVIE` player disappearing on screen-off and staying gone for the whole sleep, and returning on wake.
