### PR TITLE
fix(gamepad): cycle tabs while a bumper is held on desktop

### DIFF
--- a/lib/screens/search_screen/search_screen.dart
+++ b/lib/screens/search_screen/search_screen.dart
@@ -192,6 +192,9 @@ class _SearchScreenState extends State<SearchScreen> {
 
   Timer? _remoteTimer;
 
+  /// Deferred first load, cancelled if the tab is left before it fires.
+  Timer? _initialLoadTimer;
+
   /// Incremented per issued search; a response whose sequence no longer matches
   /// is a stale in-flight request and is dropped rather than rendered.
   int _remoteSeq = 0;
@@ -253,9 +256,13 @@ class _SearchScreenState extends State<SearchScreen> {
         onDeactivate: () => _gamepadNav.deactivate(),
       );
 
-      // Wait for the tab indicator animation (160ms AnimatedPositioned)
-      // to finish before starting any database work.
-      Future.delayed(const Duration(milliseconds: 250), _loadGames);
+      // Wait for the tab indicator animation to finish before starting any
+      // database work. Held as a cancellable timer, not a bare Future.delayed:
+      // a bumper held through the tab strip mounts and disposes this screen in
+      // passing, and an uncancelled delay still ran the full-library query for
+      // every pass — several of them landing on whichever tab the user actually
+      // stopped on.
+      _initialLoadTimer = Timer(const Duration(milliseconds: 250), _loadGames);
     });
 
     if (Platform.isAndroid) {
@@ -266,6 +273,7 @@ class _SearchScreenState extends State<SearchScreen> {
   @override
   void dispose() {
     GamepadNavigationManager.popLayer('search_screen');
+    _initialLoadTimer?.cancel();
     _remoteTimer?.cancel();
     _achievementsController.dispose();
     _gamepadNav.dispose();
@@ -278,6 +286,8 @@ class _SearchScreenState extends State<SearchScreen> {
   }
 
   Future<void> _loadGames() async {
+    if (!mounted) return;
+
     // Games the user hid are dropped here: search is a game list like any
     // other, so a hidden game must not surface through it either.
     final games = (await GameRepository.getAllGames())

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -149,8 +149,10 @@ class GamepadNavigation {
   /// new tap rather than continuing a hold.
   static bool _shoulderReleasedSinceDispatch = true;
 
-  /// Cadence at which a HELD bumper walks the tabs (~3 tabs/second).
-  static const int _shoulderRepeatIntervalMs = 300;
+  /// Cadence at which a HELD bumper walks the tabs (~4 tabs/second). Fast
+  /// enough to cross the tab bar in one hold, still slow enough to release on
+  /// the tab you want.
+  static const int _shoulderRepeatIntervalMs = 255;
 
   /// Debounce between two separate bumper TAPS. Short, so deliberate rapid
   /// taps to skip several tabs all register.
@@ -159,6 +161,53 @@ class GamepadNavigation {
   /// Safety net for a dropped release: a gap this long means the button can't
   /// still be held, so the next press counts as a fresh tap regardless.
   static const int _shoulderHoldLapsedMs = 500;
+
+  // ---------------------------------------------------------------------
+  // Desktop (Linux/Windows/macOS) synthetic shoulder repeat.
+  //
+  // The pacing above assumes the platform re-delivers a held bumper. Only
+  // Android does: the Linux joystick API (`/dev/input/jsX`, see the vendored
+  // gamepads_linux plugin) and the Windows/macOS backends report STATE CHANGES
+  // only, so a held bumper is one press event and nothing more until release.
+  // With nothing to pace, a hold moved exactly one tab and every tab needed its
+  // own press — the Steam Deck symptom. Synthesize the repeat stream with a
+  // timer instead, matching the Android cadence.
+  //
+  // The timer is STATIC for the same reason the pacing is: switching a tab
+  // rebuilds the navigation layer, so the instance that saw the press is
+  // deactivated long before the hold ends. Ticks are dispatched to whichever
+  // layer is active at the time via [_activeNavigator].
+  // ---------------------------------------------------------------------
+
+  /// Navigator currently receiving input, i.e. the layer a synthetic shoulder
+  /// repeat should be dispatched to.
+  static GamepadNavigation? _activeNavigator;
+
+  /// Running synthetic repeat for a held bumper on desktop.
+  static Timer? _shoulderHoldTimer;
+
+  /// Which bumper the synthetic repeat is walking with.
+  static GamepadInputType? _shoulderHoldInput;
+
+  /// Raw key + gamepad that started the hold. The release is matched on the RAW
+  /// key rather than a translated event because a tab switch clears the new
+  /// layer's translator state, so the release reads as "no edge" there and is
+  /// dropped — the same trap the Android release check at [_handleGamepadEvent]
+  /// works around. Matching the raw key needs no mapping and cannot miss.
+  static String? _shoulderHoldRawKey;
+  static String? _shoulderHoldGamepadId;
+
+  /// When the current synthetic hold started, for [_shoulderHoldMaxMs].
+  static DateTime? _shoulderHoldStartedAt;
+
+  /// How long a bumper must stay down before the synthetic repeat kicks in.
+  /// Longer than [_shoulderTapDebounceMs] so a normal tap never repeats.
+  static const Duration _shoulderHoldStartDelay = Duration(milliseconds: 400);
+
+  /// Hard stop for a synthetic hold. Nothing on the app side can prove the
+  /// button is still down, so if the release is ever lost the tabs would cycle
+  /// forever; this bounds the damage to a few seconds.
+  static const int _shoulderHoldMaxMs = 10000;
 
   /// Debounce duration for action buttons to prevent double-presses.
   static const int _actionDebounceMs = 128;
@@ -408,6 +457,9 @@ class GamepadNavigation {
   void activate() {
     final wasInactive = !_isActive;
     _isActive = true;
+    // Take over any synthetic shoulder repeat still running from the layer we
+    // just displaced, so a hold keeps walking tabs across the switch.
+    _activeNavigator = this;
 
     // Start grace period only on true transitions to prevent discarding mid-flight release events.
     if (wasInactive) {
@@ -433,6 +485,10 @@ class GamepadNavigation {
     _activationTime = null;
     _resetSelectModifier();
     cancelAllRepeatTimers();
+    // Leave [_shoulderHoldTimer] alone: a tab switch deactivates this layer
+    // while the bumper is still physically down, and the next layer picks the
+    // hold up. Only the release (or the safety cap) ends it.
+    if (identical(_activeNavigator, this)) _activeNavigator = null;
   }
 
   /// Clears Select chord-modifier state so it can't leak across layer changes
@@ -548,6 +604,10 @@ class GamepadNavigation {
     _subscription = null;
     _resetSelectModifier();
     cancelAllRepeatTimers();
+    if (identical(_activeNavigator, this)) {
+      _activeNavigator = null;
+      _stopShoulderHold();
+    }
 
     if (_keyboardInitialized && isDesktop) {
       ServicesBinding.instance.keyboard.removeHandler(_handleKeyEvent);
@@ -572,6 +632,13 @@ class GamepadNavigation {
 
   /// Orchestrates the processing of a raw [GamepadEvent].
   void _handleGamepadEvent(GamepadEvent event) async {
+    // Ends a synthetic shoulder repeat. Deliberately ahead of the active check:
+    // every navigator subscribes to the raw stream, and the release that ends a
+    // hold can land while this layer is the deactivated one (mid tab switch, or
+    // after a game launch deactivated everything). Dropping it there would
+    // leave the tabs cycling until the safety cap.
+    _checkShoulderHoldRelease(event);
+
     if (!_isActive) return;
 
     // NOTE: the reactivation grace period is applied AFTER translation (see
@@ -915,21 +982,9 @@ class GamepadNavigation {
       // top): a plain tap fires onSelectButton on release, combos fire on press.
 
       case GamepadInputType.buttonLB:
-        SfxService().playNavSound();
-        if (onLeftBumper != null) {
-          onLeftBumper!.call();
-        } else {
-          onPreviousTab?.call();
-        }
-        break;
-
       case GamepadInputType.buttonRB:
-        SfxService().playNavSound();
-        if (onRightBumper != null) {
-          onRightBumper!.call();
-        } else {
-          onNextTab?.call();
-        }
+        _dispatchShoulder(event.inputType);
+        _startShoulderHold(event);
         break;
 
       // L3 (left stick click) only — the UI hint shows the Left-Stick-Click
@@ -1298,6 +1353,87 @@ class GamepadNavigation {
   void _stopRepeatTimer(dynamic key) {
     _repeatTimers[key]?.cancel();
     _repeatTimers.remove(key);
+  }
+
+  /// Walks one tab for [input], honouring the per-screen bumper overrides.
+  void _dispatchShoulder(GamepadInputType input) {
+    SfxService().playNavSound();
+    if (input == GamepadInputType.buttonLB) {
+      if (onLeftBumper != null) {
+        onLeftBumper!.call();
+      } else {
+        onPreviousTab?.call();
+      }
+    } else {
+      if (onRightBumper != null) {
+        onRightBumper!.call();
+      } else {
+        onNextTab?.call();
+      }
+    }
+  }
+
+  /// Starts the synthetic repeat for a bumper held on desktop.
+  ///
+  /// No-op on Android, where the platform already delivers the hold as a stream
+  /// of auto-repeat presses that the pacing in [_handleGamepadEvent] throttles.
+  void _startShoulderHold(TranslatedGamepadEvent event) {
+    if (isAndroid) return;
+
+    _stopShoulderHold();
+    _shoulderHoldInput = event.inputType;
+    _shoulderHoldRawKey = event.originalKey.toLowerCase();
+    _shoulderHoldGamepadId = event.gamepadId;
+    _shoulderHoldStartedAt = DateTime.now();
+
+    void schedule(Duration delay) {
+      _shoulderHoldTimer = Timer(delay, () {
+        final startedAt = _shoulderHoldStartedAt;
+        final input = _shoulderHoldInput;
+        if (startedAt == null || input == null) return;
+
+        if (DateTime.now().difference(startedAt).inMilliseconds >
+            _shoulderHoldMaxMs) {
+          _stopShoulderHold();
+          return;
+        }
+
+        // Mid tab switch the old layer is already deactivated and the new one
+        // is pushed a frame later, so a tick can land with nothing active.
+        // Skip it and keep the hold alive rather than ending it early.
+        _activeNavigator?._dispatchShoulder(input);
+        schedule(const Duration(milliseconds: _shoulderRepeatIntervalMs));
+      });
+    }
+
+    schedule(_shoulderHoldStartDelay);
+  }
+
+  /// Ends the synthetic repeat when the raw event is the release of the bumper
+  /// that started it. Matching on the raw key sidesteps translated-release
+  /// detection, which a layer swap breaks.
+  static void _checkShoulderHoldRelease(GamepadEvent event) {
+    if (_shoulderHoldTimer == null) return;
+    if (event.gamepadId != _shoulderHoldGamepadId) return;
+    if (event.key.toLowerCase() != _shoulderHoldRawKey) return;
+    // Desktop reports buttons unencoded: non-zero is down, zero is up.
+    if (event.value > 0.5) return;
+    // A raw release is proof the hold ended, so the next press is a fresh tap.
+    // The translated release this normally comes from is lost whenever the tab
+    // switch rebuilt the layer, which would pace a deliberate second tap as if
+    // it were still a hold.
+    _shoulderReleasedSinceDispatch = true;
+    _stopShoulderHold();
+  }
+
+  /// Cancels the synthetic shoulder repeat and clears its tracking state.
+  static void _stopShoulderHold() {
+    _shoulderHoldTimer?.cancel();
+    _shoulderHoldTimer = null;
+    _shoulderHoldInput = null;
+    _shoulderHoldRawKey = null;
+    _shoulderHoldGamepadId = null;
+    _shoulderHoldStartedAt = null;
   }
 }
 

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -305,52 +305,76 @@ class HeaderState extends State<Header> {
                                 NavTab.values[widget.selectedTabIndex],
                               );
 
-                              return Stack(
-                                children: [
-                                  // Moving indicator
-                                  AnimatedPositioned(
-                                    left:
-                                        (selectedSlot < 0 ? 0 : selectedSlot) *
-                                        32.r,
-                                    top: 4.r,
-                                    bottom: 4.r,
-                                    width: 32.r,
-                                    duration: const Duration(milliseconds: 160),
-                                    curve: Curves.easeInOut,
-                                    child: Container(
-                                      decoration: BoxDecoration(
-                                        color: Theme.of(
-                                          context,
-                                        ).colorScheme.primary,
-                                        borderRadius:
-                                            Theme.of(context)
-                                                .extension<CornerRadii>()
-                                                ?.radiusInternal ??
-                                            BorderRadius.circular(4.r),
-                                      ),
-                                    ),
-                                  ),
-                                  // Tab buttons
-                                  Row(
-                                    mainAxisSize: MainAxisSize.min,
+                              // The indicator and the icon tints share ONE
+                              // animation. Flipping a tab's tint the instant
+                              // the selection changed, while the indicator took
+                              // 160ms to slide over, left the incoming icon
+                              // drawn in `onPrimary` on bare surface (and the
+                              // outgoing one in `onSurface` under the pill that
+                              // had not left yet) for the whole slide — read as
+                              // a flash on every tab change, and badly so once
+                              // a held bumper cycles faster than the slide.
+                              // Tinting from the ANIMATED position instead
+                              // keeps each icon's colour matched to how much of
+                              // the pill is actually under it.
+                              return TweenAnimationBuilder<double>(
+                                tween: Tween<double>(
+                                  end: (selectedSlot < 0 ? 0 : selectedSlot)
+                                      .toDouble(),
+                                ),
+                                duration: const Duration(milliseconds: 160),
+                                curve: Curves.easeInOut,
+                                builder: (context, slot, _) {
+                                  return Stack(
                                     children: [
-                                      for (final tab in visibleTabs)
-                                        SizedBox(
-                                          width: 32.r,
-                                          height: 32.r,
-                                          child: _buildTabButton(
-                                            context,
-                                            tab.index,
-                                            navTabSpec(tab).icon,
-                                            navTabSpec(
-                                              tab,
-                                            ).labelKey.getString(context),
-                                            iconData: navTabSpec(tab).iconData,
+                                      // Moving indicator
+                                      Positioned(
+                                        left: slot * 32.r,
+                                        top: 4.r,
+                                        bottom: 4.r,
+                                        width: 32.r,
+                                        child: Container(
+                                          decoration: BoxDecoration(
+                                            color: Theme.of(
+                                              context,
+                                            ).colorScheme.primary,
+                                            borderRadius:
+                                                Theme.of(context)
+                                                    .extension<CornerRadii>()
+                                                    ?.radiusInternal ??
+                                                BorderRadius.circular(4.r),
                                           ),
                                         ),
+                                      ),
+                                      // Tab buttons
+                                      Row(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          for (final (index, tab)
+                                              in visibleTabs.indexed)
+                                            SizedBox(
+                                              width: 32.r,
+                                              height: 32.r,
+                                              child: _buildTabButton(
+                                                context,
+                                                tab.index,
+                                                navTabSpec(tab).icon,
+                                                navTabSpec(
+                                                  tab,
+                                                ).labelKey.getString(context),
+                                                iconData: navTabSpec(
+                                                  tab,
+                                                ).iconData,
+                                                coverage:
+                                                    (1.0 - (slot - index).abs())
+                                                        .clamp(0.0, 1.0),
+                                              ),
+                                            ),
+                                        ],
+                                      ),
                                     ],
-                                  ),
-                                ],
+                                  );
+                                },
                               );
                             },
                           ),
@@ -486,17 +510,23 @@ class HeaderState extends State<Header> {
   //
   // Most tabs use a webp asset; [iconData] is the fallback for tabs with no
   // matching asset (Search), rendered at the same box size and tint.
+  //
+  // [coverage] is how much of the sliding indicator currently sits under this
+  // tab (1 = fully covered, 0 = uncovered). The tint follows it so the icon is
+  // only `onPrimary` where the pill has actually arrived.
   Widget _buildTabButton(
     BuildContext context,
     int tabIndex,
     String? icon,
     String label, {
     IconData? iconData,
+    required double coverage,
   }) {
-    final bool isSelected = tabIndex == widget.selectedTabIndex;
-    final Color tint = isSelected
-        ? Theme.of(context).colorScheme.onPrimary
-        : Theme.of(context).colorScheme.onSurface;
+    final Color tint = Color.lerp(
+      Theme.of(context).colorScheme.onSurface,
+      Theme.of(context).colorScheme.onPrimary,
+      coverage,
+    )!;
 
     return Material(
       color: Colors.transparent,


### PR DESCRIPTION
> [!NOTE]
> This PR was written with [Claude Code](https://claude.com/claude-code). The work was reviewed and tested on real hardware (Steam Deck and AYN Thor) before opening.

# Description

Holding a bumper to walk the nav tabs did nothing on the Steam Deck: every nav icon needed its own press.

The hold-to-repeat pacing added previously assumes the platform re-delivers a held bumper. **Only Android does.** Linux reads the pad through the joystick API (`/dev/input/jsX`, see the vendored `gamepads_linux` plugin), and the Windows/macOS backends report *state changes* only, so a held bumper is one press event and nothing more until release. With no repeat stream arriving, `_shoulderRepeatIntervalMs` had nothing to pace and a hold moved exactly one tab.

This synthesizes the repeat on the platforms that do not provide one:

* **A static timer**, started on a bumper press and paced at the Android cadence. Static for the same reason the existing pacing is: a tab switch rebuilds the navigation layer, so the instance that saw the press is deactivated long before the hold ends. Ticks are dispatched to whichever layer is active at the time.
* **Release is matched on the raw key** (plus gamepad id) captured at press, checked ahead of the active-layer guard. A *translated* release is lost whenever the switch rebuilt the layer, because the new translator has no press state and the release reads as "no edge"; it can also land while this layer is the deactivated one. This is the same trap the existing Android release check works around.
* **A 10 second cap** bounds the damage if a release is ever missed, since nothing app-side can prove the button is still down.

Android keeps its existing path untouched and skips the synthetic timer entirely.

Two further items, both surfaced by the faster cycling:

**Cadence.** Raised from ~3 to ~4 tabs/second (`_shoulderRepeatIntervalMs` 300 to 255), tuned on the Thor. Desktop shares the constant.

**Nav icon flash.** The tab indicator slid over 160ms (`AnimatedPositioned`) while the icon tint flipped the instant `selectedTabIndex` changed. For the whole slide the incoming icon was drawn in `onPrimary` on bare surface, and the outgoing one in `onSurface` under a pill that had not left yet: two icons wrong at once, which read as a flash on every tab change. The pill and the tints now share one animation, and each icon is tinted by how much of the pill actually sits over it.

**SearchScreen deferred load.** `SearchScreen` mounts and disposes on every pass through the tab, and its deferred first load was an uncancellable `Future.delayed`, so each pass fired a full library query that completed after the screen was gone. Now a cancellable `Timer` with a `mounted` guard. Measured benefit during cycling is small (see below); it is included as hygiene, not as a perf fix.

<details>
<summary><b>Measured: the remaining tab-switch cost is uniform, not Search-specific</b></summary>

The lag while cycling was initially assumed to be Search doing database work. It is not. Measured on the Thor with `atrace -c gfx`, frame intervals taken from deduped `queueBuffer` begin-markers on the raster thread (gfxinfo/SurfaceFlinger are unreliable for Flutter).

Continuous cycling at the 255ms bumper cadence, 16 switches per run:

| run | p50 | p95 | worst | severe (>33ms) | total lost |
|---|---|---|---|---|---|
| with Search in the loop | 11.8ms | 18.9ms | 115.7ms | 2 | 119.6ms |
| Search excluded | 10.8ms | 18.6ms | 115.3ms | 1 | 98.6ms |

About 21ms of difference across 4 Search passes, inside the noise of the single ~115ms outlier that dominates both runs. The cost is roughly 10-15ms lost per switch, uniform across every tab, and comes from `_buildCurrentTabContent` rebuilding each tab's whole subtree per switch. That is a structural change and is deliberately **not** in this PR; notes are parked on a separate branch.

Also worth recording: tapping a tab from rest reliably shows one 114-133ms frame, but an idle capture produces only 2 frames in 2 seconds. The app renders nothing at rest, so that stall is an idle/DVFS wake artifact of the measurement, not the tab switch. A held bumper keeps the app rendering and never pays it.

</details>

Closes #

## Steps to Reproduce

**Preconditions:** Steam Deck (or any Linux/Windows desktop) with a gamepad, launched through Game Mode so the pad is seen as a controller rather than emulated keyboard/mouse.

1. Open NeoStation and land on any tab.
2. Press and hold L1 or R1.
3. Before: the selection moves exactly one tab and stops. Every further nav icon needs its own press.
4. After: the selection walks the tabs continuously at about 4 per second for as long as the bumper is held, and stops on release.

## Steps to Verify

**Preconditions:** As above for the desktop path. For the icon flash, any device works; a larger library makes the Search item easier to observe.

1. Hold L1/R1 on the Deck and confirm the tabs cycle continuously, then stop immediately on release.
2. Tap L1/R1 rapidly and confirm each deliberate tap still registers as its own single tab move (no repeat kicking in, no swallowed taps).
3. Hold a bumper through a tab switch and release while on a different tab than the one the press started on, confirming the hold ends rather than running on.
4. Watch the nav icons during any tab change and confirm the icon colour now tracks the sliding indicator instead of flashing ahead of it.
5. On Android, confirm the held bumper still cycles as before (its path is unchanged apart from the cadence).

## Tested on

- [x] Android — device: AYN Thor (cadence, icon flash, no regression on the existing Android hold path)
- [x] Linux — device: Steam Deck (held bumper cycling, the primary fix)
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Windows and macOS share the desktop code path and are expected to benefit identically, but were not available to test.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (998)
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

No tests added: the change is driven by raw gamepad stream timing and layer-stack lifecycle, which the existing suite has no harness for. It was verified on both target devices instead.

<details>
<summary><b>Extra checks — navigation</b></summary>

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse
- [x] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()`
- [x] B cancels / goes back, including out of a focused text field

No new screens or routes. The layer lifecycle is unchanged; the new static state tracks which layer is active and is cleared in `deactivate()` and `dispose()`.

</details>

## Screenshots / video

Not captured. The change is motion (a held bumper cycling, and the icon tint tracking the indicator) and does not read in a still.
