### PR TITLE
fix(db): serialize transactions so concurrent writers stop sharing one

### DIFF
--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -14,6 +14,7 @@ import '../../models/core_emulator_model.dart';
 // import '../models/neo_sync_models.dart'; // Removido si no se usa directamente aquí
 import '../../models/database_game_model.dart';
 import '../../utils/cloud_path_builder.dart';
+import '../../utils/semaphore.dart';
 import 'sqlite_migrations.dart';
 import '../../services/config_service.dart'; // Required for ConfigService usage
 import '../../services/json_config_service.dart';
@@ -248,25 +249,60 @@ class DatabaseAdapter implements DatabaseExecutorAdapter {
   @override
   BatchAdapter batch() => BatchAdapter(_db);
 
+  /// Serializes transactions opened against this connection.
+  ///
+  /// Every caller shares one [sqlite.Database], and `package:sqlite3` is
+  /// synchronous, so a statement executed while someone else holds `BEGIN`
+  /// joins *their* transaction whether it meant to or not.
+  static final Semaphore _transactionLock = Semaphore(1);
+
+  /// Marks the async task that currently owns the open transaction.
+  ///
+  /// Zone values propagate into the continuations of the guarded action, so a
+  /// nested [transaction] call from inside the body sees its own connection
+  /// here while an unrelated task does not.
+  static const Object _transactionOwnerKey = #sqliteTransactionOwner;
+
   /// Executes a series of database operations within an atomic transaction.
+  ///
+  /// Concurrent callers are serialized: a second task waits for the first to
+  /// commit rather than writing into its transaction. Genuine nesting still
+  /// runs inline on the outermost transaction — first-run setup does this three
+  /// levels deep (`_onCreate` → `_insertInitialData` →
+  /// `_executeSqlFileOptimized`) — which is why ownership is tracked per task
+  /// instead of read back off the connection.
+  ///
+  /// Previously this branched on `_db.autocommit`, which answers "is a
+  /// transaction open" rather than "is it mine". Two overlapping writers
+  /// therefore shared one transaction: the second returned success to its
+  /// caller with nothing committed, and the first's rollback discarded its work
+  /// as well. Where both wrote the same UNIQUE column the collision surfaced as
+  /// a constraint violation; everywhere else it was silent.
   Future<T> transaction<T>(
     Future<T> Function(TransactionAdapter) action,
   ) async {
-    final bool inTransaction = !_db.autocommit;
-    if (inTransaction) {
+    if (identical(Zone.current[_transactionOwnerKey], _db)) {
       return await action(TransactionAdapter(_db));
     }
 
-    _db.execute('BEGIN');
+    await _transactionLock.acquire();
     try {
-      final result = await action(TransactionAdapter(_db));
-      _db.execute('COMMIT');
-      return result;
-    } catch (e) {
-      if (!_db.autocommit) {
-        _db.execute('ROLLBACK');
+      _db.execute('BEGIN');
+      try {
+        final result = await runZoned(
+          () => action(TransactionAdapter(_db)),
+          zoneValues: {_transactionOwnerKey: _db},
+        );
+        _db.execute('COMMIT');
+        return result;
+      } catch (e) {
+        if (!_db.autocommit) {
+          _db.execute('ROLLBACK');
+        }
+        rethrow;
       }
-      rethrow;
+    } finally {
+      _transactionLock.release();
     }
   }
 }
@@ -2532,7 +2568,12 @@ class SqliteService {
   /// [recoverRomFoldersFromStoredRoms] nothing to derive a root from.
   static Future<void> saveUserRomFolders(List<String> folders) async {
     final db = await instance.database;
-    final paths = folders.where((folder) => folder.isNotEmpty).toList();
+    // Deduplicated because `path` is UNIQUE: a caller that appended a folder it
+    // already held would otherwise collide with itself mid-transaction.
+    final paths = folders
+        .where((folder) => folder.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
 
     if (paths.isEmpty) {
       final rows = await db.rawQuery(
@@ -2552,7 +2593,9 @@ class SqliteService {
     await db.transaction((txn) async {
       await txn.delete('user_rom_folders');
       for (final folder in paths) {
-        await txn.insert('user_rom_folders', {'path': folder});
+        await txn.insert('user_rom_folders', {
+          'path': folder,
+        }, conflictAlgorithm: ConflictAlgorithm.ignore);
       }
     });
   }

--- a/lib/services/screenscraper_service.dart
+++ b/lib/services/screenscraper_service.dart
@@ -383,6 +383,13 @@ class ScreenScraperService {
           _log.e('Error getting game information: ${data['header']['error']}');
           return null;
         }
+      } else if (response.statusCode == 404) {
+        // ScreenScraper answers an unmatched ROM with 404 ("Rom/Iso/Dossier
+        // non trouvee"), which is an ordinary outcome of a scrape sweep rather
+        // than a fault. Logged at error it buried everything else: 478 of the
+        // 575 error lines in one user's log were this one line repeating.
+        _log.d('ScreenScraper has no entry for "$romName"');
+        return null;
       } else {
         _log.e('HTTP Error ${response.statusCode}: ${response.body}');
         return null;

--- a/test/sqlite_transaction_serialization_test.dart
+++ b/test/sqlite_transaction_serialization_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+
+/// Tests for [DatabaseAdapter.transaction]'s serialization.
+///
+/// Every caller shares one connection and `package:sqlite3` is synchronous, so
+/// a transaction body that awaits used to let an unrelated task run its
+/// statements inside the open transaction. The second task returned success
+/// with nothing committed, and the first task's rollback discarded its work.
+void main() {
+  late Database db;
+  late DatabaseAdapter adapter;
+
+  setUp(() {
+    db = sqlite3.openInMemory();
+    db.execute('''
+      CREATE TABLE user_rom_folders (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        path TEXT NOT NULL UNIQUE
+      )
+    ''');
+    adapter = DatabaseAdapter(db);
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  int rowCount() =>
+      db.select('SELECT COUNT(*) AS c FROM user_rom_folders').first['c'] as int;
+
+  /// The shape of `saveUserRomFolders`: replace the table's contents wholesale.
+  Future<void> replaceFolders(List<String> paths) {
+    return adapter.transaction((txn) async {
+      await txn.delete('user_rom_folders');
+      for (final path in paths) {
+        await txn.insert('user_rom_folders', {'path': path});
+      }
+    });
+  }
+
+  group('concurrent transactions', () {
+    test('overlapping writers do not share one transaction', () async {
+      const folder = 'content://tree/primary%3AROMs';
+      await replaceFolders([folder]);
+
+      // Started together and awaited together: the second call enters while the
+      // first is suspended mid-transaction. Before serialization the second
+      // re-inserted the row the first had already deleted, and the first's own
+      // insert then failed with UNIQUE constraint failed (code 2067).
+      await Future.wait([
+        replaceFolders([folder]),
+        replaceFolders([folder]),
+      ]);
+
+      expect(rowCount(), 1);
+    });
+
+    test('a failing transaction does not roll back a concurrent one', () async {
+      await adapter.execute(
+        "INSERT INTO user_rom_folders (path) VALUES ('seed')",
+      );
+
+      final failing = adapter.transaction((txn) async {
+        await txn.insert('user_rom_folders', {'path': 'from-failing'});
+        await Future<void>.delayed(Duration.zero);
+        throw StateError('boom');
+      });
+
+      final succeeding = adapter.transaction((txn) async {
+        await txn.insert('user_rom_folders', {'path': 'from-succeeding'});
+      });
+
+      await expectLater(failing, throwsStateError);
+      await succeeding;
+
+      final paths = db
+          .select('SELECT path FROM user_rom_folders ORDER BY path')
+          .map((row) => row['path'].toString())
+          .toList();
+
+      // The failing transaction takes only its own row with it.
+      expect(paths, ['from-succeeding', 'seed']);
+    });
+
+    test('transactions commit in the order they were started', () async {
+      final order = <int>[];
+      await Future.wait([
+        for (var i = 0; i < 5; i++)
+          adapter.transaction((txn) async {
+            await txn.insert('user_rom_folders', {'path': 'folder-$i'});
+            await Future<void>.delayed(Duration.zero);
+            order.add(i);
+          }),
+      ]);
+
+      expect(order, [0, 1, 2, 3, 4]);
+      expect(rowCount(), 5);
+    });
+  });
+
+  group('nested transactions', () {
+    // First-run setup nests three deep (_onCreate -> _insertInitialData ->
+    // _executeSqlFileOptimized), so the lock has to let the owning task back in
+    // rather than deadlock on itself.
+    test('a nested transaction runs inline on the outer one', () async {
+      await adapter.transaction((outer) async {
+        await outer.insert('user_rom_folders', {'path': 'outer'});
+        await adapter.transaction((inner) async {
+          await inner.insert('user_rom_folders', {'path': 'inner'});
+        });
+      });
+
+      expect(rowCount(), 2);
+    });
+
+    test('nesting three deep completes', () async {
+      await adapter.transaction((_) async {
+        await adapter.transaction((_) async {
+          await adapter.transaction((txn) async {
+            await txn.insert('user_rom_folders', {'path': 'deep'});
+          });
+        });
+      });
+
+      expect(rowCount(), 1);
+    });
+
+    test('an outer rollback discards the nested work too', () async {
+      await expectLater(
+        adapter.transaction((outer) async {
+          await outer.insert('user_rom_folders', {'path': 'outer'});
+          await adapter.transaction((inner) async {
+            await inner.insert('user_rom_folders', {'path': 'inner'});
+          });
+          throw StateError('boom');
+        }),
+        throwsStateError,
+      );
+
+      expect(rowCount(), 0);
+    });
+
+    test('the lock is released after a nested failure', () async {
+      await expectLater(
+        adapter.transaction((_) async {
+          await adapter.transaction((_) async {
+            throw StateError('boom');
+          });
+        }),
+        throwsStateError,
+      );
+
+      // Would hang if the failure path leaked the semaphore slot.
+      await replaceFolders(['after']);
+      expect(rowCount(), 1);
+    });
+  });
+}


### PR DESCRIPTION
<!-- Two commits, both from reading one user's log: the transaction fix below,
     and a logging-severity fix that made that log readable in the first place.
     Squashing loses the second from the release notes — worth splitting the
     title or merging with both commits if that matters. -->

# Description

`DatabaseAdapter.transaction()` decided whether to open a transaction by reading `_db.autocommit`, which answers "is a transaction open" rather than "is it mine".

Every caller shares one `sqlite3` connection and the package is synchronous, so two overlapping writers interleaved:

1. A finds `autocommit == true`, issues `BEGIN`, starts work, hits an `await` and yields.
2. B enters `transaction()`, finds `autocommit == false`, and runs its statements inside A's transaction. B returns success to its caller with nothing committed.
3. A resumes. If A fails, its `ROLLBACK` discards B's work along with its own.

Where both wrote the same UNIQUE column the collision surfaced; everywhere else it was silent. `saveUserRomFolders` is the visible case because it is the only delete-then-insert on a UNIQUE column. A user log (Retroid Pocket Nova, 0.10.0) shows 64 × `UNIQUE constraint failed: user_rom_folders.path` across 31 launches, with `scanSystems starting (romFolders=1, ...)` at every scan: one folder configured, the insert colliding with its own concurrent copy.

**On the actual harm, stated precisely.** In the observed case nothing is lost: A's rollback undoes A's delete, B's delete and B's insert, restoring the row that was there before, which is why the user's folder list stayed intact across all 31 launches. The visible cost is log noise plus one skipped `saveDetectedEmulatorPath` pass, and that re-detects on the next launch. The case worth fixing is the one the same interleave enables but that this log cannot prove happened: `saveUserConfig` writes settings with bare, non-transactional statements and runs immediately before `saveUserRomFolders` in `saveConfig`, so an overlapping save's settings can execute inside the other's open transaction and be rolled back with it. The caller returns successfully, the UI shows the new value, and it reverts on restart.

**Why not a plain mutex.** It would deadlock. First-run setup nests three levels deep (`_onCreate` → `_insertInitialData` → `_executeSqlFileOptimized`), which is exactly what the `autocommit` branch existed to support. So the lock is a semaphore plus an ownership marker held in a zone value: zone values propagate into the guarded action's continuations, so a nested call from inside the body still runs inline on the outermost transaction, while an unrelated task waits its turn.

Also dedupes `saveUserRomFolders`' input and inserts with `ConflictAlgorithm.ignore`, matching what `addRomFolder` already does, so it no longer sits on a constraint it can trip.

## Also here: an unmatched ROM is no longer logged as an error

Separate one-line fix, same user log. ScreenScraper answers a ROM it has no entry for with 404 (`Rom/Iso/Dossier non trouvée`), which is an ordinary outcome of a sweep over a library containing homebrew, hacks or odd regions. `fetchGameInfo` logged it through the generic HTTP branch at error level, one line per unmatched ROM: **478 of the 575 error lines in that log were this one message repeating**, which made the log useless for triaging the real faults sitting in it (including the transaction bug above, which took some digging to find underneath).

Now logged at debug, and it names the ROM, so the line says something the generic branch could not. Other status codes keep error level: a 429 or a 500 is a genuine fault and should still stand out.

## Known limitation, deliberately out of scope

This does not stop a bare, non-transactional write from executing while another task holds `BEGIN` and being rolled back with it — which is the settings-loss path described above. Closing that means routing every write through the same lock. It is a small diff (all typed writes delegate to `rawInsert`/`rawUpdate`/`rawDelete`, so it is four methods on `DatabaseAdapter`, not the 526 call sites) but it serializes every write in the app, and ROM scans are the heaviest writer. Left as a separate change so its cost can be measured on its own rather than smuggled in behind a bug fix.

## Steps to Verify

The bug is a race, so the reliable reproduction is the test rather than the UI. `test/sqlite_transaction_serialization_test.dart` fails on `main` and passes here:

**Preconditions:** none, the tests use an in-memory database.

1. `flutter test test/sqlite_transaction_serialization_test.dart` — 7 passing.
2. `git stash push lib/data/datasources/sqlite_service.dart && flutter test test/sqlite_transaction_serialization_test.dart` — 2 failures, the first being `UNIQUE constraint failed: user_rom_folders.path (code 2067)`, the user's exact error. `git stash pop` to restore.

The three nesting tests pass both with and without the change: they are there to prove the new lock does not break what the `autocommit` branch was protecting.

On-device, the risk worth smoke-testing is a deadlock: the transaction path now blocks where it used to fall through, and startup runs migrations and the scan through it.

**Preconditions:** AYN Thor, dev channel, release build, existing database (v128, 9,135 games).

1. Launch. Reaches the systems view, 36 systems loaded, `scanSystems` runs, RomM playtime pull and upload sweep both complete afterwards — so the app is progressing through DB work rather than stalled on the lock.
2. `app.log` for that session: zero `[E]` lines, no `UNIQUE constraint failed`.

What that covers is "the DB layer still works and nothing deadlocks". It does not reproduce the race — that needs two writers overlapping, which is what the unit tests do deterministically and the UI does not do on demand.

## Tested on

- [x] Android — device: AYN Thor (dev channel, release build)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1152)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — n/a

**The database**

No schema change, so no migration: this touches how transactions are opened, not what is in them. `_databaseVersion` is untouched.
