### PR TITLE
fix(romm): load saves that RomM stored under a slot-tagged name

### DIFF
--- a/lib/models/romm_asset.dart
+++ b/lib/models/romm_asset.dart
@@ -24,8 +24,16 @@ class RommAsset {
   /// Emulator label the asset is associated with, if any.
   final String? emulator;
 
-  /// Save slot, for emulators that expose multiple slots.
-  final int? slot;
+  /// Sync slot the asset belongs to, when the uploading client sent one.
+  ///
+  /// A **name**, not a number: RomM declares `slot: str | None` and suggests a
+  /// stable label such as `autosave`. Saves are paired server-side on
+  /// `(rom_id, slot)`, and a slotted upload is renamed to
+  /// `<name> [YYYY-MM-DD_HH-MM-SS].<ext>` — `RomMSyncProvider.localNameForAsset`
+  /// undoes that when choosing where to write the file locally.
+  /// Null means an archival, manual upload (RomM excludes those from pairing).
+  /// States never carry a slot; `/api/states` has no such parameter.
+  final String? slot;
 
   /// Server-relative URL to fetch the raw bytes
   /// (`/api/raw/assets/{file_path}/{file_name}?timestamp=...`). This is the
@@ -62,7 +70,7 @@ class RommAsset {
       createdAt: _parseTimestamp(json['created_at']),
       updatedAt: _parseTimestamp(json['updated_at']),
       emulator: json['emulator']?.toString(),
-      slot: int.tryParse((json['slot'] ?? '').toString()),
+      slot: _nonEmpty(json['slot']),
       downloadPath: json['download_path']?.toString(),
       isState: isState,
     );
@@ -70,6 +78,15 @@ class RommAsset {
 
   /// Milliseconds-since-epoch of [updatedAt], or 0 when unknown.
   int get updatedAtMs => updatedAt?.millisecondsSinceEpoch ?? 0;
+
+  /// A trimmed string, or null when the field is absent or blank.
+  ///
+  /// `""` and `null` mean the same thing for a slot — no slot — and collapsing
+  /// them here keeps every caller from having to test for both.
+  static String? _nonEmpty(dynamic raw) {
+    final s = raw?.toString().trim() ?? '';
+    return s.isEmpty ? null : s;
+  }
 
   /// Parses a RomM ISO-8601 timestamp, treating an offset-less string as UTC.
   ///

--- a/lib/services/romm_service.dart
+++ b/lib/services/romm_service.dart
@@ -916,11 +916,15 @@ class RommService {
   }
 
   /// Uploads [file] as a save for [romId] (`POST /api/saves`, field `saveFile`).
+  ///
+  /// [slot] is a stable *name* (RomM's own example is `autosave`), not a number.
+  /// Passing one opts the save into RomM's `(rom_id, slot)` pairing — and into
+  /// server-side renaming, since RomM datetime-tags every slotted upload.
   Future<RommAsset> uploadSave(
     int romId,
     File file, {
     String? emulator,
-    int? slot,
+    String? slot,
     String? deviceId,
     bool overwrite = true,
   }) => _uploadAsset(
@@ -937,11 +941,14 @@ class RommService {
 
   /// Uploads [file] as a save state for [romId] (`POST /api/states`, field
   /// `stateFile`).
+  ///
+  /// [slot] is accepted for symmetry with [uploadSave] only — `/api/states` has
+  /// no slot parameter, so RomM ignores it and never tags a state's filename.
   Future<RommAsset> uploadState(
     int romId,
     File file, {
     String? emulator,
-    int? slot,
+    String? slot,
     String? deviceId,
     bool overwrite = true,
   }) => _uploadAsset(
@@ -1035,7 +1042,7 @@ class RommService {
     required int romId,
     required File file,
     String? emulator,
-    int? slot,
+    String? slot,
     String? deviceId,
     required bool overwrite,
     required bool isState,
@@ -1045,7 +1052,7 @@ class RommService {
       'overwrite': '$overwrite',
     };
     if (emulator != null && emulator.isNotEmpty) params['emulator'] = emulator;
-    if (slot != null) params['slot'] = '$slot';
+    if (slot != null && slot.isNotEmpty) params['slot'] = slot;
     if (deviceId != null && deviceId.isNotEmpty) params['device_id'] = deviceId;
     final uri = Uri.parse(
       '$_baseUrl$basePath',

--- a/lib/sync/providers/romm_provider.dart
+++ b/lib/sync/providers/romm_provider.dart
@@ -276,13 +276,20 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
         _svc.listSaves(romId: romId),
         _svc.listStates(romId: romId),
       ]);
-      remote = [...results[0], ...results[1]];
+      // Collapse a slot's version history before anything looks at the listing,
+      // so the pairing loop and the remote-only pass below agree on which asset
+      // represents each local file.
+      remote = latestPerLocalName([...results[0], ...results[1]]);
     } catch (e) {
       _log.e('RomM listSaves/listStates failed for ${game.romname}: $e');
       return GameSyncStatus.error;
     }
 
-    final matchedRemote = <int>{}; // asset ids already paired with a local file
+    // Assets already paired with a local file. Keyed by kind *and* id: the two
+    // endpoints number their rows independently, so a bare id would let a save
+    // mask a state that happens to share it.
+    final matchedRemote = <String>{};
+    String remoteKey(RommAsset a) => '${a.isState ? 's' : 'f'}:${a.id}';
     int uploaded = 0, downloaded = 0, coreMismatched = 0;
     bool anyLocal = localFiles.isNotEmpty;
     bool anyRemote = remote.isNotEmpty;
@@ -293,12 +300,14 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
       final baseName = path.basename(local.filePath);
       RommAsset? match;
       for (final a in remote) {
-        if (a.isState == isState && a.fileName == baseName) {
+        // The remote name is normalised, never the local one: a slotted asset
+        // is `Game [2026-07-24_01-20-16].srm` server-side and `Game.srm` here.
+        if (a.isState == isState && localNameForAsset(a) == baseName) {
           match = a;
           break;
         }
       }
-      if (match != null) matchedRemote.add(match.id);
+      if (match != null) matchedRemote.add(remoteKey(match));
 
       final localMs = local.lastModified.millisecondsSinceEpoch;
       final recorded = await SyncRepository.getSyncState(
@@ -372,7 +381,7 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
     // 2) Remote-only files → download.
     for (final a in remote) {
       if (statusOnly || uploadOnly) break;
-      if (matchedRemote.contains(a.id)) continue;
+      if (matchedRemote.contains(remoteKey(a))) continue;
       final r = await _download(
         game,
         a,
@@ -500,6 +509,74 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
     return RegExp(r'^\.[A-Za-z0-9]{1,5}$').hasMatch(ext)
         ? romname.substring(0, dot)
         : romname;
+  }
+
+  /// RomM's server-applied version tag, copied verbatim from its own
+  /// `DATETIME_TAG_PATTERN` (`backend/endpoints/saves.py`, RomM 5.1.0).
+  static final RegExp _datetimeTag = RegExp(
+    r' \[\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\]',
+  );
+
+  /// The local filename [asset] belongs under, with RomM's datetime tag removed.
+  ///
+  /// RomM renames every save uploaded with a `slot` to
+  /// `<name> [YYYY-MM-DD_HH-MM-SS].<ext>`: the tag is how it versions a slot, so
+  /// filenames are deliberately *not* the identity server-side. Locally they are
+  /// the whole identity — RetroArch loads `<rom>.srm` and nothing else — so
+  /// writing the tagged name produces a file the emulator ignores and this
+  /// provider then refuses to sync ([syncableSaves] rejects exactly those names).
+  /// Left unfixed, the emulator boots a fresh save and the post-close hook
+  /// uploads that blank file as the copy every device syncs from.
+  ///
+  /// Two rules, both deliberate:
+  ///
+  /// * **Strip the datetime pattern, never RomM's `file_name_no_tags`.** That
+  ///   field looks like the built-in answer but strips *every* trailing bracket
+  ///   group, so `Pokemon - Pisces [Hack] [2026-07-24_01-20-16].srm` comes back
+  ///   as `Pokemon - Pisces` — losing a `[Hack]` suffix that is a permanent part
+  ///   of the name RetroArch expects. Replacing the pattern is also what the
+  ///   server itself does before re-tagging.
+  /// * **Saves only.** `/api/states` has no slot parameter and never tags, so a
+  ///   bracketed timestamp in a state's name is the name, not a version tag.
+  @visibleForTesting
+  static String localNameForAsset(RommAsset asset) => asset.isState
+      ? asset.fileName
+      : asset.fileName.replaceAll(_datetimeTag, '');
+
+  /// Collapses a remote listing to one asset per local filename, newest first.
+  ///
+  /// A slot accrues a row per upload, so a server can hold dozens of versions of
+  /// one save — all of which normalise to the same local name. Without this the
+  /// provider downloads every one of them in turn, each overwriting the last,
+  /// and the file left on disk is whichever happened to be listed last.
+  ///
+  /// Newest by `updated_at` wins, ties broken by the higher (later) asset id.
+  /// Saves and states are kept apart, matching how they are paired.
+  ///
+  /// Note what this does to a server holding *both* an old untagged NeoStation
+  /// asset and a newer slotted lineage: they collapse together, the newer one
+  /// wins, and the untagged asset is simply never matched again. That is the
+  /// intended migration — it stays put as a backup. If the untagged asset is
+  /// instead the newer one, it keeps winning until another client writes to the
+  /// slot. Pairing always follows the newest asset, so the *bytes* converge even
+  /// while the row being updated alternates between the two lineages.
+  @visibleForTesting
+  static List<RommAsset> latestPerLocalName(List<RommAsset> remote) {
+    final best = <String, RommAsset>{};
+    for (final a in remote) {
+      final key = '${a.isState ? 's' : 'f'}:${localNameForAsset(a)}';
+      final current = best[key];
+      if (current == null ||
+          a.updatedAtMs > current.updatedAtMs ||
+          (a.updatedAtMs == current.updatedAtMs && a.id > current.id)) {
+        best[key] = a;
+      }
+    }
+    // Preserve the server's ordering for the survivors; only duplicates go.
+    // Identity, not id: `/api/saves` and `/api/states` number their rows
+    // independently, so a save and a state can share an id.
+    final kept = Set<RommAsset>.identity()..addAll(best.values);
+    return remote.where(kept.contains).toList();
   }
 
   String _subfolderOf(LocalSaveFile local) {
@@ -631,11 +708,16 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
       // Placement comes from this device's own RetroArch layout, never from the
       // asset's `emulator` field — that value belongs to whichever device
       // created the asset and says nothing about where this one reads saves.
+      //
+      // The *name* comes from [localNameForAsset], not the asset: RomM's
+      // datetime tag is server-side versioning, and a file written under it is
+      // one the emulator will never load.
       final prefix = asset.isState ? 'states' : 'saves';
       final sub = await _localSubfolder(game, asset.isState, localFiles);
+      final localName = localNameForAsset(asset);
       final relativeName = sub.isNotEmpty
-          ? '$prefix/$sub/${asset.fileName}'
-          : '$prefix/${asset.fileName}';
+          ? '$prefix/$sub/$localName'
+          : '$prefix/$localName';
       final targets = await _resolveTargets(game, relativeName);
       if (targets.isEmpty) {
         _log.w('RomM download: no local target for ${asset.fileName}');

--- a/test/romm_models_test.dart
+++ b/test/romm_models_test.dart
@@ -247,7 +247,7 @@ void main() {
         'created_at': '2026-01-01T00:00:00.000Z',
         'updated_at': '2026-02-02T12:00:00.000Z',
         'emulator': 'snes9x',
-        'slot': 2,
+        'slot': 'autosave',
         'download_path': '/api/raw/assets/x/Game.srm',
       }, isState: false);
       expect(a.id, 10);
@@ -255,7 +255,10 @@ void main() {
       expect(a.fileSizeBytes, 8192);
       expect(a.contentHash, 'abc');
       expect(a.emulator, 'snes9x');
-      expect(a.slot, 2);
+      // A slot is a *name*, not a number: RomM declares `slot: str | None` and
+      // pairs saves on `(rom_id, slot)`. Parsing it as an int turned every
+      // named slot into null — indistinguishable from an archival upload.
+      expect(a.slot, 'autosave');
       expect(a.downloadPath, '/api/raw/assets/x/Game.srm');
       expect(a.isState, isFalse);
       expect(a.updatedAt, DateTime.parse('2026-02-02T12:00:00.000Z'));
@@ -278,11 +281,23 @@ void main() {
         'id': '11',
         'file_name': 'g.srm',
         'file_size_bytes': '256',
-        'slot': '3',
+        'slot': 3,
       }, isState: false);
       expect(a.id, 11);
       expect(a.fileSizeBytes, 256);
-      expect(a.slot, 3);
+      // A numerically-named slot is still a name.
+      expect(a.slot, '3');
+    });
+
+    test('reads a blank slot as no slot at all', () {
+      // '' and null both mean "archival, unpaired upload" to RomM; collapsing
+      // them here spares every caller from testing for both.
+      final a = RommAsset.fromJson({
+        'id': 12,
+        'file_name': 'g.srm',
+        'slot': '',
+      }, isState: false);
+      expect(a.slot, isNull);
     });
 
     test('parses an offset-less (naive) timestamp as UTC, not device-local', () {

--- a/test/romm_shared_memcard_test.dart
+++ b/test/romm_shared_memcard_test.dart
@@ -92,7 +92,7 @@ class _FakeRommService extends RommService {
     int romId,
     File file, {
     String? emulator,
-    int? slot,
+    String? slot,
     String? deviceId,
     bool overwrite = true,
   }) async {
@@ -106,7 +106,7 @@ class _FakeRommService extends RommService {
     int romId,
     File file, {
     String? emulator,
-    int? slot,
+    String? slot,
     String? deviceId,
     bool overwrite = true,
   }) async => throw UnimplementedError('no states in these tests');

--- a/test/romm_tagged_asset_sync_test.dart
+++ b/test/romm_tagged_asset_sync_test.dart
@@ -1,0 +1,365 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/models/neo_sync_models.dart';
+import 'package:neostation/models/romm_asset.dart';
+import 'package:neostation/providers/neo_sync_provider.dart';
+import 'package:neostation/providers/romm_provider.dart';
+import 'package:neostation/repositories/romm_save_map_repository.dart';
+import 'package:neostation/services/neosync/neo_sync_service.dart';
+import 'package:neostation/services/romm_service.dart';
+import 'package:neostation/sync/providers/romm_provider.dart';
+
+import 'database_test_helper.dart';
+
+/// End-to-end sync against a server that holds slot-tagged saves (issue #367).
+///
+/// RomM datetime-tags the filename of every save uploaded with a `slot`, so a
+/// server shared with any slot-using client serves `Game [2026-07-24_01-20-16].srm`
+/// where this device needs `Game.srm`. The failure that produced the issue was
+/// silent: the tagged file landed on disk, RetroArch ignored it and booted a
+/// fresh save, and the post-close hook then uploaded that blank save as the copy
+/// every device synced from. Every step reported success.
+///
+/// The unit rules live in `romm_tagged_asset_test.dart`; these tests drive the
+/// real `_syncGame` reconcile against an in-memory server to prove the three
+/// things a user actually experiences: the pulled file is loadable, only one
+/// version of it arrives, and writing back updates the existing asset instead of
+/// starting a second, untagged lineage beside it.
+
+/// In-memory RomM server, distinguishing creates (`POST`) from updates (`PUT`).
+class _FakeRommService extends RommService {
+  final Map<int, List<RommAsset>> savesByRom = {};
+  final Map<String, List<int>> contentByPath = {};
+
+  /// "romId/fileName" per created asset — a `POST`, i.e. a new lineage.
+  final List<String> creates = [];
+
+  /// Asset ids rewritten in place — a `PUT` into an existing row.
+  final List<int> updates = [];
+
+  /// Every asset fetch, in order: how many versions the sync pulled.
+  final List<String> downloads = [];
+
+  int _nextAssetId = 1;
+  int _stampSeq = 0;
+
+  DateTime _stamp() =>
+      DateTime.now().toUtc().add(Duration(seconds: ++_stampSeq));
+
+  /// Plants a server-side asset as if another client uploaded it.
+  RommAsset seedSave(
+    int romId,
+    String fileName,
+    List<int> bytes, {
+    required DateTime updatedAt,
+    String? slot,
+  }) {
+    final path = 'assets/$romId/${_nextAssetId}_$fileName';
+    final asset = RommAsset(
+      id: _nextAssetId++,
+      fileName: fileName,
+      fileSizeBytes: bytes.length,
+      isState: false,
+      updatedAt: updatedAt,
+      slot: slot,
+      downloadPath: path,
+    );
+    contentByPath[path] = List.of(bytes);
+    (savesByRom[romId] ??= []).add(asset);
+    return asset;
+  }
+
+  @override
+  bool get playtimeSyncAvailable => false;
+
+  @override
+  Future<List<RommAsset>> listSaves({required int romId}) async =>
+      List.of(savesByRom[romId] ?? const []);
+
+  @override
+  Future<List<RommAsset>> listStates({required int romId}) async => const [];
+
+  @override
+  Future<RommAsset> uploadSave(
+    int romId,
+    File file, {
+    String? emulator,
+    String? slot,
+    String? deviceId,
+    bool overwrite = true,
+  }) async {
+    final name = p.basename(file.path);
+    creates.add('$romId/$name');
+    return seedSave(romId, name, await file.readAsBytes(), updatedAt: _stamp());
+  }
+
+  @override
+  Future<RommAsset> uploadState(
+    int romId,
+    File file, {
+    String? emulator,
+    String? slot,
+    String? deviceId,
+    bool overwrite = true,
+  }) async => throw UnimplementedError('no states in these tests');
+
+  /// Mirrors `PUT /api/saves/{id}`: RomM writes the bytes to the row's own
+  /// `file_name` and ignores the uploaded one, so the asset keeps its tagged
+  /// name *and its slot* — which is what lets this device write into a slot's
+  /// lineage without ever sending a slot itself.
+  @override
+  Future<RommAsset> updateSave(int assetId, File file) async {
+    for (final entry in savesByRom.entries) {
+      final i = entry.value.indexWhere((a) => a.id == assetId);
+      if (i < 0) continue;
+      final old = entry.value[i];
+      final bytes = await file.readAsBytes();
+      updates.add(assetId);
+      contentByPath[old.downloadPath!] = List.of(bytes);
+      final updated = RommAsset(
+        id: old.id,
+        fileName: old.fileName,
+        fileSizeBytes: bytes.length,
+        isState: old.isState,
+        updatedAt: _stamp(),
+        slot: old.slot,
+        downloadPath: old.downloadPath,
+      );
+      entry.value[i] = updated;
+      return updated;
+    }
+    throw StateError('no asset with id $assetId');
+  }
+
+  @override
+  Future<RommAsset> updateState(int assetId, File file) async =>
+      throw UnimplementedError('no states in these tests');
+
+  @override
+  Future<Uint8List> downloadAssetByPath(String downloadPath) async {
+    downloads.add(downloadPath);
+    return Uint8List.fromList(contentByPath[downloadPath]!);
+  }
+
+  @override
+  Future<Uint8List> downloadSaveContent(int assetId) async =>
+      throw UnimplementedError('tests always provide download_path');
+}
+
+/// A connected browse provider backed by the fake service.
+class _FakeBrowse extends RommProvider {
+  final RommService fakeService;
+  bool connected = true;
+  _FakeBrowse(this.fakeService);
+
+  @override
+  bool get isConnected => connected;
+
+  @override
+  RommService get service => fakeService;
+}
+
+/// NeoSync path resolution over a temp save directory: [locate] reports what is
+/// really on disk (statted live, so mtime comparisons see the current file) and
+/// [resolveTargets] maps a `saves/<name>` relative path under the same root.
+/// The relative name the provider asks for is the assertion that matters here —
+/// it carries the filename the download decided on.
+class _TempSavePaths {
+  _TempSavePaths(this.root);
+
+  final String root;
+  final List<String> requestedNames = [];
+
+  Future<List<LocalSaveFile>> locate(GameModel game) async {
+    final dir = Directory(p.join(root, 'saves'));
+    if (!dir.existsSync()) return [];
+    return dir.listSync().whereType<File>().map((f) {
+      final stat = f.statSync();
+      return LocalSaveFile(
+        filePath: f.path,
+        fileName: p.basename(f.path),
+        fileSize: stat.size,
+        lastModified: stat.modified,
+        gameName: game.name,
+        isSynced: false,
+        relativePath: 'saves/${p.basename(f.path)}',
+      );
+    }).toList();
+  }
+
+  Future<List<String>> resolveTargets(
+    GameModel game,
+    String relativeName,
+  ) async {
+    requestedNames.add(relativeName);
+    return [p.join(root, relativeName)];
+  }
+}
+
+GameModel _game(String romname) => GameModel(
+  romname: romname,
+  realname: romname,
+  name: p.basenameWithoutExtension(romname),
+  year: '1996',
+  developer: '',
+  publisher: '',
+  genre: '',
+  players: '',
+  rating: 0,
+  romPath: '/roms/nes/$romname',
+  systemFolderName: 'nes',
+  cloudSyncEnabled: true,
+);
+
+void main() {
+  final helper = DatabaseTestHelper();
+  late Directory tempDir;
+  late _FakeRommService svc;
+  late _FakeBrowse browse;
+  late _TempSavePaths paths;
+  late RomMSyncProvider provider;
+
+  final game = _game('Game.nes');
+  const tagged = 'Game [2026-07-24_01-20-16].srm';
+
+  File localSave() => File(p.join(tempDir.path, 'saves', 'Game.srm'));
+
+  setUp(() async {
+    final db = await helper.setUp();
+    await db.execute(SqliteMigrations.createAppRommRomMapTableSql);
+    tempDir = await Directory.systemTemp.createTemp('romm_tagged_test');
+    await Directory(p.join(tempDir.path, 'saves')).create(recursive: true);
+
+    await RommSaveMapRepository.putMapping(
+      romname: 'Game.nes',
+      systemFolder: 'nes',
+      rommRomId: 1,
+    );
+
+    svc = _FakeRommService();
+    browse = _FakeBrowse(svc);
+    paths = _TempSavePaths(tempDir.path);
+    provider = RomMSyncProvider(
+      browse,
+      NeoSyncProvider(NeoSyncService()),
+      locateSaves: paths.locate,
+      resolveTargets: paths.resolveTargets,
+      autoSweep: false,
+    );
+  });
+
+  tearDown(() async {
+    await helper.tearDown();
+    await tempDir.delete(recursive: true);
+  });
+
+  test('a slot-tagged save lands under the name the emulator loads', () async {
+    svc.seedSave(
+      1,
+      tagged,
+      'REMOTE'.codeUnits,
+      updatedAt: DateTime.utc(2026, 7, 24),
+      slot: 'autosave',
+    );
+
+    await provider.syncGameSavesBeforeLaunch(game);
+
+    expect(await localSave().readAsString(), 'REMOTE');
+    expect(
+      File(p.join(tempDir.path, 'saves', tagged)).existsSync(),
+      isFalse,
+      reason: 'the tagged name is server-side versioning, not a local filename',
+    );
+    expect(paths.requestedNames, ['saves/Game.srm']);
+  });
+
+  test('the file written is one this provider will sync back', () async {
+    // The contradiction in the issue: `syncableSaves` rejects exactly the
+    // tagged names `_download` used to write, so the provider persisted files
+    // it could never recognise, compare or upload again.
+    svc.seedSave(
+      1,
+      tagged,
+      'REMOTE'.codeUnits,
+      updatedAt: DateTime.utc(2026, 7, 24),
+      slot: 'autosave',
+    );
+
+    await provider.syncGameSavesBeforeLaunch(game);
+
+    final located = await paths.locate(game);
+    expect(located, hasLength(1));
+    expect(RomMSyncProvider.syncableSaves(game, located), hasLength(1));
+  });
+
+  test('only the newest version of a slot is pulled', () async {
+    for (var hour = 1; hour <= 3; hour++) {
+      svc.seedSave(
+        1,
+        'Game [2026-07-24_0$hour-00-00].srm',
+        'VERSION-$hour'.codeUnits,
+        updatedAt: DateTime.utc(2026, 7, 24, hour),
+        slot: 'autosave',
+      );
+    }
+
+    await provider.syncGameSavesBeforeLaunch(game);
+
+    expect(svc.downloads, hasLength(1));
+    expect(await localSave().readAsString(), 'VERSION-3');
+  });
+
+  test('a changed local save updates the slot instead of starting a second '
+      'untagged lineage beside it', () async {
+    svc.seedSave(
+      1,
+      tagged,
+      'REMOTE'.codeUnits,
+      updatedAt: DateTime.utc(2026, 7, 24),
+      slot: 'autosave',
+    );
+    await localSave().writeAsString('LOCAL-PROGRESS');
+
+    await provider.syncGameSavesAfterClose(game);
+
+    expect(svc.updates, [1]);
+    expect(svc.creates, isEmpty);
+    expect(svc.savesByRom[1], hasLength(1));
+    // The row keeps its tagged name and its slot; only the bytes moved.
+    expect(svc.savesByRom[1]!.single.fileName, tagged);
+    expect(svc.savesByRom[1]!.single.slot, 'autosave');
+    expect(
+      String.fromCharCodes(svc.contentByPath.values.single),
+      'LOCAL-PROGRESS',
+    );
+  });
+
+  test('an old untagged asset beside a newer slot is left as a backup', () async {
+    // The migration case, end to end: both assets normalise to `Game.srm`, the
+    // newer slotted one wins the pairing, and the stale untagged row stays put.
+    svc.seedSave(
+      1,
+      'Game.srm',
+      'OLD-UNTAGGED'.codeUnits,
+      updatedAt: DateTime.utc(2026, 1, 1),
+    );
+    svc.seedSave(
+      1,
+      tagged,
+      'NEW-SLOTTED'.codeUnits,
+      updatedAt: DateTime.utc(2026, 7, 24),
+      slot: 'autosave',
+    );
+
+    await provider.syncGameSavesBeforeLaunch(game);
+
+    expect(svc.downloads, hasLength(1));
+    expect(await localSave().readAsString(), 'NEW-SLOTTED');
+    expect(svc.savesByRom[1], hasLength(2));
+  });
+}

--- a/test/romm_tagged_asset_test.dart
+++ b/test/romm_tagged_asset_test.dart
@@ -1,0 +1,208 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/romm_asset.dart';
+import 'package:neostation/sync/providers/romm_provider.dart';
+
+/// The two rules that let RomM's slot-based saves round-trip to a local disk.
+///
+/// RomM renames every save uploaded with a `slot` to
+/// `<name> [YYYY-MM-DD_HH-MM-SS].<ext>`: the tag is how a slot is versioned
+/// server-side, so one save accrues many rows and filenames are deliberately not
+/// the identity. Locally they are the *whole* identity — RetroArch loads
+/// `<rom>.srm` and nothing else — so a tagged file written to disk is inert, the
+/// game boots a fresh save, and the post-close hook uploads that blank file as
+/// the copy every device then syncs from. Every step reports success (issue
+/// #367; on the reporting instance 112 of 122 saves were server-tagged).
+///
+/// [RomMSyncProvider.localNameForAsset] undoes the tag, and
+/// [RomMSyncProvider.latestPerLocalName] collapses the version history a slot
+/// accrues down to the one row that represents the local file.
+void main() {
+  RommAsset asset(
+    String fileName, {
+    int id = 1,
+    bool isState = false,
+    DateTime? updatedAt,
+    String? slot,
+  }) => RommAsset(
+    id: id,
+    fileName: fileName,
+    fileSizeBytes: 1,
+    isState: isState,
+    updatedAt: updatedAt,
+    slot: slot,
+  );
+
+  group('localNameForAsset', () {
+    test('strips RomM\'s datetime tag from a slotted save', () {
+      expect(
+        RomMSyncProvider.localNameForAsset(
+          asset('Pokemon Red [2026-07-24_01-20-16].srm', slot: 'autosave'),
+        ),
+        'Pokemon Red.srm',
+      );
+    });
+
+    test('keeps a permanent bracket tag that is part of the name', () {
+      // The trap in RomM's own `file_name_no_tags`, whose TAG_GROUP_REGEX strips
+      // *every* trailing bracket group and would return "Pokemon - Pisces".
+      // `[Hack]` is part of the filename RetroArch expects.
+      expect(
+        RomMSyncProvider.localNameForAsset(
+          asset('Pokemon - Pisces [Hack] [2026-07-24_01-20-16].srm'),
+        ),
+        'Pokemon - Pisces [Hack].srm',
+      );
+    });
+
+    test('leaves an untagged save untouched', () {
+      expect(RomMSyncProvider.localNameForAsset(asset('Game.srm')), 'Game.srm');
+    });
+
+    test('strips a tag that is not followed by an extension', () {
+      expect(
+        RomMSyncProvider.localNameForAsset(asset('Game [2026-01-02_03-04-05]')),
+        'Game',
+      );
+    });
+
+    test('strips a tag sitting mid-name, before a trailing extension', () {
+      // RetroArch's auto-save-state names carry two extensions, so the tag RomM
+      // inserts before the last one lands in the middle of the string.
+      expect(
+        RomMSyncProvider.localNameForAsset(
+          asset('Game.state [2026-01-02_03-04-05].auto'),
+        ),
+        'Game.state.auto',
+      );
+    });
+
+    test('leaves a state untouched, brackets and all', () {
+      // `/api/states` has no slot parameter and never tags, so a bracketed
+      // timestamp in a state's name is the name, not a version tag.
+      expect(
+        RomMSyncProvider.localNameForAsset(
+          asset('Game [2026-07-24_01-20-16].state', isState: true),
+        ),
+        'Game [2026-07-24_01-20-16].state',
+      );
+    });
+
+    test('is a no-op on a near-miss that only looks like a tag', () {
+      expect(
+        RomMSyncProvider.localNameForAsset(asset('Game [2026-07-24].srm')),
+        'Game [2026-07-24].srm',
+      );
+    });
+  });
+
+  group('latestPerLocalName', () {
+    test('collapses a slot\'s version history to the newest row', () {
+      final kept = RomMSyncProvider.latestPerLocalName([
+        asset(
+          'Game [2026-07-24_01-00-00].srm',
+          id: 1,
+          updatedAt: DateTime.utc(2026, 7, 24, 1),
+        ),
+        asset(
+          'Game [2026-07-24_03-00-00].srm',
+          id: 3,
+          updatedAt: DateTime.utc(2026, 7, 24, 3),
+        ),
+        asset(
+          'Game [2026-07-24_02-00-00].srm',
+          id: 2,
+          updatedAt: DateTime.utc(2026, 7, 24, 2),
+        ),
+      ]);
+
+      expect(kept.map((a) => a.id), [3]);
+    });
+
+    test('collapses a tagged and an untagged asset together, newest wins', () {
+      // The migration case: an old untagged NeoStation upload sitting beside a
+      // newer slotted lineage. The untagged row stays on the server as a backup
+      // but is never paired against again.
+      final kept = RomMSyncProvider.latestPerLocalName([
+        asset('Game.srm', id: 1, updatedAt: DateTime.utc(2026, 1, 1)),
+        asset(
+          'Game [2026-07-24_01-20-16].srm',
+          id: 2,
+          updatedAt: DateTime.utc(2026, 7, 24),
+          slot: 'autosave',
+        ),
+      ]);
+
+      expect(kept.map((a) => a.id), [2]);
+    });
+
+    test('keeps the untagged asset when it is the newer one', () {
+      final kept = RomMSyncProvider.latestPerLocalName([
+        asset(
+          'Game [2026-07-24_01-20-16].srm',
+          id: 1,
+          updatedAt: DateTime.utc(2026, 7, 24),
+          slot: 'autosave',
+        ),
+        asset('Game.srm', id: 2, updatedAt: DateTime.utc(2026, 8, 1)),
+      ]);
+
+      expect(kept.map((a) => a.id), [2]);
+    });
+
+    test('never collapses a save into a state of the same name', () {
+      final kept = RomMSyncProvider.latestPerLocalName([
+        asset('Game.srm', id: 1, updatedAt: DateTime.utc(2026, 1, 1)),
+        asset(
+          'Game.srm',
+          id: 2,
+          isState: true,
+          updatedAt: DateTime.utc(2026, 2, 1),
+        ),
+      ]);
+
+      expect(kept.map((a) => a.id), [1, 2]);
+    });
+
+    test('breaks a timestamp tie on the later asset id', () {
+      final stamp = DateTime.utc(2026, 7, 24);
+      final kept = RomMSyncProvider.latestPerLocalName([
+        asset('Game [2026-07-24_01-20-16].srm', id: 7, updatedAt: stamp),
+        asset('Game [2026-07-24_01-20-17].srm', id: 9, updatedAt: stamp),
+      ]);
+
+      expect(kept.map((a) => a.id), [9]);
+    });
+
+    test('treats a missing timestamp as the oldest', () {
+      final kept = RomMSyncProvider.latestPerLocalName([
+        asset('Game [2026-07-24_01-20-16].srm', id: 4),
+        asset(
+          'Game [2026-07-24_01-20-17].srm',
+          id: 2,
+          updatedAt: DateTime.utc(2026, 7, 24),
+        ),
+      ]);
+
+      expect(kept.map((a) => a.id), [2]);
+    });
+
+    test('passes a listing with nothing to collapse through in order', () {
+      final kept = RomMSyncProvider.latestPerLocalName([
+        asset('GameA.srm', id: 1, updatedAt: DateTime.utc(2026, 1, 1)),
+        asset('GameB.srm', id: 2, updatedAt: DateTime.utc(2026, 1, 2)),
+        asset(
+          'GameA.state',
+          id: 3,
+          isState: true,
+          updatedAt: DateTime.utc(2026, 1, 3),
+        ),
+      ]);
+
+      expect(kept.map((a) => a.id), [1, 2, 3]);
+    });
+
+    test('an empty listing stays empty', () {
+      expect(RomMSyncProvider.latestPerLocalName([]), isEmpty);
+    });
+  });
+}

--- a/test/romm_upload_sweep_test.dart
+++ b/test/romm_upload_sweep_test.dart
@@ -94,7 +94,7 @@ class _FakeRommService extends RommService {
     int romId,
     File file, {
     String? emulator,
-    int? slot,
+    String? slot,
     String? deviceId,
     bool overwrite = true,
   }) async {
@@ -133,7 +133,7 @@ class _FakeRommService extends RommService {
     int romId,
     File file, {
     String? emulator,
-    int? slot,
+    String? slot,
     String? deviceId,
     bool overwrite = true,
   }) async => throw UnimplementedError('no states in these tests');


### PR DESCRIPTION
# Description

On a RomM instance that holds saves uploaded with a `slot`, NeoStation downloads them under a filename the emulator will never load, and then uploads the resulting blank save as the copy every device syncs from. Every step reports success; the only signal is one `[I]` log line.

RomM renames every slotted upload to `<name> [YYYY-MM-DD_HH-MM-SS].<ext>` (`backend/endpoints/saves.py`, `_apply_datetime_tag`). The tag is how a slot is versioned server-side, so a slot accrues many rows and **filenames are deliberately not the identity**. Locally they are the whole identity: RetroArch loads `<rom>.srm` and nothing else.

`RomMSyncProvider` paired and placed purely on exact filename equality, so:

1. `_download` wrote the tagged name to disk. The emulator ignored it, booted a fresh save, and the post-close hook pushed that blank save up.
2. The provider contradicted itself — `syncableSaves` rejects exactly the filenames `_download` had just written, so it persisted files it could never recognise, compare or upload.
3. Our own uploads never matched a tagged asset, so they started a **second, untagged lineage** beside the slot's: two sources of truth per game on any shared server.

On the reporting user's instance, 112 of 122 saves were server-tagged, so in practice every pre-existing save was unreachable.

## What this changes

**Normalise the tag when choosing the local name.** `localNameForAsset` strips RomM's own `DATETIME_TAG_PATTERN`, copied verbatim from the server.

Deliberately **not** `SaveSchema.file_name_no_tags`, which looks like the built-in answer but strips *every* trailing bracket group:

```
Pokemon - Pisces [Hack] [2026-07-24_01-20-16].srm
  file_name_no_tags   -> "Pokemon - Pisces"             <- loses [Hack]
  DATETIME_TAG strip  -> "Pokemon - Pisces [Hack].srm"  <- correct
```

Many ROM hacks and translations carry a permanent `[Hack]` / `[Translations]` suffix that is part of the filename RetroArch expects. Saves only: `/api/states` has no `slot` parameter and never tags, so a bracketed timestamp in a state's name *is* the name.

**Pair on the normalised name.** A local `Game.srm` now matches the slot's `Game [tag].srm`, so a write-back takes the existing `PUT /api/saves/{id}` path. RomM's `update_save` writes to the row's own `file_name` and ignores the uploaded one, so the asset keeps its name **and its slot** — NeoStation joins a slot's lineage without ever sending a slot, and no parallel untagged asset appears.

**Collapse a slot's version history first.** `latestPerLocalName` reduces the listing to one asset per local filename (newest `updated_at`, ties on the later id) before anything looks at it, so a save with 12 historical versions downloads once instead of 12 times, each overwriting the last.

Migration is a no-op: an old untagged asset and a newer slotted lineage collapse together, the newer wins, and the stale row stays on the server as a backup.

Two latent bugs found on the way past and fixed here:

- `RommAsset.slot` was parsed with `int.tryParse` while RomM declares `slot: str | None`, so a slot named `autosave` read as `null` — indistinguishable from a genuinely archival upload. Retyped to `String?` through `RommService.uploadSave`/`uploadState` (no caller passes it yet, so this is a pure retype).
- The paired-asset set was keyed on a bare asset id, but `/api/saves` and `/api/states` number their rows independently, so a save could mask a state sharing its id.

Not adopted, after checking the API surface in #368: slot *uploads* and `POST /api/sync/negotiate`. Normalised pairing already delivers the interop; RomM's own web frontend does not send a slot either (`frontend/src/services/api/save.ts`); states can never carry a slot; and `negotiate` is whole-library and saves-only, which fits badly with a per-game, launch-blocking sync hook. Rationale is written up on #368.

Verified against RomM 5.1.0.

Closes #367

## Steps to Reproduce

**Preconditions:** a RomM instance holding at least one save uploaded with a `slot` (RomM's Decky plugin, the EmulatorJS web player, or `POST /api/saves?rom_id=<id>&slot=autosave`), a ROM downloaded through NeoStation from that instance, RomM selected as the save provider, and cloud sync enabled for the game.

1. Confirm via `GET /api/saves?rom_id=<id>` that the asset's `file_name` is datetime-tagged, e.g. `RoboCop 2 [2026-08-16_21-58-24].srm`.
2. Launch the game from NeoStation.
3. **Before:** the file lands in the RetroArch save folder under the tagged name, the emulator boots a fresh save, and quitting uploads that blank save.
   **After:** the file lands as `RoboCop 2.srm`, the emulator loads it, and quitting updates the existing tagged asset in place — no second asset is created.

## Steps to Verify

**Preconditions:** as above.

1. Seed a tagged save: `curl -X POST "$ROMM/api/saves?rom_id=<id>&slot=autosave&emulator=fceumm" -H "Authorization: Bearer $TOKEN" -F "saveFile=@Game.srm"`. The response's `file_name` comes back tagged.
2. Launch the game in NeoStation and check the RetroArch save folder: the file must be there under the **untagged** name, and no tagged file may exist.
3. Play briefly, quit, and re-check the server: the tagged asset's `updated_at`/`content_hash` changed, its `slot` is unchanged, and the save count for that ROM did not grow.
4. Seed two more versions into the same slot and relaunch: exactly one download occurs, of the newest.

Run on an AYN Thor against RomM 5.1.0, with a tagged save seeded for a RomM-linked NES ROM (`RoboCop 2`, `fceumm`, slot `autosave`):

| Step | Before | After |
|---|---|---|
| Pre-launch pull | wrote `RoboCop 2 [2026-08-16_21-58-24].srm` — RetroArch boots a fresh save | wrote `RoboCop 2.srm` with the server's exact bytes |
| Post-close pass | `1 local` never included the pulled file | `0 up, 0 down (1 local, 1 remote)` — the file is now paired |
| Local save changed, then quit | new untagged asset created beside the slot | `1 up`; server still holds **one** asset, same id, same tagged name, `slot=autosave` kept, new `updated_at` + `content_hash` |
| Three versions in the slot | 3 downloads, three tagged files, none loadable | `1 remote`, `1 down`, local file holds the newest version |

## Tested on

- [x] Android — device: AYN Thor
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

Tests: `test/romm_tagged_asset_test.dart` covers the two rules directly (the `[Hack]` trap, the mid-name tag, states left alone, version collapse, the untagged/tagged migration case, tie-breaks). `test/romm_tagged_asset_sync_test.dart` drives the real `_syncGame` reconcile against an in-memory server: the pulled file is one `syncableSaves` accepts, only the newest version arrives, and a changed local save updates the slot's row instead of creating a second lineage. `test/romm_models_test.dart` updated for the `slot` retype.

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths — the change is to the *filename* handed to the existing path resolution, which is untouched
- [x] Verified on a device, not only on desktop

No user-facing strings, no schema change, no navigation change, no `assets/systems/` change.

</details>
