### PR TITLE
perf(ra): stop re-seeding the RetroAchievements database on every launch

### DIFF
--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -504,6 +504,9 @@ class SqliteMigrations {
       case 135:
         await _migrateToVersion135(db);
         break;
+      case 138:
+        await _migrateToVersion138(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -6196,6 +6199,46 @@ class SqliteMigrations {
       _log.i('Migration v135 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v135: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Adds `user_config.ra_seed_stamp`, which records the generation stamp of
+  /// the bundled RA seed asset currently loaded into `app_ra_game_list`.
+  ///
+  /// Before this, `refreshRetroAchievementsData()` deleted and re-inserted all
+  /// 18,079 rows on every single launch, re-parsing a 6 MB asset one character
+  /// at a time to do it. The stamp is what lets that be skipped when the asset
+  /// has not changed since the last launch.
+  ///
+  /// Defaults to `''`, which matches no real stamp, so the first launch after
+  /// upgrading re-seeds once and records the stamp — the existing rows stay
+  /// valid either way, so there is nothing to backfill.
+  ///
+  /// Slot 138, not 136 or 137: `feat/collections-feature` holds BOTH of those,
+  /// committed. The worktree scan in RA_IMPROVEMENT_PLAN.md missed its 137
+  /// because it fed `sort -n` output to `comm`, which needs lexicographic
+  /// order — the snippet has been corrected. Gaps are normal here: main already
+  /// skips 129/132/133.
+  static Future<void> _migrateToVersion138(Database db) async {
+    _log.i('Migration v138: Add ra_seed_stamp to user_config');
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_config)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toSet();
+
+      if (!columns.contains('ra_seed_stamp')) {
+        db.execute(
+          "ALTER TABLE user_config ADD COLUMN ra_seed_stamp TEXT DEFAULT ''",
+        );
+        _log.i('Column ra_seed_stamp added to user_config');
+      } else {
+        _log.i('Column ra_seed_stamp already exists');
+      }
+
+      _log.i('Migration v138 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v138: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -458,7 +458,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 135;
+  static const int _databaseVersion = 138;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -1876,6 +1876,10 @@ class SqliteService {
         hide_tab_search INTEGER DEFAULT 0,
         active_sync_provider TEXT DEFAULT 'neosync',
         systems_version TEXT DEFAULT '',
+        -- Generation stamp of the bundled RA seed asset that is currently
+        -- loaded into app_ra_game_list. Read from the file's own header, so it
+        -- moves whenever the asset is regenerated. See migration v138.
+        ra_seed_stamp TEXT DEFAULT '',
         neostation_app_version TEXT DEFAULT '',
         auto_update_app INTEGER DEFAULT 1,
         auto_update_systems INTEGER DEFAULT 1,
@@ -2691,6 +2695,7 @@ class SqliteService {
     int? hideTabSearch,
     String? activeSyncProvider,
     String? systemsVersion,
+    String? raSeedStamp,
     String? neostationAppVersion,
     int? autoUpdateApp,
     int? autoUpdateSystems,
@@ -2790,6 +2795,9 @@ class SqliteService {
     }
     if (activeSyncProvider != null) {
       updates['active_sync_provider'] = activeSyncProvider;
+    }
+    if (raSeedStamp != null) {
+      updates['ra_seed_stamp'] = raSeedStamp;
     }
     if (systemsVersion != null) {
       updates['systems_version'] = systemsVersion;
@@ -3073,6 +3081,18 @@ class SqliteService {
   /// Persists the systems manifest version after a successful update.
   static Future<void> updateSystemsVersion(String version) async {
     await saveUserConfig(systemsVersion: version);
+  }
+
+  /// Retrieves the RA seed generation stamp currently loaded into
+  /// `app_ra_game_list`, or `''` if the seed has never run.
+  static Future<String> getRaSeedStamp() async {
+    final config = await getUserConfig();
+    return config?['ra_seed_stamp']?.toString() ?? '';
+  }
+
+  /// Persists the RA seed generation stamp after a successful re-seed.
+  static Future<void> updateRaSeedStamp(String stamp) async {
+    await saveUserConfig(raSeedStamp: stamp);
   }
 
   /// Retrieves the Neostation app version recorded at last startup.
@@ -5187,10 +5207,82 @@ class SqliteService {
     return cores.map((e) => e.toMap()).toList();
   }
 
+  /// Path of the bundled RetroAchievements seed asset.
+  static const String _raSeedAsset = 'assets/data/ra_insert.sql';
+
+  /// Reads the generation stamp from the head of the RA seed asset.
+  ///
+  /// The generator writes `-- Auto-generated on <timestamp>` into the first few
+  /// lines, so the stamp moves whenever the asset is regenerated and nobody has
+  /// to remember to bump a constant. Only the first bytes are decoded — the
+  /// whole file is 6 MB and decoding it is a third of what this check exists to
+  /// avoid.
+  ///
+  /// Returns `''` if the header is missing or unreadable, which compares equal
+  /// to no stored stamp and so falls back to re-seeding.
+  Future<String> _readRaSeedStamp() async {
+    try {
+      final data = await rootBundle.load(_raSeedAsset);
+      final headLength = data.lengthInBytes < 512 ? data.lengthInBytes : 512;
+      final head = String.fromCharCodes(
+        data.buffer.asUint8List(data.offsetInBytes, headLength),
+      );
+      for (final line in head.split('\n')) {
+        if (line.startsWith('-- Auto-generated on ')) {
+          return line.trim();
+        }
+      }
+    } catch (e) {
+      _log.w('Could not read RA seed stamp, will re-seed: $e');
+    }
+    return '';
+  }
+
   /// Refreshes the local RetroAchievements game database from bundled SQL assets.
+  ///
+  /// Skips the whole re-seed when the bundled asset has not changed since the
+  /// last successful one. That block deletes and re-inserts 18,079 rows and
+  /// character-parses a 6 MB asset to do it — measured at ~275 ms on a desktop
+  /// with the database on an NVMe, and it ran on every single launch. The stamp
+  /// is only written after the seed succeeds, so a failed seed retries next
+  /// launch rather than being cached as done.
   Future<void> refreshRetroAchievementsData() async {
     try {
       final db = await database;
+      final assetStamp = await _readRaSeedStamp();
+
+      // Never let the skip-check itself cost us the seed. Anything that goes
+      // wrong reading the stored stamp (a database old enough to predate the
+      // column, a config row that is not there yet) must fall through to the
+      // re-seed that used to be unconditional, not abort it.
+      String storedStamp = '';
+      try {
+        storedStamp = await getRaSeedStamp();
+      } catch (e) {
+        _log.w('Could not read the stored RA seed stamp, will re-seed: $e');
+      }
+
+      // A matching stamp is only trustworthy if the rows are actually there.
+      // A migration that recreated the table, or a partially applied seed,
+      // would otherwise leave the app with an empty list it never rebuilds.
+      if (assetStamp.isNotEmpty && assetStamp == storedStamp) {
+        final rows = await db.rawQuery(
+          'SELECT COUNT(*) AS c FROM app_ra_game_list',
+        );
+        final count = rows.isEmpty ? 0 : (rows.first['c'] as int? ?? 0);
+        if (count > 0) {
+          _log.i(
+            'RetroAchievements seed unchanged ($assetStamp, $count rows) - '
+            'skipping re-seed.',
+          );
+          return;
+        }
+        _log.w(
+          'RetroAchievements seed stamp matched but table is empty - '
+          're-seeding.',
+        );
+      }
+
       await db.transaction((txn) async {
         _log.i('Refreshing local RetroAchievements game database...');
 
@@ -5198,12 +5290,19 @@ class SqliteService {
         await txn.execute('DELETE FROM app_ra_game_list');
 
         // Batch insert data from the SQL seed file.
-        await _executeSqlFileOptimized(
-          txn,
-          'assets/data/ra_insert.sql',
-          'ra_insert',
-        );
+        await _executeSqlFileOptimized(txn, _raSeedAsset, 'ra_insert');
       });
+
+      if (assetStamp.isNotEmpty) {
+        // Recording the stamp is an optimisation for next launch, not part of
+        // the seed: a failure here costs one redundant re-seed, and must not
+        // report the seed that just succeeded as failed.
+        try {
+          await updateRaSeedStamp(assetStamp);
+        } catch (e) {
+          _log.w('Could not record the RA seed stamp: $e');
+        }
+      }
       _log.i('RetroAchievements database synchronized successfully.');
     } catch (e, stackTrace) {
       _log.e(

--- a/test/ra_seed_skip_test.dart
+++ b/test/ra_seed_skip_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+import 'package:neostation/data/datasources/sqlite_service.dart';
+
+/// B1: `refreshRetroAchievementsData()` used to DELETE and re-insert all 18,079
+/// rows of the bundled RetroAchievements seed on every single launch. It now
+/// skips that when the asset's generation stamp matches the one recorded by the
+/// last successful seed.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late sqlite.Database db;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    db = sqlite.sqlite3.openInMemory();
+    final adapter = DatabaseAdapter(db);
+    SqliteService.setTestingDatabase(adapter);
+    await adapter.execute('''
+      CREATE TABLE user_config (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        systems_version TEXT DEFAULT '',
+        ra_seed_stamp TEXT DEFAULT ''
+      )
+    ''');
+    await adapter.execute('INSERT INTO user_config (id) VALUES (1)');
+    await adapter.execute('''
+      CREATE TABLE app_ra_game_list (
+        id INTEGER, game_id INTEGER NOT NULL, title TEXT NOT NULL,
+        console_id INTEGER NOT NULL, console_name TEXT NOT NULL,
+        image_icon TEXT, num_achievements INTEGER NOT NULL DEFAULT 0,
+        num_leaderboards INTEGER NOT NULL DEFAULT 0,
+        points INTEGER NOT NULL DEFAULT 0, date_modified TEXT,
+        forum_topic_id INTEGER, hash TEXT NOT NULL
+      )
+    ''');
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  int rowCount() =>
+      db.select('SELECT COUNT(*) AS c FROM app_ra_game_list').first['c'] as int;
+
+  String storedStamp() =>
+      db
+              .select('SELECT ra_seed_stamp FROM user_config WHERE id = 1')
+              .first['ra_seed_stamp']
+          as String;
+
+  test(
+    'the first seed populates the table and records the asset stamp',
+    () async {
+      expect(storedStamp(), '');
+
+      await SqliteService.instance.refreshRetroAchievementsData();
+
+      expect(rowCount(), greaterThan(0));
+      expect(storedStamp(), startsWith('-- Auto-generated on '));
+    },
+  );
+
+  test('a second call with an unchanged asset skips the re-seed', () async {
+    await SqliteService.instance.refreshRetroAchievementsData();
+    final seeded = rowCount();
+
+    // A sentinel row survives only if the DELETE never runs.
+    db.execute(
+      "INSERT INTO app_ra_game_list (id, game_id, title, console_id, "
+      "console_name, hash) VALUES (-1, -1, 'sentinel', 0, 'x', 'y')",
+    );
+
+    await SqliteService.instance.refreshRetroAchievementsData();
+
+    expect(rowCount(), seeded + 1, reason: 'the table was rebuilt anyway');
+    final sentinel = db.select(
+      "SELECT * FROM app_ra_game_list WHERE title = 'sentinel'",
+    );
+    expect(sentinel, hasLength(1));
+  });
+
+  test('a changed stamp re-seeds', () async {
+    await SqliteService.instance.refreshRetroAchievementsData();
+    final seeded = rowCount();
+
+    db.execute("UPDATE user_config SET ra_seed_stamp = 'stale' WHERE id = 1");
+    db.execute(
+      "INSERT INTO app_ra_game_list (id, game_id, title, console_id, "
+      "console_name, hash) VALUES (-1, -1, 'sentinel', 0, 'x', 'y')",
+    );
+
+    await SqliteService.instance.refreshRetroAchievementsData();
+
+    expect(rowCount(), seeded, reason: 'a changed asset must rebuild');
+    expect(storedStamp(), startsWith('-- Auto-generated on '));
+  });
+
+  test('a matching stamp over an empty table still re-seeds', () async {
+    await SqliteService.instance.refreshRetroAchievementsData();
+    final seeded = rowCount();
+
+    // The stamp says "done", but the rows are gone — a recreated table, or a
+    // seed that half-applied. Trusting the stamp here would leave the app with
+    // an RA list it never rebuilds.
+    db.execute('DELETE FROM app_ra_game_list');
+
+    await SqliteService.instance.refreshRetroAchievementsData();
+
+    expect(rowCount(), seeded);
+  });
+}

--- a/test/ra_seed_stamp_migration_v138_test.dart
+++ b/test/ra_seed_stamp_migration_v138_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+
+/// Tests for migration v138, which adds `user_config.ra_seed_stamp` — the
+/// generation stamp of the bundled RetroAchievements seed asset currently
+/// loaded into `app_ra_game_list`.
+void main() {
+  late Database db;
+
+  setUp(() {
+    db = sqlite3.openInMemory();
+    // The "old device" case: user_config as it stands before v138.
+    db.execute('''
+      CREATE TABLE user_config (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        last_scan TEXT,
+        ra_user TEXT,
+        systems_version TEXT DEFAULT '',
+        neostation_app_version TEXT DEFAULT ''
+      )
+    ''');
+    db.execute(
+      "INSERT INTO user_config (id, systems_version) VALUES (1, '1.2')",
+    );
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  Future<void> runV138() => SqliteMigrations.migrateToVersion(db, 138);
+
+  List<String> configColumns() => db
+      .select('PRAGMA table_info(user_config)')
+      .map((c) => c['name'].toString())
+      .toList();
+
+  group('migration v138', () {
+    test('adds ra_seed_stamp when the column is missing', () async {
+      expect(configColumns(), isNot(contains('ra_seed_stamp')));
+
+      await runV138();
+
+      expect(configColumns(), contains('ra_seed_stamp'));
+    });
+
+    test('defaults the new column to the empty stamp, so the next launch '
+        're-seeds once rather than trusting stale rows', () async {
+      await runV138();
+
+      final row = db.select(
+        'SELECT ra_seed_stamp FROM user_config WHERE id = 1',
+      );
+      expect(row.first['ra_seed_stamp'], '');
+    });
+
+    test('leaves existing config values alone', () async {
+      await runV138();
+
+      final row = db.select(
+        'SELECT systems_version FROM user_config WHERE id = 1',
+      );
+      expect(row.first['systems_version'], '1.2');
+    });
+
+    test('is a no-op when re-run', () async {
+      await runV138();
+      db.execute(
+        "UPDATE user_config SET ra_seed_stamp = 'stamp-a' WHERE id = 1",
+      );
+
+      await runV138();
+
+      expect(configColumns(), contains('ra_seed_stamp'));
+      final row = db.select(
+        'SELECT ra_seed_stamp FROM user_config WHERE id = 1',
+      );
+      expect(row.first['ra_seed_stamp'], 'stamp-a');
+    });
+
+    test('is a no-op on a database that already has the column', () async {
+      db.execute(
+        "ALTER TABLE user_config ADD COLUMN ra_seed_stamp TEXT DEFAULT ''",
+      );
+
+      await runV138();
+
+      final matches = configColumns().where((c) => c == 'ra_seed_stamp');
+      expect(matches, hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
# Description

`SqliteConfigProvider` called `refreshRetroAchievementsData()` unconditionally during init, and that method deleted all of `app_ra_game_list` and rebuilt it from the bundled SQL asset — on **every single launch**, whether or not the asset had changed. Rebuilding it means loading a 6 MB file into a string, walking it one character at a time into 18,079 statements, and batch-inserting all of them.

Startup is the known bottleneck on these devices, so this was time spent rebuilding a table that was already correct.

**Measured on the AYN Thor before assuming it mattered.** Two runs each side, bracketed by the init log lines either side of the RA step:

| run | bracketed segment | the seed itself |
|---|---|---|
| re-seed #1 | 753 ms | **431 ms** |
| re-seed #2 | 727 ms | **409 ms** |
| skipped #1 | 319 ms | — |
| skipped #2 | 323 ms | — |

**~420 ms off every launch** (bracketed mean 740 ms → 321 ms).

The seed asset already stamps its own generation into its header (`-- Auto-generated on ...`), so that is what gets recorded, rather than a version constant someone has to remember to bump when the asset is regenerated. Reading it via `rootBundle.load()` and decoding only the first 512 bytes skips the UTF-8 decode of all 6 MB, which is itself a third of the cost being avoided: the check costs ~2 ms against the ~420 ms it replaces.

Hashing the asset instead was measured too, at 35 ms, and rejected: it still decodes the whole file and buys no extra safety over a stamp the generator already writes.

### Notes for review

- **Migration v138, not 136 or 137.** `feat/collections-feature` holds both of those, committed. Worth flagging because of *how* that was nearly missed: the worktree scan documented for this repo pipes `sort -n` into `comm`, which requires lexicographic order, so it silently under-reports slots. Had this shipped at 137 the `case` would never have fired on any device that had run that branch, `ra_seed_stamp` would never have existed, and the optimisation would have quietly done nothing at all. The scan also needs to read `_databaseVersion`, not just the `case` list, since a branch can bump past its highest case (which that one does).
- **Three failure modes the naive version gets wrong**, each with a test:
  - A matching stamp over an **empty table** still re-seeds. A migration that recreated the table would otherwise leave an RA list that is never rebuilt.
  - A failure **reading** the stored stamp falls through to the re-seed that used to be unconditional, rather than aborting it. A database old enough to predate the column must not lose its seed to the optimisation. This one was a real defect caught by the harness, not foresight: the first draft let a missing `user_config` swallow the seed entirely.
  - A failure **recording** the stamp costs one redundant re-seed rather than reporting a seed that just succeeded as failed.
- **No backfill needed.** `ra_seed_stamp` defaults to `''`, which matches no real stamp, so the first launch after upgrading re-seeds once and records it. The existing rows are valid either way.
- `getUserConfig()` is a `SELECT *`, so the new column needs no query threading.

## Steps to Verify

**Preconditions:** a build of this branch on a device with an existing library, and `adb logcat` attached. NeoStation logs the RA step at `I/flutter`.

1. Install this build over an older one and launch. The DB migrates to v138 and, because the stamp starts empty, the seed runs once: `Refreshing local RetroAchievements game database...` followed by `RetroAchievements database synchronized successfully.` Note the gap between those two timestamps.
2. Kill the app and launch it again.
3. Confirm the seed no longer runs. Instead there is a single line: `RetroAchievements seed unchanged (-- Auto-generated on <stamp>, 18079 rows) - skipping re-seed.`
4. Confirm achievements still work: open a matched game and check the trophy and `n/m` count are unchanged.
5. To force the re-seed again, clear the stamp (`UPDATE user_config SET ra_seed_stamp = ''`) and relaunch: the full seed runs, records the stamp, and the launch after that skips again.

## Tested on

- [x] Android — device: AYN Thor (dev channel, md5-verified against the tree; full cycle verified end to end — stamp cleared → re-seed runs → stamp recorded → next launch skips. Device DB after: integrity ok, v138, 9,135 games / 18,079 RA rows)
- [x] Linux — device: desktop (gate only)
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1,334)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — the database</b></summary>

**The database**
- [x] Column added to the versioned migration in `sqlite_migrations.dart` **and** the `CREATE TABLE` in `sqlite_service.dart`
- [x] Migration number is above every slot in use on any open branch, not just `main` + 1 (v138; `feat/collections-feature` holds 136 and 137)
- [x] Migration is idempotent (`PRAGMA table_info` guard) and has a test
- [x] `_databaseVersion` bumped; new column selected in *every* system-loading query (`getUserConfig()` is a `SELECT *`)

**Android**
- [x] Verified on a device, not only on desktop

</details>
