### PR TITLE
feat(settings): add Android system settings shortcut in general tab

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
@@ -543,6 +543,10 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
                 "openLauncherSettings" -> {
                     openLauncherSettings(result)
                 }
+                "openSystemSettings" -> {
+                    openSystemSettings()
+                    result.success(true)
+                }
                 else -> result.notImplemented()
             }
         }
@@ -787,6 +791,16 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
             } catch (fallbackException: Exception) {
                 result.error("OPEN_FAILED", fallbackException.message, null)
             }
+        }
+    }
+
+    private fun openSystemSettings() {
+        try {
+            val intent = Intent(android.provider.Settings.ACTION_SETTINGS)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            startActivity(intent)
+        } catch (e: Exception) {
+            println("Error opening system settings: ${e.message}")
         }
     }
 

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -131,6 +131,9 @@ mixin AppLocale {
   static const String retroArchPathConfigured = 'retroarch_path_configured';
   static const String errorConfiguringRetroArchPath =
       'error_configuring_retroarch_path';
+  static const String androidSystemSettings = 'android_system_settings';
+  static const String androidSystemSettingsSubtitle =
+      'android_system_settings_subtitle';
   static const String scanOnStartup = 'scan_on_startup';
   static const String scanOnStartupSubtitle = 'scan_on_startup_subtitle';
   static const String nowPlayingDimAfter = 'now_playing_dim_after';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -119,6 +119,8 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.retroArchPathConfigured: 'RetroArch-Pfad erfolgreich konfiguriert',
   AppLocale.errorConfiguringRetroArchPath:
       'Fehler beim Konfigurieren des RetroArch-Pfads: {error}',
+  AppLocale.androidSystemSettings: 'Systemeinstellungen',
+  AppLocale.androidSystemSettingsSubtitle: 'Android-Systemeinstellungen öffnen',
   AppLocale.scanOnStartup: 'Ordner beim Start scannen',
   AppLocale.nowPlayingDimAfter: 'Now Playing abdunkeln nach',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -114,6 +114,8 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.retroArchPathConfigured: 'RetroArch path configured successfully',
   AppLocale.errorConfiguringRetroArchPath:
       'Error configuring RetroArch path: {error}',
+  AppLocale.androidSystemSettings: 'System Settings',
+  AppLocale.androidSystemSettingsSubtitle: 'Open android system settings',
   AppLocale.scanOnStartup: 'Scan folders on Startup',
   AppLocale.nowPlayingDimAfter: 'Dim Now Playing after',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -120,6 +120,8 @@ const Map<String, dynamic> appLocaleEs = {
       'Ruta de RetroArch configurada correctamente',
   AppLocale.errorConfiguringRetroArchPath:
       'Error al configurar la ruta de RetroArch: {error}',
+  AppLocale.androidSystemSettings: 'Ajustes del Sistema',
+  AppLocale.androidSystemSettingsSubtitle: 'Abrir ajustes del sistema Android',
   AppLocale.scanOnStartup: 'Escanear al Iniciar',
   AppLocale.nowPlayingDimAfter: 'Atenuar «Reproduciendo» tras',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -124,6 +124,8 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.retroArchPathConfigured: 'Chemin RetroArch configuré avec succès',
   AppLocale.errorConfiguringRetroArchPath:
       'Erreur lors de la configuration du chemin RetroArch : {error}',
+  AppLocale.androidSystemSettings: 'Paramètres du Système',
+  AppLocale.androidSystemSettingsSubtitle: 'Ouvrir les paramètres système Android',
   AppLocale.scanOnStartup: 'Analyser les dossiers au démarrage',
   AppLocale.nowPlayingDimAfter: 'Atténuer Now Playing après',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -125,7 +125,8 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.errorConfiguringRetroArchPath:
       'Erreur lors de la configuration du chemin RetroArch : {error}',
   AppLocale.androidSystemSettings: 'Paramètres du Système',
-  AppLocale.androidSystemSettingsSubtitle: 'Ouvrir les paramètres système Android',
+  AppLocale.androidSystemSettingsSubtitle:
+      'Ouvrir les paramètres système Android',
   AppLocale.scanOnStartup: 'Analyser les dossiers au démarrage',
   AppLocale.nowPlayingDimAfter: 'Atténuer Now Playing après',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -118,6 +118,8 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.retroArchPathConfigured: 'Jalur RetroArch berhasil dikonfigurasi',
   AppLocale.errorConfiguringRetroArchPath:
       'Kesalahan saat mengonfigurasi jalur RetroArch: {error}',
+  AppLocale.androidSystemSettings: 'Pengaturan Sistem',
+  AppLocale.androidSystemSettingsSubtitle: 'Buka pengaturan sistem Android',
   AppLocale.scanOnStartup: 'Pindai folder saat mulai',
   AppLocale.nowPlayingDimAfter: 'Redupkan Now Playing setelah',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -121,7 +121,8 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.errorConfiguringRetroArchPath:
       'Errore durante la configurazione del percorso RetroArch: {error}',
   AppLocale.androidSystemSettings: 'Impostazioni del Sistema',
-  AppLocale.androidSystemSettingsSubtitle: 'Apri le impostazioni di sistema Android',
+  AppLocale.androidSystemSettingsSubtitle:
+      'Apri le impostazioni di sistema Android',
   AppLocale.scanOnStartup: 'Scansiona cartelle all’avvio',
   AppLocale.nowPlayingDimAfter: 'Oscura Now Playing dopo',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -120,6 +120,8 @@ const Map<String, dynamic> appLocaleIt = {
       'Percorso RetroArch configurato con successo',
   AppLocale.errorConfiguringRetroArchPath:
       'Errore durante la configurazione del percorso RetroArch: {error}',
+  AppLocale.androidSystemSettings: 'Impostazioni del Sistema',
+  AppLocale.androidSystemSettingsSubtitle: 'Apri le impostazioni di sistema Android',
   AppLocale.scanOnStartup: 'Scansiona cartelle all’avvio',
   AppLocale.nowPlayingDimAfter: 'Oscura Now Playing dopo',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -105,6 +105,8 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.retroArchPathConfigured: 'RetroArchのパスが正常に設定されました',
   AppLocale.errorConfiguringRetroArchPath:
       'RetroArchのパス設定中にエラーが発生しました: {error}',
+  AppLocale.androidSystemSettings: 'システム設定',
+  AppLocale.androidSystemSettingsSubtitle: 'Androidのシステム設定を開く',
   AppLocale.scanOnStartup: '起動時にフォルダをスキャン',
   AppLocale.nowPlayingDimAfter: 'Now Playingを暗くするまでの時間',
   AppLocale.nowPlayingDimAfterSubtitle: 'セカンダリ画面でパネルが暗くなるまでの操作なしの時間',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -103,6 +103,8 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.errorConfiguringPath: '경로 설정 오류: {error}',
   AppLocale.retroArchPathConfigured: 'RetroArch 경로 설정에 성공했습니다',
   AppLocale.errorConfiguringRetroArchPath: 'RetroArch 경로 설정 오류: {error}',
+  AppLocale.androidSystemSettings: '시스템 설정',
+  AppLocale.androidSystemSettingsSubtitle: 'Android 시스템 설정 열기',
   AppLocale.scanOnStartup: '시작할 때 폴더 검색',
   AppLocale.nowPlayingDimAfter: '플레이 중 화면 어둡게',
   AppLocale.nowPlayingDimAfterSubtitle: '보조 화면의 게임 패널이 어두워질 때까지의 대기 시간입니다',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -121,7 +121,8 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.errorConfiguringRetroArchPath:
       'Erro ao configurar o caminho do RetroArch: {error}',
   AppLocale.androidSystemSettings: 'Configurações do Sistema',
-  AppLocale.androidSystemSettingsSubtitle: 'Abrir configurações do sistema Android',
+  AppLocale.androidSystemSettingsSubtitle:
+      'Abrir configurações do sistema Android',
   AppLocale.scanOnStartup: 'Varrer pastas ao iniciar',
   AppLocale.nowPlayingDimAfter: 'Escurecer Now Playing após',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -120,6 +120,8 @@ const Map<String, dynamic> appLocalePt = {
       'Caminho do RetroArch configurado com sucesso',
   AppLocale.errorConfiguringRetroArchPath:
       'Erro ao configurar o caminho do RetroArch: {error}',
+  AppLocale.androidSystemSettings: 'Configurações do Sistema',
+  AppLocale.androidSystemSettingsSubtitle: 'Abrir configurações do sistema Android',
   AppLocale.scanOnStartup: 'Varrer pastas ao iniciar',
   AppLocale.nowPlayingDimAfter: 'Escurecer Now Playing após',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -118,6 +118,8 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.retroArchPathConfigured: 'Путь для RetroArch успешно настроен',
   AppLocale.errorConfiguringRetroArchPath:
       'Ошибка при настройке пути для RetroArch: {error}',
+  AppLocale.androidSystemSettings: 'Настройки системы',
+  AppLocale.androidSystemSettingsSubtitle: 'Открыть настройки системы Android',
   AppLocale.scanOnStartup: 'Сканировать папки при запуске',
   AppLocale.nowPlayingDimAfter: 'Затемнять Now Playing через',
   AppLocale.nowPlayingDimAfterSubtitle:

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -103,6 +103,8 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.errorConfiguringPath: '配置路径时出错: {error}',
   AppLocale.retroArchPathConfigured: 'RetroArch 路径配置成功',
   AppLocale.errorConfiguringRetroArchPath: '配置 RetroArch 路径时出错: {error}',
+  AppLocale.androidSystemSettings: '系统设置',
+  AppLocale.androidSystemSettingsSubtitle: '打开 Android 系统设置',
   AppLocale.scanOnStartup: '启动时扫描文件夹',
   AppLocale.nowPlayingDimAfter: 'Now Playing 变暗延时',
   AppLocale.nowPlayingDimAfterSubtitle: '在副屏上游戏面板变暗前的无操作时间',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -103,6 +103,8 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.errorConfiguringPath: '設定路徑時發生錯誤: {error}',
   AppLocale.retroArchPathConfigured: 'RetroArch 路徑設定成功',
   AppLocale.errorConfiguringRetroArchPath: '設定 RetroArch 路徑時發生錯誤: {error}',
+  AppLocale.androidSystemSettings: '系統設定',
+  AppLocale.androidSystemSettingsSubtitle: '打開 Android 系統設定',
   AppLocale.scanOnStartup: '啟動時掃描資料夾',
   AppLocale.nowPlayingDimAfter: 'Now Playing 變暗延時',
   AppLocale.nowPlayingDimAfterSubtitle: '在副螢幕上遊戲面板變暗前的無操作時間',

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -221,6 +221,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
 
   /// Selection Dispatcher: Executes the action associated with the specified setting index.
   void selectItem(int index) {
+    SfxService().playNavSound();
     int currentItemIndex = 0;
     final configProvider = context.read<SqliteConfigProvider>();
 
@@ -425,6 +426,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     final index = currentItemIdx++;
                     return SettingRow(
                       key: _itemKeys[index],
+                      onTap: () => selectItem(index),
                       focused:
                           widget.isContentFocused &&
                           widget.selectedContentIndex == index,
@@ -447,6 +449,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                   final index = currentItemIdx++;
                   return SettingRow(
                     key: _itemKeys[index],
+                    onTap: () => selectItem(index),
                     focused:
                         widget.isContentFocused &&
                         widget.selectedContentIndex == index,
@@ -472,6 +475,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                   final index = currentItemIdx++;
                   return SettingRow(
                     key: _itemKeys[index],
+                    onTap: () => selectItem(index),
                     focused:
                         widget.isContentFocused &&
                         widget.selectedContentIndex == index,
@@ -497,6 +501,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                   final index = currentItemIdx++;
                   return SettingRow(
                     key: _itemKeys[index],
+                    onTap: () => selectItem(index),
                     focused:
                         widget.isContentFocused &&
                         widget.selectedContentIndex == index,
@@ -522,6 +527,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                   final index = currentItemIdx++;
                   return SettingRow(
                     key: _itemKeys[index],
+                    onTap: () => selectItem(index),
                     focused:
                         widget.isContentFocused &&
                         widget.selectedContentIndex == index,
@@ -547,6 +553,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                   final index = currentItemIdx++;
                   return SettingRow(
                     key: _itemKeys[index],
+                    onTap: () => selectItem(index),
                     focused:
                         widget.isContentFocused &&
                         widget.selectedContentIndex == index,
@@ -574,18 +581,14 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     opacity: config.sfxEnabled ? 1.0 : 0.4,
                     child: SettingRow(
                       key: _itemKeys[index],
+                      onTap: () => selectItem(index),
                       focused:
                           widget.isContentFocused &&
                           widget.selectedContentIndex == index,
                       title: AppLocale.sfxVolume.getString(context),
                       subtitle: AppLocale.sfxVolumeSubtitle.getString(context),
-                      trailing: GestureDetector(
-                        onTap: config.sfxEnabled
-                            ? () => _cycleSfxVolume(provider)
-                            : null,
-                        child: SettingValueChip(
-                          text: _sfxVolumeLabel(context, config.sfxVolume),
-                        ),
+                      trailing: SettingValueChip(
+                        text: _sfxVolumeLabel(context, config.sfxVolume),
                       ),
                     ),
                   );
@@ -597,6 +600,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                   final index = currentItemIdx++;
                   return SettingRow(
                     key: _itemKeys[index],
+                    onTap: () => selectItem(index),
                     focused:
                         widget.isContentFocused &&
                         widget.selectedContentIndex == index,
@@ -627,6 +631,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     final hidden = spec.hidden?.call(config) ?? false;
                     return SettingRow(
                       key: _itemKeys[index],
+                      onTap: () => selectItem(index),
                       focused:
                           widget.isContentFocused &&
                           widget.selectedContentIndex == index,
@@ -653,20 +658,16 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                   final index = currentItemIdx++;
                   return SettingRow(
                     key: _itemKeys[index],
+                    onTap: () => selectItem(index),
                     focused:
                         widget.isContentFocused &&
                         widget.selectedContentIndex == index,
                     title: AppLocale.language.getString(context),
                     subtitle: AppLocale.languageSub.getString(context),
-                    trailing: GestureDetector(
-                      onTap: () =>
-                          _showLanguagePicker(context, _itemKeys[index]),
-                      child: SettingValueChip(
-                        text:
-                            AppLocale.supportedLanguages[config.appLanguage] ??
-                            config.appLanguage,
-                        trailingIcon: Symbols.arrow_drop_down_rounded,
-                      ),
+                    trailing: SettingValueChip(
+                      text: AppLocale.supportedLanguages[config.appLanguage] ??
+                          config.appLanguage,
+                      trailingIcon: Symbols.arrow_drop_down_rounded,
                     ),
                   );
                 }(),
@@ -681,6 +682,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     final index = currentItemIdx++;
                     return SettingRow(
                       key: _itemKeys[index],
+                      onTap: () => selectItem(index),
                       expandTitle: false,
                       focused:
                           widget.isContentFocused &&
@@ -705,6 +707,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     final index = currentItemIdx++;
                     return SettingRow(
                       key: _itemKeys[index],
+                      onTap: () => selectItem(index),
                       focused:
                           widget.isContentFocused &&
                           widget.selectedContentIndex == index,
@@ -752,6 +755,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     final index = currentItemIdx++;
                     return SettingRow(
                       key: _itemKeys[index],
+                      onTap: () => selectItem(index),
                       focused:
                           widget.isContentFocused &&
                           widget.selectedContentIndex == index,
@@ -775,6 +779,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     final index = currentItemIdx++;
                     return SettingRow(
                       key: _itemKeys[index],
+                      onTap: () => selectItem(index),
                       focused:
                           widget.isContentFocused &&
                           widget.selectedContentIndex == index,
@@ -806,6 +811,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     final index = currentItemIdx++;
                     return SettingRow(
                       key: _itemKeys[index],
+                      onTap: () => selectItem(index),
                       focused:
                           widget.isContentFocused &&
                           widget.selectedContentIndex == index,

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -177,9 +177,24 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
     }
   }
 
+  /// Platform: Android - Triggers the native system settings activity.
+  Future<void> _openSystemSettings() async {
+    if (Platform.isAndroid) {
+      try {
+        const platform = MethodChannel('com.neogamelab.neostation/launcher');
+        await platform.invokeMethod('openSystemSettings');
+      } catch (e) {
+        _log.e('System settings activity could not be resolved: $e');
+      }
+    }
+  }
+
   /// Dynamic Item Resolution: Calculates the total setting items available for the current platform/configuration.
   int getItemCount() {
     int count = 0;
+    if (Platform.isAndroid) {
+      count++; // System Settings
+    }
     count++; // Scan on Startup
     count++; // Ignore hidden files in scan
     count++; // Auto-update App
@@ -208,6 +223,15 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
   void selectItem(int index) {
     int currentItemIndex = 0;
     final configProvider = context.read<SqliteConfigProvider>();
+
+    // Protocol: Native Android Settings.
+    if (Platform.isAndroid) {
+      if (index == currentItemIndex) {
+        _openSystemSettings();
+        return;
+      }
+      currentItemIndex++;
+    }
 
     // Protocol: Background ROM Scanning.
     if (index == currentItemIndex) {
@@ -395,6 +419,29 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                // Setting: System Settings (Android only).
+                if (Platform.isAndroid) ...[
+                  () {
+                    final index = currentItemIdx++;
+                    return SettingRow(
+                      key: _itemKeys[index],
+                      focused:
+                          widget.isContentFocused &&
+                          widget.selectedContentIndex == index,
+                      title: AppLocale.androidSystemSettings.getString(context),
+                      subtitle: AppLocale.androidSystemSettingsSubtitle
+                          .getString(context),
+                      trailing: Icon(
+                        Symbols.open_in_new_rounded,
+                        size: 18.r,
+                        color:
+                            theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                      ),
+                    );
+                  }(),
+                  SizedBox(height: 12.r),
+                ],
+
                 // Setting: Scan on Startup.
                 () {
                   final index = currentItemIdx++;

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -436,8 +436,9 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                       trailing: Icon(
                         Symbols.open_in_new_rounded,
                         size: 18.r,
-                        color:
-                            theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                        color: theme.colorScheme.onSurface.withValues(
+                          alpha: 0.7,
+                        ),
                       ),
                     );
                   }(),
@@ -665,7 +666,8 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     title: AppLocale.language.getString(context),
                     subtitle: AppLocale.languageSub.getString(context),
                     trailing: SettingValueChip(
-                      text: AppLocale.supportedLanguages[config.appLanguage] ??
+                      text:
+                          AppLocale.supportedLanguages[config.appLanguage] ??
                           config.appLanguage,
                       trailingIcon: Symbols.arrow_drop_down_rounded,
                     ),

--- a/lib/screens/settings_screen/new_settings_options/widgets/setting_row.dart
+++ b/lib/screens/settings_screen/new_settings_options/widgets/setting_row.dart
@@ -97,8 +97,12 @@ class SettingRow extends StatelessWidget {
           highlightColor: Colors.transparent,
           splashColor: Colors.transparent,
           child: Padding(
-            padding:
-                EdgeInsets.only(left: 12.r, right: 12.r, top: 6.r, bottom: 6.r),
+            padding: EdgeInsets.only(
+              left: 12.r,
+              right: 12.r,
+              top: 6.r,
+              bottom: 6.r,
+            ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [

--- a/lib/screens/settings_screen/new_settings_options/widgets/setting_row.dart
+++ b/lib/screens/settings_screen/new_settings_options/widgets/setting_row.dart
@@ -32,6 +32,9 @@ class SettingRow extends StatelessWidget {
   /// `true`; a small number of legacy rows lay out without it.
   final bool expandTitle;
 
+  /// Touch handler for the entire row.
+  final VoidCallback? onTap;
+
   const SettingRow({
     super.key,
     required this.title,
@@ -40,6 +43,7 @@ class SettingRow extends StatelessWidget {
     required this.trailing,
     required this.focused,
     this.expandTitle = true,
+    this.onTap,
   });
 
   @override
@@ -74,7 +78,6 @@ class SettingRow extends StatelessWidget {
     );
 
     return Container(
-      padding: EdgeInsets.only(left: 12.r, right: 12.r, top: 6.r, bottom: 6.r),
       decoration: BoxDecoration(
         color: theme.colorScheme.surface.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(8.r),
@@ -83,13 +86,29 @@ class SettingRow extends StatelessWidget {
           width: 2,
         ),
       ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          expandTitle ? Expanded(child: titleColumn) : titleColumn,
-          SizedBox(width: 12.r),
-          trailing,
-        ],
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(8.r),
+          canRequestFocus: false,
+          focusColor: Colors.transparent,
+          hoverColor: Colors.transparent,
+          highlightColor: Colors.transparent,
+          splashColor: Colors.transparent,
+          child: Padding(
+            padding:
+                EdgeInsets.only(left: 12.r, right: 12.r, top: 6.r, bottom: 6.r),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                expandTitle ? Expanded(child: titleColumn) : titleColumn,
+                SizedBox(width: 12.r),
+                trailing,
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.3"
+    version: "0.20.2"
   jni:
     dependency: transitive
     description:
@@ -553,10 +553,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.20"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -577,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1006,10 +1006,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -1126,10 +1126,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.2.0"
   video_player:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   jni:
     dependency: transitive
     description:
@@ -553,10 +553,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -577,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -1006,10 +1006,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -1126,10 +1126,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   video_player:
     dependency: "direct main"
     description:


### PR DESCRIPTION
# Description

Adds a dedicated "System Settings" card to the top of the General Settings screen on Android devices, allowing users to launch the native Android OS Settings app directly from NeoStation via platform channel intent.

- Conditionally rendered only on Android (`Platform.isAndroid`) to prevent desktop/multiplatform regressions.
- Fully integrated with gamepad/D-pad navigation, focus highlighting, and touch support.
- Fully localized across all 12 supported locale files.

Closes #

## Steps to Verify

**Preconditions:**

1. Install and launch NeoStation on an Android device.

**Steps:**

1. Navigate to the **Setup / Settings** tab (gear icon).
2. Select **General** settings.
3. Observe the top item labeled **System Settings** ("Open android system settings").
4. Highlight the item using the gamepad D-pad or touch and press **A / Select / Tap**.
5. Verify that the native Android OS Settings app opens cleanly over NeoStation.
6. (Optional) Run on Windows/Linux desktop and confirm the "System Settings" tile is hidden and the list begins with "Scan folders on Startup".

## Tested on

- [x] Android — device: Android Handheld / ARM64 device
- [x] Windows
- [ ] Linux — device:
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details open>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [x] No hardcoded UI strings — everything goes through `AppLocale`

**The database**
- [ ] Column added to the versioned migration in `sqlite_migrations.dart` **and** the `CREATE TABLE` in `sqlite_service.dart`
- [ ] Migration number is above every slot in use on any open branch, not just `main` + 1
- [ ] Migration is idempotent (`PRAGMA table_info` guard) and has a test
- [ ] `_databaseVersion` bumped; new column selected in *every* system-loading query

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse
- [ ] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()`
- [x] B cancels / goes back, including out of a focused text field

**Android**
- [ ] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths
- [x] Verified on a device, not only on desktop

**`assets/systems/` or emulator launching**
- [ ] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible
- [ ] `assets/manifest.json` version bumped if this should reach existing installs OTA

</details>

## Screenshots / video

<img width="1920" height="1080" alt="Screenshot_20260816-091325" src="https://github.com/user-attachments/assets/af1a37cf-3ce9-4a9d-aa60-694585434449" />
