### PR TITLE
fix(m3u): ignore media files during organization

### DIFF
--- a/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
@@ -120,6 +120,10 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
         .expand((system) => [system.folderName, ...system.folders])
         .where((folder) => folder.isNotEmpty)
         .toSet();
+    final supportedRomExtensions = multiDiscSystems
+        .expand((system) => system.extensions)
+        .where((extension) => extension.isNotEmpty)
+        .toSet();
 
     String? completionMessage;
     NotificationType? completionType;
@@ -137,6 +141,7 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
 
       final result = await RomFolderOrganizerService.organizeRomFolders(
         _currentRomFolders,
+        supportedRomExtensions: supportedRomExtensions,
         supportedSystemFolders: supportedFolders,
         onProgress: (completed, total) {
           if (total == 0) return;

--- a/lib/services/rom_folder_organizer_service.dart
+++ b/lib/services/rom_folder_organizer_service.dart
@@ -89,10 +89,14 @@ class RomFolderOrganizerService {
 
   static Future<RomFolderOrganizerResult> organizeRomFolders(
     List<String> romRoots, {
+    required Set<String> supportedRomExtensions,
     Set<String>? supportedSystemFolders,
     void Function(int completed, int total)? onProgress,
   }) async {
     final result = _MutableResult();
+    final allowedExtensions = supportedRomExtensions
+        .map((extension) => extension.toLowerCase().replaceFirst('.', ''))
+        .toSet();
     final allowedFolders = supportedSystemFolders
         ?.map((folder) => folder.toLowerCase())
         .toSet();
@@ -129,9 +133,9 @@ class RomFolderOrganizerService {
     for (var index = 0; index < scanRoots.length; index++) {
       final scanRoot = scanRoots[index];
       if (scanRoot.startsWith('content://')) {
-        await _organizeSafRoot(scanRoot, result);
+        await _organizeSafRoot(scanRoot, allowedExtensions, result);
       } else {
-        await _organizeRoot(Directory(scanRoot), result);
+        await _organizeRoot(Directory(scanRoot), allowedExtensions, result);
       }
       onProgress?.call(index + 1, scanRoots.length);
     }
@@ -177,6 +181,7 @@ class RomFolderOrganizerService {
 
   static Future<void> _organizeRoot(
     Directory rootDir,
+    Set<String> allowedExtensions,
     _MutableResult result,
   ) async {
     final filesByDir = <String, List<File>>{};
@@ -199,6 +204,7 @@ class RomFolderOrganizerService {
       await _organizeDirectory(
         directoryPath: entry.key,
         files: entry.value,
+        allowedExtensions: allowedExtensions,
         result: result,
       );
     }
@@ -207,6 +213,7 @@ class RomFolderOrganizerService {
   static Future<void> _organizeDirectory({
     required String directoryPath,
     required List<File> files,
+    required Set<String> allowedExtensions,
     required _MutableResult result,
   }) async {
     final groups = <String, _DiscGroup>{};
@@ -225,6 +232,7 @@ class RomFolderOrganizerService {
         }
         continue;
       }
+      if (!_isAllowedRomExtension(filename, allowedExtensions)) continue;
 
       final discInfo = _extractDiscInfo(filename);
       if (discInfo == null) continue;
@@ -343,6 +351,7 @@ class RomFolderOrganizerService {
 
   static Future<void> _organizeSafRoot(
     String rootUri,
+    Set<String> allowedExtensions,
     _MutableResult result,
   ) async {
     final directories = <String, _SafDirectory>{};
@@ -378,6 +387,7 @@ class RomFolderOrganizerService {
         entry.key,
         entry.value.name,
         entry.value.files,
+        allowedExtensions,
         result,
       );
     }
@@ -387,6 +397,7 @@ class RomFolderOrganizerService {
     String directoryUri,
     String directoryName,
     List<Map<String, dynamic>> entries,
+    Set<String> allowedExtensions,
     _MutableResult result,
   ) async {
     final groups = <String, _DiscGroup>{};
@@ -405,6 +416,7 @@ class RomFolderOrganizerService {
         if (key.isNotEmpty) playlistsByGroupKey[key] = entry;
         continue;
       }
+      if (!_isAllowedRomExtension(filename, allowedExtensions)) continue;
 
       final discInfo = _extractDiscInfo(filename);
       if (discInfo == null) continue;
@@ -546,6 +558,15 @@ class RomFolderOrganizerService {
       normalizedGroupKey: groupKey,
       discNumber: discNumber,
     );
+  }
+
+  static bool _isAllowedRomExtension(
+    String filename,
+    Set<String> allowedExtensions,
+  ) {
+    final extension = path.extension(filename).toLowerCase();
+    return extension.length > 1 &&
+        allowedExtensions.contains(extension.substring(1));
   }
 
   static String _normalizeForGrouping(String value) {

--- a/test/rom_folder_organizer_service_test.dart
+++ b/test/rom_folder_organizer_service_test.dart
@@ -49,9 +49,10 @@ void main() {
         "INSERT INTO user_screenscraper_metadata (filename, app_system_id, real_name, is_fully_scraped) VALUES ('Final Fantasy VIII (Disc 1).chd', 'psx', 'Final Fantasy VIII', 1)",
       );
 
-      final result = await RomFolderOrganizerService.organizeRomFolders([
-        root.path,
-      ]);
+      final result = await RomFolderOrganizerService.organizeRomFolders(
+        [root.path],
+        supportedRomExtensions: {'chd', 'm3u'},
+      );
 
       expect(result.groupsOrganized, 1);
       expect(result.foldersCreated, 1);
@@ -105,9 +106,10 @@ void main() {
           '${saturnDir.path}/Panzer Dragoon Saga - CD 2.cue',
         ).writeAsStringSync('disk2');
 
-        final result = await RomFolderOrganizerService.organizeRomFolders([
-          root.path,
-        ]);
+        final result = await RomFolderOrganizerService.organizeRomFolders(
+          [root.path],
+          supportedRomExtensions: {'cue', 'm3u'},
+        );
 
         expect(result.groupsOrganized, 1);
         expect(result.playlistsCreated, 1);
@@ -126,6 +128,37 @@ void main() {
       },
     );
 
+    test(
+      'ignores Skraper media files with disc markers in their names',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'neostation_organize_',
+        );
+        addTearDown(() async {
+          if (await root.exists()) await root.delete(recursive: true);
+        });
+
+        final psxDir = Directory('${root.path}/psx')
+          ..createSync(recursive: true);
+        final mediaDir = Directory('${psxDir.path}/media')
+          ..createSync(recursive: true);
+        File('${psxDir.path}/Game Disc 1.chd').writeAsStringSync('1');
+        File('${psxDir.path}/Game Disc 2.chd').writeAsStringSync('2');
+        File('${mediaDir.path}/Game Disc 1.png').writeAsStringSync('image1');
+        File('${mediaDir.path}/Game Disc 2.png').writeAsStringSync('image2');
+
+        final result = await RomFolderOrganizerService.organizeRomFolders(
+          [root.path],
+          supportedRomExtensions: {'chd', 'm3u'},
+        );
+
+        expect(result.groupsOrganized, 1);
+        expect(await File('${mediaDir.path}/Game Disc 1.png').exists(), isTrue);
+        expect(await File('${mediaDir.path}/Game Disc 2.png').exists(), isTrue);
+        expect(await File('${mediaDir.path}/Game/Game.m3u').exists(), isFalse);
+      },
+    );
+
     test('organizes multi-disc files found in nested subfolders', () async {
       final root = await Directory.systemTemp.createTemp(
         'neostation_organize_',
@@ -139,9 +172,10 @@ void main() {
       File('${nestedDir.path}/Suikoden II Disc 1.chd').writeAsStringSync('1');
       File('${nestedDir.path}/Suikoden II Disc 2.chd').writeAsStringSync('2');
 
-      final result = await RomFolderOrganizerService.organizeRomFolders([
-        root.path,
-      ]);
+      final result = await RomFolderOrganizerService.organizeRomFolders(
+        [root.path],
+        supportedRomExtensions: {'chd', 'm3u'},
+      );
 
       expect(result.groupsOrganized, 1);
       expect(
@@ -170,6 +204,7 @@ void main() {
         final progress = <String>[];
         final result = await RomFolderOrganizerService.organizeRomFolders(
           [root.path],
+          supportedRomExtensions: {'chd', 'm3u'},
           supportedSystemFolders: {'psx'},
           onProgress: (completed, total) => progress.add('$completed/$total'),
         );
@@ -204,9 +239,10 @@ void main() {
       File('${playlistDir.path}/Game Disc 1.chd').writeAsStringSync('1');
       File('${playlistDir.path}/Game Disc 2.chd').writeAsStringSync('2');
 
-      final result = await RomFolderOrganizerService.organizeRomFolders([
-        root.path,
-      ]);
+      final result = await RomFolderOrganizerService.organizeRomFolders(
+        [root.path],
+        supportedRomExtensions: {'chd', 'm3u'},
+      );
 
       expect(result.groupsOrganized, 0);
       expect(result.foldersCreated, 0);


### PR DESCRIPTION
# Description

The multi-disc organizer recursively scanned all files and interpreted Skraper artwork names containing Disc N as ROMs. This change filters disc candidates by configured ROM extensions before grouping, while preserving existing playlist handling. The filter is shared by desktop and Android SAF scanning.

## Steps to Verify

**Preconditions:**

1. Configure a multi-disc-capable system such as PS1 with a ROM folder.
2. Place two disc images in the system folder and two artwork files such as `Game Disc 1.png` and `Game Disc 2.png` in a nested `media` folder.

1. Open Settings > Tools.
2. Select Organize Multi-Disc Games and confirm.
3. Confirm the disc images are moved under `Game/` and `Game.m3u` lists only the disc images.
4. Confirm the artwork remains in `media/` and no `.m3u` is created there.

## Tested on

- [X] Android — device: AYN Thor
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors or warnings)
- [ ] `flutter test` — focused organizer test passes; full suite currently has 13 unrelated failures in emulator discovery/seed, migration, and symlink tests
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses (no new assets)

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**Android**
- [x] Path logic handles SAF `content://` URIs; the extension filter is applied in both desktop and SAF paths
- [ ] Verified on a device, not only on desktop

</details>