### PR TITLE
feat(header): scroll the nav tab strip when more tabs are shown than fit

### DIFF
--- a/lib/utils/header_layout.dart
+++ b/lib/utils/header_layout.dart
@@ -72,3 +72,33 @@ double statusPillMaxWidth({
   final free = ((totalWidth - navStripWidth) / 2) - margin - gutter;
   return free < 0 ? 0 : free;
 }
+
+/// How many tab slots the centred strip may show before it would meet the
+/// right-hand status pill.
+///
+/// The inverse of [statusPillMaxWidth]. The strip is centred, so the pill and
+/// its [margin] and [gutter] are mirrored on the left when working out what is
+/// left for the strip; the shoulder glyphs and the pill's own padding come off
+/// that, and the rest divides into slots.
+///
+/// Pass a *worst-case* [statusPillWidth] — the widest clock string the locale
+/// and 12/24-hour setting can produce, with the battery block reserved whenever
+/// the device has one. Sizing off the live pill would let the slot count flip
+/// as the clock ticked past a digit or the battery fell to one.
+///
+/// Never returns fewer than [minSlots]: a screen too narrow even for those is
+/// handled by the pill scaling itself down, not by shrinking the strip further.
+int navStripMaxSlots({
+  required double totalWidth,
+  required double statusPillWidth,
+  double slot = 32,
+  double shoulder = 36,
+  double pillPadding = 4,
+  double margin = 8,
+  double gutter = 4,
+  int minSlots = 5,
+}) {
+  final free = totalWidth - (2 * (statusPillWidth + margin + gutter));
+  final slots = (free - (shoulder * 2) - (pillPadding * 2)) ~/ slot;
+  return slots < minSlots ? minSlots : slots;
+}

--- a/lib/utils/nav_tabs.dart
+++ b/lib/utils/nav_tabs.dart
@@ -156,11 +156,12 @@ const int maxVisibleNavTabSlots = 6;
 /// First slot shown by the scrolling strip after selection moves to
 /// [selectedSlot].
 ///
-/// Minimal-scroll windowing: the window is untouched while the selection stays
-/// inside it and shifts just far enough to include the selection when it walks
-/// off either edge, so cycling with the bumpers scrolls one slot at a time
-/// (with a jump only on wrap-around). A [selectedSlot] of -1 (selected tab
-/// hidden by a config change) keeps the current window rather than snapping
+/// Centered windowing: the selection sits in the window's middle slot (the
+/// left-of-middle slot when [maxSlots] is even), clamped at both ends of the
+/// strip — so the selection only reaches an edge slot when it is genuinely
+/// near the first or last tab, and everywhere else the strip scrolls under a
+/// stationary highlight. A [selectedSlot] of -1 (selected tab hidden by a
+/// config change) keeps the current [windowStart] rather than snapping
 /// anywhere. The result is always clamped so the window never shows blank
 /// slots past either end.
 int navTabWindowStart({
@@ -170,12 +171,8 @@ int navTabWindowStart({
   int maxSlots = maxVisibleNavTabSlots,
 }) {
   if (tabCount <= maxSlots) return 0;
-  var start = windowStart;
-  if (selectedSlot >= 0) {
-    if (selectedSlot < start) start = selectedSlot;
-    if (selectedSlot > start + maxSlots - 1) {
-      start = selectedSlot - maxSlots + 1;
-    }
-  }
+  final start = selectedSlot >= 0
+      ? selectedSlot - (maxSlots - 1) ~/ 2
+      : windowStart;
   return start.clamp(0, tabCount - maxSlots);
 }

--- a/lib/utils/nav_tabs.dart
+++ b/lib/utils/nav_tabs.dart
@@ -147,3 +147,35 @@ List<NavTab> visibleNavTabs(ConfigModel config) => NavTab.values
 List<NavTab> hidableNavTabs() => NavTab.values
     .where((tab) => navTabSpec(tab).isHidable)
     .toList(growable: false);
+
+/// Most tab slots the header strip shows at once. With more visible tabs than
+/// this, the strip scrolls; with this many or fewer it renders exactly as a
+/// static strip and never scrolls.
+const int maxVisibleNavTabSlots = 6;
+
+/// First slot shown by the scrolling strip after selection moves to
+/// [selectedSlot].
+///
+/// Minimal-scroll windowing: the window is untouched while the selection stays
+/// inside it and shifts just far enough to include the selection when it walks
+/// off either edge, so cycling with the bumpers scrolls one slot at a time
+/// (with a jump only on wrap-around). A [selectedSlot] of -1 (selected tab
+/// hidden by a config change) keeps the current window rather than snapping
+/// anywhere. The result is always clamped so the window never shows blank
+/// slots past either end.
+int navTabWindowStart({
+  required int windowStart,
+  required int selectedSlot,
+  required int tabCount,
+  int maxSlots = maxVisibleNavTabSlots,
+}) {
+  if (tabCount <= maxSlots) return 0;
+  var start = windowStart;
+  if (selectedSlot >= 0) {
+    if (selectedSlot < start) start = selectedSlot;
+    if (selectedSlot > start + maxSlots - 1) {
+      start = selectedSlot - maxSlots + 1;
+    }
+  }
+  return start.clamp(0, tabCount - maxSlots);
+}

--- a/lib/utils/nav_tabs.dart
+++ b/lib/utils/nav_tabs.dart
@@ -148,10 +148,15 @@ List<NavTab> hidableNavTabs() => NavTab.values
     .where((tab) => navTabSpec(tab).isHidable)
     .toList(growable: false);
 
-/// Most tab slots the header strip shows at once. With more visible tabs than
-/// this, the strip scrolls; with this many or fewer it renders exactly as a
-/// static strip and never scrolls.
-const int maxVisibleNavTabSlots = 5;
+/// Fewest tab slots the header strip will show.
+///
+/// The strip normally shows as many slots as fit beside the status pill, which
+/// varies with the screen and with whether the device reports a battery — see
+/// `navStripMaxSlots` in `header_layout.dart`. This is the floor for screens
+/// too narrow even for that, where the pill scales itself down instead. With
+/// more visible tabs than the strip has slots it scrolls; with that many or
+/// fewer it renders as a static strip and never scrolls.
+const int minNavTabSlots = 5;
 
 /// First slot shown by the scrolling strip after selection moves to
 /// [selectedSlot].
@@ -168,7 +173,7 @@ int navTabWindowStart({
   required int windowStart,
   required int selectedSlot,
   required int tabCount,
-  int maxSlots = maxVisibleNavTabSlots,
+  int maxSlots = minNavTabSlots,
 }) {
   if (tabCount <= maxSlots) return 0;
   final start = selectedSlot >= 0

--- a/lib/utils/nav_tabs.dart
+++ b/lib/utils/nav_tabs.dart
@@ -151,7 +151,7 @@ List<NavTab> hidableNavTabs() => NavTab.values
 /// Most tab slots the header strip shows at once. With more visible tabs than
 /// this, the strip scrolls; with this many or fewer it renders exactly as a
 /// static strip and never scrolls.
-const int maxVisibleNavTabSlots = 6;
+const int maxVisibleNavTabSlots = 5;
 
 /// First slot shown by the scrolling strip after selection moves to
 /// [selectedSlot].

--- a/lib/utils/time_format.dart
+++ b/lib/utils/time_format.dart
@@ -14,3 +14,12 @@ String formatClockTime(DateTime time, {required bool use12Hour}) {
   if (hour12 == 0) hour12 = 12;
   return '$hour12:$minute $period';
 }
+
+/// The widest string [formatClockTime] can return for this setting.
+///
+/// Header geometry is sized off this rather than the current time, so the
+/// layout cannot shift as the clock ticks: 24-hour hours are not zero-padded,
+/// so a two-digit hour is the widest, and the 12-hour form adds the period
+/// suffix. 'AM' and 'PM' are treated as equally wide.
+String widestClockText({required bool use12Hour}) =>
+    use12Hour ? '12:59 PM' : '23:59';

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -48,6 +48,12 @@ class HeaderState extends State<Header> {
   Timer? _timeUpdateTimer;
   late final List<FocusNode> _tabFocusNodes;
 
+  /// First slot shown when the tab strip has more visible tabs than
+  /// [maxVisibleNavTabSlots]. Recomputed during build (not in setState) because
+  /// every input that can move it — tab selection, hide toggles — already
+  /// triggers a rebuild through the widget or the config provider.
+  int _windowStart = 0;
+
   @override
   void initState() {
     super.initState();
@@ -317,7 +323,7 @@ class HeaderState extends State<Header> {
                               // Tinting from the ANIMATED position instead
                               // keeps each icon's colour matched to how much of
                               // the pill is actually under it.
-                              return TweenAnimationBuilder<double>(
+                              final strip = TweenAnimationBuilder<double>(
                                 tween: Tween<double>(
                                   end: (selectedSlot < 0 ? 0 : selectedSlot)
                                       .toDouble(),
@@ -375,6 +381,16 @@ class HeaderState extends State<Header> {
                                     ],
                                   );
                                 },
+                              );
+                              if (visibleTabs.length <= maxVisibleNavTabSlots) {
+                                _windowStart = 0;
+                                return strip;
+                              }
+
+                              return _buildScrollingStrip(
+                                strip,
+                                visibleTabs.length,
+                                selectedSlot,
                               );
                             },
                           ),
@@ -504,6 +520,56 @@ class HeaderState extends State<Header> {
       textScaler: MediaQuery.textScalerOf(context),
     )..layout();
     return painter.width;
+  }
+
+  // Windows the full-width [strip] to [maxVisibleNavTabSlots] slots, sliding it
+  // so the selected tab stays in view. The slide shares the indicator's
+  // duration/curve so the two motions read as one. Icons at a scrollable edge
+  // fade out (alpha mask, so it works over the translucent pill) to signal that
+  // the strip continues past the window.
+  Widget _buildScrollingStrip(Widget strip, int tabCount, int selectedSlot) {
+    _windowStart = navTabWindowStart(
+      windowStart: _windowStart,
+      selectedSlot: selectedSlot,
+      tabCount: tabCount,
+    );
+
+    final viewportWidth = maxVisibleNavTabSlots * 32.r;
+    final canScrollLeft = _windowStart > 0;
+    final canScrollRight = _windowStart < tabCount - maxVisibleNavTabSlots;
+    final fade = 12.r / viewportWidth;
+
+    return SizedBox(
+      width: viewportWidth,
+      height: 32.r,
+      child: ClipRect(
+        child: ShaderMask(
+          shaderCallback: (rect) => LinearGradient(
+            colors: [
+              canScrollLeft ? Colors.transparent : Colors.white,
+              Colors.white,
+              Colors.white,
+              canScrollRight ? Colors.transparent : Colors.white,
+            ],
+            stops: [0, fade, 1 - fade, 1],
+          ).createShader(rect),
+          blendMode: BlendMode.dstIn,
+          child: Stack(
+            children: [
+              AnimatedPositioned(
+                left: -_windowStart * 32.r,
+                top: 0,
+                width: tabCount * 32.r,
+                height: 32.r,
+                duration: const Duration(milliseconds: 160),
+                curve: Curves.easeInOut,
+                child: strip,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   // Steam-style tab button.

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -216,7 +216,13 @@ class HeaderState extends State<Header> {
               final pillAllowance = statusPillMaxWidth(
                 totalWidth: constraints.maxWidth,
                 navStripWidth: navStripWidth(
-                  tabCount: visibleNavTabs(configProvider.config).length,
+                  // The strip never renders more than [maxVisibleNavTabSlots]
+                  // slots — past that it scrolls instead of growing — so the
+                  // collision bound must use the rendered width, not the tab
+                  // count, or the pill gives up room the strip never takes.
+                  tabCount: visibleNavTabs(
+                    configProvider.config,
+                  ).length.clamp(0, maxVisibleNavTabSlots),
                   slot: 32.r,
                   shoulder: 36.r,
                   pillPadding: 4.r,
@@ -382,6 +388,7 @@ class HeaderState extends State<Header> {
                                   );
                                 },
                               );
+
                               if (visibleTabs.length <= maxVisibleNavTabSlots) {
                                 _windowStart = 0;
                                 return strip;

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -563,11 +563,19 @@ class HeaderState extends State<Header> {
           blendMode: BlendMode.dstIn,
           child: Stack(
             children: [
+              // `top`/`bottom` rather than an explicit `height`: the pill's
+              // 1.r border deflates the space its child gets, so the slots are
+              // 2.r shorter than 32.r. A positioned child with a stated height
+              // ignores that and renders the icons at full size (BoxFit sizes
+              // them off the shorter axis), which made every icon jump ~14%
+              // larger the moment a hidden tab pushed the strip into scrolling.
+              // Filling the box keeps the scrolled strip identical to the
+              // static one.
               AnimatedPositioned(
                 left: -_windowStart * 32.r,
                 top: 0,
+                bottom: 0,
                 width: tabCount * 32.r,
-                height: 32.r,
                 duration: const Duration(milliseconds: 160),
                 curve: Curves.easeInOut,
                 child: strip,

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -48,8 +48,8 @@ class HeaderState extends State<Header> {
   Timer? _timeUpdateTimer;
   late final List<FocusNode> _tabFocusNodes;
 
-  /// First slot shown when the tab strip has more visible tabs than
-  /// [maxVisibleNavTabSlots]. Recomputed during build (not in setState) because
+  /// First slot shown when the tab strip has more visible tabs than it has
+  /// slots. Recomputed during build (not in setState) because
   /// every input that can move it — tab selection, hide toggles — already
   /// triggers a rebuild through the widget or the config provider.
   int _windowStart = 0;
@@ -213,16 +213,62 @@ class HeaderState extends State<Header> {
                 letterSpacing: 0.3.r,
               );
 
+              final visibleTabs = visibleNavTabs(configProvider.config);
+
+              // How many slots actually fit beside the status pill. A device
+              // with no battery to report (most desktops) frees enough room for
+              // several more, so the strip only scrolls where it genuinely has
+              // to rather than at a fixed count everywhere.
+              //
+              // Measured against the widest the pill can ever be, so the count
+              // cannot flip as the clock ticks past a digit or the battery
+              // falls to one.
+              final maxSlots = navStripMaxSlots(
+                totalWidth: constraints.maxWidth,
+                statusPillWidth: statusPillWidth(
+                  clockTextWidth: _measureText(
+                    context,
+                    widestClockText(
+                      use12Hour: configProvider.config.use12HourClock,
+                    ),
+                    labelStyle,
+                  ),
+                  batteryTextWidth: showBattery
+                      ? _measureText(context, '100%', labelStyle)
+                      : 0,
+                  // Without the clock glyph: it is already the first thing the
+                  // pill gives up when space runs short, so reserving room for
+                  // it here would spend a whole tab slot saving an icon that
+                  // sits next to a label already reading as a time. Slots first,
+                  // glyph second.
+                  withClockGlyph: false,
+                  horizontalPadding: 10.r,
+                  bell: 14.r,
+                  bellGap: 10.r,
+                  glyph: 14.r,
+                  glyphGap: 4.r,
+                  batteryGap: 12.r,
+                  batteryIcon: 16.r,
+                  batteryIconGap: 4.r,
+                ),
+                slot: 32.r,
+                shoulder: 36.r,
+                pillPadding: 4.r,
+                margin: 8.r,
+                gutter: 4.r,
+                minSlots: minNavTabSlots,
+              );
+
               final pillAllowance = statusPillMaxWidth(
                 totalWidth: constraints.maxWidth,
                 navStripWidth: navStripWidth(
-                  // The strip never renders more than [maxVisibleNavTabSlots]
-                  // slots — past that it scrolls instead of growing — so the
-                  // collision bound must use the rendered width, not the tab
-                  // count, or the pill gives up room the strip never takes.
-                  tabCount: visibleNavTabs(
-                    configProvider.config,
-                  ).length.clamp(0, maxVisibleNavTabSlots),
+                  // The strip stops growing once it runs out of slots — past
+                  // that it scrolls — so the collision bound must use the
+                  // rendered width, not the tab count, or the pill gives up
+                  // room the strip never takes.
+                  tabCount: visibleTabs.length < maxSlots
+                      ? visibleTabs.length
+                      : maxSlots,
                   slot: 32.r,
                   shoulder: 36.r,
                   pillPadding: 4.r,
@@ -307,9 +353,6 @@ class HeaderState extends State<Header> {
                           ),
                           child: Builder(
                             builder: (context) {
-                              final visibleTabs = visibleNavTabs(
-                                configProvider.config,
-                              );
                               // The indicator tracks the tab's slot in the *rendered*
                               // strip, not its canonical index — otherwise hiding a tab
                               // parks it past the end of a shortened strip.
@@ -389,7 +432,7 @@ class HeaderState extends State<Header> {
                                 },
                               );
 
-                              if (visibleTabs.length <= maxVisibleNavTabSlots) {
+                              if (visibleTabs.length <= maxSlots) {
                                 _windowStart = 0;
                                 return strip;
                               }
@@ -398,6 +441,7 @@ class HeaderState extends State<Header> {
                                 strip,
                                 visibleTabs.length,
                                 selectedSlot,
+                                maxSlots,
                               );
                             },
                           ),
@@ -529,21 +573,27 @@ class HeaderState extends State<Header> {
     return painter.width;
   }
 
-  // Windows the full-width [strip] to [maxVisibleNavTabSlots] slots, sliding it
+  // Windows the full-width [strip] to [maxSlots] slots, sliding it
   // so the selected tab stays in view. The slide shares the indicator's
   // duration/curve so the two motions read as one. Icons at a scrollable edge
   // fade out (alpha mask, so it works over the translucent pill) to signal that
   // the strip continues past the window.
-  Widget _buildScrollingStrip(Widget strip, int tabCount, int selectedSlot) {
+  Widget _buildScrollingStrip(
+    Widget strip,
+    int tabCount,
+    int selectedSlot,
+    int maxSlots,
+  ) {
     _windowStart = navTabWindowStart(
       windowStart: _windowStart,
       selectedSlot: selectedSlot,
       tabCount: tabCount,
+      maxSlots: maxSlots,
     );
 
-    final viewportWidth = maxVisibleNavTabSlots * 32.r;
+    final viewportWidth = maxSlots * 32.r;
     final canScrollLeft = _windowStart > 0;
-    final canScrollRight = _windowStart < tabCount - maxVisibleNavTabSlots;
+    final canScrollRight = _windowStart < tabCount - maxSlots;
     final fade = 12.r / viewportWidth;
 
     return SizedBox(

--- a/test/nav_strip_slots_test.dart
+++ b/test/nav_strip_slots_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/header_layout.dart';
+import 'package:neostation/utils/time_format.dart';
+
+void main() {
+  group('navStripMaxSlots', () {
+    test('divides what the centred strip has left into slots', () {
+      // 1000 wide, a 200 pill mirrored either side with its margin and gutter:
+      // 1000 - 2*(200+8+4) = 576, less 2*36 shoulders and 2*4 padding = 496.
+      expect(
+        navStripMaxSlots(totalWidth: 1000, statusPillWidth: 200),
+        496 ~/ 32,
+      );
+    });
+
+    test('a wider pill costs slots', () {
+      final narrow = navStripMaxSlots(totalWidth: 1000, statusPillWidth: 200);
+      final wide = navStripMaxSlots(totalWidth: 1000, statusPillWidth: 260);
+      expect(wide, lessThan(narrow));
+    });
+
+    test('a partial slot does not count', () {
+      // Exactly six slots' worth of room, then one pixel less.
+      expect(
+        navStripMaxSlots(totalWidth: 496, statusPillWidth: 100, minSlots: 1),
+        6,
+      );
+      expect(
+        navStripMaxSlots(totalWidth: 495, statusPillWidth: 100, minSlots: 1),
+        5,
+      );
+    });
+
+    test('never goes below the floor, however narrow the screen', () {
+      expect(navStripMaxSlots(totalWidth: 600, statusPillWidth: 200), 5);
+      expect(navStripMaxSlots(totalWidth: 0, statusPillWidth: 200), 5);
+    });
+
+    test('an AYN Thor fits six slots with its battery showing', () {
+      // Measured on the device: 832.5 logical wide, a 208.1 status pill with
+      // the clock glyph and battery block, and .r scaling the strip by 1.3008.
+      expect(
+        navStripMaxSlots(
+          totalWidth: 832.5,
+          statusPillWidth: 208.1,
+          slot: 41.63,
+          shoulder: 46.83,
+          pillPadding: 5.2,
+          margin: 10.41,
+          gutter: 5.2,
+        ),
+        6,
+      );
+    });
+
+    test('dropping the battery block buys several more slots', () {
+      // Same screen, a desktop that reports no battery: the block is worth the
+      // gap, icon, its gap and the '100%' text.
+      final withBattery = navStripMaxSlots(
+        totalWidth: 832.5,
+        statusPillWidth: 208.1,
+        slot: 41.63,
+        shoulder: 46.83,
+        pillPadding: 5.2,
+        margin: 10.41,
+        gutter: 5.2,
+      );
+      final withoutBattery = navStripMaxSlots(
+        totalWidth: 832.5,
+        statusPillWidth: 208.1 - 67.6,
+        slot: 41.63,
+        shoulder: 46.83,
+        pillPadding: 5.2,
+        margin: 10.41,
+        gutter: 5.2,
+      );
+      expect(withoutBattery, greaterThanOrEqualTo(7));
+      expect(withoutBattery, greaterThan(withBattery));
+    });
+  });
+
+  group('widestClockText', () {
+    test('covers every time the formatter can produce', () {
+      for (final use12Hour in [false, true]) {
+        final widest = widestClockText(use12Hour: use12Hour).length;
+        for (var hour = 0; hour < 24; hour++) {
+          for (final minute in [0, 9, 59]) {
+            final text = formatClockTime(
+              DateTime(2026, 1, 1, hour, minute),
+              use12Hour: use12Hour,
+            );
+            expect(
+              text.length,
+              lessThanOrEqualTo(widest),
+              reason: '$text is wider than the reserved worst case',
+            );
+          }
+        }
+      }
+    });
+
+    test('reserves room for the AM/PM suffix only in 12-hour form', () {
+      expect(widestClockText(use12Hour: true), contains('PM'));
+      expect(widestClockText(use12Hour: false), '23:59');
+    });
+  });
+}

--- a/test/nav_tab_icon_size_test.dart
+++ b/test/nav_tab_icon_size_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The header's tab strip renders inside a pill whose `Border` deflates the
+/// space its child gets. The scrolling strip must live within that deflated
+/// box like the static one does: a positioned child with a stated height
+/// ignores the border and renders the icons off a taller axis, which showed up
+/// as every icon jumping ~14% larger the moment a hidden tab pushed the strip
+/// past [maxVisibleNavTabSlots].
+///
+/// Mirrors `_buildScrollingStrip` / the static branch in `lib/widgets/header.dart`.
+void main() {
+  const slot = 32.0;
+  const pad = 8.0;
+  const border = 1.0;
+
+  final boxes = <BoxConstraints>[];
+
+  Widget tabButton() => Container(
+    padding: const EdgeInsets.all(pad),
+    child: LayoutBuilder(
+      builder: (context, constraints) {
+        boxes.add(constraints);
+        return const SizedBox.expand();
+      },
+    ),
+  );
+
+  Widget strip(int tabCount) => Stack(
+    children: [
+      Positioned(left: 0, top: 4, bottom: 4, width: slot, child: Container()),
+      Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (var i = 0; i < tabCount; i++)
+            SizedBox(width: slot, height: slot, child: tabButton()),
+        ],
+      ),
+    ],
+  );
+
+  /// The pill: fixed height, and a border that eats into the child's box.
+  Widget pill(Widget child) => Container(
+    height: slot,
+    decoration: BoxDecoration(border: Border.all(width: border)),
+    child: child,
+  );
+
+  Widget scrolling(int tabCount) => SizedBox(
+    width: 5 * slot,
+    height: slot,
+    child: ClipRect(
+      child: Stack(
+        children: [
+          Positioned(
+            left: -slot,
+            top: 0,
+            bottom: 0,
+            width: tabCount * slot,
+            child: strip(tabCount),
+          ),
+        ],
+      ),
+    ),
+  );
+
+  Future<BoxConstraints> iconBox(WidgetTester tester, Widget child) async {
+    boxes.clear();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Align(child: pill(child)),
+      ),
+    );
+    return boxes.first;
+  }
+
+  testWidgets('scrolled and static strips give icons the same box', (
+    tester,
+  ) async {
+    final staticBox = await iconBox(tester, strip(5));
+    final scrolledBox = await iconBox(tester, scrolling(6));
+
+    expect(scrolledBox, staticBox);
+    // And the box is the one the border leaves behind, not the nominal slot.
+    expect(staticBox.maxHeight, slot - (2 * pad) - (2 * border));
+  });
+}

--- a/test/nav_tab_icon_size_test.dart
+++ b/test/nav_tab_icon_size_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 /// box like the static one does: a positioned child with a stated height
 /// ignores the border and renders the icons off a taller axis, which showed up
 /// as every icon jumping ~14% larger the moment a hidden tab pushed the strip
-/// past [maxVisibleNavTabSlots].
+/// past [minNavTabSlots].
 ///
 /// Mirrors `_buildScrollingStrip` / the static branch in `lib/widgets/header.dart`.
 void main() {

--- a/test/nav_tab_window_test.dart
+++ b/test/nav_tab_window_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/nav_tabs.dart';
+
+void main() {
+  group('navTabWindowStart', () {
+    test('never scrolls when tabs fit in the window', () {
+      for (var count = 1; count <= 6; count++) {
+        expect(
+          navTabWindowStart(
+            windowStart: 3,
+            selectedSlot: count - 1,
+            tabCount: count,
+            maxSlots: 6,
+          ),
+          0,
+          reason: '$count tabs fit in 6 slots',
+        );
+      }
+    });
+
+    test('keeps the window still while the selection stays inside it', () {
+      for (var slot = 1; slot <= 6; slot++) {
+        expect(
+          navTabWindowStart(
+            windowStart: 1,
+            selectedSlot: slot,
+            tabCount: 8,
+            maxSlots: 6,
+          ),
+          1,
+        );
+      }
+    });
+
+    test(
+      'shifts right just far enough when the selection walks off the end',
+      () {
+        expect(
+          navTabWindowStart(
+            windowStart: 0,
+            selectedSlot: 6,
+            tabCount: 8,
+            maxSlots: 6,
+          ),
+          1,
+        );
+      },
+    );
+
+    test('shifts left to the selection when it walks off the start', () {
+      expect(
+        navTabWindowStart(
+          windowStart: 2,
+          selectedSlot: 1,
+          tabCount: 8,
+          maxSlots: 6,
+        ),
+        1,
+      );
+    });
+
+    test('wrap-around jumps the window to the far end', () {
+      // R1 from the last tab wraps to slot 0.
+      expect(
+        navTabWindowStart(
+          windowStart: 2,
+          selectedSlot: 0,
+          tabCount: 8,
+          maxSlots: 6,
+        ),
+        0,
+      );
+      // L1 from the first tab wraps to the last slot.
+      expect(
+        navTabWindowStart(
+          windowStart: 0,
+          selectedSlot: 7,
+          tabCount: 8,
+          maxSlots: 6,
+        ),
+        2,
+      );
+    });
+
+    test('keeps the current window when the selected tab is hidden', () {
+      expect(
+        navTabWindowStart(
+          windowStart: 1,
+          selectedSlot: -1,
+          tabCount: 8,
+          maxSlots: 6,
+        ),
+        1,
+      );
+    });
+
+    test('clamps a stale window after tabs are hidden', () {
+      // Window sat at the end of a 9-tab strip; two tabs got hidden.
+      expect(
+        navTabWindowStart(
+          windowStart: 3,
+          selectedSlot: -1,
+          tabCount: 7,
+          maxSlots: 6,
+        ),
+        1,
+      );
+    });
+  });
+}

--- a/test/nav_tab_window_test.dart
+++ b/test/nav_tab_window_test.dart
@@ -18,40 +18,35 @@ void main() {
       }
     });
 
-    test('keeps the window still while the selection stays inside it', () {
-      for (var slot = 1; slot <= 6; slot++) {
-        expect(
-          navTabWindowStart(
-            windowStart: 1,
-            selectedSlot: slot,
-            tabCount: 8,
-            maxSlots: 6,
-          ),
-          1,
-        );
-      }
-    });
-
-    test(
-      'shifts right just far enough when the selection walks off the end',
-      () {
-        expect(
-          navTabWindowStart(
-            windowStart: 0,
-            selectedSlot: 6,
-            tabCount: 8,
-            maxSlots: 6,
-          ),
-          1,
-        );
-      },
-    );
-
-    test('shifts left to the selection when it walks off the start', () {
+    test('keeps the selection in the middle slot mid-strip', () {
+      // 6 tabs through a 3-slot window: slots 2 and 3 are far enough from
+      // both ends to center exactly.
       expect(
         navTabWindowStart(
-          windowStart: 2,
-          selectedSlot: 1,
+          windowStart: 0,
+          selectedSlot: 2,
+          tabCount: 6,
+          maxSlots: 3,
+        ),
+        1,
+      );
+      expect(
+        navTabWindowStart(
+          windowStart: 1,
+          selectedSlot: 3,
+          tabCount: 6,
+          maxSlots: 3,
+        ),
+        2,
+      );
+    });
+
+    test('sits left of middle for an even window width', () {
+      // 8 tabs through a 6-slot window: slot 3 renders in window slot 2.
+      expect(
+        navTabWindowStart(
+          windowStart: 0,
+          selectedSlot: 3,
           tabCount: 8,
           maxSlots: 6,
         ),
@@ -59,27 +54,34 @@ void main() {
       );
     });
 
-    test('wrap-around jumps the window to the far end', () {
-      // R1 from the last tab wraps to slot 0.
-      expect(
-        navTabWindowStart(
-          windowStart: 2,
-          selectedSlot: 0,
-          tabCount: 8,
-          maxSlots: 6,
-        ),
-        0,
-      );
-      // L1 from the first tab wraps to the last slot.
-      expect(
-        navTabWindowStart(
-          windowStart: 0,
-          selectedSlot: 7,
-          tabCount: 8,
-          maxSlots: 6,
-        ),
-        2,
-      );
+    test('clamps at the far left instead of showing blank slots', () {
+      for (final slot in [0, 1]) {
+        expect(
+          navTabWindowStart(
+            windowStart: 2,
+            selectedSlot: slot,
+            tabCount: 6,
+            maxSlots: 3,
+          ),
+          0,
+          reason: 'slot $slot is within half a window of the start',
+        );
+      }
+    });
+
+    test('clamps at the far right instead of showing blank slots', () {
+      for (final slot in [4, 5]) {
+        expect(
+          navTabWindowStart(
+            windowStart: 0,
+            selectedSlot: slot,
+            tabCount: 6,
+            maxSlots: 3,
+          ),
+          3,
+          reason: 'slot $slot is within half a window of the end',
+        );
+      }
     });
 
     test('keeps the current window when the selected tab is hidden', () {


### PR DESCRIPTION
# Description

The nav tab strip grew by one slot for every tab shown, so it widened toward the status pill with each new tab (RomM makes seven). It now renders a bounded number of slots and scrolls when there are more visible tabs than slots, and that bound is derived from the room actually available beside the status pill instead of being a fixed number.

What changed:

- **Windowed strip.** With more visible tabs than slots the strip becomes a window that slides just far enough to keep the selected tab in view, with the icons at a scrollable edge fading out to signal it continues. With that many tabs or fewer it renders exactly as before and never scrolls.
- **Centred selection.** The selected tab sits in the middle slot, clamped at both ends, so the strip scrolls under a stationary highlight rather than the highlight running to the edge.
- **Slot count from available width.** `navStripMaxSlots()` inverts the arithmetic `statusPillMaxWidth()` already does: the strip is centred, so the pill plus its margin and gutter are mirrored either side, the shoulder glyphs and pill padding come off what is left, and the rest divides into slots. `maxVisibleNavTabSlots` becomes `minNavTabSlots`, a floor for screens too narrow even for that, where the pill's existing scale-down takes over.

Two details the arithmetic depends on:

- It measures against the widest pill the settings can produce (`widestClockText()`, `100%` for the battery) rather than the live one, so the count cannot flip as the clock ticks past a digit or the battery falls to one. The 12-hour clock reserves its AM/PM suffix and so legitimately costs width.
- It reserves no room for the clock glyph. The glyph is already the first thing the pill drops when space runs short, so reserving it would spend a whole tab slot to save an icon sitting next to a label that already reads as a time. Slots first, glyph second.

Two defects were found and fixed while building this. Both were introduced within this branch, so neither is reachable on `main`:

- The status pill's collision bound sized itself from the tab count, but the strip stops growing once it runs out of slots, so the pill was giving up room the strip never takes and dropping the clock glyph for nothing.
- The pill's `Border.all(width: 1.r)` deflates the box its child gets. The scrolling strip escaped that squeeze, because a positioned child with a stated height keeps it regardless, so `BoxFit` sized the icons off a taller axis and every icon rendered about 14% larger the moment the strip scrolled, overflowing the pill's inner edge and being hidden by the `ClipRect`. Hiding or showing a tab visibly resized every icon.

## Steps to Verify

**Preconditions:** an Android handheld, and Settings > General with every "Show ... tab" toggle on (seven tabs).

1. Look at the header. The strip shows as many tabs as fit beside the clock and battery pill (six on an AYN Thor) and scrolls the rest, instead of a fixed five.
2. Change tabs. The selected tab stays in the middle slot while the strip slides under it, and the icons at whichever edge can still scroll fade out.
3. Turn off "Show Search tab" so six tabs remain, then on again. The remaining icons must stay exactly the same size. Before this PR they changed by about 14% each way.
4. Turn tabs off until five or fewer remain. The strip stops scrolling and renders statically, again with no change in icon size.
5. Turn on "Use 12-Hour Clock". The AM/PM suffix widens the pill, which may cost a slot on a narrow screen, but nothing flickers as the clock ticks.
6. Raise the OS font size (or `./sim-device.sh nova 320 1.5`). The pill widens, the clock glyph is dropped first, and only then does the strip give up a slot and scroll.

## Tested on

- [x] Android - device: AYN Thor (dev channel, release build), plus Retroid Nova geometry and a 1.5x OS font scale via `./sim-device.sh`
- [x] Linux - device: CachyOS desktop, 3440x1440, release build
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested - why:

Measurements taken from device screenshots, in device px at the Thor's 2.30625 dpr:

| check | before | after |
| --- | --- | --- |
| NeoSync icon, strip scrolling vs static | 40 vs 34 | 34 vs 34 |
| Achievements icon, scrolling vs static | 40 vs 36 | 36 vs 36 |
| RomM icon, scrolling vs static | 48 vs 42 | 42 vs 42 |
| selection indicator height when scrolling | 72 (overflowing the pill) | 66 (matches static) |
| tabs shown on a Thor, 12-hour clock | 5 of 6, scrolling | 6 of 6, no scrolling |
| tabs shown on a Linux desktop | 5 of 7, scrolling | 7 of 7, no scrolling |

Desktop is the case this most benefits, and it now checks out on one: a machine that reports no battery drops that block from the pill, leaving it 253 px wide against a strip carrying all seven tabs at a uniform 96 px pitch, with the clock glyph kept and over 1000 px still clear between the two. That is the configuration the old fixed cap of five would have scrolled for no reason.

## Checklist

- [x] `dart format .` - no diff
- [x] `flutter analyze` - clean (no errors *or* warnings)
- [x] `flutter test` - all passing (1297)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [ ] New assets have compatible licenses (no new assets)

New tests: `test/nav_tab_window_test.dart` (windowing and centring), `test/nav_strip_slots_test.dart` (slot arithmetic, and that `widestClockText()` covers every time the formatter can produce), `test/nav_tab_icon_size_test.dart` (both paths hand icons the same box, which fails against the pre-fix layout).

<details>
<summary><b>Extra checks</b></summary>

**Navigation**

- Tab selection is unchanged by this PR. The screen still owns the selected index and drives the strip through `selectedTabIndex`; the strip stays presentational, and the window is derived during build from the selection, with no new state to get out of step.
- Cycling tabs with LB/RB through a scrolling strip has been checked on hardware and behaves correctly: the window follows the selection and the highlight stays put in the middle slot.
- No new full-screen route, so no `GamepadNavigationManager` layer is involved.

**User-facing text, database, Android paths, emulator launching**

- None touched. No new strings (the strip is icons only), no schema change, no path handling, no launch changes.

</details>

## Screenshots / video

Not attached. The behaviour is captured by the measurement table above and reproducible with the steps; happy to add before and after captures if useful.
