### PR TITLE
fix(esde): never write into the user's ES-DE media folder

### DIFF
--- a/lib/models/game_model.dart
+++ b/lib/models/game_model.dart
@@ -287,45 +287,12 @@ class GameModel {
     FileProvider? fileProvider,
   ]) {
     if (fileProvider != null && fileProvider.isInitialized) {
-      final pngPath = fileProvider.getMediaPath(
+      final owned = _existingNeoStationImagePath(
+        fileProvider,
         systemFolderName,
         imageType,
-        romname,
-        'png',
       );
-      if (File(pngPath).existsSync()) {
-        return pngPath;
-      }
-      final jpgPath = fileProvider.getMediaPath(
-        systemFolderName,
-        imageType,
-        romname,
-        'jpg',
-      );
-      if (File(jpgPath).existsSync()) {
-        return jpgPath;
-      }
-
-      // Fallback for files with complex extensions (e.g., 'v1.11.zip').
-      final pngPathOriginal = path.join(
-        fileProvider.getMediaDirectoryPath(),
-        systemFolderName,
-        imageType,
-        '$romname.png',
-      );
-      if (File(pngPathOriginal).existsSync()) {
-        return pngPathOriginal;
-      }
-
-      final jpgPathOriginal = path.join(
-        fileProvider.getMediaDirectoryPath(),
-        systemFolderName,
-        imageType,
-        '$romname.jpg',
-      );
-      if (File(jpgPathOriginal).existsSync()) {
-        return jpgPathOriginal;
-      }
+      if (owned != null) return owned;
 
       // ES-DE read-time fallback: use the user's ES-DE downloaded_media art
       // when NeoStation has no art of its own. A later NeoStation scrape writes
@@ -340,10 +307,82 @@ class GameModel {
         }
       }
 
-      return pngPath;
+      return fileProvider.getMediaPath(
+        systemFolderName,
+        imageType,
+        romname,
+        'png',
+      );
     }
 
     // Manual filesystem lookup logic.
+    return _manualImagePath(systemFolderName, imageType);
+  }
+
+  /// Resolves the path new art for [imageType] must be *written* to.
+  ///
+  /// Always inside NeoStation's own `media/` directory: an existing NeoStation
+  /// file when there is one (so replacing art keeps the same file), otherwise
+  /// the default `.png` destination. Unlike [getImagePath] this never returns a
+  /// path inside ES-DE's `downloaded_media/`, which is the user's own library
+  /// and must stay untouched — writing there would destroy their ES-DE art
+  /// (e.g. a miximage) instead of shadowing it.
+  String getWritableImagePath(
+    String systemFolderName,
+    String imageType, [
+    FileProvider? fileProvider,
+  ]) {
+    if (fileProvider != null && fileProvider.isInitialized) {
+      return _existingNeoStationImagePath(
+            fileProvider,
+            systemFolderName,
+            imageType,
+          ) ??
+          fileProvider.getMediaPath(
+            systemFolderName,
+            imageType,
+            romname,
+            'png',
+          );
+    }
+
+    return _manualImagePath(systemFolderName, imageType);
+  }
+
+  /// The existing NeoStation-owned media file for [imageType], or null when
+  /// NeoStation has no art of its own for this ROM.
+  String? _existingNeoStationImagePath(
+    FileProvider fileProvider,
+    String systemFolderName,
+    String imageType,
+  ) {
+    for (final extension in const ['png', 'jpg']) {
+      final candidate = fileProvider.getMediaPath(
+        systemFolderName,
+        imageType,
+        romname,
+        extension,
+      );
+      if (File(candidate).existsSync()) return candidate;
+    }
+
+    // Fallback for files with complex extensions (e.g., 'v1.11.zip').
+    for (final extension in const ['png', 'jpg']) {
+      final candidate = path.join(
+        fileProvider.getMediaDirectoryPath(),
+        systemFolderName,
+        imageType,
+        '$romname.$extension',
+      );
+      if (File(candidate).existsSync()) return candidate;
+    }
+
+    return null;
+  }
+
+  /// Relative-path lookup used when no initialized [FileProvider] is available.
+  /// Resolves inside NeoStation's `media/` folder only.
+  String _manualImagePath(String systemFolderName, String imageType) {
     final baseName = _stripRomExtension(romname);
 
     final pngRelativePath = path.join(

--- a/lib/providers/file_provider.dart
+++ b/lib/providers/file_provider.dart
@@ -66,11 +66,18 @@ class FileProvider extends ChangeNotifier {
   /// preference order. ES-DE scrapes more categories than NeoStation renders
   /// and users routinely enable only some of them, so each type falls back to
   /// the next-best ES-DE category rather than showing nothing.
+  ///
+  /// ES-DE's `miximages` are deliberately absent: they are composites (a
+  /// screenshot with the box art and usually the marquee baked in, on a padded
+  /// canvas), so they are not what any NeoStation slot means. In the fanart
+  /// slot they read worst of all — NeoStation draws the wheel on top of the
+  /// full-bleed background, so the logo lands twice on a letterboxed collage.
+  /// A missing slot is preferred over art that misrepresents it.
   static const Map<String, List<String>> _esdeMediaCategories = {
     'box2d': ['covers', '3dboxes'],
     'wheels': ['marquees'],
-    'screenshots': ['screenshots', 'titlescreens', 'miximages'],
-    'fanarts': ['fanart', 'miximages'],
+    'screenshots': ['screenshots', 'titlescreens'],
+    'fanarts': ['fanart'],
     'videos': ['videos'],
   };
 

--- a/lib/screens/game_screen/game_settings_dialog/game_settings_scrapping_tab.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_scrapping_tab.dart
@@ -330,7 +330,15 @@ class GameSettingsScrappingTabState extends State<GameSettingsScrappingTab> {
     if (srcPath == null || !mounted) return;
 
     try {
-      final targetPath = _pathForImageType(type);
+      // Write into NeoStation's own media folder, never over the path the
+      // thumbnail happens to be read from: for an ES-DE imported library that
+      // path is the user's `downloaded_media` file (e.g. a miximage), which is
+      // read-only to us. The new file shadows it everywhere from now on.
+      final targetPath = widget.game.getWritableImagePath(
+        _folder,
+        type,
+        widget.fileProvider,
+      );
       await File(targetPath).parent.create(recursive: true);
       await File(srcPath).copy(targetPath);
       await evictScrapedArtwork([targetPath]);

--- a/test/esde_media_write_protection_test.dart
+++ b/test/esde_media_write_protection_test.dart
@@ -1,0 +1,212 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/providers/file_provider.dart';
+import 'package:path/path.dart' as path;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'database_test_helper.dart';
+
+/// ES-DE's `downloaded_media/` belongs to the user's ES-DE install: NeoStation
+/// reads it as a fallback and must never write into it. Replacing artwork used
+/// to write to whatever path the *read* resolver returned, which for an ES-DE
+/// imported library is the ES-DE file itself — destroying the user's art.
+///
+/// Two layers guard that here: behavioural tests that every write destination
+/// lands in NeoStation's own media folder, and a structural test that the ES-DE
+/// path helpers gain no new consumers (the read resolvers are the only code
+/// allowed to produce an ES-DE path at all).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Every media type the artwork-replacement UI can write.
+  const mediaTypes = ['screenshots', 'fanarts', 'wheels', 'box2d'];
+
+  const game = GameModel(
+    romname: 'sonic.smc',
+    realname: 'Sonic',
+    name: 'Sonic',
+    year: '1991',
+    developer: '',
+    publisher: '',
+    genre: '',
+    players: '1',
+    rating: 0,
+    systemId: 'snes',
+    systemFolderName: 'snes',
+  );
+
+  group('write destinations', () {
+    final dbHelper = DatabaseTestHelper();
+    late Directory tempDir;
+    late Directory esdeRoot;
+    late FileProvider provider;
+
+    setUp(() async {
+      final db = await dbHelper.setUp();
+      tempDir = await Directory.systemTemp.createTemp('neostation_media_test');
+      esdeRoot = Directory(path.join(tempDir.path, 'ES-DE'));
+      await esdeRoot.create(recursive: true);
+
+      // FileProvider resolves the media root through the custom user-data path.
+      SharedPreferences.setMockInitialValues({
+        'custom_user_data_path': tempDir.path,
+      });
+
+      await db.execute(
+        "INSERT INTO app_systems (id, real_name, folder_name, screenscraper_id) VALUES ('snes', 'SNES', 'snes', 4)",
+      );
+      await db.execute(
+        "INSERT INTO user_config (id, esde_folder_path) VALUES (1, '${esdeRoot.path}')",
+      );
+      await db.execute(
+        "INSERT INTO user_system_settings (app_system_id, esde_media_dir) VALUES ('snes', 'snes')",
+      );
+
+      provider = FileProvider();
+      await provider.initialize();
+      expect(provider.isInitialized, isTrue);
+    });
+
+    tearDown(() async {
+      await dbHelper.tearDown();
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    /// Writes an ES-DE asset in [category] for the test ROM and returns it.
+    Future<File> writeEsdeAsset(String category) async {
+      final file = File(
+        path.join(
+          esdeRoot.path,
+          'downloaded_media',
+          'snes',
+          category,
+          'sonic.png',
+        ),
+      );
+      await file.parent.create(recursive: true);
+      await file.writeAsString('es-de $category');
+      return file;
+    }
+
+    /// The ES-DE category each NeoStation media type falls back to first.
+    const esdeCategoryFor = {
+      'screenshots': 'screenshots',
+      'fanarts': 'fanart',
+      'wheels': 'marquees',
+      'box2d': 'covers',
+    };
+
+    test('reads ES-DE art when NeoStation has none of its own', () async {
+      for (final type in mediaTypes) {
+        final esdeFile = await writeEsdeAsset(esdeCategoryFor[type]!);
+
+        expect(
+          game.getImagePath('snes', type, provider),
+          esdeFile.path,
+          reason: '$type should fall back to ES-DE art',
+        );
+      }
+    });
+
+    test('never writes into ES-DE, for any media type', () async {
+      final mediaRoot = path.join(tempDir.path, 'media');
+
+      for (final type in mediaTypes) {
+        final esdeFile = await writeEsdeAsset(esdeCategoryFor[type]!);
+        final target = game.getWritableImagePath('snes', type, provider);
+
+        expect(
+          path.isWithin(mediaRoot, target),
+          isTrue,
+          reason: '$type write target must be inside NeoStation media: $target',
+        );
+        expect(
+          path.isWithin(esdeRoot.path, target),
+          isFalse,
+          reason: '$type write target must be outside ES-DE: $target',
+        );
+
+        // Simulate the replacement the game settings dialog performs.
+        await File(target).parent.create(recursive: true);
+        await File(target).writeAsString('user picked art');
+
+        // The ES-DE file survives untouched...
+        expect(await esdeFile.readAsString(), 'es-de ${esdeCategoryFor[type]}');
+        // ...and the NeoStation copy now shadows it everywhere.
+        expect(game.getImagePath('snes', type, provider), target);
+      }
+    });
+
+    test('the default destination is a NeoStation png', () async {
+      expect(
+        game.getWritableImagePath('snes', 'screenshots', provider),
+        path.join(tempDir.path, 'media', 'snes', 'screenshots', 'sonic.png'),
+      );
+    });
+
+    test('reuses an existing NeoStation file as the write target', () async {
+      final existing = File(
+        path.join(tempDir.path, 'media', 'snes', 'box2d', 'sonic.jpg'),
+      );
+      await existing.parent.create(recursive: true);
+      await existing.writeAsString('old art');
+
+      expect(
+        game.getWritableImagePath('snes', 'box2d', provider),
+        existing.path,
+      );
+    });
+
+    test(
+      'falls back to the default png destination without a file provider',
+      () {
+        expect(
+          game.getWritableImagePath('snes', 'wheels'),
+          path.join('media', 'snes', 'wheels', 'sonic.png'),
+        );
+      },
+    );
+  });
+
+  group('ES-DE paths cannot leak to new call sites', () {
+    /// Only these files may mention the ES-DE path helpers: [FileProvider]
+    /// defines them, and [GameModel]'s two *read* resolvers are the sole
+    /// consumers. A new consumer anywhere else is how ES-DE art becomes
+    /// writable again — the artwork-replacement bug was exactly that shape,
+    /// a write target taken from a resolver that could return an ES-DE path.
+    const allowedFiles = {
+      'lib/providers/file_provider.dart',
+      'lib/models/game_model.dart',
+    };
+
+    const esdeApis = ['getEsdeMediaCandidates(', 'getEsdeVideoPath('];
+
+    test('only the read resolvers consume ES-DE path helpers', () {
+      final offenders = <String>[];
+
+      for (final entity in Directory('lib').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final relative = path.relative(entity.path).replaceAll(r'\', '/');
+        if (allowedFiles.contains(relative)) continue;
+
+        final source = entity.readAsStringSync();
+        for (final api in esdeApis) {
+          if (source.contains(api)) offenders.add('$relative calls $api');
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'ES-DE downloaded_media is read-only to NeoStation. If a new call '
+            'site genuinely needs an ES-DE path it must be read-only too — add '
+            'it to allowedFiles deliberately, never to silence this test.',
+      );
+    });
+  });
+}

--- a/test/file_provider_test.dart
+++ b/test/file_provider_test.dart
@@ -99,5 +99,43 @@ void main() {
         isEmpty,
       );
     });
+
+    test('never offers a miximage for any media type', () {
+      // Miximages are composites (screenshot + box + marquee baked together),
+      // so they misrepresent every slot NeoStation renders — worst of all the
+      // fanart background, over which the wheel is drawn a second time.
+      for (final type in const [
+        'box2d',
+        'wheels',
+        'screenshots',
+        'fanarts',
+        'videos',
+      ]) {
+        expect(
+          provider.getEsdeMediaCandidates('snes', type, 'sonic.smc'),
+          isNot(contains(contains('miximages'))),
+          reason: '$type must not fall back to an ES-DE miximage',
+        );
+      }
+    });
+
+    test('screenshots fall back to titlescreens only', () {
+      expect(
+        provider.getEsdeMediaCandidates('snes', 'screenshots', 'sonic.smc'),
+        [
+          '/esde/downloaded_media/snes/screenshots/sonic.png',
+          '/esde/downloaded_media/snes/screenshots/sonic.jpg',
+          '/esde/downloaded_media/snes/titlescreens/sonic.png',
+          '/esde/downloaded_media/snes/titlescreens/sonic.jpg',
+        ],
+      );
+    });
+
+    test('fanarts resolve from the fanart category alone', () {
+      expect(provider.getEsdeMediaCandidates('snes', 'fanarts', 'sonic.smc'), [
+        '/esde/downloaded_media/snes/fanart/sonic.png',
+        '/esde/downloaded_media/snes/fanart/sonic.jpg',
+      ]);
+    });
   });
 }


### PR DESCRIPTION
# Description

Two ES-DE fixes.

**1. NeoStation was overwriting the user's ES-DE artwork.** Replacing a game's art (Game Settings, Scraping, Scraping Media, Change) wrote to whatever path the *read* resolver returned. For a library imported from ES-DE that path is the user's own file under `downloaded_media/`, so picking new art destroyed their ES-DE image instead of shadowing it.

`GameModel.getImagePath` gained its ES-DE fallback in #121, whose import is read-only by design. #188 then added the artwork-replacement UI and took its write target from that resolver. Neither is wrong alone; the combination is.

New `GameModel.getWritableImagePath` resolves write destinations inside NeoStation's own `media/` directory only: an existing NeoStation file if there is one, otherwise the default `.png` destination. It can never return a `downloaded_media/` path. The read resolver is untouched, so ES-DE art still shows everywhere it did and the new file simply shadows it.

I audited every other media write and delete: they all resolve through `getMediaPath()` or are scoped to the media directory (`deleteNeoStationScrapedMedia`, `MetadataCleanupService`, `ScrapedMediaMigrationService`), and `EsdeImportService` never writes at all. This was the only hole. **ES-DE `downloaded_media/` is read-only to NeoStation.**

**2. Miximages are no longer served as screenshots or fanart.** A miximage is a composite (screenshot plus box art plus, usually, the marquee, on a padded canvas), so it misrepresents whichever slot it fills. Worst in the fanart slot: NeoStation draws the wheel over the full-bleed background, so the logo lands on screen twice, letterboxed, with the composite's drop shadows over the theme colour. A missing slot is preferred over art that misrepresents it.

Nothing changes for libraries scraped with covers, screenshots, marquees or fanart, which is the common case. The import side already agreed with this: `EsdeImportService._esdeMediaExists` only ever considered those four categories.

Closes #

## Steps to Verify

**Preconditions:** an ES-DE folder imported into NeoStation (Settings, Directories, ES-DE Import), and a game whose art comes from ES-DE rather than a NeoStation scrape. On the Thor I used Game Boy, `Balloon Kid`, which has `covers`, `fanart` and `marquees` in `downloaded_media/gb/` and no NeoStation media.

Before this fix, step 5 overwrote the ES-DE file in place.

1. Note the checksum of the ES-DE source file, e.g. `md5sum '<ES-DE>/downloaded_media/gb/marquees/Balloon Kid.png'`.
2. Open the game, then Game Settings, Scraping, Scraping Media. The Wheel row shows the ES-DE marquee.
3. Press Change on the Wheel row and pick any image.
4. The row updates to the new art.
5. Re-run the checksum from step 1: unchanged.
6. Confirm the new file landed in NeoStation instead: `ls -l <user-data>/media/gb/wheels/'Balloon Kid.png'`.

For the miximage change: a system whose `downloaded_media/<system>/` contains only `miximages/` now renders without screenshot or fanart, rather than with the composite in those slots.

## Tested on

- [x] Android — device: AYN Thor
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Verified against a real ES-DE import on the Thor: replacing the wheel left all three of that game's ES-DE files byte-identical (`covers`, `fanart`, `marquees` checksums unchanged, marquee mtime still the original scrape date) and wrote the picked image, byte for byte, to `media/gb/wheels/`. Test artefact removed afterwards.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1032)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

**Tests added** (`test/esde_media_write_protection_test.dart`, plus three cases in `test/file_provider_test.dart`):

- Behavioural: with ES-DE art present, the write destination for all four media types is inside NeoStation's media root and outside the ES-DE root; the write is then simulated and the ES-DE file's contents re-asserted.
- Structural: fails if the ES-DE path helpers (`getEsdeMediaCandidates`, `getEsdeVideoPath`) gain a consumer outside the two read resolvers, which is how ES-DE paths would become writable again.
- Fallback map: miximages are never offered for any media type; screenshots stop at `titlescreens`; fanarts resolve from `fanart` alone.

Both guards were mutation-checked: reverting `getWritableImagePath` to the old behaviour fails the behavioural test, and a probe file calling `getEsdeMediaCandidates` fails the structural one.

## Screenshots / video

Not applicable. The user-visible change is that ES-DE files stop being modified; the replacement flow looks the same.
