### PR TITLE
fix(search): restore the Go-to-game / Play chooser on a tapped result

### DIFF
--- a/lib/screens/search_screen/search_filter.dart
+++ b/lib/screens/search_screen/search_filter.dart
@@ -1,4 +1,5 @@
 import 'package:neostation/models/database_game_model.dart';
+import 'package:neostation/models/romm_rom.dart';
 
 /// Pure search / filter logic backing the library-wide [SearchScreen].
 ///
@@ -343,6 +344,126 @@ List<int> _ratingFacet(List<DatabaseGameModel> games, SearchCriteria criteria) {
   final active = criteria.rating;
   if (active != null) scores.add(active);
   return scores.toList()..sort();
+}
+
+/// One line in the results list.
+///
+/// Local games, the "On RomM" divider, remote ROMs and the remote section's
+/// loading / error / load-more line all share a single flat list so the
+/// existing index-based gamepad navigation and fixed-extent scroll maths keep
+/// working unchanged. Rows the user can't focus (the header, the spinner) are
+/// simply left out of the focusable index.
+sealed class ResultRow {
+  const ResultRow();
+}
+
+class LocalRow extends ResultRow {
+  const LocalRow(this.game);
+  final DatabaseGameModel game;
+}
+
+class RemoteHeaderRow extends ResultRow {
+  const RemoteHeaderRow();
+}
+
+class RemoteRow extends ResultRow {
+  const RemoteRow(this.rom);
+  final RommRom rom;
+}
+
+/// The remote section's trailing line: a spinner, an error, "load more", or a
+/// note that the active filters can't be applied to RomM results.
+enum RemoteStatus { loading, error, loadMore, unsupported, noEquivalent }
+
+class RemoteStatusRow extends ResultRow {
+  const RemoteStatusRow(this.status);
+  final RemoteStatus status;
+}
+
+/// Headers and the spinner are skipped by Up/Down; everything else stops.
+bool isFocusableRow(ResultRow row) => switch (row) {
+  LocalRow() => true,
+  RemoteRow() => true,
+  RemoteStatusRow(:final status) =>
+    status == RemoteStatus.loadMore || status == RemoteStatus.error,
+  RemoteHeaderRow() => false,
+};
+
+/// The rendered rows plus the subset of their indices that can take focus.
+///
+/// The two index spaces are deliberately separate and must not be used
+/// interchangeably: [rows] is what the list builder renders, while selection is
+/// tracked as a position in [focusable]. They coincide only while the results
+/// are local-only — as soon as the unfocusable RomM header is present, every
+/// row below it sits at a different index in each. Translate with
+/// [focusableIndexOfRow].
+class ResultRows {
+  const ResultRows({required this.rows, required this.focusable});
+
+  final List<ResultRow> rows;
+  final List<int> focusable;
+
+  static const ResultRows empty = ResultRows(rows: [], focusable: []);
+
+  /// The selection index for a row at [rowIndex] in [rows], or -1 when that row
+  /// can't take focus (the RomM header, the spinner).
+  int focusableIndexOfRow(int rowIndex) => focusable.indexOf(rowIndex);
+
+  /// The row [selectionIndex] points at, or null when the list is empty.
+  ResultRow? rowAtSelection(int selectionIndex) =>
+      selectionIndex >= 0 && selectionIndex < focusable.length
+      ? rows[focusable[selectionIndex]]
+      : null;
+}
+
+/// Builds the flat row list from the local results plus the RomM section.
+///
+/// The chip filters deliberately do not narrow the RomM section beyond what
+/// [visibleRemote] already carries: [RommRom] has no rating, so applying that
+/// criterion remotely would silently drop everything. The caller reports that
+/// case through [rommFilterable] instead, and a filter value RomM's vocabulary
+/// has no entry for through [unmatchedFilter] — each replaces the remote rows
+/// with a single explanatory line rather than an unexplained empty list.
+ResultRows buildResultRows({
+  required List<DatabaseGameModel> results,
+  bool remoteSectionVisible = false,
+  bool rommFilterable = true,
+  String? unmatchedFilter,
+  List<RommRom> visibleRemote = const [],
+  bool hasError = false,
+  bool isLoading = false,
+  bool hasMore = false,
+}) {
+  final rows = <ResultRow>[...results.map(LocalRow.new)];
+
+  if (remoteSectionVisible) {
+    rows.add(const RemoteHeaderRow());
+
+    if (!rommFilterable) {
+      // A rating filter is active and can't be evaluated remotely; say so
+      // instead of listing rows the filter never touched.
+      rows.add(const RemoteStatusRow(RemoteStatus.unsupported));
+    } else if (unmatchedFilter != null) {
+      rows.add(const RemoteStatusRow(RemoteStatus.noEquivalent));
+    } else {
+      rows.addAll(visibleRemote.map(RemoteRow.new));
+      if (hasError) {
+        rows.add(const RemoteStatusRow(RemoteStatus.error));
+      } else if (isLoading) {
+        rows.add(const RemoteStatusRow(RemoteStatus.loading));
+      } else if (hasMore) {
+        rows.add(const RemoteStatusRow(RemoteStatus.loadMore));
+      }
+    }
+  }
+
+  return ResultRows(
+    rows: rows,
+    focusable: [
+      for (var i = 0; i < rows.length; i++)
+        if (isFocusableRow(rows[i])) i,
+    ],
+  );
 }
 
 /// Cycles through [options] with an "Any" (null) slot at the head, moving by

--- a/lib/screens/search_screen/search_screen.dart
+++ b/lib/screens/search_screen/search_screen.dart
@@ -65,40 +65,6 @@ enum _FocusRegion { search, filters, results, filterMenu, action }
 /// as a local one.
 enum _ResultAction { goTo, play, download }
 
-/// One line in the results list.
-///
-/// Local games, the "On RomM" divider, remote ROMs and the remote section's
-/// loading / error / load-more line all share a single flat list so the
-/// existing index-based gamepad navigation and fixed-extent scroll maths keep
-/// working unchanged. Rows the user can't focus (the header, the spinner) are
-/// simply left out of the focusable index.
-sealed class _ResultRow {
-  const _ResultRow();
-}
-
-class _LocalRow extends _ResultRow {
-  const _LocalRow(this.game);
-  final DatabaseGameModel game;
-}
-
-class _RemoteHeaderRow extends _ResultRow {
-  const _RemoteHeaderRow();
-}
-
-class _RemoteRow extends _ResultRow {
-  const _RemoteRow(this.rom);
-  final RommRom rom;
-}
-
-/// The remote section's trailing line: a spinner, an error, "load more", or a
-/// note that the active filters can't be applied to RomM results.
-enum _RemoteStatus { loading, error, loadMore, unsupported, noEquivalent }
-
-class _RemoteStatusRow extends _ResultRow {
-  const _RemoteStatusRow(this.status);
-  final _RemoteStatus status;
-}
-
 class _SearchScreenState extends State<SearchScreen> {
   late GamepadNavigation _gamepadNav;
 
@@ -210,8 +176,10 @@ class _SearchScreenState extends State<SearchScreen> {
   final Map<int, bool> _remoteDownloaded = {};
 
   /// Rows as rendered, and the subset of their indices that can take focus.
-  List<_ResultRow> _rows = const [];
-  List<int> _focusable = const [];
+  ///
+  /// [_resultIndex] is a position in `_rowModel.focusable`, never in
+  /// `_rowModel.rows` — see [ResultRows].
+  ResultRows _rowModel = ResultRows.empty;
 
   // Resolved box-art path per ROM (null == no art); see [_resolveBoxArt].
   final Map<String, String?> _artCache = {};
@@ -348,56 +316,27 @@ class _SearchScreenState extends State<SearchScreen> {
     _searchIndex = _searchIndex.clamp(0, _lastSearchIndex);
   }
 
-  /// Rebuilds the flat row list from the local results plus the RomM section,
-  /// keeping the focused row index in range.
-  ///
-  /// The chip filters deliberately do not narrow the RomM section: [RommRom]
-  /// carries no developer, year or rating, so applying those criteria remotely
-  /// would silently drop everything. Remote results answer the text query only,
-  /// which is also all the server itself matches on.
+  /// Rebuilds the flat row list via [buildResultRows], keeping the focused row
+  /// index in range.
   void _rebuildRows() {
-    final rows = <_ResultRow>[..._results.map(_LocalRow.new)];
-
-    if (_remoteSectionVisible) {
-      rows.add(const _RemoteHeaderRow());
-
-      if (!_criteria.rommFilterable) {
-        // A rating filter is active and can't be evaluated remotely; say so
-        // instead of listing rows the filter never touched.
-        rows.add(const _RemoteStatusRow(_RemoteStatus.unsupported));
-      } else if (_remoteUnmatchedFilter != null) {
-        rows.add(const _RemoteStatusRow(_RemoteStatus.noEquivalent));
-      } else {
-        rows.addAll(_visibleRemote.map(_RemoteRow.new));
-        if (_remoteError != null) {
-          rows.add(const _RemoteStatusRow(_RemoteStatus.error));
-        } else if (_remoteLoading) {
-          rows.add(const _RemoteStatusRow(_RemoteStatus.loading));
-        } else if (_remoteHasMore) {
-          rows.add(const _RemoteStatusRow(_RemoteStatus.loadMore));
-        }
-      }
-    }
-
-    _rows = rows;
-    _focusable = [
-      for (var i = 0; i < rows.length; i++)
-        if (_isFocusableRow(rows[i])) i,
-    ];
+    _rowModel = buildResultRows(
+      results: _results,
+      remoteSectionVisible: _remoteSectionVisible,
+      rommFilterable: _criteria.rommFilterable,
+      unmatchedFilter: _remoteUnmatchedFilter,
+      visibleRemote: _visibleRemote,
+      hasError: _remoteError != null,
+      isLoading: _remoteLoading,
+      hasMore: _remoteHasMore,
+    );
 
     if (_resultIndex >= _focusable.length) {
       _resultIndex = _focusable.isEmpty ? 0 : _focusable.length - 1;
     }
   }
 
-  /// Headers and the spinner are skipped by Up/Down; everything else stops.
-  bool _isFocusableRow(_ResultRow row) => switch (row) {
-    _LocalRow() => true,
-    _RemoteRow() => true,
-    _RemoteStatusRow(:final status) =>
-      status == _RemoteStatus.loadMore || status == _RemoteStatus.error,
-    _RemoteHeaderRow() => false,
-  };
+  List<ResultRow> get _rows => _rowModel.rows;
+  List<int> get _focusable => _rowModel.focusable;
 
   /// Fetched RomM results that survive the filters RomM couldn't apply itself.
   ///
@@ -487,8 +426,7 @@ class _SearchScreenState extends State<SearchScreen> {
   }
 
   /// The row currently holding focus, or null when the list is empty.
-  _ResultRow? get _focusedRow =>
-      _resultIndex < _focusable.length ? _rows[_focusable[_resultIndex]] : null;
+  ResultRow? get _focusedRow => _rowModel.rowAtSelection(_resultIndex);
 
   // ── RomM search ───────────────────────────────────────────────────────────
 
@@ -916,10 +854,10 @@ class _SearchScreenState extends State<SearchScreen> {
     final row = _focusedRow;
     switch (row) {
       case null:
-      case _RemoteHeaderRow():
+      case RemoteHeaderRow():
         return;
 
-      case _LocalRow(:final game):
+      case LocalRow(:final game):
         setState(() {
           _actionTarget = game;
           _actionRemoteTarget = null;
@@ -929,16 +867,16 @@ class _SearchScreenState extends State<SearchScreen> {
         });
         SfxService().playNavSound();
 
-      case _RemoteStatusRow(:final status):
+      case RemoteStatusRow(:final status):
         // The error row doubles as a retry button.
-        if (status == _RemoteStatus.error) {
+        if (status == RemoteStatus.error) {
           _runRemoteSearch(reset: true);
-        } else if (status == _RemoteStatus.loadMore) {
+        } else if (status == RemoteStatus.loadMore) {
           _loadMoreRemote();
         }
         SfxService().playNavSound();
 
-      case _RemoteRow(:final rom):
+      case RemoteRow(:final rom):
         SfxService().playNavSound();
         final local = (_remoteDownloaded[rom.id] ?? false)
             ? await _localGameForRemote(rom)
@@ -1215,20 +1153,22 @@ class _SearchScreenState extends State<SearchScreen> {
     SfxService().playNavSound();
   }
 
-  /// Touch handler for a result row.
+  /// Touch handler for a result row, keyed by its index in [_rows].
   ///
   /// Follows the same two-step contract as the games list/grid: touch users
   /// have no A button, so the first tap only moves the selection onto the row
-  /// and a second tap on that same row confirms it — here opening the
-  /// Go-to-game / Play chooser, exactly as [_handleSelect] does.
-  void _handleResultTap(int index) {
+  /// and a second tap on that same row confirms it. The confirm hands off to
+  /// [_selectFocusedRow] rather than opening the chooser itself, so touch and
+  /// the A button always offer the same actions for a given row.
+  void _handleResultTap(int rowIndex) {
+    // Selection is tracked as an index into _focusable, not into _rows: the
+    // RomM header is rendered but not selectable, so the two diverge as soon
+    // as remote results are on screen.
+    final index = _rowModel.focusableIndexOfRow(rowIndex);
+    if (index < 0) return;
+
     if (_region == _FocusRegion.results && _resultIndex == index) {
-      SfxService().playEnterSound();
-      setState(() {
-        _actionTarget = _results[index];
-        _actionIndex = 0;
-        _region = _FocusRegion.action;
-      });
+      _selectFocusedRow();
       return;
     }
 
@@ -2063,10 +2003,10 @@ class _SearchScreenState extends State<SearchScreen> {
       itemExtent: _resultExtent.r,
       itemCount: _rows.length,
       itemBuilder: (context, index) => switch (_rows[index]) {
-        _LocalRow(:final game) => _buildResultTile(theme, game, index),
-        _RemoteHeaderRow() => _buildRemoteHeader(theme),
-        _RemoteRow(:final rom) => _buildRemoteTile(theme, rom, index),
-        _RemoteStatusRow(:final status) => _buildRemoteStatus(
+        LocalRow(:final game) => _buildResultTile(theme, game, index),
+        RemoteHeaderRow() => _buildRemoteHeader(theme),
+        RemoteRow(:final rom) => _buildRemoteTile(theme, rom, index),
+        RemoteStatusRow(:final status) => _buildRemoteStatus(
           theme,
           status,
           index,
@@ -2126,11 +2066,11 @@ class _SearchScreenState extends State<SearchScreen> {
   }
 
   /// The RomM section's trailing line: spinner, tappable error, or load-more.
-  Widget _buildRemoteStatus(ThemeData theme, _RemoteStatus status, int index) {
+  Widget _buildRemoteStatus(ThemeData theme, RemoteStatus status, int index) {
     final scheme = theme.colorScheme;
     final isFocused = _rowFocused(index);
 
-    if (status == _RemoteStatus.loading) {
+    if (status == RemoteStatus.loading) {
       return Center(
         child: SizedBox(
           width: 18.r,
@@ -2140,9 +2080,9 @@ class _SearchScreenState extends State<SearchScreen> {
       );
     }
 
-    if (status == _RemoteStatus.unsupported ||
-        status == _RemoteStatus.noEquivalent) {
-      final text = status == _RemoteStatus.unsupported
+    if (status == RemoteStatus.unsupported ||
+        status == RemoteStatus.noEquivalent) {
+      final text = status == RemoteStatus.unsupported
           ? AppLocale.searchRatingLocalOnly.getString(context)
           : AppLocale.searchNoRommEquivalent
                 .getString(context)
@@ -2172,7 +2112,7 @@ class _SearchScreenState extends State<SearchScreen> {
       );
     }
 
-    final isError = status == _RemoteStatus.error;
+    final isError = status == RemoteStatus.error;
     return GestureDetector(
       onTap: () => isError ? _runRemoteSearch(reset: true) : _loadMoreRemote(),
       child: Padding(
@@ -2238,63 +2178,67 @@ class _SearchScreenState extends State<SearchScreen> {
       if (rom.genre != null && rom.genre!.trim().isNotEmpty) rom.genre!.trim(),
     ];
 
-    return Padding(
-      padding: EdgeInsets.symmetric(vertical: 3.r),
-      child: Container(
-        padding: EdgeInsets.symmetric(horizontal: 10.r, vertical: 6.r),
-        decoration: BoxDecoration(
-          color: isFocused
-              ? scheme.primary.withValues(alpha: 0.18)
-              : scheme.surface.withValues(alpha: 0.5),
-          borderRadius: BorderRadius.circular(12.r),
-          border: Border.all(
-            color: isFocused ? scheme.primary : Colors.transparent,
-            width: 2.r,
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => _handleResultTap(index),
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: 3.r),
+        child: Container(
+          padding: EdgeInsets.symmetric(horizontal: 10.r, vertical: 6.r),
+          decoration: BoxDecoration(
+            color: isFocused
+                ? scheme.primary.withValues(alpha: 0.18)
+                : scheme.surface.withValues(alpha: 0.5),
+            borderRadius: BorderRadius.circular(12.r),
+            border: Border.all(
+              color: isFocused ? scheme.primary : Colors.transparent,
+              width: 2.r,
+            ),
           ),
-        ),
-        child: Row(
-          children: [
-            _buildRemoteCover(theme, rom),
-            SizedBox(width: 10.r),
-            Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    rom.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 13.r,
-                      fontWeight: FontWeight.w700,
-                      color: scheme.onSurface,
-                    ),
-                  ),
-                  if (subtitleParts.isNotEmpty)
+          child: Row(
+            children: [
+              _buildRemoteCover(theme, rom),
+              SizedBox(width: 10.r),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitleParts.join('  •  '),
+                      rom.name,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
-                        fontSize: 11.r,
-                        color: scheme.onSurface.withValues(alpha: 0.6),
+                        fontSize: 13.r,
+                        fontWeight: FontWeight.w700,
+                        color: scheme.onSurface,
                       ),
                     ),
-                ],
+                    if (subtitleParts.isNotEmpty)
+                      Text(
+                        subtitleParts.join('  •  '),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 11.r,
+                          color: scheme.onSurface.withValues(alpha: 0.6),
+                        ),
+                      ),
+                  ],
+                ),
               ),
-            ),
-            SizedBox(width: 8.r),
-            Icon(
-              downloaded
-                  ? Symbols.check_circle_rounded
-                  : Symbols.cloud_download_rounded,
-              size: 16.r,
-              color: downloaded
-                  ? scheme.primary
-                  : scheme.onSurface.withValues(alpha: 0.45),
-            ),
-          ],
+              SizedBox(width: 8.r),
+              Icon(
+                downloaded
+                    ? Symbols.check_circle_rounded
+                    : Symbols.cloud_download_rounded,
+                size: 16.r,
+                color: downloaded
+                    ? scheme.primary
+                    : scheme.onSurface.withValues(alpha: 0.45),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/test/search_result_rows_test.dart
+++ b/test/search_result_rows_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:neostation/models/database_game_model.dart';
+import 'package:neostation/models/romm_rom.dart';
+import 'package:neostation/screens/search_screen/search_filter.dart';
+
+/// Builds a minimal local result; only the identity matters to the row model.
+DatabaseGameModel game(String filename) =>
+    DatabaseGameModel(filename: filename, romPath: '/roms/$filename');
+
+/// Builds a minimal RomM result; only the identity matters to the row model.
+RommRom rom(int id, String name) => RommRom(
+  id: id,
+  name: name,
+  platformId: 1,
+  platformSlug: 'snes',
+  fsName: '$name.zip',
+  fsNameNoExt: name,
+  fsExtension: 'zip',
+);
+
+void main() {
+  group('buildResultRows local-only', () {
+    test('every local result is focusable, in order', () {
+      final built = buildResultRows(
+        results: [game('a.sfc'), game('b.sfc'), game('c.sfc')],
+      );
+
+      expect(built.rows, hasLength(3));
+      expect(built.rows.every((r) => r is LocalRow), isTrue);
+      expect(
+        built.focusable,
+        [0, 1, 2],
+        reason: 'with no RomM section the two index spaces coincide',
+      );
+    });
+
+    test('an empty library produces no rows and nothing focusable', () {
+      final built = buildResultRows(results: []);
+
+      expect(built.rows, isEmpty);
+      expect(built.focusable, isEmpty);
+      expect(built.rowAtSelection(0), isNull);
+    });
+  });
+
+  group('buildResultRows with a RomM section', () {
+    ResultRows withRemote({bool hasMore = false, bool isLoading = false}) =>
+        buildResultRows(
+          results: [game('a.sfc'), game('b.sfc')],
+          remoteSectionVisible: true,
+          visibleRemote: [rom(1, 'Remote One'), rom(2, 'Remote Two')],
+          hasMore: hasMore,
+          isLoading: isLoading,
+        );
+
+    test('the header is rendered but never focusable', () {
+      final built = withRemote();
+
+      expect(built.rows[2], isA<RemoteHeaderRow>());
+      expect(
+        built.focusable,
+        [0, 1, 3, 4],
+        reason: 'row 2 is the header and has to be skipped by Up/Down',
+      );
+    });
+
+    test('selection indices resolve past the header to the right row', () {
+      final built = withRemote();
+
+      // Selection 2 is the *third focusable* row, which is the first remote
+      // ROM at row index 3 — not row 2, which is the header.
+      expect((built.rowAtSelection(2)! as RemoteRow).rom.name, 'Remote One');
+      expect((built.rowAtSelection(3)! as RemoteRow).rom.name, 'Remote Two');
+      expect((built.rowAtSelection(0)! as LocalRow).game.filename, 'a.sfc');
+    });
+
+    test('a row index maps back to its selection index across the header', () {
+      final built = withRemote();
+
+      expect(built.focusableIndexOfRow(0), 0);
+      expect(built.focusableIndexOfRow(1), 1);
+      expect(
+        built.focusableIndexOfRow(3),
+        2,
+        reason: 'the first remote ROM renders at row 3 but selects at 2',
+      );
+      expect(built.focusableIndexOfRow(4), 3);
+    });
+
+    test('the header reports no selection index rather than a neighbour', () {
+      expect(
+        withRemote().focusableIndexOfRow(2),
+        -1,
+        reason: 'tapping the header must be a no-op, not select around it',
+      );
+    });
+
+    test('round-tripping every focusable row returns that same row', () {
+      final built = withRemote(hasMore: true);
+
+      for (final rowIndex in built.focusable) {
+        final selection = built.focusableIndexOfRow(rowIndex);
+        expect(built.rowAtSelection(selection), same(built.rows[rowIndex]));
+      }
+    });
+
+    test('load-more is focusable, the spinner is not', () {
+      final loadMore = withRemote(hasMore: true);
+      expect(loadMore.rows.last, isA<RemoteStatusRow>());
+      expect(
+        loadMore.focusable.last,
+        loadMore.rows.length - 1,
+        reason: 'load-more doubles as a button',
+      );
+
+      final loading = withRemote(isLoading: true);
+      expect(
+        loading.focusable,
+        isNot(contains(loading.rows.length - 1)),
+        reason: 'the spinner is not something the user can select',
+      );
+    });
+
+    test('the error row is focusable so it can double as retry', () {
+      final built = buildResultRows(
+        results: [],
+        remoteSectionVisible: true,
+        hasError: true,
+      );
+
+      expect(built.rows, hasLength(2));
+      expect(built.focusable, [1], reason: 'header out, error row in');
+    });
+  });
+
+  group('buildResultRows remote explanations', () {
+    test('an unfilterable rating replaces the remote rows with a note', () {
+      final built = buildResultRows(
+        results: [game('a.sfc')],
+        remoteSectionVisible: true,
+        rommFilterable: false,
+        visibleRemote: [rom(1, 'Remote One')],
+        hasMore: true,
+      );
+
+      expect(built.rows, hasLength(3));
+      expect(
+        (built.rows[2] as RemoteStatusRow).status,
+        RemoteStatus.unsupported,
+      );
+      expect(
+        built.focusable,
+        [0],
+        reason: 'the note is not selectable, and it suppresses load-more',
+      );
+    });
+
+    test('a filter RomM has no vocabulary for replaces the remote rows', () {
+      final built = buildResultRows(
+        results: [game('a.sfc')],
+        remoteSectionVisible: true,
+        unmatchedFilter: 'Role-Playing',
+        visibleRemote: [rom(1, 'Remote One')],
+      );
+
+      expect(built.rows, hasLength(3));
+      expect(
+        (built.rows[2] as RemoteStatusRow).status,
+        RemoteStatus.noEquivalent,
+      );
+      expect(built.focusable, [0]);
+    });
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with [Claude Code](https://claude.com/claude-code). All changes were reviewed and tested by me before submission. Commits carry an `AI-Assisted:` trailer.

# Description

Tapping a search result twice opens the chooser overlay with the game's title and nothing under it: no **Go to game**, no **Play**, no way out but the backdrop. The A button is unaffected, so the screen only looks broken to touch users.

Two code paths open that chooser. #287 added the touch one, `_handleResultTap`, at a time when the overlay rendered a file-level `static const _resultActions = [goTo, play]` — setting `_actionTarget` was all a caller had to do. #95 then made the action set per row, because a RomM result that isn't downloaded yet has to offer **Download** instead of Play. It did that by replacing the const with a mutable `_actionOptions` and populating it in `_selectFocusedRow`, the gamepad path. The touch path was left setting the old two fields, so it opens the overlay over an `_actionOptions` that is still `const []`, and the overlay's `for (var i = 0; i < _actionOptions.length; i++)` renders nothing.

The fix routes the touch confirm through `_selectFocusedRow` rather than reproducing what it does. Both entry points now resolve a row's actions in one place and cannot drift apart again — which is the actual regression here, not the missing list. The confirm plays the nav sound that path already emits rather than the enter sound, matching what the A button does on the same row.

## Two index bugs behind that one

`_handleResultTap` is called from the list builder with an index into `_rows`, but compared it against `_resultIndex`, assigned it there, and read `_results[index]`. All three are the *focusable* index space, which excludes the unfocusable "On RomM" header.

The two spaces coincide while the results are local-only, which is why this survived review and a device check: it only misfires once a RomM section is on screen, and then it selects or launches the row above the one under the user's finger. Tapping now translates through `_focusable` first, and a tap on a non-focusable row is a no-op instead of selecting around it.

RomM rows also had no `onTap` at all, so they were gamepad-only. They are wired to the same handler now: a downloaded ROM offers Go to game / Play like any local result, one that isn't offers Download.

## Extracting the row model to get it under test

The row model was private state on the `State` class, so none of the above was reachable from a test, and a `SearchScreen` widget test would be mock scaffolding rather than a test — the screen pulls `SqliteService`, `RommProvider`, `FileProvider`, `SyncManager`, `SecondaryDisplayState` and the gamepad layer stack in `initState`.

So `_rebuildRows` moves to `search_filter.dart`, next to the pure filter logic it belongs with, as `buildResultRows`. It returns a `ResultRows` that owns both lists and the two translations between them (`focusableIndexOfRow`, `rowAtSelection`), with the invariant written down: the two index spaces coincide *only* while the results are local-only. The screen holds one `ResultRows` and reads `_rows` / `_focusable` off it, so the parallel lists can no longer be desynchronised or indexed into by hand.

No behaviour change in that move. `_visibleRemote` and `_remoteUnmatchedFilter` are now evaluated as arguments rather than lazily inside the branch; both are pure and cheap.

`test/search_result_rows_test.dart` (11 cases) covers what the screen got wrong: the header rendered but never focusable, selection indices resolving past it to the right row, the row → selection mapping across it, a tap on the header reporting no selection rather than a neighbour, and a round trip over every focusable row. Load-more and the error row stay focusable as buttons; the spinner does not.

Worth being straight about the limit: this pins the contract, not every way a caller can misuse it. It would not catch a future call site that ignores `focusableIndexOfRow` and indexes `_results` directly, which is exactly what the original bug did. What guards against that is the structural half — the raw parallel lists are no longer lying around to be confused.

## Steps to Reproduce

**Preconditions:** any install with a scanned library; the Search tab enabled.

1. Open the **Search** tab and type a term that returns local results.
2. Tap a result once — it becomes selected.
3. Tap the same row again.
4. The overlay appears with the game's title and no actions beneath it.

## Steps to Verify

**Preconditions:** an AYN Thor (or any touch device) with a scanned library; for steps 4–6, a connected RomM server.

1. Open the **Search** tab and type a term with local results.
2. Tap a result twice — the chooser offers **Go to game** and **Play**.
3. Both act on the row that was tapped; B / the backdrop dismisses.
4. Type a term that also returns RomM results, so the "On RomM" header and remote rows appear.
5. Tap a remote row *below* the header twice — the chooser targets that row, not the one above it, and offers **Download**.
6. Confirm Download; the ROM downloads.
7. On the gamepad, D-pad down through the list: the header is still skipped, and A opens the same chooser it did before.

## Tested on

- [x] Android — device: AYN Thor
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Verified on the Thor: a local result taps through to Go to game / Play, and with a RomM server connected, a remote row below the header offers Download for that row and the download runs. Download landing on the right ROM is the useful half — a remote row below the header is exactly the case the index bug broke.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1013, up from 1002)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — no new assets

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse — this PR closes the opposite gap: RomM rows were gamepad-only and are now tappable too
- [x] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()` — unchanged; `SearchScreen` already does
- [x] B cancels / goes back, including out of a focused text field — unchanged

**User-facing text** — no new strings; the chooser's labels (`searchGoToGame`, `play`, `download`) already exist in all 12 locales.

**The database**, **Android paths**, **`assets/systems/` or emulator launching** — not touched.

</details>

## Screenshots / video

Not captured — the visual change is the chooser overlay gaining the two buttons it was always meant to render. Happy to add a before/after if useful.
