### PR TITLE
chore: commit the analyzer excludes the Flutter SDK writes on its own

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,6 +12,12 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   # The lint rules applied to this project can be customized in the


### PR DESCRIPTION
# Description

Since #391 migrated to the latest stable Flutter, every `flutter analyze` run
appends the platform directories to the analyzer excludes and prints
`Upgrading analysis_options.yaml to exclude build and platform directories`.

`analysis_options.yaml` is tracked, so that lands as an unstaged modification in
the working tree of anyone who runs the local gate, on every branch, every time.
Committing the SDK's own output once makes the runs idempotent and stops the
phantom diff.

The committed file is byte-identical to what the SDK generates. `ios/**` and
`web/**` are in there even though this project ships neither: the SDK writes
them regardless and re-adds anything trimmed, which would bring the noise
straight back.

No behaviour change. The analyzer never had anything to say about those
directories anyway (they hold Gradle, Xcode and CMake files, not Dart), so this
narrows its scope without changing a single result: `flutter analyze` is clean
before and after.

## Steps to Verify

**Preconditions:** any checkout on the pinned Flutter 3.47.1.

1. On `main`, run `flutter analyze`. It prints the `Upgrading
   analysis_options.yaml ...` line, and `git status` then shows
   `analysis_options.yaml` as modified.
2. `git checkout analysis_options.yaml`, then run `flutter analyze` again. Same
   message, same dirty file. It repeats indefinitely.
3. On this branch, run `flutter analyze`. No upgrade message, and `git status`
   stays clean.

## Tested on

<!-- Name the device. Desktop-only testing does not catch Android SAF path bugs. -->

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: analyzer configuration only. No Dart code changes, nothing reaches the built app.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated — not applicable, no code under test
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — not applicable, no new assets

Verified on Flutter 3.47.1 as pinned in `.fvmrc`: format clean, analyze clean,
1323 tests passing.

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

None apply. This PR touches one YAML config file and no Dart, SQL, assets or
platform code.

</details>
