### PR TITLE
feat(settings): enter a category with A and back out with B

### DIFF
--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -441,6 +441,8 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
   void _handleBackNavigation() {
     if (_selectedTabIndex == AppTabs.scraper) {
       NewScraperOptionsScreen.backCurrent();
+    } else if (_selectedTabIndex == AppTabs.settings) {
+      NewSettingsScreen.backCurrent();
     }
   }
 

--- a/lib/screens/settings_screen/new_settings_options/about_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/about_settings_content.dart
@@ -5,6 +5,7 @@ import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/services/sfx_service.dart';
+import 'package:neostation/utils/adaptive_scroll.dart';
 import 'package:neostation/data/datasources/sqlite_service.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'settings_title.dart';
@@ -25,6 +26,14 @@ class AboutSettingsContent extends StatefulWidget {
 
 class AboutSettingsContentState extends State<AboutSettingsContent> {
   final ScrollController _scrollController = ScrollController();
+
+  /// Snaps during rapid D-pad navigation, animates on a single move.
+  final AdaptiveScroller _scroller = AdaptiveScroller();
+
+  /// Keys used for calculating viewport alignment during navigation, one per
+  /// link card.
+  final List<GlobalKey> _itemKeys = List.generate(5, (_) => GlobalKey());
+
   String _appVersion = '';
   String _systemsVersion = '';
 
@@ -41,12 +50,12 @@ class AboutSettingsContentState extends State<AboutSettingsContent> {
     super.dispose();
   }
 
+  /// Synchronizes the scroll viewport with the currently focused link card.
   void scrollToIndex(int index) {
-    if (!_scrollController.hasClients) return;
-    _scrollController.animateTo(
-      (index * 110.h).clamp(0, _scrollController.position.maxScrollExtent),
-      duration: const Duration(milliseconds: 200),
-      curve: Curves.easeInOut,
+    _scroller.ensureVisibleIndex(
+      index,
+      keys: _itemKeys,
+      controller: _scrollController,
     );
   }
 
@@ -177,6 +186,7 @@ class AboutSettingsContentState extends State<AboutSettingsContent> {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       _buildInfoCard(
+                        cardKey: _itemKeys[0],
                         icon: Symbols.code_rounded,
                         title: AppLocale.openSourceLicense.getString(context),
                         value: AppLocale.openSourceLicenseDesc.getString(
@@ -190,6 +200,7 @@ class AboutSettingsContentState extends State<AboutSettingsContent> {
                       ),
                       SizedBox(height: 8.h),
                       _buildInfoCard(
+                        cardKey: _itemKeys[1],
                         icon: Symbols.coffee_rounded,
                         title: AppLocale.supportOnKofi.getString(context),
                         value: 'ko-fi.com/neostation',
@@ -201,6 +212,7 @@ class AboutSettingsContentState extends State<AboutSettingsContent> {
                       ),
                       SizedBox(height: 8.h),
                       _buildInfoCard(
+                        cardKey: _itemKeys[2],
                         icon: Symbols.favorite_rounded,
                         title: AppLocale.supportOnPatreon.getString(context),
                         value: 'patreon.com/NeoStation',
@@ -212,6 +224,7 @@ class AboutSettingsContentState extends State<AboutSettingsContent> {
                       ),
                       SizedBox(height: 8.h),
                       _buildInfoCard(
+                        cardKey: _itemKeys[3],
                         icon: Symbols.chat_bubble_outline_rounded,
                         title: AppLocale.joinCommunity.getString(context),
                         value: 'discord.gg/xE2kgKsRVq',
@@ -223,6 +236,7 @@ class AboutSettingsContentState extends State<AboutSettingsContent> {
                       ),
                       SizedBox(height: 8.h),
                       _buildInfoCard(
+                        cardKey: _itemKeys[4],
                         icon: Symbols.language_rounded,
                         title: AppLocale.visitWebsite.getString(context),
                         value: 'neostation.dev',
@@ -244,6 +258,7 @@ class AboutSettingsContentState extends State<AboutSettingsContent> {
   }
 
   Widget _buildInfoCard({
+    required GlobalKey cardKey,
     required IconData icon,
     required String title,
     required String value,
@@ -252,6 +267,7 @@ class AboutSettingsContentState extends State<AboutSettingsContent> {
     bool isFocused = false,
   }) {
     return InkWell(
+      key: cardKey,
       onTap: () {
         SfxService().playNavSound();
         _launchUrl(url);

--- a/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
@@ -96,12 +96,11 @@ class DirectoriesSettingsContentState
     // Use the focused row's own key so scrolling tracks its real height —
     // section headers and path-chip cards aren't a uniform height, so a
     // fixed per-row estimate drifts and overshoots as the list scrolls.
-    if (index >= 0 && index < _itemKeys.length) {
-      final ctx = _itemKeys[index].currentContext;
-      if (ctx != null) {
-        _scroller.ensureVisible(ctx);
-      }
-    }
+    _scroller.ensureVisibleIndex(
+      index,
+      keys: _itemKeys,
+      controller: _scrollController,
+    );
   }
 
   void _buildDirectoryItems() {

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -401,12 +401,11 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
 
   /// Synchronizes the scroll viewport with the currently focused setting item.
   void scrollToIndex(int index) {
-    if (index >= 0 && index < _itemKeys.length) {
-      final context = _itemKeys[index].currentContext;
-      if (context != null) {
-        _scroller.ensureVisible(context);
-      }
-    }
+    _scroller.ensureVisibleIndex(
+      index,
+      keys: _itemKeys,
+      controller: _scrollController,
+    );
   }
 
   @override

--- a/lib/screens/settings_screen/new_settings_options/secondary_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/secondary_settings_content.dart
@@ -153,12 +153,11 @@ class SecondarySettingsContentState extends State<SecondarySettingsContent>
 
   /// Scrolls the item at [index] into view for gamepad navigation.
   void scrollToIndex(int index) {
-    if (index >= 0 && index < _itemKeys.length) {
-      final ctx = _itemKeys[index].currentContext;
-      if (ctx != null) {
-        _scroller.ensureVisible(ctx);
-      }
-    }
+    _scroller.ensureVisibleIndex(
+      index,
+      keys: _itemKeys,
+      controller: _scrollController,
+    );
   }
 
   /// Human label for a dim delay; 0 reads as "Never".

--- a/lib/screens/settings_screen/new_settings_options/system_art_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/system_art_settings_content.dart
@@ -11,6 +11,7 @@ import 'package:neostation/services/game_service.dart'
     show GamepadNavigationManager;
 import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/services/sfx_service.dart';
+import 'package:neostation/utils/adaptive_scroll.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:provider/provider.dart';
 import 'settings_title.dart';
@@ -36,6 +37,9 @@ class SystemArtSettingsContent extends StatefulWidget {
 
 class SystemArtSettingsContentState extends State<SystemArtSettingsContent> {
   final ScrollController _scrollController = ScrollController();
+
+  /// Snaps during rapid D-pad navigation, animates on a single move.
+  final AdaptiveScroller _scroller = AdaptiveScroller();
   final List<GlobalKey> _itemKeys = [];
 
   int get _gridColumns => Responsive.getThemesCrossAxisCount(context);
@@ -50,17 +54,11 @@ class SystemArtSettingsContentState extends State<SystemArtSettingsContent> {
   }
 
   void _ensureSelectedItemVisible(int index) {
-    if (index >= 0 && index < _itemKeys.length) {
-      final ctx = _itemKeys[index].currentContext;
-      if (ctx != null) {
-        Scrollable.ensureVisible(
-          ctx,
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeInOut,
-          alignment: 0.5,
-        );
-      }
-    }
+    _scroller.ensureVisibleIndex(
+      index,
+      keys: _itemKeys,
+      controller: _scrollController,
+    );
   }
 
   void navigateUp() {

--- a/lib/screens/settings_screen/new_settings_options/systems_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/systems_settings_content.dart
@@ -49,12 +49,11 @@ class SystemsSettingsContentState extends State<SystemsSettingsContent> {
 
   /// Synchronizes the viewport to ensure the currently focused setting is visible.
   void scrollToIndex(int index) {
-    if (index >= 0 && index < _itemKeys.length) {
-      final ctx = _itemKeys[index].currentContext;
-      if (ctx != null) {
-        _scroller.ensureVisible(ctx);
-      }
-    }
+    _scroller.ensureVisibleIndex(
+      index,
+      keys: _itemKeys,
+      controller: _scrollController,
+    );
   }
 
   /// Calculates the total number of navigable settings (Global Card + Detected Systems).

--- a/lib/screens/settings_screen/new_settings_options/themes_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/themes_settings_content.dart
@@ -6,6 +6,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/services/sfx_service.dart';
+import 'package:neostation/utils/adaptive_scroll.dart';
 import 'package:provider/provider.dart';
 import 'package:neostation/providers/theme_provider.dart';
 import 'package:neostation/services/permission_service.dart';
@@ -42,6 +43,9 @@ class ThemesSettingsContent extends StatefulWidget {
 class ThemesSettingsContentState extends State<ThemesSettingsContent> {
   final _log = LoggerService.instance;
   final ScrollController _scrollController = ScrollController();
+
+  /// Snaps during rapid D-pad navigation, animates on a single move.
+  final AdaptiveScroller _scroller = AdaptiveScroller();
 
   /// Keys used for calculating viewport alignment during grid-based navigation.
   final List<GlobalKey> _itemKeys = [];
@@ -129,19 +133,16 @@ class ThemesSettingsContentState extends State<ThemesSettingsContent> {
     _ensureSelectedItemVisible(newIndex);
   }
 
+  /// Brings the focused grid cell into view (used when focus re-enters the panel).
+  void scrollToIndex(int index) => _ensureSelectedItemVisible(index);
+
   /// Orchestrates visual alignment to ensure the focused theme card is within the viewport.
   void _ensureSelectedItemVisible(int index) {
-    if (index >= 0 && index < _itemKeys.length) {
-      final context = _itemKeys[index].currentContext;
-      if (context != null) {
-        Scrollable.ensureVisible(
-          context,
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeInOut,
-          alignment: 0.5,
-        );
-      }
-    }
+    _scroller.ensureVisibleIndex(
+      index,
+      keys: _itemKeys,
+      controller: _scrollController,
+    );
   }
 
   /// Persistence Protocol: Updates the active application theme.

--- a/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
@@ -16,6 +16,7 @@ import 'package:neostation/services/global_notification_service.dart';
 import 'package:neostation/services/metadata_cleanup_service.dart';
 import 'package:neostation/services/retroachievements_hash_service.dart';
 import 'package:neostation/services/rom_folder_organizer_service.dart';
+import 'package:neostation/utils/adaptive_scroll.dart';
 import 'package:neostation/widgets/confirm_action_dialog.dart';
 import 'package:neostation/widgets/custom_notification.dart';
 import 'package:neostation/widgets/info_dialog.dart';
@@ -39,6 +40,16 @@ class ToolsSettingsContent extends StatefulWidget {
 
 class ToolsSettingsContentState extends State<ToolsSettingsContent> {
   static final _log = LoggerService.instance;
+
+  final ScrollController _scrollController = ScrollController();
+
+  /// Snaps during rapid D-pad navigation, animates on a single move.
+  final AdaptiveScroller _scroller = AdaptiveScroller();
+
+  /// Keys used for calculating viewport alignment during navigation, one per
+  /// tool row.
+  final List<GlobalKey> _itemKeys = List.generate(3, (_) => GlobalKey());
+
   bool _isOrganizingMultiDisc = false;
   bool _isCleaningMetadata = false;
   List<String> _currentRomFolders = [];
@@ -47,6 +58,12 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
   void initState() {
     super.initState();
     _loadRomFolders();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
   }
 
   Future<void> _loadRomFolders() async {
@@ -60,7 +77,14 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
 
   int getItemCount() => 3;
 
-  void scrollToIndex(int index) {}
+  /// Synchronizes the scroll viewport with the currently focused tool row.
+  void scrollToIndex(int index) {
+    _scroller.ensureVisibleIndex(
+      index,
+      keys: _itemKeys,
+      controller: _scrollController,
+    );
+  }
 
   void selectItem(int index) {
     switch (index) {
@@ -564,9 +588,11 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
               );
 
               return ListView(
+                controller: _scrollController,
                 physics: const ClampingScrollPhysics(),
                 children: [
                   SettingsCardRow(
+                    key: _itemKeys[0],
                     icon: Symbols.emoji_events_rounded,
                     title: AppLocale.rematchAchievements.getString(context),
                     subtitle: AppLocale.rematchAchievementsSubtitle.getString(
@@ -587,6 +613,7 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
                     ),
                   ),
                   SettingsCardRow(
+                    key: _itemKeys[1],
                     icon: Symbols.cleaning_services_rounded,
                     title: AppLocale.cleanOrphanedMetadata.getString(context),
                     subtitle: AppLocale.cleanOrphanedMetadataSubtitle.getString(
@@ -609,6 +636,7 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
                     ),
                   ),
                   SettingsCardRow(
+                    key: _itemKeys[2],
                     icon: Symbols.folder_managed_rounded,
                     title: AppLocale.organizeMultiDiscGames.getString(context),
                     subtitle: AppLocale.organizeMultiDiscGamesSubtitle

--- a/lib/screens/settings_screen/new_settings_screen.dart
+++ b/lib/screens/settings_screen/new_settings_screen.dart
@@ -39,6 +39,7 @@ class NewSettingsScreen extends StatefulWidget {
   static void navigateLeft() => _currentInstance?._navigateLeft();
   static void navigateRight() => _currentInstance?._navigateRight();
   static void selectCurrent() => _currentInstance?._selectItem();
+  static void backCurrent() => _currentInstance?._navigateBack();
   static void deleteCurrent() => _currentInstance?._deleteCurrentItem();
 
   static _NewSettingsScreenState? _currentInstance;
@@ -274,6 +275,10 @@ class _NewSettingsScreenState extends State<NewSettingsScreen> {
       _systemsSettingsKey.currentState?.scrollToIndex(_selectedContentIndex);
     } else if (selectedKey == AppLocale.about) {
       _aboutSettingsKey.currentState?.scrollToIndex(_selectedContentIndex);
+    } else if (selectedKey == AppLocale.themes) {
+      _themesSettingsKey.currentState?.scrollToIndex(_selectedContentIndex);
+    } else if (selectedKey == AppLocale.systemArt) {
+      _systemArtSettingsKey.currentState?.scrollToIndex(_selectedContentIndex);
     }
   }
 
@@ -358,12 +363,33 @@ class _NewSettingsScreenState extends State<NewSettingsScreen> {
   }
 
   /// Execution Protocol: Triggers the action associated with the current focus point.
+  ///
+  /// On the category menu, A enters the detail panel, matching the A-to-open /
+  /// B-to-back convention used by the game list. D-pad Right still does the
+  /// same thing, so the existing muscle memory keeps working.
   void _selectItem() {
     if (_focusOnMenu) {
       _onMenuItemSelected(_selectedMenuIndex);
+      // Exit auto-focuses its own content, so only step right when the
+      // selection actually stayed on the menu.
+      if (_focusOnMenu) _navigateRight();
     } else {
       _selectContentItem();
     }
+  }
+
+  /// Back Protocol: B always returns focus to the category menu in one press.
+  ///
+  /// It deliberately does not reuse [_navigateLeft]: in the grid-based
+  /// categories (Themes, System Art) Left is a cell move, so delegating there
+  /// would make B walk the row instead of backing out. On the menu itself B is
+  /// a no-op, as elsewhere at the root of a tab.
+  void _navigateBack() {
+    if (_focusOnMenu) return;
+    setState(() {
+      _focusOnMenu = true;
+      _selectedContentIndex = 0;
+    });
   }
 
   /// Delete Protocol: routes the X button to a delete action on the focused

--- a/lib/screens/settings_screen/new_settings_screen.dart
+++ b/lib/screens/settings_screen/new_settings_screen.dart
@@ -312,6 +312,19 @@ class _NewSettingsScreenState extends State<NewSettingsScreen> {
     return _selectedContentIndex != previousIndex;
   }
 
+  /// Hands focus back to the category menu and resets the content cursor.
+  ///
+  /// The panel is scrolled back to its first item as well: the cursor moves to
+  /// index 0, so leaving the viewport parked wherever the user had scrolled to
+  /// would show a selection that is off-screen until focus re-enters.
+  void _returnFocusToMenu() {
+    setState(() {
+      _focusOnMenu = true;
+      _selectedContentIndex = 0;
+    });
+    _triggerContentScroll();
+  }
+
   /// Leftward Navigation Protocol: Returns focus to the master menu from the detail panel.
   void _navigateLeft() {
     if (_focusOnMenu) return;
@@ -320,26 +333,13 @@ class _NewSettingsScreenState extends State<NewSettingsScreen> {
     if (selectedKey == AppLocale.themes) {
       final returnToMenu =
           _themesSettingsKey.currentState?.navigateLeft() ?? true;
-      if (returnToMenu) {
-        setState(() {
-          _focusOnMenu = true;
-          _selectedContentIndex = 0;
-        });
-      }
+      if (returnToMenu) _returnFocusToMenu();
     } else if (selectedKey == AppLocale.systemArt) {
       final returnToMenu =
           _systemArtSettingsKey.currentState?.navigateLeft() ?? true;
-      if (returnToMenu) {
-        setState(() {
-          _focusOnMenu = true;
-          _selectedContentIndex = 0;
-        });
-      }
+      if (returnToMenu) _returnFocusToMenu();
     } else {
-      setState(() {
-        _focusOnMenu = true;
-        _selectedContentIndex = 0;
-      });
+      _returnFocusToMenu();
     }
   }
 
@@ -386,10 +386,7 @@ class _NewSettingsScreenState extends State<NewSettingsScreen> {
   /// a no-op, as elsewhere at the root of a tab.
   void _navigateBack() {
     if (_focusOnMenu) return;
-    setState(() {
-      _focusOnMenu = true;
-      _selectedContentIndex = 0;
-    });
+    _returnFocusToMenu();
   }
 
   /// Delete Protocol: routes the X button to a delete action on the focused
@@ -682,12 +679,7 @@ class _NewSettingsScreenState extends State<NewSettingsScreen> {
         isContentFocused: !_focusOnMenu,
         selectedContentIndex: _selectedContentIndex,
         onExitPressed: _executeExit,
-        onCancel: () {
-          setState(() {
-            _focusOnMenu = true;
-            _selectedContentIndex = 0;
-          });
-        },
+        onCancel: _returnFocusToMenu,
       );
     } else {
       return Center(

--- a/lib/utils/adaptive_scroll.dart
+++ b/lib/utils/adaptive_scroll.dart
@@ -30,6 +30,34 @@ class AdaptiveScroller {
 
   DateTime? _lastScroll;
 
+  /// Ensures the item at [index] is visible, given the per-item [keys] and the
+  /// list's [controller].
+  ///
+  /// Prefer this over [ensureVisible] for list/grid panels: a lazy list
+  /// (`ListView.builder`) only mounts what is on screen, so an item scrolled
+  /// far out of view has no context and [ensureVisible] would silently do
+  /// nothing — which is what happens when focus re-enters a panel at index 0
+  /// from far down the list. The top of the list is unambiguous without a
+  /// context, so it falls back to [controller]; any other unmounted index is
+  /// left alone rather than guessed at from an estimated row height.
+  void ensureVisibleIndex(
+    int index, {
+    required List<GlobalKey> keys,
+    ScrollController? controller,
+  }) {
+    if (index < 0 || index >= keys.length) return;
+
+    final ctx = keys[index].currentContext;
+    if (ctx != null) {
+      ensureVisible(ctx);
+      return;
+    }
+
+    if (index == 0 && (controller?.hasClients ?? false)) {
+      controller!.jumpTo(0);
+    }
+  }
+
   /// Ensures [context]'s item is visible, snapping during rapid navigation.
   void ensureVisible(BuildContext context) {
     final now = DateTime.now();


### PR DESCRIPTION
# Description

A now enters a settings category and B backs out of it, matching the A-to-open /
B-to-back convention the game list already uses. Settings was the odd one out:
the only way in was D-pad Right, and the only way back was Left, which in the
grid categories had to be walked to column 0 first.

Right and Left still do exactly what they did, so existing muscle memory keeps
working. B on the category menu itself is a no-op, as it is at the root of any
other tab.

Two supporting changes came out of building it:

- **Every panel scrolls focus into view through one helper.** Eight panels each
  had their own copy of the same "look up the key, bail if the context is null"
  block, plus two that had drifted: About scrolled by an assumed 110px row
  height, and Tools had an empty stub, so focus there could move with no scroll
  response at all. They all go through `AdaptiveScroller.ensureVisibleIndex` now.

- **Leaving a panel scrolls it back to the top.** Backing out reset the content
  cursor to index 0 but left the viewport wherever the user had scrolled to, so
  the selection sat off-screen until focus re-entered.

The new `ensureVisibleIndex` exists because `Scrollable.ensureVisible` silently
does nothing for an item a lazy `ListView.builder` has not mounted, which is
exactly the case when focus re-enters a panel at index 0 from far down the list.
It falls back to the controller for index 0, where the target is unambiguous,
and leaves any other unmounted index alone rather than guessing from an
estimated row height.

## Steps to Verify

**Preconditions:** any build, Settings tab, a ROM folder configured so
Directories has more rows than fit on screen.

1. Open Settings, press **A** on a category. Focus moves into the detail panel.
   Press **B**. Focus returns to the category menu.
2. In **Directories**, enter and hold Down until the selection is well past the
   fold. Press **B**, then **A** again. The panel is back at the top with the
   first row selected. Before this change the viewport stayed where it was and
   the selection was off-screen above it.
3. In **Themes** or **System Art** (grids), enter and move Right a column or
   two, then press **B**. Focus returns to the menu in one press. **Left** from
   the same spot still walks the row and only exits from column 0, unchanged.
4. On the category menu, press **B**. Nothing happens, same as the root of any
   other tab.
5. Press **A** on **Exit**. Focus lands on its confirmation content as before,
   not one step further in.

## Tested on

<!-- Name the device. Desktop-only testing does not catch Android SAF path bugs. -->

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: not yet driven on a handheld. No path or SAF logic is involved (nav and scroll only), but the button mapping itself deserves a device pass before merge.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1323)
- [ ] Tests added or updated — none; the settings navigation has no existing test harness
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — not applicable, no new assets

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse — A now reaches what Right already reached; nothing became pad-unreachable
- [x] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()` — no new routes. Confirmed the dialogs reachable from settings (`ConfirmActionDialog`, `TvDirectoryPicker`, `LanguagePickerOverlay`, `SystemEmulatorSettingsDialog`, System Art's overlay) each push their own layer, so B inside one cannot leak through to the new handler underneath
- [x] B cancels / goes back, including out of a focused text field — there are no text fields anywhere under `lib/screens/settings_screen/`, so the field-escape path is not reachable here

No user-facing strings, database, Android path or emulator-launch changes.

</details>

## Notes for review

One consequence worth a deliberate call before merge: **A now enters, so a
second A actuates content item 0.** Double-tapping A used to be harmless on the
category menu. It now fires the first row of whatever panel you landed in:
`setTheme('system')` in Themes, the "None" tile in System Art, `scanOnStartup`
on desktop General, and the system settings intent on Android General.

Themes is the one that stings, since it silently drops the user's theme with no
confirmation. The cleanest fix is to enter at the *applied* item instead of
index 0 (both panels already expose it via `ThemeProvider.currentThemeName` and
`NeoAssetsProvider.activeThemeFolder`), which makes the second A a no-op and is
better behaviour on its own. Left out of this PR to keep the nav change
reviewable in isolation, and happy to fold it in here if preferred.
