### PR TITLE
fix(ra): match ROMs whose set is registered under another console

### DIFF
--- a/lib/repositories/retro_achievements_repository.dart
+++ b/lib/repositories/retro_achievements_repository.dart
@@ -93,9 +93,27 @@ class RetroAchievementsRepository {
 
   // ── Game ID lookups (for RA game matching) ────────────────────────────────
 
-  /// Resolves RA game_id by MD5 hash and console ID string.
-  static Future<int?> getGameIdByHash(String raHash, String raConsoleId) =>
-      SqliteService.getRetroAchievementsGameIdByHash(raHash, raConsoleId);
+  /// Resolves RA game_id by MD5 hash, preferring the ROM's own console.
+  ///
+  /// Falls back to a console-agnostic lookup when the scoped one finds
+  /// nothing. An MD5 is unique in practice, so restricting it to one console
+  /// buys no safety — it only loses matches whenever a ROM sits in a folder
+  /// whose RA console differs from the one its set is registered under: 32X
+  /// titles kept in a Mega Drive folder, a Game Boy set for a ROM filed under
+  /// Game Boy Color, an SG-1000 title in a Master System folder. Those are
+  /// correct matches for the exact dump, and the lazy per-game path already
+  /// accepted them, so the scoped-only lookup just made the two paths
+  /// disagree.
+  static Future<int?> getGameIdByHash(String raHash, String raConsoleId) async {
+    final scoped = await SqliteService.getRetroAchievementsGameIdByHash(
+      raHash,
+      raConsoleId,
+    );
+    if (scoped != null && scoped != 0) return scoped;
+
+    final anyConsole = await findGameIdByHash(raHash);
+    return (anyConsole == null || anyConsole == 0) ? null : anyConsole;
+  }
 
   // ── ROM RA-data update ─────────────────────────────────────────────────────
 

--- a/lib/utils/optimized_md5_utils.dart
+++ b/lib/utils/optimized_md5_utils.dart
@@ -221,11 +221,13 @@ class OptimizedMd5Utils {
     }
   }
 
-  /// Calculates the MD5 hash for NES/Famicom ROMs.
+  /// Calculates the MD5 hash for NES/Famicom and Famicom Disk System ROMs.
   ///
-  /// If the ROM includes an iNES header ("NES\x1a"), the first 16 bytes are
-  /// skipped before hashing to match RetroAchievements requirements.
-  /// Handles compressed (.zip, .7z) files by extracting them first.
+  /// If the ROM includes an iNES header ("NES\x1a") or an FDS header
+  /// ("FDS\x1a"), the first 16 bytes are skipped before hashing, which is what
+  /// rcheevos does and therefore what RetroAchievements' registered hashes are
+  /// computed over. Handles compressed (.zip, .7z) files by extracting them
+  /// first.
   static Future<String> calculateNesMd5(String filePath) async {
     try {
       if (!await fileExists(filePath)) {
@@ -266,12 +268,10 @@ class OptimizedMd5Utils {
         }
       }
 
-      // Check for iNES header ("NES\x1a").
-      if (romBytes.length >= 4 &&
-          romBytes[0] == 0x4E &&
-          romBytes[1] == 0x45 &&
-          romBytes[2] == 0x53 &&
-          romBytes[3] == 0x1A) {
+      // Check for an iNES ("NES\x1a") or FDS ("FDS\x1a") header. Both are
+      // 16 bytes and both are excluded from the hash RetroAchievements
+      // registers; a headered .fds hashed whole matches nothing.
+      if (_hasNesOrFdsHeader(romBytes)) {
         // Strip 16-byte header.
         return crypto.md5
             .convert(romBytes.length > 16 ? romBytes.sublist(16) : romBytes)
@@ -283,6 +283,18 @@ class OptimizedMd5Utils {
       _log.e('Error calculating NES MD5 for $filePath: $e');
       rethrow;
     }
+  }
+
+  /// Whether [bytes] starts with a 16-byte iNES or FDS header.
+  ///
+  /// Both magics share a layout — three ASCII letters then 0x1A — and both
+  /// precede 16 bytes that RetroAchievements excludes from the hash.
+  static bool _hasNesOrFdsHeader(List<int> bytes) {
+    if (bytes.length < 4 || bytes[3] != 0x1A) return false;
+    // "NES" or "FDS".
+    final isNes = bytes[0] == 0x4E && bytes[1] == 0x45 && bytes[2] == 0x53;
+    final isFds = bytes[0] == 0x46 && bytes[1] == 0x44 && bytes[2] == 0x53;
+    return isNes || isFds;
   }
 
   /// Calculates the MD5 hash for SNES/Super Famicom ROMs.

--- a/test/nes_fds_hash_test.dart
+++ b/test/nes_fds_hash_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/optimized_md5_utils.dart';
+
+/// RetroAchievements hashes NES and Famicom Disk System ROMs over the ROM data
+/// only, excluding the 16-byte iNES ("NES\x1a") or FDS ("FDS\x1a") header when
+/// one is present. A headered `.fds` hashed whole matches nothing in RA's
+/// database, which is why FDS libraries came up almost entirely unmatched.
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('nes_fds_hash_test');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) await tempDir.delete(recursive: true);
+  });
+
+  /// Disk/ROM payload that stays identical across the headered and headerless
+  /// cases, so the tests compare like with like.
+  final payload = List<int>.generate(4096, (i) => i % 256);
+  String md5Of(List<int> bytes) => crypto.md5.convert(bytes).toString();
+
+  Future<String> writeAndHash(String name, List<int> bytes) async {
+    final file = File('${tempDir.path}/$name');
+    await file.writeAsBytes(bytes);
+    return OptimizedMd5Utils.calculateNesMd5(file.path);
+  }
+
+  test('skips the 16-byte FDS header', () async {
+    final header = <int>[0x46, 0x44, 0x53, 0x1A, ...List.filled(12, 0)];
+
+    expect(
+      await writeAndHash('game.fds', [...header, ...payload]),
+      md5Of(payload),
+    );
+  });
+
+  test('skips the 16-byte iNES header', () async {
+    final header = <int>[0x4E, 0x45, 0x53, 0x1A, ...List.filled(12, 0)];
+
+    expect(
+      await writeAndHash('game.nes', [...header, ...payload]),
+      md5Of(payload),
+    );
+  });
+
+  test('hashes a headerless disk image whole', () async {
+    // Raw FDS disk images start with 0x01 0x2A 'N' 'I' and carry no header,
+    // so the whole file is the hash input.
+    final raw = <int>[0x01, 0x2A, 0x4E, 0x49, ...payload];
+
+    expect(await writeAndHash('raw.fds', raw), md5Of(raw));
+  });
+
+  test('does not strip a header from a lookalike magic', () async {
+    // Same three letters, no 0x1A terminator: not a header.
+    final notHeader = <int>[0x46, 0x44, 0x53, 0x20, ...payload];
+
+    expect(await writeAndHash('lookalike.fds', notHeader), md5Of(notHeader));
+  });
+}

--- a/test/retro_achievements_repository_test.dart
+++ b/test/retro_achievements_repository_test.dart
@@ -95,6 +95,58 @@ void main() {
       expect(result.first['id_ra'], 1234);
     });
 
+    group('getGameIdByHash', () {
+      test('resolves a hash registered under the ROM\'s own console', () async {
+        await db.execute(
+          "INSERT INTO app_ra_game_list (hash, game_id, console_id, console_name, title) "
+          "VALUES ('abc123', 500, 7, 'NES/Famicom', 'Mario')",
+        );
+
+        expect(
+          await RetroAchievementsRepository.getGameIdByHash('abc123', '7'),
+          500,
+        );
+      });
+
+      test('resolves a hash registered under a different console', () async {
+        // A 32X title kept in the Mega Drive folder: the set is registered
+        // under console 10, the system's ra_id is 1. The dump is still that
+        // game, so the scoped miss must fall through rather than give up.
+        await db.execute(
+          "INSERT INTO app_ra_game_list (hash, game_id, console_id, console_name, title) "
+          "VALUES ('32xhash', 600, 10, '32X', 'Knuckles'' Chaotix')",
+        );
+
+        expect(
+          await RetroAchievementsRepository.getGameIdByHash('32xhash', '1'),
+          600,
+        );
+      });
+
+      test('prefers the ROM\'s own console when both are registered', () async {
+        await db.execute(
+          "INSERT INTO app_ra_game_list (hash, game_id, console_id, console_name, title) "
+          "VALUES ('shared', 700, 10, '32X', 'Other')",
+        );
+        await db.execute(
+          "INSERT INTO app_ra_game_list (hash, game_id, console_id, console_name, title) "
+          "VALUES ('shared', 701, 1, 'Genesis/Mega Drive', 'Own console')",
+        );
+
+        expect(
+          await RetroAchievementsRepository.getGameIdByHash('shared', '1'),
+          701,
+        );
+      });
+
+      test('returns null when the hash is not registered at all', () async {
+        expect(
+          await RetroAchievementsRepository.getGameIdByHash('missing', '7'),
+          isNull,
+        );
+      });
+    });
+
     test('findRAHashByConsoleName returns hash and gameId', () async {
       await db.execute(
         "INSERT INTO app_ra_game_list (hash, game_id, console_name, title) VALUES ('deadbeef', 99, 'Nintendo Entertainment System', 'Mario')",


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Two matching bugs, found by hashing a 9,133-ROM library end to end and then auditing what was left unmatched.

**1. A ROM whose set is registered under a different RA console never matches.**

There are two hash lookups and they disagree. The lazy per-game path (`findGameIdByHash`) matches on the MD5 alone. Everything going through `getGameIdByHash` also requires `app_ra_game_list.console_id` to equal the system's `ra_id`. An MD5 is unique in practice, so that filter buys no safety — it only rejects correct matches when a ROM sits in a folder whose RA console differs from the one its set is registered under:

| case | count on the test library |
|---|---|
| Sega 32X titles kept in the `megadrive` folder (sets under console 10, folder `ra_id` 1) | 22 |
| ROMs filed under Game Boy Color whose sets RA registers under Game Boy (console 4 vs 6) | 4 |
| an SG-1000 title in the `mastersystem` folder (console 33 vs 11) | 1 |
| **total recovered** | **28** |

Every one is the exact dump RA registered — *Knuckles' Chaotix*, *Doom*, *Virtua Fighter*, *Kolibri*, *Star Wars Arcade* and the rest of the 32X line-up. Opening those games individually already matched them; only the bulk path refused, which is also what produced the `No game ID found in internal DB for RA hash: …` warnings in the log.

NeoStation does define a `32x` system with `ra_id 10`, but plenty of libraries keep 32X inside the Mega Drive folder (RetroArch's Genesis Plus GX and PicoDrive both load them from there), so this shouldn't depend on how someone files their ROMs.

`getGameIdByHash` now prefers the ROM's own console and falls back to a console-agnostic lookup, so the two paths agree.

**2. FDS images are hashed over the wrong bytes.**

`calculateNesMd5` strips a 16-byte header only on the iNES magic `NES\x1a`. Famicom Disk System images use `FDS\x1a` with the same 16-byte header, which rcheevos excludes — so RA's registered hashes are computed without it and a headered `.fds` hashed whole matches nothing. 13 of 15 sampled `.fds` files in the test library are headered.

Payoff is small by nature: RA publishes only 36 FDS sets and 62 hashes in total, and most FDS dumps in the wild aren't the ones registered. Correcting the header recovers 3 of the 15 sampled. It is still the right hash.

Related: #346.

## Steps to Verify

**Preconditions:** a library with 32X ROMs stored in the Mega Drive folder, and/or headered `.fds` files. Signed in to RetroAchievements.

1. Before this change, open a 32X game kept in `megadrive` (e.g. *Knuckles' Chaotix*) — achievements do not resolve during a library pass, and the log shows `No game ID found in internal DB for RA hash: …`.
2. With this change, run Settings → Tools → **Match RetroAchievements Games**.
3. The 32X titles now match their real sets, as do Game Boy sets for ROMs kept under GBC.
4. For FDS: a headered `.fds` (first four bytes `46 44 53 1A`) now hashes to the same value rcheevos produces, so titles RA has registered resolve.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: verified offline against real ROM data instead, which is stronger here than a UI pass. The 28 cross-console recoveries were identified by testing the already-computed `ra_hash` values of a fully-hashed 9,133-ROM library against the bundled snapshot; the FDS result was confirmed by hashing the actual `.fds` files both ways and looking each result up. Both fixes are covered by unit tests. Happy to run a device pass before merge if you'd prefer.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1,021)
- [x] Tests added or updated — cross-console lookup (4 cases, including that the ROM's own console still wins when both are registered) and NES/FDS header handling (4 cases, including a lookalike magic that must *not* be stripped)
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

## Note

Stacks naturally with #363 (snapshot refresh, +62 games) and #361 (library-wide matching + manual override). The three are independent; this one needs neither of the others.
