### PR TITLE
fix(systems): list a PS2 multi-disc game once by indexing its .m3u

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.12"
+  "latest_version": "0.3.14"
 }

--- a/assets/systems/ps2.json
+++ b/assets/systems/ps2.json
@@ -37,7 +37,8 @@
       "img",
       "cso",
       "elf",
-      "isz"
+      "isz",
+      "m3u"
     ]
   },
   "emulators": [

--- a/test/multi_disc_playlist_extensions_test.dart
+++ b/test/multi_disc_playlist_extensions_test.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the extension list every multi-disc system depends on.
+///
+/// A PS2 game split across two CHDs listed itself twice, once per disc: the
+/// scan only collapses a disc set into its `.m3u` when the system's extension
+/// list names `m3u` (`SqliteDatabaseService._filterM3uReferencedFiles` is
+/// gated on exactly that), and `ps2.json` did not name it — so the playlist was
+/// never even indexed, whether the user wrote it by hand or with the built-in
+/// multi-disc organizer. The flag saying PS2 *has* multi-disc games lives in
+/// the same file and is easy to set without its other half, so pin both.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<Map<String, dynamic>> loadSystem(String name) async {
+    final json =
+        jsonDecode(await rootBundle.loadString('assets/systems/$name'))
+            as Map<String, dynamic>;
+    return json['system'] as Map<String, dynamic>;
+  }
+
+  /// Systems that organize disc sets into a folder plus a playlist. Each one
+  /// has to index that playlist, or the discs it lists stay separate entries.
+  const multiDiscSystemsIndexingPlaylists = [
+    '3do.json',
+    'amiga.json',
+    'dc.json',
+    'dos.json',
+    'gc.json',
+    'pccd.json',
+    'ps1.json',
+    'ps2.json',
+    'sat.json',
+    'scd.json',
+    'tgcd.json',
+    'wii.json',
+  ];
+
+  for (final file in multiDiscSystemsIndexingPlaylists) {
+    test('$file indexes .m3u playlists alongside its disc images', () async {
+      final system = await loadSystem(file);
+
+      expect(system['multidisc'], isTrue, reason: '$file is multi-disc');
+      expect(
+        (system['extensions'] as List).map((e) => e.toString().toLowerCase()),
+        contains('m3u'),
+        reason: '$file must index the playlists the organizer writes',
+      );
+    });
+  }
+}


### PR DESCRIPTION
# Description

A PS2 game split across two discs listed itself twice, once per CHD. Neither a hand-written `.m3u` nor the built-in multi-disc organizer made any difference.

The scan only collapses a disc set into its playlist when the system's own extension list names `m3u`. That is what gates `_filterM3uReferencedFiles` (`lib/data/datasources/sqlite_database_service.dart:262`), which reads each scanned playlist and drops every file it references. `ps2.json` did not list `m3u`, so the walkers never collected the playlist in the first place (`sqlite_database_service.dart:1176`, and the native SAF walk at `MainActivity.kt:1347`) and the filter never ran. The secondary per-directory filter could not cover for it either: its candidate list is `{.bin,.iso,.img,.sub,.dat,.wav,.flac}`, so `.chd` discs are never suppressed by it.

`multidisc: true` was already set on PS2, but nothing in scanning or launching reads that flag. It only drives the organizer tool and the RetroAchievements queries. The extension list is the real switch, and the two had drifted apart. `psp`, `xbox`, `xbox360`, `cdi` and `jagcd` also carry `multidisc: true` without `m3u`, but they are deliberately left alone: none of them has a multi-disc library the organizer should be folding. They are flagged because the RetroAchievements query reads `multidisc` as "is this disc-based" (`includeDiscSystems`), which is a second, different meaning for the same flag. Untangling that is follow-up work, and now cheap: #375 gave every system an explicit `ra_hash` policy, which is a better predicate for that query than `multidisc`.

`assets/manifest.json` is bumped so existing installs pick the definition up over the air. Without it, anyone with a downloaded systems cache keeps shadowing the bundled file.

Two things worth knowing when this ships:

- **Existing PS2 libraries need a rescan.** The extension list syncs into the database on every launch, but the two `.chd` rows are already there and the `.m3u` is not.
- **RomM multi-disc unpacking now applies to PS2.** `lib/providers/romm_provider.dart` gates "unpack a multi-disc zip into playlist plus discs" on `exts.contains('m3u')`, so PS2 now behaves like PS1 on that path.

## Steps to Verify

**Preconditions:** Android, a PS2 game split across two discs (e.g. `Star Ocean - Till the End of Time (Disc 1).chd` and `(Disc 2).chd`) in the `ps2` ROM folder.

1. On a build without this change, scan the PS2 system and note the game appears twice, once per disc.
2. Run Settings > Tools > organize multi-disc games. The discs move into a per-game folder with a `<Game>.m3u` next to them, and the game still lists twice.
3. Install this build, then rescan the PS2 system.
4. The game now lists once, under the playlist's name, and launches.

## Tested on

- [x] Android — device: reporter's device (fix applied to `ps2.json` locally, listing collapses to one entry and the game launches)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1197)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths — no new path logic; the existing SAF-aware playlist filter is simply reached now
- [x] Verified on a device, not only on desktop

**`assets/systems/` or emulator launching**
- [x] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible — JSON only, no code change
- [x] `assets/manifest.json` version bumped if this should reach existing installs OTA

</details>

