### PR TITLE
ci(labeler): cover UX/UI, desktop and dependencies, and move off Node 20

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,9 @@
 # write or triage permission on this repository. These rules apply the platform and
 # area labels on their behalf. Release-note categories are NOT set here: they come
 # from the Conventional Commits prefix in the PR title (see .github/changelog-config.json).
+#
+# `bug`, `enhancement` and `performance` stay manual on purpose: nothing about a
+# changed path predicts them.
 
 android:
   - changed-files:
@@ -28,6 +31,19 @@ macos:
           - 'macos/**'
           - 'build-utils/build-macos.sh'
 
+# The three desktop platforms share a Flutter runner and the same build-utils
+# scripts, so a change to any one of them is desktop-relevant. Deliberately
+# overlaps the per-platform rules above rather than replacing them.
+desktop:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'linux/**'
+          - 'windows/**'
+          - 'macos/**'
+          - 'build-utils/build-linux*.sh'
+          - 'build-utils/build-windows.ps1'
+          - 'build-utils/build-macos.sh'
+
 systems:
   - changed-files:
       - any-glob-to-any-file:
@@ -39,6 +55,15 @@ themes:
       - any-glob-to-any-file:
           - 'lib/themes/**'
           - 'THEMES.md'
+
+# Anything the user actually sees: screens and the shared widgets they compose.
+# Services, repositories and datasources are deliberately excluded — they change
+# behaviour, not presentation.
+UX/UI:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/screens/**'
+          - 'lib/widgets/**'
 
 RetroAchievements:
   - changed-files:
@@ -55,6 +80,15 @@ screenscraper:
           - 'lib/services/screenscraper/**'
           - 'lib/services/screenscraper_service.dart'
           - 'lib/repositories/scraper_repository.dart'
+
+# Matches what Dependabot touches. The vendored packages under /packages/ carry
+# their own pubspec, and the pub workspace resolves them into the root lockfile.
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'pubspec.yaml'
+          - 'pubspec.lock'
+          - 'packages/*/pubspec.yaml'
 
 ci:
   - changed-files:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -22,7 +22,11 @@ jobs:
     name: Apply path labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      # v7, not v5: v5 runs on Node 20, which the runners now force onto Node 24
+      # and warn about on every run. v6 moved the action to Node 24 (needs runner
+      # v2.327.1+, well below what the hosted images ship) and v7 moved it to ESM.
+      # Neither touched the config schema, so .github/labeler.yml is unchanged.
+      - uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml


### PR DESCRIPTION
# Description

The labeler action itself was fine: it ran green on every PR since #349 and
`github-actions[bot]` genuinely applied labels on #375, #376 and #380. It only
looked dead because most PRs had already been labelled by hand before the run
finished, so the bot had nothing left to add, and because labeler v5 logs its
matches at debug level only, making a no-match run and a successful run look
identical in the log.

The real gap is coverage. Four of this repository's labels had no path rule at
all: `UX/UI`, `desktop`, `dependencies` and `performance`. #385 (screens, a util
and a test) matched nothing in the config and came out completely bare.

This adds rules for the first three:

- **`UX/UI`** — `lib/screens/**` and `lib/widgets/**`. Services, repositories and
  datasources are deliberately excluded: they change behaviour, not presentation.
- **`desktop`** — the three desktop runners and their `build-utils` scripts.
  Deliberately overlaps the existing per-platform rules rather than replacing them.
- **`dependencies`** — the root pubspec pair plus `packages/*/pubspec.yaml`, since
  the vendored packages carry their own pubspec and the pub workspace resolves
  them into the root lockfile. Matches what Dependabot touches.

`bug`, `enhancement` and `performance` stay manual on purpose, with a comment in
the config saying so: nothing about a changed path predicts them. Worth noting
they are triage-only either way, because `.github/changelog-config.json` builds
release-note categories from its own `label_extractor` regex over the PR *title*,
not from the labels on the PR.

Separately, this bumps `actions/labeler` from v5 to v7 to clear the
`Node.js 20 is deprecated` warning on every run. v5 targets Node 20, which the
runners now force onto Node 24. v6 moved the action to Node 24 (requiring runner
v2.327.1+, well below the v2.336.0 the hosted images ship) and v7 moved it to ESM.
Neither release changed the configuration schema, so the rules file needs nothing
for the bump.

Closes #

## Steps to Verify

Not a bug fix in the app, but the config change is verifiable on this PR itself.

**Preconditions:** this PR is open against `main`.

1. Note that `pull_request_target` reads `.github/labeler.yml` from the **base**
   branch, so this PR is labelled by the *old* config: expect only `ci`
   (`.github/workflows/**`) and nothing else.
2. After merge, open any PR touching `lib/screens/**` and confirm
   `github-actions[bot]` applies `UX/UI`.
3. Confirm the next Dependabot PR gets `dependencies` from the bot rather than by hand.
4. Confirm the run log no longer carries the `Node.js 20 is deprecated` annotation.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: CI configuration only, no application code. The
      YAML was parsed locally and every rule key was checked against the
      repository's actual label list; the globs were checked against the real
      `packages/` and `build-utils/` layouts.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses
