### PR TITLE
fix(gamepad): stop the games carousel locking the screen on a bumper press

### DIFF
--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -564,6 +564,14 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
   /// Steps [step] places through the visible tabs, wrapping at both ends, so a
   /// hidden tab is skipped rather than selected and immediately bounced.
   void _cycleTab(int step) {
+    // A pushed full-screen route (the system games list and its grid/carousel
+    // views, a game's details screen) covers AppScreen entirely. Switching the
+    // tab underneath one is invisible on the main display and leaves the user
+    // driving a screen they cannot see — see the bumper comment in
+    // my_games_carousel.dart. Screens on a route own their own bumpers; the
+    // app strip is only reachable from the tab that is actually on screen.
+    if (Navigator.maybeOf(context)?.canPop() ?? false) return;
+
     final visible = _visibleTabs;
     if (visible.isEmpty) return;
 

--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -15,7 +15,6 @@ import 'package:neostation/services/game_service.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:neostation/utils/letter_jump.dart';
-import 'package:neostation/screens/app_screen.dart';
 import 'package:neostation/widgets/achievements_badge.dart';
 import 'package:neostation/widgets/game_view_mode_dropdown.dart';
 import 'package:neostation/widgets/game_action_buttons.dart';
@@ -377,10 +376,17 @@ class _GamesCarouselState extends State<GamesCarousel> {
       onSelectModifierB: _toggleLegend, // Select + B - Hide/show legend.
       onSelectModifierY: widget.onRandom, // Select + Y - Random game.
       onSettings: widget.onSettings,
-      onPreviousTab: AppNavigation.previousTab,
-      onNextTab: AppNavigation.nextTab,
-      onLeftBumper: AppNavigation.previousTab,
-      onRightBumper: AppNavigation.nextTab,
+      // The bumpers deliberately bind nothing here. This view lives on a route
+      // PUSHED OVER AppScreen, so cycling the app's top-level tabs from it
+      // switched the tab underneath a screen that stays on top: the main
+      // display never changed while the secondary display and the tab sounds
+      // said it had. Landing on a tab that hosts its own navigation layer
+      // (Search, NeoSync, RomM) then stacked that layer above this one, so
+      // every further press — B included — went to a screen the user could not
+      // see, and the device needed a restart. The list and grid views never
+      // reached the app tabs from here either (the list sends its bumpers to
+      // the details card's tabs, the grid binds none), which is why only
+      // carousel mode locked up.
     );
 
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -983,8 +983,7 @@ class GamepadNavigation {
 
       case GamepadInputType.buttonLB:
       case GamepadInputType.buttonRB:
-        _dispatchShoulder(event.inputType);
-        _startShoulderHold(event);
+        if (_dispatchShoulder(event.inputType)) _startShoulderHold(event);
         break;
 
       // L3 (left stick click) only — the UI hint shows the Left-Stick-Click
@@ -1124,16 +1123,13 @@ class GamepadNavigation {
       }
       handled = true;
     } else if (key == LogicalKeyboardKey.keyQ) {
-      if (isKeyDown) {
-        SfxService().playNavSound();
-        onPreviousTab?.call();
-      }
+      // Q/E are the keyboard's bumpers, so they go through the same dispatch:
+      // it honours a screen's bumper override and stays silent where the
+      // screen binds nothing.
+      if (isKeyDown) _dispatchShoulder(GamepadInputType.buttonLB);
       handled = true;
     } else if (key == LogicalKeyboardKey.keyE) {
-      if (isKeyDown) {
-        SfxService().playNavSound();
-        onNextTab?.call();
-      }
+      if (isKeyDown) _dispatchShoulder(GamepadInputType.buttonRB);
       handled = true;
     } else if (key == LogicalKeyboardKey.enter) {
       if (isKeyDown) {
@@ -1356,21 +1352,22 @@ class GamepadNavigation {
   }
 
   /// Walks one tab for [input], honouring the per-screen bumper overrides.
-  void _dispatchShoulder(GamepadInputType input) {
+  ///
+  /// Screens that bind neither the override nor the tab walk (the games grid
+  /// and carousel) stay silent rather than clicking: a nav sound with nothing
+  /// behind it is what made the carousel's dead bumpers read as a frozen
+  /// screen rather than an unbound button.
+  /// Returns whether anything was bound to walk, so an unbound bumper does not
+  /// start a hold-repeat that would fire into the void.
+  bool _dispatchShoulder(GamepadInputType input) {
+    final action = input == GamepadInputType.buttonLB
+        ? (onLeftBumper ?? onPreviousTab)
+        : (onRightBumper ?? onNextTab);
+    if (action == null) return false;
+
     SfxService().playNavSound();
-    if (input == GamepadInputType.buttonLB) {
-      if (onLeftBumper != null) {
-        onLeftBumper!.call();
-      } else {
-        onPreviousTab?.call();
-      }
-    } else {
-      if (onRightBumper != null) {
-        onRightBumper!.call();
-      } else {
-        onNextTab?.call();
-      }
-    }
+    action();
+    return true;
   }
 
   /// Starts the synthetic repeat for a bumper held on desktop.

--- a/test/pushed_route_tab_cycle_test.dart
+++ b/test/pushed_route_tab_cycle_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Screens that live on a route PUSHED OVER `AppScreen` must not walk the app's
+/// top-level tab strip.
+///
+/// The strip and its header are behind the pushed route, so cycling it changes
+/// nothing the user can see: the main display keeps showing the pushed screen
+/// while the secondary display and the nav sounds report a tab switch. Worse,
+/// tabs that host their own gamepad layer (Search, NeoSync, RomM) stack that
+/// layer above the pushed screen's, so every later press — B included — is
+/// handled by a screen that is not on the display, and the device needs a
+/// restart. The games carousel shipped with `AppNavigation.previousTab` /
+/// `nextTab` on its bumpers and did exactly that.
+///
+/// `AppScreenState._cycleTab` also refuses to cycle while `Navigator.canPop()`,
+/// so this is the second of two locks. Keep both: the guard covers screens
+/// nobody has written yet, this test keeps the wiring honest at the source.
+void main() {
+  /// Everything under these paths is reached by `Navigator.push`, never as tab
+  /// content.
+  const pushedRouteSources = <String>[
+    'lib/screens/game_screen',
+    'lib/screens/settings_screen/standalone_emulators_screen.dart',
+  ];
+
+  final tabCycleCall = RegExp(r'AppNavigation\.(previousTab|nextTab)\b');
+
+  test('screens on a pushed route never cycle the app tab strip', () {
+    final offenders = <String>[];
+
+    for (final path in pushedRouteSources) {
+      final entity = FileSystemEntity.isDirectorySync(path)
+          ? Directory(path)
+          : null;
+      final files = entity == null
+          ? [File(path)]
+          : entity
+                .listSync(recursive: true)
+                .whereType<File>()
+                .where((f) => f.path.endsWith('.dart'))
+                .toList();
+
+      expect(files, isNotEmpty, reason: '$path matched no Dart source');
+
+      for (final file in files) {
+        final lines = file.readAsLinesSync();
+        for (var i = 0; i < lines.length; i++) {
+          // Skip comments: the carousel documents this rule in prose.
+          final code = lines[i].trimLeft();
+          if (code.startsWith('//') || code.startsWith('///')) continue;
+          if (tabCycleCall.hasMatch(code)) {
+            offenders.add('${file.path}:${i + 1}: ${code.trim()}');
+          }
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'These screens sit on a pushed route, so switching the app tab under '
+          'them freezes the main display (see this file\'s doc comment). Bind '
+          'the bumpers to something local, or leave them unbound:\n'
+          '${offenders.join('\n')}',
+    );
+  });
+}


### PR DESCRIPTION
# Description

In carousel view a shoulder press froze the main display. The screen kept showing the carousel while the nav sounds and the secondary display reported that something was happening, and only a device restart recovered it. Reported by a user and reproduced locally.

The carousel bound its bumpers to `AppNavigation.previousTab/nextTab`, but `SystemGamesList` and its views live on a route **pushed over** `AppScreen`. Cycling the tab strip from there switched the tab underneath a screen that stays on top, so the main display could not show the change the secondary display was already reporting.

It went from confusing to fatal when the walk landed on a tab that hosts its own navigation layer (Search, NeoSync, RomM): that layer stacked above the carousel's, so every later press, B included, was handled by a screen the user could not see. The list view sends its bumpers to the details card's tabs and the grid view binds none, which is why only carousel mode locked up. The wiring has been there since the carousel was written, copy-pasted from a screen that really is tab content.

**The fix, in three parts:**

- `my_games_carousel.dart` binds nothing to the bumpers, with the reasoning in a comment so it does not get pasted back.
- `AppScreenState._cycleTab` refuses to cycle while a route covers `AppScreen`, so a screen written later cannot reintroduce the same lock. `AppScreen` is mounted directly under `home:` and is never itself pushed, so this never blocks normal tab switching.
- `_dispatchShoulder` reports whether anything was bound: an unbound bumper no longer plays a nav sound with nothing behind it (that phantom click is part of what read as a frozen screen) and no longer starts a hold-repeat that fires into the void. Q/E go through the same dispatch, since desktop had the same lock through the keyboard path. Every screen wires `onLeftBumper` and `onPreviousTab` to the same callback today, so nothing else changes behaviour.

A new test scans the pushed-route sources and fails if any of them reaches for the app tab strip again.

No linked issue — reported directly.

## Steps to Verify

**Preconditions:** Android handheld with a gamepad, any system with a few games, games list view set to **carousel** (X → View Mode). A dual-screen device makes the old behaviour obvious but is not required.

Before this change:

1. Open any system so the carousel is on screen.
2. Press L1 or R1.
3. The main display freezes on the carousel. On a dual-screen device the nav tabs are visibly changing on the bottom screen, and each press still plays a nav sound.
4. Nothing recovers it, B included. The device needs a restart.

After this change:

1. Open any system so the carousel is on screen.
2. Press L1 and R1 — nothing happens, and no sound plays.
3. Press D-pad left/right — the carousel still moves, so the view is live rather than frozen.
4. Press B — it exits back to the systems screen as usual.
5. On the systems screen, press L1 — the tab strip still cycles, so ordinary tab navigation is untouched.

## Tested on

- [x] Android — device: AYN Thor (dual screen)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Verified by driving the Thor's own controller input node with `sendevent`, so the app saw real gamepad events rather than injected key events (which this navigation ignores). The same injected L1 that does nothing in the carousel still cycles tabs on the systems screen, so the pass is not a dead input path.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse
- [x] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()`
- [x] B cancels / goes back, including out of a focused text field

</details>

## Screenshots / video

Not applicable — the fix is the absence of a state change. The verification steps above cover it.
