### PR TITLE
feat(systems): add Windows emulators to Steam

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.14"
+  "latest_version": "0.3.15"
 }

--- a/assets/systems/steam.json
+++ b/assets/systems/steam.json
@@ -26,7 +26,16 @@
       "#66c0f4"
     ],
     "extensions": [
-      "steam"
+      "exe",
+      "desktop",
+      "lnk",
+      "pcgame",
+      "gog",
+      "epic",
+      "customgame",
+      "amazon",
+      "steam",
+      "localgameid"
     ]
   },
 "emulators": [

--- a/assets/systems/steam.json
+++ b/assets/systems/steam.json
@@ -29,13 +29,276 @@
       "steam"
     ]
   },
-  "emulators": [
+"emulators": [
+    {
+      "name": "Standalone Winlator CMod",
+      "unique_id": "windows.winlator.cmod",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: desktop.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.winlator.cmod/.XServerDisplayActivity -e shortcut_path \"{file.path}\" --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone Winlator CMod Proot",
+      "unique_id": "windows.winlator.cmodproot",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: desktop.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.cmodded.winlator/com.winlator.XServerDisplayActivity -e shortcut_path \"{file.path}\" --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone Winlator Cmod (Old)",
+      "unique_id": "windows.winlator.cmod.old",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: desktop.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.winlator/.XServerDisplayActivity -e shortcut_path \"{file.path}\" --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone Winlator Ludashi",
+      "unique_id": "windows.winlator.ludashi",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: desktop.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.winlator.vanilla/com.winlator.cmod.XServerDisplayActivity -e shortcut_path \"{file.path}\" --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone MiceWine",
+      "unique_id": "windows.micewine.emu",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: lnk.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.micewine.emu/com.micewine.emu.activities.MainActivity -e exePath \"{file.path}\" --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone GameHub Lite (Local Games)",
+      "unique_id": "windows.gamehub.lite.local",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a gamehub.lite.LAUNCH_GAME -n gamehub.lite/com.xj.landscape.launcher.ui.gamedetail.GameDetailActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true"
+        }
+      }
+    },
+    {
+      "name": "Standalone GameHub Lite (Local Games - Antutu)",
+      "unique_id": "windows.gamehub.lite.local.antutu",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a gamehub.lite.LAUNCH_GAME -n com.antutu.ABenchMark/com.xj.landscape.launcher.ui.gamedetail.GameDetailActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true"
+        }
+      }
+    },
+    {
+      "name": "Standalone GameHub Lite (Local Games - PUBG)",
+      "unique_id": "windows.gamehub.lite.local.pubg",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a gamehub.lite.LAUNCH_GAME -n com.tencent.ig/com.xj.landscape.launcher.ui.gamedetail.GameDetailActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true"
+        }
+      }
+    },
+    {
+      "name": "Standalone GameHub Lite (Local Games - Ludashi)",
+      "unique_id": "windows.gamehub.lite.ludashi",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a gamehub.lite.LAUNCH_GAME -n com.ludashi.aibench/com.xj.landscape.launcher.ui.gamedetail.GameDetailActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v5 (Normal - Local Games) [legacy 5.3.5]",
+      "unique_id": "windows.banner.hub.local",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. Legacy BannerHub v5 (GameHub 5.3.5 base). Use v6 entries below for current builds.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a banner.hub.LAUNCH_GAME -n banner.hub/com.xj.landscape.launcher.ui.gamedetail.GameDetailActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v5 Lite (Normal - Local Games) [legacy 5.3.5]",
+      "unique_id": "windows.banner.hub.lite.local",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. Legacy BannerHub v5 Lite (GameHub 5.3.5 base). Use v6 entries below for current builds.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a banner.hub.lite.LAUNCH_GAME -n banner.hub.lite/com.xj.landscape.launcher.ui.gamedetail.GameDetailActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v6 (Normal)",
+      "unique_id": "windows.banner.hub.v6.normal",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. BannerHub v6 (GameHub 6.0.4 base). Covers both Full and Lite — Lite uses the same package and replaces Full on install.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a banner.hub.LAUNCH_GAME -n banner.hub/com.xiaoji.egggame.DeepLinkActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v6 (Normal - GameHub Lite pkg)",
+      "unique_id": "windows.banner.hub.v6.normal.ghl",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. BannerHub v6 Normal-GHL variant — installs over the upstream gamehub.lite package.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a gamehub.lite.LAUNCH_GAME -n gamehub.lite/com.xiaoji.egggame.DeepLinkActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v6 (PuBG)",
+      "unique_id": "windows.banner.hub.v6.pubg",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. BannerHub v6 PuBG variant — installs over com.tencent.ig.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a com.tencent.ig.LAUNCH_GAME -n com.tencent.ig/com.xiaoji.egggame.DeepLinkActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v6 (AnTuTu)",
+      "unique_id": "windows.banner.hub.v6.antutu",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. BannerHub v6 AnTuTu variant — installs over com.antutu.ABenchMark.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a com.antutu.ABenchMark.LAUNCH_GAME -n com.antutu.ABenchMark/com.xiaoji.egggame.DeepLinkActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v6 (alt-AnTuTu)",
+      "unique_id": "windows.banner.hub.v6.alt.antutu",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. BannerHub v6 alt-AnTuTu variant — installs over com.antutu.benchmark.full.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a com.antutu.benchmark.full.LAUNCH_GAME -n com.antutu.benchmark.full/com.xiaoji.egggame.DeepLinkActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v6 (PuBG CrossFire)",
+      "unique_id": "windows.banner.hub.v6.pubg.crossfire",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. BannerHub v6 PuBG-CrossFire variant — installs over com.tencent.tmgp.cf.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a com.tencent.tmgp.cf.LAUNCH_GAME -n com.tencent.tmgp.cf/com.xiaoji.egggame.DeepLinkActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v6 (Ludashi)",
+      "unique_id": "windows.banner.hub.v6.ludashi",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. BannerHub v6 Ludashi variant — installs over com.ludashi.aibench.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a com.ludashi.aibench.LAUNCH_GAME -n com.ludashi.aibench/com.xiaoji.egggame.DeepLinkActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v6 (Genshin)",
+      "unique_id": "windows.banner.hub.v6.genshin",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. BannerHub v6 Genshin variant — installs over com.miHoYo.GenshinImpact.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a com.miHoYo.GenshinImpact.LAUNCH_GAME -n com.miHoYo.GenshinImpact/com.xiaoji.egggame.DeepLinkActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone BannerHub v6 (Original)",
+      "unique_id": "windows.banner.hub.v6.original",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: localgameid. BannerHub v6 Original variant — replaces stock XiaoJi GameHub (com.xiaoji.egggame).",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a com.xiaoji.egggame.LAUNCH_GAME -n com.xiaoji.egggame/com.xiaoji.egggame.DeepLinkActivity --es localGameId \"{tags.localgameid}\" --ez autoStartGame true --activity-clear-task --activity-clear-top --activity-no-history"
+        }
+      }
+    },
+    {
+      "name": "Standalone GameNative (GOG)",
+      "unique_id": "windows.app.gamenative.gog",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: gog.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a app.gamenative.LAUNCH_GAME -n app.gamenative/.MainActivity --ei app_id \"{tags.gog}\" --es game_source GOG"
+        }
+      }
+    },
+    {
+      "name": "Standalone GameNative (Epic Games)",
+      "unique_id": "windows.app.gamenative.epic",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: epic.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a app.gamenative.LAUNCH_GAME -n app.gamenative/.MainActivity --ei app_id \"{tags.epicgame}\" --es game_source EPIC"
+        }
+      }
+    },
+    {
+      "name": "Standalone GameNative (Custom Game)",
+      "unique_id": "windows.app.gamenative.custom",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: pcgame.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a app.gamenative.LAUNCH_GAME -n app.gamenative/.MainActivity --ei app_id \"{tags.customgame}\" --es game_source CUSTOM_GAME"
+        }
+      }
+    },
+    {
+      "name": "Standalone GameNative (Amazon)",
+      "unique_id": "windows.app.gamenative.amazon",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: amazon.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-a app.gamenative.LAUNCH_GAME -n app.gamenative/.MainActivity --ei app_id \"{tags.amazon}\" --es game_source AMAZON"
+        }
+      }
+    },
     {
       "name": "Standalone GameNative (Steam)",
-      "unique_id": "steam.app.gamenative.steam",
-      "default_standalone": true,
+      "unique_id": "windows.app.gamenative.steam",
       "is_retroachievements_compatible": false,
-      "description": "Supported extensions: steamappid.",
+      "description": "Supported extensions: steam.",
       "platforms": {
         "android": {
           "launch_arguments": "-a app.gamenative.LAUNCH_GAME -n app.gamenative/.MainActivity --ei app_id \"{tags.steamappid}\" --es game_source STEAM"


### PR DESCRIPTION
# Description

Adds Android launch definitions for Winlator variants, MiceWine, GameHub Lite, BannerHub, and GameNative under the Steam system configuration. Bumps `assets/manifest.json` to `0.3.15` so existing installations download the updated system definitions.

This lets users configure and launch supported Windows-game apps through NeoStation without an app release.

Closes #

## Steps to Verify

**Preconditions:**

1. An Android device with one of the supported apps installed and a compatible game/tag configuration.

1. Refresh or restart NeoStation so it downloads systems manifest version `0.3.15`.
2. Open the Steam system emulator selection and confirm the new Windows emulator entries are available.
3. Configure a compatible tag and launch a game to verify the target app receives the expected intent.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — JSON syntax and whitespace validated locally; Android apps were not available in this environment.

## Checklist

- [x] `dart format .` — no diff (not applicable; JSON-only change)
- [ ] `flutter analyze` — clean (no errors *or* warnings)
- [ ] `flutter test` — all passing
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [ ] New assets have compatible licenses

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**`assets/systems/` or emulator launching**
- [x] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible
- [x] `assets/manifest.json` version bumped if this should reach existing installs OTA

</details>

## Screenshots / video

Not applicable; this is a system-definition change.