### PR TITLE
feat(sync): show which provider owns save sync on the RomM and NeoSync screens

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -1055,6 +1055,7 @@ mixin AppLocale {
   static const String rommSaveSyncActive = 'romm_save_sync_active';
   static const String saveSyncHandledBy = 'save_sync_handled_by';
   static const String saveSyncSingleProvider = 'save_sync_single_provider';
+  static const String saveSyncNoneActive = 'save_sync_none_active';
   static const String rommBrowseLibrary = 'romm_browse_library';
   static const String rommStatusConnected = 'romm_status_connected';
   static const String rommStatusDisconnected = 'romm_status_disconnected';

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -1053,6 +1053,8 @@ mixin AppLocale {
   static const String rommUseForSaveSync = 'romm_use_for_save_sync';
   static const String rommSaveSyncLabel = 'romm_save_sync_label';
   static const String rommSaveSyncActive = 'romm_save_sync_active';
+  static const String saveSyncHandledBy = 'save_sync_handled_by';
+  static const String saveSyncSingleProvider = 'save_sync_single_provider';
   static const String rommBrowseLibrary = 'romm_browse_library';
   static const String rommStatusConnected = 'romm_status_connected';
   static const String rommStatusDisconnected = 'romm_status_disconnected';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -1000,6 +1000,10 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.rommUseForSaveSync: 'RomM für Spielstand-Sync verwenden',
   AppLocale.rommSaveSyncLabel: 'RomM-Sync',
   AppLocale.rommSaveSyncActive: 'RomM ist dein Anbieter für Spielstand-Sync',
+  AppLocale.saveSyncHandledBy:
+      'Die Spielstand-Synchronisierung übernimmt {provider}',
+  AppLocale.saveSyncSingleProvider:
+      'Es synchronisiert immer nur ein Anbieter die Spielstände',
   AppLocale.rommBrowseLibrary: 'Bibliothek durchstöbern',
   AppLocale.rommStatusConnected: 'Verbunden',
   AppLocale.rommStatusDisconnected: 'Nicht verbunden',

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -1004,6 +1004,7 @@ const Map<String, dynamic> appLocaleDe = {
       'Die Spielstand-Synchronisierung übernimmt {provider}',
   AppLocale.saveSyncSingleProvider:
       'Es synchronisiert immer nur ein Anbieter die Spielstände',
+  AppLocale.saveSyncNoneActive: 'Keine Speicherstand-Synchronisierung aktiv',
   AppLocale.rommBrowseLibrary: 'Bibliothek durchstöbern',
   AppLocale.rommStatusConnected: 'Verbunden',
   AppLocale.rommStatusDisconnected: 'Nicht verbunden',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -967,6 +967,8 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.rommUseForSaveSync: 'Use RomM for save sync',
   AppLocale.rommSaveSyncLabel: 'RomM Sync',
   AppLocale.rommSaveSyncActive: 'RomM is your save-sync provider',
+  AppLocale.saveSyncHandledBy: 'Save sync is handled by {provider}',
+  AppLocale.saveSyncSingleProvider: 'Only one provider syncs saves at a time',
   AppLocale.rommBrowseLibrary: 'Browse Library',
   AppLocale.rommStatusConnected: 'Connected',
   AppLocale.rommStatusDisconnected: 'Not connected',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -969,6 +969,7 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.rommSaveSyncActive: 'RomM is your save-sync provider',
   AppLocale.saveSyncHandledBy: 'Save sync is handled by {provider}',
   AppLocale.saveSyncSingleProvider: 'Only one provider syncs saves at a time',
+  AppLocale.saveSyncNoneActive: 'No save sync active',
   AppLocale.rommBrowseLibrary: 'Browse Library',
   AppLocale.rommStatusConnected: 'Connected',
   AppLocale.rommStatusDisconnected: 'Not connected',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -1002,6 +1002,7 @@ const Map<String, dynamic> appLocaleEs = {
       'La sincronización de partidas la gestiona {provider}',
   AppLocale.saveSyncSingleProvider:
       'Solo un proveedor sincroniza las partidas a la vez',
+  AppLocale.saveSyncNoneActive: 'Sin sincronización de partidas activa',
   AppLocale.rommBrowseLibrary: 'Explorar biblioteca',
   AppLocale.rommStatusConnected: 'Conectado',
   AppLocale.rommStatusDisconnected: 'No conectado',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -998,6 +998,10 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.rommSaveSyncLabel: 'Sinc. RomM',
   AppLocale.rommSaveSyncActive:
       'RomM es tu proveedor de sincronización de partidas',
+  AppLocale.saveSyncHandledBy:
+      'La sincronización de partidas la gestiona {provider}',
+  AppLocale.saveSyncSingleProvider:
+      'Solo un proveedor sincroniza las partidas a la vez',
   AppLocale.rommBrowseLibrary: 'Explorar biblioteca',
   AppLocale.rommStatusConnected: 'Conectado',
   AppLocale.rommStatusDisconnected: 'No conectado',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -1004,6 +1004,10 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.rommSaveSyncLabel: 'Sync RomM',
   AppLocale.rommSaveSyncActive:
       'RomM est votre fournisseur de synchro des sauvegardes',
+  AppLocale.saveSyncHandledBy:
+      'La synchronisation des sauvegardes est gérée par {provider}',
+  AppLocale.saveSyncSingleProvider:
+      'Un seul fournisseur synchronise les sauvegardes à la fois',
   AppLocale.rommBrowseLibrary: 'Parcourir la bibliothèque',
   AppLocale.rommStatusConnected: 'Connecté',
   AppLocale.rommStatusDisconnected: 'Non connecté',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -1008,6 +1008,7 @@ const Map<String, dynamic> appLocaleFr = {
       'La synchronisation des sauvegardes est gérée par {provider}',
   AppLocale.saveSyncSingleProvider:
       'Un seul fournisseur synchronise les sauvegardes à la fois',
+  AppLocale.saveSyncNoneActive: 'Aucune synchronisation des sauvegardes active',
   AppLocale.rommBrowseLibrary: 'Parcourir la bibliothèque',
   AppLocale.rommStatusConnected: 'Connecté',
   AppLocale.rommStatusDisconnected: 'Non connecté',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -971,6 +971,10 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.rommSaveSyncLabel: 'Sinkron RomM',
   AppLocale.rommSaveSyncActive:
       'RomM adalah penyedia sinkronisasi simpanan Anda',
+  AppLocale.saveSyncHandledBy:
+      'Sinkronisasi simpanan ditangani oleh {provider}',
+  AppLocale.saveSyncSingleProvider:
+      'Hanya satu penyedia yang menyinkronkan simpanan dalam satu waktu',
   AppLocale.rommBrowseLibrary: 'Jelajahi Pustaka',
   AppLocale.rommStatusConnected: 'Terhubung',
   AppLocale.rommStatusDisconnected: 'Tidak terhubung',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -975,6 +975,7 @@ const Map<String, dynamic> appLocaleId = {
       'Sinkronisasi simpanan ditangani oleh {provider}',
   AppLocale.saveSyncSingleProvider:
       'Hanya satu penyedia yang menyinkronkan simpanan dalam satu waktu',
+  AppLocale.saveSyncNoneActive: 'Tidak ada sinkronisasi simpanan yang aktif',
   AppLocale.rommBrowseLibrary: 'Jelajahi Pustaka',
   AppLocale.rommStatusConnected: 'Terhubung',
   AppLocale.rommStatusDisconnected: 'Tidak terhubung',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -999,6 +999,8 @@ const Map<String, dynamic> appLocaleIt = {
       'La sincronizzazione dei salvataggi è gestita da {provider}',
   AppLocale.saveSyncSingleProvider:
       'Solo un provider sincronizza i salvataggi alla volta',
+  AppLocale.saveSyncNoneActive:
+      'Nessuna sincronizzazione dei salvataggi attiva',
   AppLocale.rommBrowseLibrary: 'Sfoglia libreria',
   AppLocale.rommStatusConnected: 'Connesso',
   AppLocale.rommStatusDisconnected: 'Non connesso',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -995,6 +995,10 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.rommSaveSyncLabel: 'Sinc. RomM',
   AppLocale.rommSaveSyncActive:
       'RomM è il tuo servizio di sincronizzazione dei salvataggi',
+  AppLocale.saveSyncHandledBy:
+      'La sincronizzazione dei salvataggi è gestita da {provider}',
+  AppLocale.saveSyncSingleProvider:
+      'Solo un provider sincronizza i salvataggi alla volta',
   AppLocale.rommBrowseLibrary: 'Sfoglia libreria',
   AppLocale.rommStatusConnected: 'Connesso',
   AppLocale.rommStatusDisconnected: 'Non connesso',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -881,6 +881,8 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.rommUseForSaveSync: 'セーブデータの同期に RomM を使用',
   AppLocale.rommSaveSyncLabel: 'RomM 同期',
   AppLocale.rommSaveSyncActive: 'RomM がセーブデータ同期の提供元です',
+  AppLocale.saveSyncHandledBy: 'セーブデータの同期は {provider} が担当しています',
+  AppLocale.saveSyncSingleProvider: 'セーブデータを同期できる提供元は同時に 1 つだけです',
   AppLocale.rommBrowseLibrary: 'ライブラリを閲覧',
   AppLocale.rommStatusConnected: '接続済み',
   AppLocale.rommStatusDisconnected: '未接続',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -883,6 +883,7 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.rommSaveSyncActive: 'RomM がセーブデータ同期の提供元です',
   AppLocale.saveSyncHandledBy: 'セーブデータの同期は {provider} が担当しています',
   AppLocale.saveSyncSingleProvider: 'セーブデータを同期できる提供元は同時に 1 つだけです',
+  AppLocale.saveSyncNoneActive: 'セーブデータの同期は無効です',
   AppLocale.rommBrowseLibrary: 'ライブラリを閲覧',
   AppLocale.rommStatusConnected: '接続済み',
   AppLocale.rommStatusDisconnected: '未接続',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -891,6 +891,8 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.rommUseForSaveSync: '저장 동기화에 RomM 사용',
   AppLocale.rommSaveSyncLabel: 'RomM 동기화',
   AppLocale.rommSaveSyncActive: 'RomM이 저장 동기화 제공자입니다',
+  AppLocale.saveSyncHandledBy: '세이브 동기화는 {provider}에서 처리합니다',
+  AppLocale.saveSyncSingleProvider: '한 번에 하나의 제공자만 세이브를 동기화합니다',
   AppLocale.rommBrowseLibrary: '라이브러리 탐색',
   AppLocale.rommStatusConnected: '연결됨',
   AppLocale.rommStatusDisconnected: '연결되지 않음',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -893,6 +893,7 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.rommSaveSyncActive: 'RomM이 저장 동기화 제공자입니다',
   AppLocale.saveSyncHandledBy: '세이브 동기화는 {provider}에서 처리합니다',
   AppLocale.saveSyncSingleProvider: '한 번에 하나의 제공자만 세이브를 동기화합니다',
+  AppLocale.saveSyncNoneActive: '활성화된 세이브 동기화가 없습니다',
   AppLocale.rommBrowseLibrary: '라이브러리 탐색',
   AppLocale.rommStatusConnected: '연결됨',
   AppLocale.rommStatusDisconnected: '연결되지 않음',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -984,6 +984,7 @@ const Map<String, dynamic> appLocalePt = {
       'A sincronização de saves é feita pelo {provider}',
   AppLocale.saveSyncSingleProvider:
       'Apenas um provedor sincroniza os saves de cada vez',
+  AppLocale.saveSyncNoneActive: 'Nenhuma sincronização de saves ativa',
   AppLocale.rommBrowseLibrary: 'Navegar na biblioteca',
   AppLocale.rommStatusConnected: 'Conectado',
   AppLocale.rommStatusDisconnected: 'Não conectado',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -980,6 +980,10 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.rommSaveSyncLabel: 'Sinc. RomM',
   AppLocale.rommSaveSyncActive:
       'O RomM é seu provedor de sincronização de saves',
+  AppLocale.saveSyncHandledBy:
+      'A sincronização de saves é feita pelo {provider}',
+  AppLocale.saveSyncSingleProvider:
+      'Apenas um provedor sincroniza os saves de cada vez',
   AppLocale.rommBrowseLibrary: 'Navegar na biblioteca',
   AppLocale.rommStatusConnected: 'Conectado',
   AppLocale.rommStatusDisconnected: 'Não conectado',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -969,6 +969,10 @@ const Map<String, dynamic> appLocaleRu = {
       'Использовать RomM для синхронизации сохранений',
   AppLocale.rommSaveSyncLabel: 'Синх. RomM',
   AppLocale.rommSaveSyncActive: 'RomM — ваш сервис синхронизации сохранений',
+  AppLocale.saveSyncHandledBy:
+      'Синхронизацией сохранений занимается {provider}',
+  AppLocale.saveSyncSingleProvider:
+      'Сохранения синхронизирует только один провайдер одновременно',
   AppLocale.rommBrowseLibrary: 'Просмотр библиотеки',
   AppLocale.rommStatusConnected: 'Подключено',
   AppLocale.rommStatusDisconnected: 'Не подключено',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -973,6 +973,7 @@ const Map<String, dynamic> appLocaleRu = {
       'Синхронизацией сохранений занимается {provider}',
   AppLocale.saveSyncSingleProvider:
       'Сохранения синхронизирует только один провайдер одновременно',
+  AppLocale.saveSyncNoneActive: 'Синхронизация сохранений не активна',
   AppLocale.rommBrowseLibrary: 'Просмотр библиотеки',
   AppLocale.rommStatusConnected: 'Подключено',
   AppLocale.rommStatusDisconnected: 'Не подключено',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -868,6 +868,7 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.rommSaveSyncActive: 'RomM 是你的存档同步服务',
   AppLocale.saveSyncHandledBy: '存档同步由 {provider} 负责',
   AppLocale.saveSyncSingleProvider: '同一时间只有一个提供方同步存档',
+  AppLocale.saveSyncNoneActive: '当前没有启用存档同步',
   AppLocale.rommBrowseLibrary: '浏览库',
   AppLocale.rommStatusConnected: '已连接',
   AppLocale.rommStatusDisconnected: '未连接',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -866,6 +866,8 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.rommUseForSaveSync: '使用 RomM 同步存档',
   AppLocale.rommSaveSyncLabel: 'RomM 同步',
   AppLocale.rommSaveSyncActive: 'RomM 是你的存档同步服务',
+  AppLocale.saveSyncHandledBy: '存档同步由 {provider} 负责',
+  AppLocale.saveSyncSingleProvider: '同一时间只有一个提供方同步存档',
   AppLocale.rommBrowseLibrary: '浏览库',
   AppLocale.rommStatusConnected: '已连接',
   AppLocale.rommStatusDisconnected: '未连接',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -866,6 +866,8 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.rommUseForSaveSync: '使用 RomM 同步存檔',
   AppLocale.rommSaveSyncLabel: 'RomM 同步',
   AppLocale.rommSaveSyncActive: 'RomM 是你的存檔同步服務',
+  AppLocale.saveSyncHandledBy: '存檔同步由 {provider} 負責',
+  AppLocale.saveSyncSingleProvider: '同一時間只有一個提供方同步存檔',
   AppLocale.rommBrowseLibrary: '瀏覽庫',
   AppLocale.rommStatusConnected: '已連線',
   AppLocale.rommStatusDisconnected: '未連線',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -868,6 +868,7 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.rommSaveSyncActive: 'RomM 是你的存檔同步服務',
   AppLocale.saveSyncHandledBy: '存檔同步由 {provider} 負責',
   AppLocale.saveSyncSingleProvider: '同一時間只有一個提供方同步存檔',
+  AppLocale.saveSyncNoneActive: '目前沒有啟用存檔同步',
   AppLocale.rommBrowseLibrary: '瀏覽庫',
   AppLocale.rommStatusConnected: '已連線',
   AppLocale.rommStatusDisconnected: '未連線',

--- a/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
+++ b/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
@@ -498,12 +498,16 @@ class NeoSyncContentState extends State<NeoSyncContent>
           return const SizedBox.shrink();
         }
         final owner = syncManager.active;
-        if (owner == null || !owner.isAuthenticated) {
-          return const SizedBox.shrink();
-        }
+        final ownerSignedIn = owner != null && owner.isAuthenticated;
         final theme = Theme.of(context);
         final radii = theme.extension<CornerRadii>() ?? CornerRadii.m();
-        final providerName = owner.meta.name;
+        // Signed into NeoSync but another provider holds save sync while it is
+        // signed out: nothing is syncing, and being signed in here is exactly
+        // what makes that hard to guess.
+        final text = ownerSignedIn
+            ? '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', owner.meta.name)} · '
+                  '${AppLocale.saveSyncSingleProvider.getString(context)}'
+            : AppLocale.saveSyncNoneActive.getString(context);
         return Padding(
           padding: EdgeInsets.only(bottom: 8.r),
           child: Container(
@@ -526,8 +530,7 @@ class NeoSyncContentState extends State<NeoSyncContent>
                 SizedBox(width: 8.r),
                 Expanded(
                   child: Text(
-                    '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', providerName)} · '
-                    '${AppLocale.saveSyncSingleProvider.getString(context)}',
+                    text,
                     style: TextStyle(
                       fontSize: 11.r,
                       color: theme.colorScheme.onSurface,

--- a/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
+++ b/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
@@ -20,6 +20,8 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:neostation/services/gamepad/gamepad_navigation_manager.dart';
 import 'package:neostation/themes/corner_radii.dart';
+import 'package:neostation/sync/sync_manager.dart';
+import 'package:neostation/sync/providers/neo_sync_adapter.dart';
 import '../../app_screen.dart';
 import 'save_list_view.dart';
 import 'neo_sync_shared.dart';
@@ -452,6 +454,10 @@ class NeoSyncContentState extends State<NeoSyncContent>
           return Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              // Tells the user when their saves are going somewhere else:
+              // save sync has a single owner, so this dashboard otherwise
+              // looks fully live while another provider holds it.
+              _buildSaveSyncOwnerNotice(),
               // Main row: profile header (left) + menu options (right)
               Expanded(
                 child: Row(
@@ -473,6 +479,61 @@ class NeoSyncContentState extends State<NeoSyncContent>
           );
         },
       ),
+    );
+  }
+
+  /// Notice shown when another provider (e.g. RomM) owns save sync.
+  ///
+  /// Only one provider syncs saves at a time ([SyncManager] holds a single
+  /// active id), and nothing else on this screen reflects that — the account,
+  /// plan and save list all render normally while NeoSync sync is idle.
+  Widget _buildSaveSyncOwnerNotice() {
+    return Consumer<SyncManager>(
+      builder: (context, syncManager, _) {
+        if (syncManager.activeProviderId == NeoSyncAdapter.kProviderId) {
+          return const SizedBox.shrink();
+        }
+        final theme = Theme.of(context);
+        final radii = theme.extension<CornerRadii>() ?? CornerRadii.m();
+        final providerName =
+            syncManager.active?.meta.name ?? syncManager.activeProviderId;
+        return Padding(
+          padding: EdgeInsets.only(bottom: 8.r),
+          child: Container(
+            padding: EdgeInsets.symmetric(horizontal: 10.r, vertical: 8.r),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.tertiary.withValues(alpha: 0.12),
+              borderRadius: radii.radiusExternal,
+              border: Border.all(
+                color: theme.colorScheme.tertiary.withValues(alpha: 0.5),
+                width: 1.r,
+              ),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  Symbols.info_rounded,
+                  size: 16.r,
+                  color: theme.colorScheme.tertiary,
+                ),
+                SizedBox(width: 8.r),
+                Expanded(
+                  child: Text(
+                    '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', providerName)} · '
+                    '${AppLocale.saveSyncSingleProvider.getString(context)}',
+                    style: TextStyle(
+                      fontSize: 11.r,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 2,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 

--- a/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
+++ b/lib/screens/neo_sync_screen/login_screen/neo_sync_content.dart
@@ -487,16 +487,23 @@ class NeoSyncContentState extends State<NeoSyncContent>
   /// Only one provider syncs saves at a time ([SyncManager] holds a single
   /// active id), and nothing else on this screen reflects that — the account,
   /// plan and save list all render normally while NeoSync sync is idle.
+  ///
+  /// Gated on the owner actually being signed in. A provider that holds save
+  /// sync while logged out is not handling anything, so naming it would trade
+  /// one wrong impression for another.
   Widget _buildSaveSyncOwnerNotice() {
     return Consumer<SyncManager>(
       builder: (context, syncManager, _) {
         if (syncManager.activeProviderId == NeoSyncAdapter.kProviderId) {
           return const SizedBox.shrink();
         }
+        final owner = syncManager.active;
+        if (owner == null || !owner.isAuthenticated) {
+          return const SizedBox.shrink();
+        }
         final theme = Theme.of(context);
         final radii = theme.extension<CornerRadii>() ?? CornerRadii.m();
-        final providerName =
-            syncManager.active?.meta.name ?? syncManager.activeProviderId;
+        final providerName = owner.meta.name;
         return Padding(
           padding: EdgeInsets.only(bottom: 8.r),
           child: Container(

--- a/lib/screens/romm_screen/romm_browse_screen.dart
+++ b/lib/screens/romm_screen/romm_browse_screen.dart
@@ -939,8 +939,9 @@ class _RommBrowseScreenState extends State<RommBrowseScreen> {
                       ),
                       Text(
                         AppLocale.rommConnectedAs
-                            .getString(context)
-                            .replaceAll('{user}', provider.username),
+                                .getString(context)
+                                .replaceAll('{user}', provider.username) +
+                            _saveSyncOwnerSuffix(),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
@@ -1106,6 +1107,22 @@ class _RommBrowseScreenState extends State<RommBrowseScreen> {
   bool get _isSaveSyncActive =>
       SyncManager.instance.activeProviderId == RomMSyncProvider.kProviderId;
 
+  /// Names the provider that owns save sync, appended to the account line when
+  /// it is not RomM.
+  ///
+  /// A connected server, its downloads and its playtime all keep working while
+  /// another provider holds save sync — connecting to RomM deliberately does
+  /// not take it off a NeoSync account that is still signed in — so without
+  /// this the screen reads as "RomM is syncing everything". Empty when RomM
+  /// owns it: the toggle beside this line already says so.
+  String _saveSyncOwnerSuffix() {
+    if (_isSaveSyncActive) return '';
+    final active = SyncManager.instance.active;
+    final name = active?.meta.name ?? SyncManager.instance.activeProviderId;
+    return ' · '
+        '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', name)}';
+  }
+
   /// Toggles whether RomM is the active save-sync provider (vs NeoSync).
   Future<void> _toggleSaveSync() async {
     final persist = context
@@ -1116,9 +1133,15 @@ class _RommBrowseScreenState extends State<RommBrowseScreen> {
         : RomMSyncProvider.kProviderId;
     await SyncManager.instance.setActive(target, persist: persist);
     if (!mounted) return;
+    // Name the provider that just took over rather than echoing the toggle's
+    // own label: only one provider syncs saves, and which one it now is the
+    // only thing the toast can usefully confirm.
+    final owner = SyncManager.instance.active?.meta.name ?? target;
     AppNotification.showNotification(
       context,
-      AppLocale.rommUseForSaveSync.getString(context),
+      AppLocale.saveSyncHandledBy
+          .getString(context)
+          .replaceFirst('{provider}', owner),
       type: NotificationType.info,
     );
     setState(() {});

--- a/lib/screens/romm_screen/romm_browse_screen.dart
+++ b/lib/screens/romm_screen/romm_browse_screen.dart
@@ -1089,12 +1089,10 @@ class _RommBrowseScreenState extends State<RommBrowseScreen> {
     // NeoSync. Leaving "romm" active against a server we just forgot would
     // silently stop ALL save sync — RomM errors out, NeoSync sits idle —
     // until the user thought to re-toggle it.
-    if (SyncManager.instance.activeProviderId == RomMSyncProvider.kProviderId) {
-      await SyncManager.instance.setActive(
-        NeoSyncAdapter.kProviderId,
-        persist: persist,
-      );
-    }
+    await SyncManager.instance.releaseIfActive(
+      RomMSyncProvider.kProviderId,
+      persist: persist,
+    );
     if (!mounted) return;
     AppNotification.showNotification(
       context,

--- a/lib/screens/romm_screen/romm_browse_screen.dart
+++ b/lib/screens/romm_screen/romm_browse_screen.dart
@@ -1118,9 +1118,13 @@ class _RommBrowseScreenState extends State<RommBrowseScreen> {
   String _saveSyncOwnerSuffix() {
     if (_isSaveSyncActive) return '';
     final owner = SyncManager.instance.active;
-    // Signed out, it is not handling save sync either: naming it would just
-    // point at a second thing that is not syncing.
-    if (owner == null || !owner.isAuthenticated) return '';
+    // Signed out, it is not handling save sync either — so say that nothing
+    // is, rather than naming a second provider that also isn't syncing. This
+    // is the state where a connected server, its downloads and its playtime
+    // all look healthy while no save leaves the device.
+    if (owner == null || !owner.isAuthenticated) {
+      return ' · ${AppLocale.saveSyncNoneActive.getString(context)}';
+    }
     return ' · '
         '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', owner.meta.name)}';
   }
@@ -1137,9 +1141,9 @@ class _RommBrowseScreenState extends State<RommBrowseScreen> {
     if (!mounted) return;
     // Name the provider that just took over rather than echoing the toggle's
     // own label: only one provider syncs saves, and which one it now is the
-    // only thing the toast can usefully confirm. Unless it is signed out, in
-    // which case it is not handling saves and the toggle's own label is the
-    // honest confirmation.
+    // only thing the toast can usefully confirm. When that provider is signed
+    // out it took over nothing, and the honest confirmation is that save sync
+    // is now off entirely.
     final owner = SyncManager.instance.active;
     final signedIn = owner != null && owner.isAuthenticated;
     AppNotification.showNotification(
@@ -1148,7 +1152,7 @@ class _RommBrowseScreenState extends State<RommBrowseScreen> {
           ? AppLocale.saveSyncHandledBy
                 .getString(context)
                 .replaceFirst('{provider}', owner.meta.name)
-          : AppLocale.rommUseForSaveSync.getString(context),
+          : AppLocale.saveSyncNoneActive.getString(context),
       type: NotificationType.info,
     );
     setState(() {});

--- a/lib/screens/romm_screen/romm_browse_screen.dart
+++ b/lib/screens/romm_screen/romm_browse_screen.dart
@@ -1117,10 +1117,12 @@ class _RommBrowseScreenState extends State<RommBrowseScreen> {
   /// owns it: the toggle beside this line already says so.
   String _saveSyncOwnerSuffix() {
     if (_isSaveSyncActive) return '';
-    final active = SyncManager.instance.active;
-    final name = active?.meta.name ?? SyncManager.instance.activeProviderId;
+    final owner = SyncManager.instance.active;
+    // Signed out, it is not handling save sync either: naming it would just
+    // point at a second thing that is not syncing.
+    if (owner == null || !owner.isAuthenticated) return '';
     return ' · '
-        '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', name)}';
+        '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', owner.meta.name)}';
   }
 
   /// Toggles whether RomM is the active save-sync provider (vs NeoSync).
@@ -1135,13 +1137,18 @@ class _RommBrowseScreenState extends State<RommBrowseScreen> {
     if (!mounted) return;
     // Name the provider that just took over rather than echoing the toggle's
     // own label: only one provider syncs saves, and which one it now is the
-    // only thing the toast can usefully confirm.
-    final owner = SyncManager.instance.active?.meta.name ?? target;
+    // only thing the toast can usefully confirm. Unless it is signed out, in
+    // which case it is not handling saves and the toggle's own label is the
+    // honest confirmation.
+    final owner = SyncManager.instance.active;
+    final signedIn = owner != null && owner.isAuthenticated;
     AppNotification.showNotification(
       context,
-      AppLocale.saveSyncHandledBy
-          .getString(context)
-          .replaceFirst('{provider}', owner),
+      signedIn
+          ? AppLocale.saveSyncHandledBy
+                .getString(context)
+                .replaceFirst('{provider}', owner.meta.name)
+          : AppLocale.rommUseForSaveSync.getString(context),
       type: NotificationType.info,
     );
     setState(() {});

--- a/lib/screens/romm_screen/romm_connect_content.dart
+++ b/lib/screens/romm_screen/romm_connect_content.dart
@@ -306,12 +306,10 @@ class _RommConnectContentState extends State<RommConnectContent>
     // NeoSync. Leaving "romm" active against a server we just forgot would
     // silently stop ALL save sync — RomM errors out, NeoSync sits idle —
     // until the user thought to re-toggle it.
-    if (SyncManager.instance.activeProviderId == RomMSyncProvider.kProviderId) {
-      await SyncManager.instance.setActive(
-        NeoSyncAdapter.kProviderId,
-        persist: persist,
-      );
-    }
+    await SyncManager.instance.releaseIfActive(
+      RomMSyncProvider.kProviderId,
+      persist: persist,
+    );
     if (!mounted) return;
     _clearSecretFields();
     resetSelection();

--- a/lib/screens/romm_screen/romm_connect_content.dart
+++ b/lib/screens/romm_screen/romm_connect_content.dart
@@ -772,15 +772,20 @@ class _RommConnectContentState extends State<RommConnectContent>
   Widget _buildSaveSyncCaption(ThemeData theme) {
     final scheme = theme.colorScheme;
     final owner = SyncManager.instance.active;
-    // Same gate as the library header: a provider that owns save sync while
-    // signed out is not handling it, so say nothing rather than name it.
-    if (!_isSaveSyncActive && (owner == null || !owner.isAuthenticated)) {
-      return const SizedBox.shrink();
+    // Same rule as the library header: a provider that owns save sync while
+    // signed out is not handling it, so report that nothing is rather than
+    // name it.
+    final ownerSignedIn = owner != null && owner.isAuthenticated;
+    final String text;
+    if (_isSaveSyncActive) {
+      text = AppLocale.rommSaveSyncActive.getString(context);
+    } else if (!ownerSignedIn) {
+      text = AppLocale.saveSyncNoneActive.getString(context);
+    } else {
+      text =
+          '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', owner.meta.name)} · '
+          '${AppLocale.saveSyncSingleProvider.getString(context)}';
     }
-    final text = _isSaveSyncActive
-        ? AppLocale.rommSaveSyncActive.getString(context)
-        : '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', owner!.meta.name)} · '
-              '${AppLocale.saveSyncSingleProvider.getString(context)}';
     return Padding(
       padding: EdgeInsets.only(top: 4.r, left: 12.r, right: 12.r),
       child: Text(

--- a/lib/screens/romm_screen/romm_connect_content.dart
+++ b/lib/screens/romm_screen/romm_connect_content.dart
@@ -771,10 +771,15 @@ class _RommConnectContentState extends State<RommConnectContent>
   /// Not focusable — it is a label for the row above it.
   Widget _buildSaveSyncCaption(ThemeData theme) {
     final scheme = theme.colorScheme;
-    final active = SyncManager.instance.active;
+    final owner = SyncManager.instance.active;
+    // Same gate as the library header: a provider that owns save sync while
+    // signed out is not handling it, so say nothing rather than name it.
+    if (!_isSaveSyncActive && (owner == null || !owner.isAuthenticated)) {
+      return const SizedBox.shrink();
+    }
     final text = _isSaveSyncActive
         ? AppLocale.rommSaveSyncActive.getString(context)
-        : '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', active?.meta.name ?? SyncManager.instance.activeProviderId)} · '
+        : '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', owner!.meta.name)} · '
               '${AppLocale.saveSyncSingleProvider.getString(context)}';
     return Padding(
       padding: EdgeInsets.only(top: 4.r, left: 12.r, right: 12.r),

--- a/lib/screens/romm_screen/romm_connect_content.dart
+++ b/lib/screens/romm_screen/romm_connect_content.dart
@@ -751,6 +751,7 @@ class _RommConnectContentState extends State<RommConnectContent>
         toggleValue: _isSaveSyncActive,
         onTap: _toggleSaveSync,
       ),
+      _buildSaveSyncCaption(theme),
       SizedBox(height: 10.r),
       _buildActionRow(
         theme,
@@ -760,6 +761,33 @@ class _RommConnectContentState extends State<RommConnectContent>
         onTap: _disconnect,
       ),
     ];
+  }
+
+  /// Caption under the save-sync toggle naming who currently owns save sync.
+  ///
+  /// Connecting a RomM server does not take save sync off a NeoSync account
+  /// that is still signed in (see [_connect]), so a connected server plus
+  /// downloads plus playtime can all look healthy while saves go elsewhere.
+  /// Not focusable — it is a label for the row above it.
+  Widget _buildSaveSyncCaption(ThemeData theme) {
+    final scheme = theme.colorScheme;
+    final active = SyncManager.instance.active;
+    final text = _isSaveSyncActive
+        ? AppLocale.rommSaveSyncActive.getString(context)
+        : '${AppLocale.saveSyncHandledBy.getString(context).replaceFirst('{provider}', active?.meta.name ?? SyncManager.instance.activeProviderId)} · '
+              '${AppLocale.saveSyncSingleProvider.getString(context)}';
+    return Padding(
+      padding: EdgeInsets.only(top: 4.r, left: 12.r, right: 12.r),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 9.r,
+          color: scheme.onSurface.withValues(alpha: 0.7),
+        ),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
   }
 
   Widget _buildFieldRow(

--- a/lib/sync/i_sync_provider.dart
+++ b/lib/sync/i_sync_provider.dart
@@ -55,6 +55,17 @@ abstract class ISyncProvider {
   Future<SyncResult> login();
 
   /// Clear credentials and end the session.
+  ///
+  /// **Signing a provider out does not release save sync.** A provider cannot
+  /// do that itself: handing ownership back means `SyncManager.setActive`,
+  /// which needs a `persist` callback that lives at the config layer. The
+  /// caller must therefore pair a sign-out with
+  /// `SyncManager.instance.releaseIfActive(providerId, persist: …)`, or the
+  /// signed-out provider keeps owning save sync and every save hook fails
+  /// silently while the other providers sit idle.
+  ///
+  /// Both RomM disconnect paths do this today; this method has no callers at
+  /// all, so nothing currently depends on the pairing being remembered.
   Future<void> logout();
 
   // ── Core Sync Operations ───────────────────────────────────────────────────

--- a/lib/sync/sync_manager.dart
+++ b/lib/sync/sync_manager.dart
@@ -81,6 +81,24 @@ class SyncManager extends ChangeNotifier {
     return true;
   }
 
+  /// Hands save sync back to NeoSync if [providerId] currently owns it.
+  ///
+  /// Called when a provider is deliberately signed out. Leaving a disconnected
+  /// provider active silently stops **all** save sync — it errors out on every
+  /// hook while NeoSync sits idle — and nothing in the UI would attribute that
+  /// to the disconnect that caused it.
+  ///
+  /// Returns true when ownership actually moved. A provider that did not own
+  /// save sync is a no-op, so signing out of RomM never disturbs a NeoSync
+  /// user's setting, and [persist] is not called.
+  Future<bool> releaseIfActive(
+    String providerId, {
+    required Future<void> Function(String) persist,
+  }) async {
+    if (_activeProviderId != providerId) return false;
+    return setActive(NeoSyncAdapter.kProviderId, persist: persist);
+  }
+
   /// Restore the user's previously chosen provider from config on startup.
   /// Falls back to NeoSync if [savedProviderId] is null or not registered.
   void restoreActive(String? savedProviderId) {

--- a/test/save_sync_handback_test.dart
+++ b/test/save_sync_handback_test.dart
@@ -1,0 +1,190 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/models/neo_sync_models.dart';
+import 'package:neostation/sync/i_sync_provider.dart';
+import 'package:neostation/sync/providers/neo_sync_adapter.dart';
+import 'package:neostation/sync/providers/romm_provider.dart';
+import 'package:neostation/sync/sync_manager.dart';
+
+/// Guards the rule that signing out of a provider must not leave it holding
+/// save sync.
+///
+/// Both RomM disconnect paths (the library header's logout button and the
+/// connect panel's Disconnect row) call [SyncManager.releaseIfActive]. Without
+/// it, "romm" stays active against a server the user just forgot, every save
+/// hook errors out, NeoSync sits idle, and nothing on screen connects the dead
+/// sync to the disconnect that caused it. There was no coverage of this before;
+/// the same gap is why `RomMSyncProvider.logout()` was written without a
+/// handback and nobody noticed.
+void main() {
+  late _FakeProvider neoSync;
+  late _FakeProvider romm;
+  late List<String> persisted;
+
+  setUp(() {
+    neoSync = _FakeProvider(NeoSyncAdapter.kProviderId, 'NeoSync');
+    romm = _FakeProvider(RomMSyncProvider.kProviderId, 'RomM');
+    persisted = [];
+    SyncManager.instance.register(neoSync);
+    SyncManager.instance.register(romm);
+  });
+
+  tearDown(() {
+    // The manager is a singleton, so an un-torn-down registration leaks into
+    // every later test in the run.
+    SyncManager.instance.unregister(RomMSyncProvider.kProviderId);
+    SyncManager.instance.unregister(NeoSyncAdapter.kProviderId);
+  });
+
+  Future<void> persist(String id) async => persisted.add(id);
+
+  test(
+    'disconnecting the active provider hands save sync back to NeoSync',
+    () async {
+      await SyncManager.instance.setActive(
+        RomMSyncProvider.kProviderId,
+        persist: persist,
+      );
+      persisted.clear();
+
+      final moved = await SyncManager.instance.releaseIfActive(
+        RomMSyncProvider.kProviderId,
+        persist: persist,
+      );
+
+      expect(moved, isTrue);
+      expect(SyncManager.instance.activeProviderId, NeoSyncAdapter.kProviderId);
+      // Persisted, not just held in memory: the choice has to survive a restart,
+      // or the next launch resurrects the disconnected provider.
+      expect(persisted, [NeoSyncAdapter.kProviderId]);
+    },
+  );
+
+  test(
+    'disconnecting a provider that does not own save sync changes nothing',
+    () async {
+      await SyncManager.instance.setActive(
+        NeoSyncAdapter.kProviderId,
+        persist: persist,
+      );
+      persisted.clear();
+
+      final moved = await SyncManager.instance.releaseIfActive(
+        RomMSyncProvider.kProviderId,
+        persist: persist,
+      );
+
+      expect(moved, isFalse);
+      expect(SyncManager.instance.activeProviderId, NeoSyncAdapter.kProviderId);
+      // A NeoSync user who merely disconnects a RomM server must not have their
+      // setting rewritten underneath them.
+      expect(persisted, isEmpty);
+    },
+  );
+
+  test(
+    'handing back notifies listeners so the UI can drop its owner line',
+    () async {
+      await SyncManager.instance.setActive(
+        RomMSyncProvider.kProviderId,
+        persist: persist,
+      );
+      var notifications = 0;
+      void listener() => notifications++;
+      SyncManager.instance.addListener(listener);
+      addTearDown(() => SyncManager.instance.removeListener(listener));
+
+      await SyncManager.instance.releaseIfActive(
+        RomMSyncProvider.kProviderId,
+        persist: persist,
+      );
+
+      expect(notifications, greaterThan(0));
+    },
+  );
+}
+
+/// Minimal [ISyncProvider] stand-in: these tests only exercise registration and
+/// active-id bookkeeping, so every transfer method is left unimplemented.
+class _FakeProvider implements ISyncProvider {
+  _FakeProvider(this.providerId, this._name);
+
+  @override
+  final String providerId;
+
+  final String _name;
+
+  @override
+  SyncProviderMeta get meta => SyncProviderMeta(
+    id: providerId,
+    name: _name,
+    description: '',
+    author: '',
+  );
+
+  @override
+  SyncProviderStatus get status => SyncProviderStatus.connected;
+
+  @override
+  bool get isAuthenticated => true;
+
+  @override
+  String? get lastError => null;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  void dispose() {}
+
+  @override
+  Future<SyncResult> login() async => SyncResult.ok();
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<SyncResult> uploadSave(
+    String gameId,
+    File file, {
+    String? customFileName,
+  }) async => SyncResult.ok();
+
+  @override
+  Future<SyncResult> downloadSave(String gameId, String fileId) async =>
+      SyncResult.ok();
+
+  @override
+  Future<List<SyncFile>> listSaves({String? gameId}) async => const [];
+
+  @override
+  Future<SyncResult> fullSync() async => SyncResult.ok();
+
+  @override
+  Future<SyncResult> detectGameSaveFiles(GameModel game) async =>
+      SyncResult.ok();
+
+  @override
+  GameSyncState? getGameSyncState(String gameId) => null;
+
+  @override
+  Future<SyncResult> syncGameSavesBeforeLaunch(
+    GameModel game, {
+    SyncDeadline? deadline,
+  }) async => SyncResult.ok();
+
+  @override
+  Future<SyncResult> syncGameSavesAfterClose(GameModel game) async =>
+      SyncResult.ok();
+
+  @override
+  Future<void> updateGameCloudSyncEnabled(String gameId, bool enabled) async {}
+
+  @override
+  Future<SyncQuota?> getQuota() async => null;
+
+  @override
+  Future<SyncResult> deleteRemote(String fileId) async => SyncResult.ok();
+}


### PR DESCRIPTION
# Description

Save sync has exactly one owner: `SyncManager` holds a single `_activeProviderId`, and every save path (pre-launch download, post-exit upload, the per-game cloud badge) resolves `SyncManager.active`. Nothing in the UI said which provider that was, which produces three recurring support questions:

- Connecting a RomM server deliberately does **not** take save sync off a NeoSync account that is still signed in (`romm_connect_content.dart`, `_connect`). The server connects, ROMs download, playtime appears on the server, and saves keep going to NeoSync. Nothing on screen says so.
- The NeoSync dashboard has no `SyncManager` reference at all, so account, plan and save list render identically whether or not NeoSync is the active provider. It looks live while it is idle.
- Disconnecting a RomM server hands save sync back to NeoSync automatically. Also silent.

This PR names the owner in each place, and adds no new behaviour. Every line is gated on that owner actually being signed in (`ISyncProvider.isAuthenticated`, which is NeoSync's auth state and RomM's connection state): a provider that holds save sync while logged out is not handling anything, so naming it would trade one wrong impression for another. When nothing signed in holds save sync, the line says `No save sync active` instead — a connected RomM server with its toggle off and no NeoSync account syncs nothing at all, and downloads, artwork and playtime all keep working in a way that reads as proof the saves are covered too.

- **RomM library header** (the screen users are actually on): the account line becomes `Connected as neil · Save sync is handled by NeoSync` whenever RomM is not the owner. Nothing is appended when it is, because the toggle beside it already reads `RomM Sync · Enabled`.
- **Save-sync toggle toast**: now names the provider that took over, instead of echoing the toggle's own label (`Use RomM for save sync`) in both directions.
- **NeoSync dashboard**: a notice above the profile/menu row naming the provider that owns save sync, shown only when it is not NeoSync.
- **RomM connect panel**: the same caption under its save-sync row, and its connected state now renders `rommSaveSyncActive`, a string that was defined in all 12 locales but never displayed.

The rule both disconnect paths duplicated (hand save sync back to NeoSync when the provider being signed out owns it) moves into `SyncManager.releaseIfActive`, which is the seam the new test drives. Behaviour is unchanged; it previously had no coverage at all, which is also why `RomMSyncProvider.logout()` was written without a handback and went unnoticed (it has no callers, so it is a latent trap rather than a live bug — say the word and I'll delete it or wire it up).

Three new keys — `saveSyncHandledBy` (`Save sync is handled by {provider}`), `saveSyncSingleProvider` (`Only one provider syncs saves at a time`) and `saveSyncNoneActive` (`No save sync active`) — all filled in for all 12 locales. Provider names come from `ISyncProvider.meta.name`, so a future third provider is covered without another string.

Closes #

## Steps to Verify

**Preconditions:** a connected RomM server, the RomM tab visible in the nav bar, and a NeoSync account signed in for steps 2-4.

1. Open the RomM tab. With `RomM Sync · Enabled`, the account line reads only `Connected as <user>`.
2. Tap the `RomM Sync` pill to disable it. The pill reads `Disabled` and the account line becomes `Connected as <user> · Save sync is handled by NeoSync`. The toast names NeoSync.
3. Tap it again. The suffix disappears and the toast names RomM.
4. Signed into NeoSync with RomM set as the save-sync provider, open the NeoSync tab: the dashboard shows `Save sync is handled by RomM · Only one provider syncs saves at a time` above the profile header. With NeoSync as the provider, no notice appears.
5. Signed **out** of NeoSync, repeat step 2: the pill reads `Disabled` and the account line becomes `Connected as <user> · No save sync active`, because a signed-out NeoSync is not handling save sync either. The toast says the same.

## Tested on

- [x] Android — device: AYN Thor (dev channel, RomM connected to a live server, no NeoSync account). Steps 1-3 and step 5 verified on device, and the device left in its original state afterwards. Step 4 verified on the same device with a throwaway local build that forced the signed-in branch of `NeoSyncContent.build` (the test device has no NeoSync account): the dashboard shows `Save sync is handled by RomM · Only one provider syncs saves at a time` above the profile header, with the menu rows and logout button unaffected. That patch is not part of this branch; the device was reflashed from the committed tree afterwards.
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1216)
- [x] Tests added or updated — `test/save_sync_handback_test.dart` (3 tests) covers the sign-out handback via the new `SyncManager.releaseIfActive`, verified to fail against a stubbed-out implementation; the locale keys are covered by the existing `test/app_locale_test.dart`
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — no new assets

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [x] No hardcoded UI strings — everything goes through `AppLocale`

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad — no new interactive elements; both additions are labels, and the RomM connect panel's caption sits outside the indexed rows so the existing selection indices are unchanged

## Screenshots / video

RomM header, before: `Connected as neil`, pill reading `RomM Sync · Disabled`, nothing saying where saves go.
RomM header, after: `Connected as neil · Save sync is handled by NeoSync`, same pill. With no NeoSync account: `Connected as neil · No save sync active`.
NeoSync dashboard, with RomM active: a full-width info strip above the profile header reading `Save sync is handled by RomM · Only one provider syncs saves at a time`.
