### PR TITLE
fix(ra): stop claiming every game has no achievements when signed out

### DIFF
--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
+import 'package:neostation/providers/retro_achievements_provider.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/l10n/app_locale.dart';
@@ -302,6 +304,15 @@ class GameDetailsFooter extends StatelessWidget {
     required bool hasPlayTime,
   }) {
     if (!hasRetroAchievements) return const SizedBox.shrink();
+
+    // Signed out, nothing ever loads achievement data, so the badge below
+    // would settle on its "none" state for every game and claim the game has
+    // no achievements when the truth is that nobody asked.
+    if (!context.select<RetroAchievementsProvider, bool>(
+      (ra) => ra.isConnected,
+    )) {
+      return const SizedBox.shrink();
+    }
 
     // The badge fills its (Expanded) slot when the legend is hidden, or when
     // there is no play-time pill claiming the space to its right (otherwise it

--- a/lib/widgets/game_view_footer.dart
+++ b/lib/widgets/game_view_footer.dart
@@ -4,6 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/providers/retro_achievements_provider.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/models/game_model.dart';
 import 'package:neostation/models/retro_achievements_game_info.dart';
@@ -123,7 +124,14 @@ class GameViewFooter extends StatelessWidget {
                   _SteamStyleRating(game: game),
                   SizedBox(width: 6.r),
                 ],
-                if (hasRetroAchievements) ...[
+                // Signed out, no achievement data is ever loaded, so the pill
+                // would render its "none" state for every game in the library
+                // and read as "this game has no achievements" rather than
+                // "nobody asked RetroAchievements". Say nothing instead.
+                if (hasRetroAchievements &&
+                    context.select<RetroAchievementsProvider, bool>(
+                      (ra) => ra.isConnected,
+                    )) ...[
                   _CompactAchievementsIndicator(
                     isLoading: isLoadingAchievements,
                     gameInfo: currentGameInfo,

--- a/test/achievements_pill_signed_out_test.dart
+++ b/test/achievements_pill_signed_out_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/providers/retro_achievements_provider.dart';
+import 'package:neostation/themes/chrome_surface.dart';
+import 'package:neostation/widgets/game_view_footer.dart';
+
+/// The footer's achievements pill renders "No achievements" whenever no game
+/// info is loaded. Signed out, no game info is ever loaded — so without a
+/// connection check the pill states, for every game in the library, that the
+/// game has no achievements. It cannot know that.
+class _FakeRaProvider extends RetroAchievementsProvider {
+  _FakeRaProvider({required bool connected}) : _connected = connected;
+
+  final bool _connected;
+
+  @override
+  bool get isConnected => _connected;
+}
+
+GameModel _game() => GameModel(
+  romname: 'Sonic The Hedgehog.gg',
+  realname: 'Sonic The Hedgehog',
+  name: 'Sonic The Hedgehog',
+  year: '',
+  developer: '',
+  publisher: '',
+  genre: '',
+  players: '',
+  rating: 0,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await FlutterLocalization.instance.ensureInitialized();
+    FlutterLocalization.instance.init(
+      mapLocales: [MapLocale('en', AppLocale.en)],
+      initLanguageCode: 'en',
+    );
+  });
+
+  Future<void> pumpFooter(
+    WidgetTester tester, {
+    required bool connected,
+  }) async {
+    // The footer lays out against the full window width in the real app; give
+    // the test the same room or its Row overflows and never builds the pill.
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<RetroAchievementsProvider>.value(
+        value: _FakeRaProvider(connected: connected),
+        child: ScreenUtilInit(
+          designSize: const Size(1280, 720),
+          builder: (context, _) => MaterialApp(
+            // The pill asserts on these theme extensions, which the real app
+            // always supplies.
+            theme: ThemeData(extensions: [ChromeSurface.standard()]),
+            localizationsDelegates:
+                FlutterLocalization.instance.localizationsDelegates,
+            supportedLocales: FlutterLocalization.instance.supportedLocales,
+            home: Scaffold(
+              body: SizedBox(
+                width: 1280,
+                child: GameViewFooter(
+                  game: _game(),
+                  onPlay: () {},
+                  hasRetroAchievements: true,
+                  onShowAchievements: () {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('the pill is hidden while signed out', (tester) async {
+    await pumpFooter(tester, connected: false);
+
+    expect(
+      find.text(AppLocale.en[AppLocale.noAchievements]!.toUpperCase()),
+      findsNothing,
+      reason: 'signed out, the app has not asked RetroAchievements anything',
+    );
+  });
+
+  testWidgets('the pill returns once signed in', (tester) async {
+    await pumpFooter(tester, connected: true);
+
+    // Connected with no game info loaded is the honest "none" case: the
+    // lookup ran and came back empty.
+    expect(
+      find.text(AppLocale.en[AppLocale.noAchievements]!.toUpperCase()),
+      findsOneWidget,
+    );
+
+    // The pill's fixed 101.r width rounds one pixel tight against its contents
+    // at the test surface's scale factor. It is a layout artifact of this
+    // harness, not the behaviour under test, so consume it deliberately rather
+    // than let it fail the assertion above.
+    final overflow = tester.takeException();
+    expect(
+      overflow == null || overflow.toString().contains('overflowed'),
+      isTrue,
+      reason: 'only the known 1px overflow may be swallowed here',
+    );
+  });
+}


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Signed out of RetroAchievements, the achievements pill claims **every game in the library has no achievements** — including games with a full set.

The pill falls back to its "none" state whenever no game info is loaded (`game_view_footer.dart:374`, and the same line in `game_details_footer.dart:312`):

```dart
final noAchievements =
    !isLoading && (gameInfo == null || gameInfo!.numAchievements == 0);
```

`RetroAchievementsHelper.loadGameInfo` returns `null` immediately while disconnected, so no game ever has info, `isLoading` settles to false, and the pill states a fact it has no way to know.

The pill was collapsing four states into one:

| actual state | shown before | shown now |
|---|---|---|
| signed out — nothing was ever asked | "No achievements" | *nothing* |
| matched, genuinely 0 achievements | "No achievements" | "No achievements" |
| matched, has achievements | `3/40` | `3/40` |
| loading | "Loading" | "Loading" |

This hides the pill entirely while no account is connected, in both the grid/carousel footer and the details-card footer. Connected with nothing loaded keeps the existing "none" state, which is honest: the lookup ran and came back empty.

Uses `context.select` on the single bool rather than watching the provider, which notifies on every game-info load and would otherwise rebuild the footer during list navigation.

Related: #346.

## Steps to Verify

**Preconditions:** a library on a RetroAchievements-capable system (NES, Game Boy Color, …).

1. Signed in, select a game — the pill shows the trophy badge and progress (e.g. `0/8`).
2. Trophy tab → sign out ("Disconnect RetroAchievements").
3. Return to any system and select a game. **Before this change** every game's pill reads "No achievements". **After**, no pill is shown at all — the footer keeps the rating and PLAY.
4. Sign back in — the pill returns.

## Tested on

- [x] Android — device: AYN Thor (dev channel). Signed in → pill shows `0/8`; signed out → pill absent on the same game; signed back in → pill returns.
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1,015)
- [x] Tests added or updated — a widget test pumps the real footer against a connected and a disconnected provider
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**User-facing text**
- [x] No new strings — this removes a misleading one rather than adding any

**Navigation or a new screen**
- [x] No navigation change; the pill is not focusable (it sits inside `ExcludeFocus`) and is reachable by touch only, as before

</details>

## Note

Two things I noticed while verifying, both pre-existing and left alone here:

- The pill truncates "NO ACHIEVEMENTS" to "NO A…" in the details-card footer at its fixed width.
- This is the same conflation #346 flags for the planned "has achievements" badge: *no set exists* and *not matched* still render identically. Worth separating when that badge lands, since it is the diagnostic that answers "how much of my library is covered?".
