### PR TITLE
fix(secondary): matte the letterbox bars behind preview media

### DIFF
--- a/lib/screens/secondary_screen/background_builders.dart
+++ b/lib/screens/secondary_screen/background_builders.dart
@@ -40,6 +40,40 @@ Widget buildDefaultBackground() {
   return const SizedBox.shrink();
 }
 
+/// How far the media matte blends the theme background towards black.
+const double _matteBlend = 0.88;
+
+/// Dark matte for letterboxed game media — the preview video and the
+/// contain-fitted screenshot — drawn above the app background and below the
+/// media itself.
+///
+/// Without it the bars around a 4:3 snap on this wide panel show the theme's
+/// background, so a light theme frames a dark, moving video in white: the eye
+/// adapts to the bright surround and the video reads as muddy. Blending the
+/// theme background most of the way to black keeps a hint of the user's theme
+/// rather than punching a black hole in the UI, and is a no-op for the dark and
+/// OLED themes that already sit near black.
+///
+/// A flat [ColoredBox] rather than a blurred copy of the frame: compositing
+/// over this panel's video layer is what stalled the main display's raster
+/// thread before, so the backdrop stays free of extra layers.
+///
+/// Fades on the same 256ms curve as the media it backs, so a screenshot giving
+/// way to the video stays a single crossfade.
+Widget buildMediaMatte(BuildContext context, {required bool visible}) {
+  return AnimatedOpacity(
+    opacity: visible ? 1.0 : 0.0,
+    duration: const Duration(milliseconds: 256),
+    child: ColoredBox(
+      color: Color.lerp(
+        Theme.of(context).scaffoldBackgroundColor,
+        Colors.black,
+        _matteBlend,
+      )!,
+    ),
+  );
+}
+
 /// Offset of the wheel logo's drop shadow on the secondary display.
 ///
 /// Derived from the main screen's treatment rather than picked by eye: it

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -667,6 +667,19 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     }
   }
 
+  /// Whether the game layer is currently showing letterboxed media, so the
+  /// bars around it need [buildMediaMatte] instead of the theme background.
+  ///
+  /// True for the preview video and for the contain-fitted screenshot (either
+  /// source: pushed bytes or a file path). Deliberately false for the
+  /// fanart/logo fallback — fanart is cover-fitted so it leaves no bars, and a
+  /// logo-only game is just a wheel centred on the app background, which the
+  /// matte would darken for no gain.
+  bool _showsLetterboxedMedia(SecondaryDisplayStateData value) =>
+      (_showVideo && _videoController != null) ||
+      value.gameImageBytes != null ||
+      value.gameScreenshot != null;
+
   @override
   void dispose() {
     // Shared singleton — detach our listener, never dispose the instance.
@@ -867,6 +880,13 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                               Stack(
                                 fit: StackFit.expand,
                                 children: [
+                                  // Backs the letterboxed media below, so the
+                                  // bars around a 4:3 snap aren't the theme's
+                                  // (possibly white) background.
+                                  buildMediaMatte(
+                                    context,
+                                    visible: _showsLetterboxedMedia(value),
+                                  ),
                                   AnimatedSwitcher(
                                     duration: const Duration(milliseconds: 256),
                                     transitionBuilder: (child, animation) =>


### PR DESCRIPTION
> [!NOTE]
> This PR was written with [Claude Code](https://claude.com/claude-code). Every change was reviewed and runtime-tested on hardware before opening.

# Description

On the secondary display the preview video and the game screenshot are contain-fitted, so media whose aspect does not match the bottom panel leaves bars on two sides: a 4:3 snap letterboxes top and bottom, a vertical arcade video pillarboxes left and right.

Those bars showed the base background layer, which resolves to the theme's `scaffoldBackgroundColor` (or the background colour the main engine pushed). With a light theme applied that meant the video played inside a white frame. On a handheld panel that is the worst case: the eye adapts to the bright surround and the video itself reads as muddy, and it is the highest-power thing the panel can display.

This adds a matte behind the letterboxed media, above the app background and below the media itself:

- It blends the theme background 88% towards black rather than using hard black, so a light theme keeps a trace of the user's colours instead of a black hole punched in the UI. Dark and OLED themes already sit near black, so nothing visibly changes for them.
- It covers the whole panel, not just the bars. A single dark field with the media centred reads as deliberate letterboxing; darkening only the bars would leave a light frame around a dark frame, which looks like a bug.
- It fades on the same 256ms curve as the media it backs, so a screenshot giving way to the video stays one crossfade.
- It is a flat `ColoredBox`, not a blurred cover-fit copy of the frame. The blurred backdrop is the prettier option, but compositing over this panel's video layer is exactly what stalled the main display's raster thread once before, and the blur would need a second decode or a live `BackdropFilter` on the weakest GPU in the app.

The fanart/logo fallback is deliberately excluded: fanart is cover-fitted so it leaves no bars, and a logo-only game is a wheel centred on the app background that the matte would only darken for no gain.

## Steps to Verify

**Preconditions:** a dual-screen Android handheld (AYN Thor), a light theme applied in Settings > Themes, and at least one game with a cached preview video and one with a screenshot but no video. Atari 2600 works well: `2005 MiniGame MultiCart` has a video, `32-in-1 Game Cartridge` has a screenshot only.

1. Apply a light theme and go to the systems grid.
2. Enter Atari 2600 and leave `2005 MiniGame MultiCart` selected. Wait for the preview video to start on the bottom screen.
3. Look at the bars above and below the video. Before this change they were the theme's background (white); now they are a dark matte.
4. Move the selection to `32-in-1 Game Cartridge`, which has no video. The contain-fitted screenshot gets the same matte.
5. Move to a game with fanart but no screenshot (`A Misterious Thief`). The fanart still fills the panel cover-fitted and is not darkened.
6. Switch to a dark or OLED theme and repeat step 2: no visible change.

## Tested on

- [x] Android — device: AYN Thor (dual screen, dev channel)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1002)
- [ ] Tests added or updated — the change is a paint-only layer on the secondary display, which is driven by a second Flutter engine and is not covered by widget tests
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — no new assets

## Screenshots / video

Captured from the Thor's bottom display with a light theme active (`screencap` on the physical display id), sampling the bar colour directly. The theme's background on that device is `(238,238,238)`, which is what the bars showed before this change; a capture of the letterboxed 4:3 case confirms it.

| Case | Bar colour after |
| --- | --- |
| 4:3 video, letterboxed (`2005 MiniGame MultiCart`, 640x480) | `(29,29,29)` matte |
| Portrait video, pillarboxed (`1941: Counter Attack`, 480x640) | `(29,29,29)` matte |
| Contain-fitted screenshot, no video (`32-in-1 Game Cartridge`) | `(29,29,29)` matte |
| Fanart + logo (`A Misterious Thief`) | unchanged, fanart still cover-fit |

`(29,29,29)` is exactly `(238,238,238)` blended 88% to black, so the matte is what is painting and it still carries the theme's tint rather than being hard black.
