### PR TITLE
chore: commit the analyzer excludes in the vendored packages too

### DIFF
--- a/packages/flutter_7zip/analysis_options.yaml
+++ b/packages/flutter_7zip/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/packages/flutter_chd/analysis_options.yaml
+++ b/packages/flutter_chd/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/packages/gamepads/analysis_options.yaml
+++ b/packages/gamepads/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at


### PR DESCRIPTION
# Description

Follow-up to #397, which committed the SDK's own output for the root `analysis_options.yaml`.

The three vendored packages that ship one of their own (`flutter_7zip`, `flutter_chd`, `gamepads`) have exactly the same problem: every `flutter analyze` run rewrites them and prints *"Upgrading analysis_options.yaml to exclude build and platform directories"*. So the phantom diff #397 was meant to kill came straight back, three files at a time, on every branch.

Byte-identical to what the SDK generates, `ios/**` and `web/**` included, for the same reason as #397: the SDK re-adds anything trimmed. The block lands above `include:` in these files rather than below it, because `include:` is line 1 here and that is where the SDK writes it.

After this, `flutter analyze` is idempotent across the whole workspace: no issues found, and a clean working tree afterwards.

Closes #

## Steps to Verify

Not a bug fix in the app, but the phantom diff is reproducible:

**Preconditions:** a clean working tree on `main`.

1. `git status` — clean.
2. `flutter analyze` — note the three "Upgrading analysis_options.yaml..." lines.
3. `git status` — the three `packages/*/analysis_options.yaml` files are now modified.
4. On this branch, repeat 1-3: analyze is quiet and the tree stays clean.

## Tested on

- [x] Linux — device: CachyOS dev box (`flutter analyze`, `dart format`, `flutter test`)
- [ ] Android — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: analyzer configuration only, no code in the build.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated — n/a, config only
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — n/a, no assets
