### PR TITLE
fix(scan): report a desktop scan that has no ROM folder to walk

### DIFF
--- a/lib/providers/sqlite_config_provider/scanning.dart
+++ b/lib/providers/sqlite_config_provider/scanning.dart
@@ -15,6 +15,10 @@ const String _unreachableRomFoldersNotificationId = 'rom-folders-unreachable';
 /// Bell entry for a ROM folder refused because its path was transient.
 const String _transientRomFolderNotificationId = 'rom-folder-transient';
 
+/// Bell entry for a desktop scan that had no ROM root left to walk. A fixed id
+/// for the same reason as [_unreachableRomFoldersNotificationId].
+const String _noRomFoldersNotificationId = 'rom-folders-missing';
+
 extension SqliteConfigScanning on SqliteConfigProvider {
   /// Registers a new filesystem directory as a ROM source.
   ///
@@ -237,10 +241,50 @@ extension SqliteConfigScanning on SqliteConfigProvider {
       }
     }
 
+    // The same silence covers the case where no root is configured at all.
+    // `_isFastScan` below turns an empty folder list into a scan that walks
+    // nothing and still reports success: that is deliberate on Android, where
+    // the virtual Android Apps systems are injected regardless, but off
+    // Android it leaves nothing to scan and no way to tell. The list can empty
+    // itself without the user removing anything — a blanket config save that
+    // carried no folders (fixed in #316, but older databases already lost
+    // theirs), or a `loadConfig` failure falling back to `ConfigModel.empty` —
+    // while Settings > Directories reads the folder table directly and so
+    // still shows a folder that is configured as far as the user can tell.
+    // Every scan is then a no-op that flickers past, and the library keeps
+    // working from stored `rom_path` rows, so nothing new is ever picked up.
+    if (!Platform.isAndroid &&
+        _config.romFolders.isEmpty &&
+        await _hasStoredRoms()) {
+      _error =
+          'No ROM folder is configured, so there was nothing to scan. '
+          'Existing games were kept. Add your ROM folder again in '
+          'Settings > Directories.';
+      SqliteConfigProvider._log.e(
+        'Scan aborted, no ROM folders configured while the library holds '
+        'ROMs; library preserved',
+      );
+      // Same reasoning as the unreachable-roots branch above: flip
+      // `_scanCompleted` so the systems screen renders the preserved library,
+      // and report through the bell because `_error` only reaches the
+      // initial-setup widget.
+      _scanCompleted = true;
+      GlobalNotificationService().show(
+        id: _noRomFoldersNotificationId,
+        title: 'No ROM folder configured',
+        message: _error!,
+        type: GlobalNotificationType.error,
+      );
+      _setScanning(false);
+      _notify();
+      return;
+    }
+
     // Getting this far means nothing blocked the scan, so retire a warning
     // left by an earlier one instead of leaving the user chasing a folder they
     // have already reconnected or removed.
     GlobalNotificationService().dismiss(_unreachableRomFoldersNotificationId);
+    GlobalNotificationService().dismiss(_noRomFoldersNotificationId);
 
     // Initialize progress
     _totalSystemsToScan = 0;

--- a/lib/providers/sqlite_config_provider/scanning.dart
+++ b/lib/providers/sqlite_config_provider/scanning.dart
@@ -126,8 +126,17 @@ extension SqliteConfigScanning on SqliteConfigProvider {
     // Re-probe the fast SAF walk once per scan: the permission behind it can be
     // granted or revoked between scans, but not during one.
     SafDirectoryService.resetFastWalkAvailability();
+    // Settle fast-scan mode before anything reports it. `_config.romFolders`
+    // cannot change for the rest of this call, so deciding here is the same
+    // decision the scan phase used to make further down — except the line
+    // below now describes the scan actually about to run. It used to print the
+    // value left by provider init, so the first scan after a folder was added
+    // logged `romFolders=1, fastScan=true`: self-contradictory, and misleading
+    // in exactly the situation this log line exists to diagnose.
+    _isFastScan = _config.romFolders.isEmpty;
     SqliteConfigProvider._log.i(
-      'scanSystems starting (romFolders=${_config.romFolders.length}, fastScan=$_isFastScan)',
+      'scanSystems starting (romFolders=${_config.romFolders.length}, '
+      'fastScan=$_isFastScan)',
     );
 
     // Verify permissions in Android BEFORE scanning
@@ -296,8 +305,8 @@ extension SqliteConfigScanning on SqliteConfigProvider {
       // Reload from synchronized database during initialization
       await _loadAvailableSystems();
 
-      // Detect if we are in "Fast Scan" mode (without ROM folders)
-      _isFastScan = _config.romFolders.isEmpty;
+      // Fast Scan mode (no ROM folders) was settled before the opening log
+      // line, so that it and this agree.
       final bool isFastScan = _isFastScan;
 
       // Detect systems

--- a/test/rom_scan_no_folders_guard_test.dart
+++ b/test/rom_scan_no_folders_guard_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+import 'package:neostation/providers/sqlite_config_provider.dart';
+import 'package:neostation/services/global_notification_service.dart';
+
+import 'database_test_helper.dart';
+
+/// Off Android, a scan with no configured ROM root walks nothing and used to
+/// report success anyway: the library kept working from stored `rom_path`
+/// rows while every scan was a silent no-op, so new files were never picked
+/// up and nothing said why. Settings > Directories reads the folder table
+/// directly, so a folder could still appear configured throughout.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final helper = DatabaseTestHelper();
+  late DatabaseAdapter db;
+
+  setUp(() async {
+    db = await helper.setUp();
+    GlobalNotificationService().dismiss();
+  });
+
+  tearDown(() async {
+    await helper.tearDown();
+    GlobalNotificationService().dismiss();
+  });
+
+  /// Inserts a ROM row so the library counts as non-empty.
+  Future<void> storeRom() async {
+    await db.rawInsert(
+      'INSERT INTO user_roms (app_system_id, filename, rom_path) '
+      'VALUES (?, ?, ?)',
+      ['nes', 'Game.nes', '/roms/nes/Game.nes'],
+    );
+  }
+
+  bool hasNoFoldersNotification() => GlobalNotificationService().notifier.value
+      .any((n) => n.id == 'rom-folders-missing');
+
+  test('aborts and reports when no ROM folder is configured', () async {
+    await storeRom();
+    final provider = SqliteConfigProvider();
+
+    await provider.scanSystems();
+
+    expect(provider.config.romFolders, isEmpty);
+    expect(provider.error, contains('No ROM folder is configured'));
+    expect(hasNoFoldersNotification(), isTrue);
+    // The systems screen renders neither the library nor the setup prompt
+    // until this flips, so an early return without it leaves a blank page.
+    expect(provider.scanCompleted, isTrue);
+    expect(provider.isScanning, isFalse);
+  });
+
+  test('leaves the stored ROMs in place', () async {
+    await storeRom();
+    final provider = SqliteConfigProvider();
+
+    await provider.scanSystems();
+
+    final rows = await db.rawQuery('SELECT COUNT(*) AS c FROM user_roms');
+    expect(rows.first['c'], 1);
+  });
+
+  test('a fresh install with no ROMs is not an error', () async {
+    final provider = SqliteConfigProvider();
+
+    await provider.scanSystems();
+
+    expect(hasNoFoldersNotification(), isFalse);
+    expect(provider.error, isNot(contains('No ROM folder is configured')));
+  });
+
+  test('a configured folder does not trip the guard', () async {
+    await storeRom();
+    final romRoot = await Directory.systemTemp.createTemp('neostation_scan_');
+    addTearDown(() async {
+      if (await romRoot.exists()) await romRoot.delete(recursive: true);
+    });
+    final provider = SqliteConfigProvider();
+    await provider.addRomFolder(romRoot.path, scan: false);
+
+    await provider.scanSystems();
+
+    expect(provider.config.romFolders, [romRoot.path]);
+    expect(hasNoFoldersNotification(), isFalse);
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission. Commits carry an `AI-Assisted:` trailer.

# Description

Off Android, a scan with no configured ROM root walks nothing and reports success anyway. `_isFastScan` turns an empty folder list into a scan that detects nothing, sets `_scanCompleted` and ends without a word: that is deliberate on Android, where the virtual Android Apps systems are injected regardless, but on desktop `fastScanFolders` is an empty list, so there is genuinely nothing left to do and nothing said about it.

The folder list can empty itself without the user removing anything:

- a blanket config save carrying no folders (guarded at the DB layer in #316, but databases that already lost theirs stay lost), or
- a `loadConfig` failure falling back to `ConfigModel.empty`, which zeroes `romFolders` for the whole session.

Two things then conspire to hide it. Settings > Directories calls `ConfigRepository.getUserRomFolders()` against the database directly rather than reading the config object, so the folder still appears configured. And the library keeps working, because launching a game reads `rom_path` from `user_roms` and never consults the ROM root. The user is left with a scan that flickers past, a library that looks healthy, and no way to find out that new files will never be picked up.

Reported on Windows 11 (ROG Ally X, ROM library on an SD card): games launched fine for weeks while every scan silently did nothing. It was only noticed after merging Neo Geo ROMs into the MAME folder, when the new files never appeared. Deleting and re-adding the same folder in Settings restored scanning, which is what pointed at the config list rather than the filesystem.

This treats it the way #311 already treats an unreachable root: abort, keep the library, flip `_scanCompleted` so the systems screen still renders the library instead of a blank page, and report through the notification bell, which is the one surface that survives the scan ending and needs no `BuildContext` from the provider layer. `_hasStoredRoms()` keeps a genuinely fresh install quiet, so first-run setup still reaches the folder prompt rather than an error.

## Second commit: the scan log was lying about fast-scan mode

`scanSystems` logs `_isFastScan` in its opening line, but the field was only recomputed further down inside the `try`, so the value printed was the one left by provider init. The first scan after a folder was added therefore logged `romFolders=1, fastScan=true`, which is self-contradictory, and wrong in precisely the situation the line exists to diagnose — taken at face value during a support triage it points at a folder-less config that isn't there. It came up while triaging the report above.

The mode is now settled once, before anything reports it. `_config.romFolders` cannot change for the rest of the call, so this is the same decision the scan phase already made, taken early enough for the log to describe the scan actually about to run. Nothing outside `scanSystems` reads the field (no getter, no other consumer), so no behaviour changes — which is also why it carries no test of its own.

**Note on strings:** the two user-facing strings are hardcoded English, matching the adjacent #311 guard immediately above. `AppLocale.getString()` needs a `BuildContext` and there is no context-free lookup anywhere in `lib/providers/` or `lib/services/` today. Both guards should be localised together rather than one of them; happy to do that here instead if preferred.

No linked issue: reported on Discord rather than filed.

## Steps to Verify

**Preconditions:** a desktop build (Linux/Windows/macOS), an existing library with at least one scanned ROM, and the app closed.

1. With the app closed, empty the configured ROM roots directly in the database: `sqlite3 <user-data>/data.sqlite "DELETE FROM user_rom_folders;"`. Deleting the folder through Settings will not reproduce it, because `removeRomFolder` purges the matching ROM rows too and leaves no library to preserve.
2. Confirm the library rows survived: `sqlite3 <user-data>/data.sqlite "SELECT COUNT(*) FROM user_roms"` returns a non-zero count.
3. Launch the app with "Scan folders on Startup" enabled.
4. **Before this change:** the scan completes instantly and silently, no error anywhere. **After:** the scan aborts, the library still renders, and the bell carries "No ROM folder configured". `app.log` reads `Scan aborted, no ROM folders configured while the library holds ROMs; library preserved`.
5. Confirm the ROM rows are untouched — nothing reached the prune phase.
6. Re-add the ROM folder in Settings > Directories. A real scan runs and the bell entry clears.
7. Fresh-install case: with `user_roms` empty and no folders configured, launch and confirm no bell and no error — first-run setup still shows the folder prompt.

## Tested on

- [ ] Android — device:
- [x] Linux — device: Steam Deck (SteamOS 3.x, AppImage)
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Verified on a Steam Deck with the folder table emptied and 1084 ROM rows in place: the startup scan aborted, the library rendered, the bell reported it, all 1084 rows survived, and re-adding the folder scanned for real and cleared the warning. The guard is `!Platform.isAndroid`, so Android behaviour is unchanged by construction.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1002)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

`test/rom_scan_no_folders_guard_test.dart` drives the real `SqliteConfigProvider` against an in-memory database and covers four cases: the abort itself (error, bell, `scanCompleted`, `isScanning`), the stored ROMs surviving it, a fresh install with no ROMs not being an error, and a configured folder not tripping the guard.

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [ ] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [ ] No hardcoded UI strings — everything goes through `AppLocale`

Both deliberately unchecked, see the note in the description: the strings match the #311 guard directly above them, which is also hardcoded, and the provider layer has no `BuildContext`.

</details>

## Screenshots / video

Not applicable — the visible change is a notification-bell entry where there was previously nothing at all.
