### PR TITLE
fix(romm): show the cover art a RomM download already fetched

### DIFF
--- a/lib/models/game_model.dart
+++ b/lib/models/game_model.dart
@@ -385,6 +385,15 @@ class GameModel {
     return _manualImagePath(systemFolderName, imageType);
   }
 
+  /// Extensions a NeoStation-owned media file may carry, in probe order.
+  ///
+  /// `webp` is last and costs a stat only for a ROM that has no art at all:
+  /// scrapes write `png`/`jpg`, so any game with artwork answers on the first
+  /// or second entry. It is probed because RomM imports before 0.10.1 saved
+  /// covers under the source's own extension, leaving `.webp` box art on disk
+  /// that nothing could resolve.
+  static const List<String> _mediaExtensions = ['png', 'jpg', 'webp'];
+
   /// The existing NeoStation-owned media file for [imageType], or null when
   /// NeoStation has no art of its own for this ROM.
   String? _existingNeoStationImagePath(
@@ -392,7 +401,7 @@ class GameModel {
     String systemFolderName,
     String imageType,
   ) {
-    for (final extension in const ['png', 'jpg']) {
+    for (final extension in _mediaExtensions) {
       final candidate = fileProvider.getMediaPath(
         systemFolderName,
         imageType,
@@ -403,7 +412,7 @@ class GameModel {
     }
 
     // Fallback for files with complex extensions (e.g., 'v1.11.zip').
-    for (final extension in const ['png', 'jpg']) {
+    for (final extension in _mediaExtensions) {
       final candidate = path.join(
         fileProvider.getMediaDirectoryPath(),
         systemFolderName,

--- a/lib/models/romm_rom.dart
+++ b/lib/models/romm_rom.dart
@@ -60,7 +60,20 @@ class RommRom {
   final bool hasMultipleFiles;
 
   /// Relative or absolute cover URL (may need the server base URL + auth).
+  ///
+  /// This is the metadata provider's own copy (IGDB, SteamGridDB,
+  /// ScreenScraper…), which RomM leaves empty for some matches — see
+  /// [pathCoverLarge] for the server-cached copy that stands in for it.
   final String? urlCover;
+
+  /// RomM's *locally cached* cover files, as server-relative paths under
+  /// `/assets/romm/resources/`, or null when RomM stored no file.
+  ///
+  /// Same artwork as [urlCover] from a different place: a library can hold
+  /// either one, both, or neither, so the cover a ROM actually has is whichever
+  /// of the three answers first.
+  final String? pathCoverLarge;
+  final String? pathCoverSmall;
 
   /// RetroAchievements game id RomM matched this ROM to, or null if none.
   /// A non-null id means the game has a RetroAchievements set.
@@ -100,6 +113,8 @@ class RommRom {
     this.files = const [],
     this.hasMultipleFiles = false,
     this.urlCover,
+    this.pathCoverLarge,
+    this.pathCoverSmall,
     this.raId,
     this.raTotalAchievements = 0,
     this.genres = const [],
@@ -143,6 +158,8 @@ class RommRom {
       files: files,
       hasMultipleFiles: json['has_multiple_files'] == true,
       urlCover: json['url_cover']?.toString(),
+      pathCoverLarge: json['path_cover_large']?.toString(),
+      pathCoverSmall: json['path_cover_small']?.toString(),
       raId: (json['ra_id'] as num?)?.toInt(),
       raTotalAchievements: _parseRaTotal(json),
       genres: _parseStringList(json, 'genres'),

--- a/lib/providers/romm_provider.dart
+++ b/lib/providers/romm_provider.dart
@@ -1528,13 +1528,20 @@ class RommProvider extends ChangeNotifier {
       final ss =
           (detail['ss_metadata'] as Map?)?.cast<String, dynamic>() ?? const {};
 
-      // Cover -> box2d (the box art proper).
-      final coverPath =
-          (detail['path_cover_large']?.toString().isNotEmpty ?? false)
-          ? detail['path_cover_large'].toString()
-          : detail['path_cover_small']?.toString();
+      // Cover -> box2d (the box art proper), taken from the first source that
+      // actually yields an image. `path_cover_*` is RomM's own cached copy;
+      // `url_cover` is the metadata provider's original, and is exactly what
+      // the RomM browse grid draws. A library RomM holds no cached cover file
+      // for therefore showed box art in the browser while the download saved
+      // none — reading the same sources here keeps the two in step, so whatever
+      // the browser can draw, a download keeps.
+      final coverSources = <String?>[
+        detail['path_cover_large']?.toString(),
+        detail['path_cover_small']?.toString(),
+        _service.coverUrl(rom),
+      ];
       await _saveRommMedia(
-        coverPath,
+        coverSources,
         'box2d',
         system,
         indexedName,
@@ -1545,7 +1552,7 @@ class RommProvider extends ChangeNotifier {
       // fanart, the cover doubles as the background so the card is never blank.
       final fanartPath = _rommResourcePath(ss['fanart_path']);
       await _saveRommMedia(
-        fanartPath ?? coverPath,
+        [fanartPath, ...coverSources],
         'fanarts',
         system,
         indexedName,
@@ -1562,7 +1569,7 @@ class RommProvider extends ChangeNotifier {
           _rommResourcePath(ss['logo_path']) ??
           _rommResourcePath(ss['marquee_path']);
       await _saveRommMedia(
-        wheelPath,
+        [wheelPath],
         'wheels',
         system,
         indexedName,
@@ -1575,11 +1582,11 @@ class RommProvider extends ChangeNotifier {
               ?.whereType<String>()
               .toList() ??
           const <String>[];
-      final shotPath = screenshots.isNotEmpty
-          ? screenshots.first
-          : _rommResourcePath(ss['title_screen_path']);
       await _saveRommMedia(
-        shotPath,
+        [
+          if (screenshots.isNotEmpty) screenshots.first,
+          _rommResourcePath(ss['title_screen_path']),
+        ],
         'screenshots',
         system,
         indexedName,
@@ -1595,7 +1602,7 @@ class RommProvider extends ChangeNotifier {
       if (videoPath != null) {
         final vext = videoPath.toLowerCase().contains('.webm') ? 'webm' : 'mp4';
         await _saveRommMedia(
-          videoPath,
+          [videoPath],
           'videos',
           system,
           indexedName,
@@ -1621,14 +1628,23 @@ class RommProvider extends ChangeNotifier {
     return '/assets/romm/resources/$s';
   }
 
-  /// Fetches [pathOrUrl] from RomM and writes it into the [folder] media folder
-  /// keyed by [indexedName], picking the on-disk extension from the actual bytes
-  /// (RomM serves JPEG even from `*.png` paths and the library's lookup is
-  /// extension-sensitive) unless [forcedExt] is given. Removes stale variants in
-  /// [siblingExts] so `getImagePath`/`getVideoPath` resolve this one. No-op when
-  /// the path is empty or the fetch yields nothing.
+  /// Fetches the first of [sources] that yields usable bytes and writes it into
+  /// the [folder] media folder keyed by [indexedName], picking the on-disk
+  /// extension from the actual bytes (RomM serves JPEG even from `*.png` paths
+  /// and the library's lookup is extension-sensitive) unless [forcedExt] is
+  /// given. Removes stale variants in [siblingExts] so
+  /// `getImagePath`/`getVideoPath` resolve this one. No-op when every source is
+  /// empty or fetches nothing.
+  ///
+  /// Sources are tried in order because RomM's cached copy and the metadata
+  /// provider's original are the same artwork from two places, and a given
+  /// library may only have one of them.
+  ///
+  /// Failures are contained here rather than at the call site: the media types
+  /// are independent, and a single unwritable folder or dead URL must not cost
+  /// the caller every type queued behind it.
   Future<void> _saveRommMedia(
-    String? pathOrUrl,
+    List<String?> sources,
     String folder,
     SystemModel system,
     String indexedName,
@@ -1636,31 +1652,62 @@ class RommProvider extends ChangeNotifier {
     String? forcedExt,
     List<String> siblingExts = const ['png', 'jpg', 'webp'],
   }) async {
-    if (pathOrUrl == null || pathOrUrl.isEmpty) return;
-    final bytes = await _service.fetchImageBytes(pathOrUrl);
-    if (bytes == null || bytes.isEmpty) return;
-    final ext = forcedExt ?? RommService.imageExtensionFor(bytes);
-    final dest = fileProvider.getMediaPath(
-      system.folderName,
-      folder,
-      indexedName,
-      ext,
-    );
-    final destFile = File(dest);
-    await destFile.parent.create(recursive: true);
-    await destFile.writeAsBytes(bytes);
-    for (final other in siblingExts) {
-      if (other == ext) continue;
-      final stale = File(
-        fileProvider.getMediaPath(
-          system.folderName,
-          folder,
-          indexedName,
-          other,
-        ),
+    try {
+      Uint8List? bytes;
+      for (final source in sources) {
+        if (source == null || source.isEmpty) continue;
+        // A video's bytes are not an image, so only art is content-checked.
+        bytes = await _service.fetchImageBytes(
+          source,
+          requireImage: forcedExt == null,
+        );
+        if (bytes != null && bytes.isNotEmpty) break;
+        bytes = null;
+      }
+      if (bytes == null) return;
+
+      final ext = forcedExt ?? _mediaExtensionFor(bytes);
+      final dest = fileProvider.getMediaPath(
+        system.folderName,
+        folder,
+        indexedName,
+        ext,
       );
-      if (await stale.exists()) await stale.delete();
+      final destFile = File(dest);
+      await destFile.parent.create(recursive: true);
+      await destFile.writeAsBytes(bytes);
+      for (final other in siblingExts) {
+        if (other == ext) continue;
+        final stale = File(
+          fileProvider.getMediaPath(
+            system.folderName,
+            folder,
+            indexedName,
+            other,
+          ),
+        );
+        if (await stale.exists()) await stale.delete();
+      }
+    } catch (e) {
+      _log.e('RomM media import failed for $folder/$indexedName: $e');
     }
+  }
+
+  /// The extension art must be *saved* under, which is not always the one the
+  /// bytes imply.
+  ///
+  /// RomM stores every cover as `big.png` whatever the source served, so an
+  /// import can come back holding WebP (SteamGridDB and LaunchBox both serve
+  /// it). Saved under its true `.webp` name that art was invisible to the
+  /// library — and `siblingExts` had already deleted the `.png` a previous
+  /// scrape left behind, so a RomM download could *remove* working box art.
+  /// `GameModel` now reads `.webp` too, but art still lands under the
+  /// extensions every scrape writes: it keeps one shape of file on disk, and
+  /// the library's lookup answers on its first probe rather than its third.
+  /// Flutter decodes by content, not by name, so WebP under `.png` renders.
+  static String _mediaExtensionFor(Uint8List bytes) {
+    final ext = RommService.imageExtensionFor(bytes);
+    return ext == 'jpg' ? ext : 'png';
   }
 
   /// Requests cancellation of an in-flight download.

--- a/lib/screens/romm_screen/romm_rom_card.dart
+++ b/lib/screens/romm_screen/romm_rom_card.dart
@@ -48,10 +48,24 @@ class RommRomCard extends StatefulWidget {
 class RommRomCardState extends State<RommRomCard> {
   bool _alreadyDownloaded = false;
 
+  /// Index into `RommService.coverUrlCandidates` of the cover being drawn.
+  /// A failed load advances it rather than settling for the placeholder: which
+  /// of RomM's cover sources a given library populated is not knowable up
+  /// front, and only the load can tell us the first one was a dead end.
+  int _coverAttempt = 0;
+
   @override
   void initState() {
     super.initState();
     _checkDownloaded();
+  }
+
+  @override
+  void didUpdateWidget(RommRomCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Grid tiles recycle across ROMs; the previous ROM's dead sources say
+    // nothing about this one's.
+    if (oldWidget.rom.id != widget.rom.id) _coverAttempt = 0;
   }
 
   Future<void> _checkDownloaded() async {
@@ -67,7 +81,10 @@ class RommRomCardState extends State<RommRomCard> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final coverUrl = widget.provider.service.coverUrl(widget.rom);
+    final covers = widget.provider.service.coverUrlCandidates(widget.rom);
+    final coverUrl = _coverAttempt < covers.length
+        ? covers[_coverAttempt]
+        : null;
     final download = widget.provider.downloadFor(widget.rom.id);
     final scheme = theme.colorScheme;
 
@@ -381,6 +398,18 @@ class RommRomCardState extends State<RommRomCard> {
     );
   }
 
+  /// Advances to the next cover source after a failed load, on the next frame
+  /// — `errorBuilder` runs *during* build, where `setState` is illegal. Guarded
+  /// on the attempt that failed so repeated error frames for the same source
+  /// only skip it once.
+  void _tryNextCover() {
+    final failed = _coverAttempt;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _coverAttempt != failed) return;
+      setState(() => _coverAttempt = failed + 1);
+    });
+  }
+
   Widget _buildCover(ThemeData theme, String? coverUrl) {
     if (coverUrl == null) {
       return _coverPlaceholder(theme);
@@ -389,7 +418,10 @@ class RommRomCardState extends State<RommRomCard> {
       coverUrl,
       fit: BoxFit.cover,
       headers: widget.provider.service.imageHeadersFor(coverUrl),
-      errorBuilder: (_, _, _) => _coverPlaceholder(theme),
+      errorBuilder: (_, _, _) {
+        _tryNextCover();
+        return _coverPlaceholder(theme);
+      },
       loadingBuilder: (context, child, progress) {
         if (progress == null) return child;
         return _coverPlaceholder(theme);

--- a/lib/services/romm_service.dart
+++ b/lib/services/romm_service.dart
@@ -605,7 +605,17 @@ class RommService {
   /// The caller picks the on-disk extension from the actual content — RomM
   /// serves JPEG even from `*.png` cover paths, and the app's image lookup is
   /// extension-sensitive.
-  Future<Uint8List?> fetchImageBytes(String pathOrUrl) async {
+  ///
+  /// With [requireImage] (the default) a body that isn't a recognisable image
+  /// counts as a miss: a resource path RomM no longer has a file for falls
+  /// through to its SPA shell, which answers **200 with HTML**. Writing that
+  /// out would leave an undecodable `.png` behind — art that looks downloaded
+  /// but renders as nothing — and would hide the miss from any caller trying a
+  /// second source. Video fetches pass `requireImage: false`.
+  Future<Uint8List?> fetchImageBytes(
+    String pathOrUrl, {
+    bool requireImage = true,
+  }) async {
     try {
       final url = pathOrUrl.startsWith('http')
           ? pathOrUrl
@@ -613,12 +623,61 @@ class RommService {
       final resp = await _httpClient
           .get(Uri.parse(url), headers: imageHeadersFor(url))
           .timeout(const Duration(seconds: 30));
-      if (resp.statusCode != 200) return null;
-      return resp.bodyBytes;
+      if (resp.statusCode != 200) {
+        _log.w('RomM image fetch: HTTP ${resp.statusCode} for $url');
+        return null;
+      }
+      final bytes = resp.bodyBytes;
+      if (requireImage && !looksLikeImage(bytes)) {
+        _log.w('RomM image fetch: non-image body for $url');
+        return null;
+      }
+      return bytes;
     } catch (e) {
       _log.e('RomM image fetch failed: $e');
       return null;
     }
+  }
+
+  /// Whether [bytes] start with the magic numbers of an image format the app
+  /// can decode. Deliberately content-based: RomM names every stored cover
+  /// `big.png` whatever the source served, so the extension proves nothing.
+  static bool looksLikeImage(Uint8List bytes) {
+    if (bytes.length >= 3 &&
+        bytes[0] == 0xFF &&
+        bytes[1] == 0xD8 &&
+        bytes[2] == 0xFF) {
+      return true; // JPEG
+    }
+    if (bytes.length >= 8 &&
+        bytes[0] == 0x89 &&
+        bytes[1] == 0x50 &&
+        bytes[2] == 0x4E &&
+        bytes[3] == 0x47) {
+      return true; // PNG
+    }
+    if (bytes.length >= 12 &&
+        bytes[0] == 0x52 &&
+        bytes[1] == 0x49 &&
+        bytes[2] == 0x46 &&
+        bytes[3] == 0x46 &&
+        bytes[8] == 0x57 &&
+        bytes[9] == 0x45 &&
+        bytes[10] == 0x42 &&
+        bytes[11] == 0x50) {
+      return true; // WEBP
+    }
+    if (bytes.length >= 6 &&
+        bytes[0] == 0x47 &&
+        bytes[1] == 0x49 &&
+        bytes[2] == 0x46 &&
+        bytes[3] == 0x38) {
+      return true; // GIF
+    }
+    if (bytes.length >= 2 && bytes[0] == 0x42 && bytes[1] == 0x4D) {
+      return true; // BMP
+    }
+    return false;
   }
 
   /// Returns the image file extension ('jpg'/'png'/'webp') implied by [bytes]'
@@ -641,13 +700,31 @@ class RommService {
   }
 
   /// Builds an absolute, authenticated-fetchable cover URL for [rom], or null.
-  String? coverUrl(RommRom rom) {
-    final cover = rom.urlCover;
-    if (cover == null || cover.isEmpty) return null;
-    if (cover.startsWith('http://') || cover.startsWith('https://')) {
-      return cover;
+  String? coverUrl(RommRom rom) => coverUrlCandidates(rom).firstOrNull;
+
+  /// Every cover URL [rom] could be drawn from, best first: the metadata
+  /// provider's own copy, then RomM's cached large and small files.
+  ///
+  /// RomM populates these independently — a ROM matched without a provider
+  /// cover still has the cached file, and a library RomM never cached covers
+  /// for only has the provider URL. Anything that draws a cover should walk the
+  /// list rather than give up on the first entry, or a ROM whose art the server
+  /// plainly has renders as a blank card.
+  List<String> coverUrlCandidates(RommRom rom) {
+    final urls = <String>[];
+    for (final cover in [
+      rom.urlCover,
+      rom.pathCoverLarge,
+      rom.pathCoverSmall,
+    ]) {
+      if (cover == null || cover.isEmpty) continue;
+      urls.add(
+        (cover.startsWith('http://') || cover.startsWith('https://'))
+            ? cover
+            : '$_baseUrl${cover.startsWith('/') ? '' : '/'}$cover',
+      );
     }
-    return '$_baseUrl${cover.startsWith('/') ? '' : '/'}$cover';
+    return urls;
   }
 
   /// Absolute, authenticated-fetchable cover URLs making up [collection]'s

--- a/test/romm_service_test.dart
+++ b/test/romm_service_test.dart
@@ -22,7 +22,11 @@ RommService _service({
   return s;
 }
 
-RommRom _rom({String? urlCover}) => RommRom(
+RommRom _rom({
+  String? urlCover,
+  String? pathCoverLarge,
+  String? pathCoverSmall,
+}) => RommRom(
   id: 1,
   name: 'Game',
   platformId: 1,
@@ -31,6 +35,8 @@ RommRom _rom({String? urlCover}) => RommRom(
   fsNameNoExt: 'game',
   fsExtension: 'sfc',
   urlCover: urlCover,
+  pathCoverLarge: pathCoverLarge,
+  pathCoverSmall: pathCoverSmall,
 );
 
 RommPlatform _platform({String? urlLogo, String slug = 'snes'}) =>
@@ -91,6 +97,50 @@ void main() {
         _service().coverUrl(_rom(urlCover: 'assets/cover.png')),
         'https://romm.local/assets/cover.png',
       );
+    });
+
+    test(
+      'falls back to RomM\'s cached cover when there is no provider URL',
+      () {
+        // The case behind the "no art in the browser, but the download has it"
+        // report: RomM cached a cover file but recorded no url_cover.
+        expect(
+          _service().coverUrl(
+            _rom(
+              pathCoverLarge: '/assets/romm/resources/roms/1/2/cover/big.png',
+            ),
+          ),
+          'https://romm.local/assets/romm/resources/roms/1/2/cover/big.png',
+        );
+      },
+    );
+  });
+
+  group('coverUrlCandidates', () {
+    test('orders provider URL, then cached large, then cached small', () {
+      final urls = _service().coverUrlCandidates(
+        _rom(
+          urlCover: 'https://cdn.igdb/cover.png',
+          pathCoverLarge: '/assets/big.png',
+          pathCoverSmall: '/assets/small.png',
+        ),
+      );
+      expect(urls, [
+        'https://cdn.igdb/cover.png',
+        'https://romm.local/assets/big.png',
+        'https://romm.local/assets/small.png',
+      ]);
+    });
+
+    test('skips sources the server left empty', () {
+      final urls = _service().coverUrlCandidates(
+        _rom(urlCover: '', pathCoverLarge: '', pathCoverSmall: '/assets/s.png'),
+      );
+      expect(urls, ['https://romm.local/assets/s.png']);
+    });
+
+    test('is empty when the ROM has no cover at all', () {
+      expect(_service().coverUrlCandidates(_rom()), isEmpty);
     });
   });
 

--- a/test/romm_webp_media_test.dart
+++ b/test/romm_webp_media_test.dart
@@ -1,0 +1,137 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/providers/file_provider.dart';
+import 'package:neostation/services/romm_service.dart';
+import 'package:path/path.dart' as path;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'database_test_helper.dart';
+
+/// RomM stores every cover as `big.png` whatever the source served, so a cover
+/// import can come back holding WebP bytes (SteamGridDB and LaunchBox both
+/// serve it). Saved under its true `.webp` name, that art was downloaded
+/// correctly and then invisible: the library's lookup only ever probed
+/// `.png`/`.jpg`, so the game showed no box art while the file sat on disk —
+/// which is what issue #355 reported.
+///
+/// Two halves of the fix are covered here: art already on disk from a 0.10.0
+/// import resolves, and a body that isn't an image at all is refused rather
+/// than written out as art.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const game = GameModel(
+    romname: 'Adventure Island II (USA, Europe).gb',
+    realname: 'Adventure Island II',
+    name: 'Adventure Island II',
+    year: '1991',
+    developer: '',
+    publisher: '',
+    genre: '',
+    players: '1',
+    rating: 0,
+    systemId: 'gb',
+    systemFolderName: 'gb',
+  );
+
+  group('media lookup', () {
+    final dbHelper = DatabaseTestHelper();
+    late Directory tempDir;
+    late FileProvider provider;
+
+    setUp(() async {
+      final db = await dbHelper.setUp();
+      tempDir = await Directory.systemTemp.createTemp('neostation_webp_test');
+
+      SharedPreferences.setMockInitialValues({
+        'custom_user_data_path': tempDir.path,
+      });
+
+      await db.execute(
+        "INSERT INTO app_systems (id, real_name, folder_name, screenscraper_id) "
+        "VALUES ('gb', 'Game Boy', 'gb', 9)",
+      );
+
+      provider = FileProvider();
+      await provider.initialize();
+      expect(provider.isInitialized, isTrue);
+    });
+
+    tearDown(() async {
+      await dbHelper.tearDown();
+      if (await tempDir.exists()) await tempDir.delete(recursive: true);
+    });
+
+    /// Writes [name] into the ROM's `box2d` folder and returns it.
+    Future<File> writeBox2d(String name) async {
+      final file = File(path.join(tempDir.path, 'media', 'gb', 'box2d', name));
+      await file.parent.create(recursive: true);
+      await file.writeAsString('art');
+      return file;
+    }
+
+    test(
+      'resolves a .webp cover left behind by an older RomM import',
+      () async {
+        final webp = await writeBox2d('Adventure Island II (USA, Europe).webp');
+
+        expect(game.getImagePath('gb', 'box2d', provider), webp.path);
+      },
+    );
+
+    test('still prefers .png over .webp when both exist', () async {
+      final png = await writeBox2d('Adventure Island II (USA, Europe).png');
+      await writeBox2d('Adventure Island II (USA, Europe).webp');
+
+      expect(game.getImagePath('gb', 'box2d', provider), png.path);
+    });
+  });
+
+  group('looksLikeImage', () {
+    test('accepts the formats RomM serves', () {
+      expect(
+        RommService.looksLikeImage(
+          Uint8List.fromList([0xFF, 0xD8, 0xFF, 0xE0, 0x00]),
+        ),
+        isTrue,
+        reason: 'JPEG',
+      );
+      expect(
+        RommService.looksLikeImage(
+          Uint8List.fromList([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+        ),
+        isTrue,
+        reason: 'PNG',
+      );
+      expect(
+        RommService.looksLikeImage(
+          Uint8List.fromList([
+            0x52, 0x49, 0x46, 0x46, // RIFF
+            0x00, 0x00, 0x00, 0x00, // size
+            0x57, 0x45, 0x42, 0x50, // WEBP
+          ]),
+        ),
+        isTrue,
+        reason: 'WEBP',
+      );
+    });
+
+    test('rejects the SPA shell RomM answers with for a missing resource', () {
+      // A resource path RomM has no file for returns 200 + HTML, which written
+      // out would look like downloaded art and render as nothing.
+      final html = Uint8List.fromList('<!doctype html><html>'.codeUnits);
+      expect(RommService.looksLikeImage(html), isFalse);
+    });
+
+    test('rejects empty and truncated bodies', () {
+      expect(RommService.looksLikeImage(Uint8List(0)), isFalse);
+      expect(
+        RommService.looksLikeImage(Uint8List.fromList([0xFF, 0xD8])),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

A game downloaded from RomM could end up with no box art even though the cover had been fetched and written to disk.

RomM names every cached cover `big.png` whatever the source actually served, so a cover from SteamGridDB or LaunchBox arrives as WebP. The import saved it under its true `.webp` name, which is an extension `GameModel.getImagePath` never probed (`png`/`jpg` only), so the art was invisible to the library. `siblingExts` had already deleted the `.png` a previous scrape left behind, so a RomM download could also *remove* box art that had been working.

Two changes:

* `GameModel` now probes `.webp` as well, so art already imported by 0.10.0 shows without re-downloading. It is probed last, so it costs a stat only for a ROM that has no art at all: a game with artwork still answers on the first or second probe.
* RomM art is saved under `png`/`jpg` regardless of the source format. Flutter decodes by content rather than by name, so WebP bytes under `.png` render, and keeping one shape of file on disk keeps the rest of the media code honest.

While tracing that, a second split turned up. The browse grid drew only `url_cover` (the metadata provider's own copy) and the download import read only `path_cover_*` (RomM's cached file). RomM populates those independently, so each could find art the other could not, in both directions: covers visible in the browser that a download saved none of, and covers a download fetched fine that the browser drew as blank cards. Both now walk the same ordered list (provider URL, cached large, cached small) and take the first that answers, and the grid falls through to the next source on a failed load.

Two robustness fixes came out of the same path:

* Non-image bodies are refused rather than written out. A resource path RomM has no file for falls through to its SPA shell, which answers 200 with HTML: writing that out left a file that looked like downloaded art and rendered as nothing, and it hid the miss from any caller trying a second source. Fetch misses now log the status code instead of returning null silently.
* Each media type is guarded individually, so one dead source or one unwritable folder no longer cancels every type queued behind it (previously a failure on the cover, which is imported first, skipped fanart, wheel, screenshot and video too).

**Not in this PR**, both of which are also mentioned in #355:

* Wheel and fanart still come only from `ss_metadata`, which is empty on any RomM library matched by IGDB, LaunchBox or MobyGames rather than ScreenScraper. That needs a new artwork source, not a fix.
* Games already in the library when RomM is connected are still never given RomM media. The import only runs on download.

Refs #355

## Steps to Verify

**Preconditions:** a connected RomM server, and a system with at least one ROM you have not downloaded yet. The natural trigger is a RomM library whose covers came from SteamGridDB or LaunchBox (those serve WebP); the forced repro below covers any library.

Natural repro:

1. In the RomM tab, download a game whose cover in RomM came from SteamGridDB or LaunchBox.
2. Open that system in the library. **Before:** no box art, though `user-data/media/<system>/box2d/<rom>.webp` exists on disk. **After:** box art shows, and the file on disk is `<rom>.png`.

Forced repro, for a library with no WebP covers:

1. Download any game from the RomM tab and confirm its box art shows.
2. Convert `user-data/media/<system>/box2d/<rom>.png` to a real WebP file, save it beside the original as `<rom>.webp`, and delete the `.png`. This is the exact on-disk state a WebP-cover library ends up in.
3. Restart the app so nothing is served from the image cache, then open that system. **Before:** the tile has no box art. **After:** the tile renders the `.webp`.

Cover source fallback:

1. Browse a platform in the RomM tab. Every ROM whose cover RomM can serve from either source now draws one, where previously a ROM with only a cached file and no `url_cover` drew a blank card.
2. Download one of those and confirm the box art carries into the library.

## Tested on

- [x] Android — device: AYN Thor
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Both halves were verified on the Thor. A fresh RomM download imported box2d (PNG 600x900), fanart (JPEG 1920x1080), wheel (PNG 400x139) and screenshot, all rendering. For the WebP half, that cover was converted to a real WebP, pushed back as the only `box2d` file for that ROM and the app hard-restarted: the box art still renders, where 0.10.0 showed nothing for the same file.

Desktop was not runtime-tested. The changed lookup and fetch paths are platform-independent and covered by unit tests.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1098)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses (no new assets)

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [ ] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [ ] No hardcoded UI strings — everything goes through `AppLocale`

No user-facing strings are added or changed.

**Android**
- [ ] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths
- [x] Verified on a device, not only on desktop

Media paths are plain filesystem paths under `user-data/`, not SAF URIs, and the media-path helpers themselves are unchanged.

</details>

## Screenshots / video

No visual change beyond artwork appearing where it previously did not.
