### PR TITLE
fix(android): surface ROM folders that lost their SAF grant

### DIFF
--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -231,6 +231,10 @@ class SqliteDatabaseService {
     ];
 
     final walkedDirs = <String>{};
+    _log.i(
+      'Scan[${system.realName}]: ${scanTargets.length} target(s) resolved '
+      '(folders=${allPossibleFolderNames.join(', ')}, romFolders=${romFolders.length})',
+    );
     for (final target in orderedTargets) {
       // An alias pointing at a directory already walked for this system.
       if (!walkedDirs.add(target.canonicalPath)) continue;
@@ -250,6 +254,10 @@ class SqliteDatabaseService {
                 ignoreHiddenFiles: ignoreHiddenFiles,
               );
 
+        _log.i(
+          'Scan[${system.realName}]: walked ${target.dirPath} -> '
+          '${entries.length} entries',
+        );
         if (entries.isNotEmpty) {
           romEntries.addAll(entries);
         }
@@ -257,6 +265,11 @@ class SqliteDatabaseService {
         _log.e('Error scanning folder ${target.dirPath}: $e');
       }
     }
+
+    _log.i(
+      'Scan[${system.realName}]: ${romEntries.length} raw entries before '
+      'dedup/filter',
+    );
 
     // Apply M3U and redundancy filters
     if (validExtensionsSet.contains('m3u') && romEntries.isNotEmpty) {
@@ -1160,11 +1173,23 @@ class SqliteDatabaseService {
           ),
         );
       }
+      final fastWalkNote = fastEntries.isEmpty ? ' (empty, non-null)' : '';
+      _log.i(
+        'SafScan[${path.basename(uri)}]: fast walk found ${entries.length} '
+        'entries$fastWalkNote',
+      );
       return entries;
     }
 
     try {
       final content = await SafDirectoryService.listFiles(uri);
+      // _scanSafUri recurses through subdirectories on this slow path, so this
+      // line fires once per directory — keep it at debug level to avoid
+      // flooding (and rotating away) the production log.
+      _log.d(
+        'SafScan[${path.basename(uri)}]: SAF walk returned ${content.length} '
+        'items',
+      );
       for (final item in content) {
         final name = item['name'].toString();
         final itemUri = item['uri'].toString();

--- a/lib/providers/sqlite_config_provider/scanning.dart
+++ b/lib/providers/sqlite_config_provider/scanning.dart
@@ -19,6 +19,11 @@ const String _transientRomFolderNotificationId = 'rom-folder-transient';
 /// for the same reason as [_unreachableRomFoldersNotificationId].
 const String _noRomFoldersNotificationId = 'rom-folders-missing';
 
+/// Bell entry for Android ROM folders that are configured but hold no
+/// persistent SAF grant, so their games silently scan as empty. A fixed id so
+/// consecutive scans replace the warning in place.
+const String _safPermissionNotificationId = 'rom-folders-saf-permission';
+
 extension SqliteConfigScanning on SqliteConfigProvider {
   /// Registers a new filesystem directory as a ROM source.
   ///
@@ -104,6 +109,55 @@ extension SqliteConfigScanning on SqliteConfigProvider {
     }
   }
 
+  /// On Android, every configured ROM root must hold its own persistent SAF
+  /// grant for the scan to read it. A folder can end up configured without one
+  /// (a path entered outside the SAF picker, or a grant revoked in system
+  /// settings), and the scan then silently walks it as if it were empty and
+  /// every game inside is lost — exactly the "Switch games on a second disk
+  /// never show up" report.
+  ///
+  /// Rather than opening the system picker from inside a background scan
+  /// (which risks a hung `_isScanning` if the activity is recreated while the
+  /// picker is up, and re-prompts on every scan because a re-picked parent
+  /// rarely matches the stored URI), this just tells the user what is wrong and
+  /// where to fix it via a bell notification. The re-grant happens on the
+  /// Settings > Directories screen, where a picker can never stall the scan.
+  ///
+  /// Note: even with All-Files-Access held, the native fast walk only covers
+  /// the primary volume on API 30+; folders on SD/USB volumes still fall back
+  /// to the SAF walk and need their own grant, so every configured root is
+  /// checked here regardless of the broad-permission flag.
+  Future<void> _ensureAndroidSafPermissions() async {
+    if (!Platform.isAndroid) return;
+
+    final missing = <String>[];
+    for (final folder in _config.romFolders) {
+      if (!folder.startsWith('content://')) continue;
+      final ok = await SafDirectoryService.hasPermission(folder);
+      if (!ok) {
+        missing.add(folder);
+      }
+    }
+
+    if (missing.isEmpty) {
+      GlobalNotificationService().dismiss(_safPermissionNotificationId);
+      return;
+    }
+
+    final plural = missing.length == 1 ? '' : 's';
+    SqliteConfigProvider._log.w(
+      'SAF permission missing for ${missing.length} ROM folder(s): $missing',
+    );
+    GlobalNotificationService().show(
+      id: _safPermissionNotificationId,
+      title: 'ROM folder$plural missing storage access',
+      message:
+          '${missing.length} ROM folder$plural cannot be read. '
+          'Re-grant access in Settings > Directories.',
+      type: GlobalNotificationType.error,
+    );
+  }
+
   /// Scans the registered ROM folders to detect supported emulation systems.
   ///
   /// Orchestrates permission checks, platform identification, and background
@@ -173,6 +227,18 @@ extension SqliteConfigScanning on SqliteConfigProvider {
           _notify();
           return;
         }
+      }
+
+      // Detect configured folders that lost their persistent SAF grant and
+      // tell the user, otherwise the scan walks them as empty and drops the
+      // games inside. Guarded so a surprise failure here can never leave the
+      // scan half-started (`_isScanning` is only cleared in the finally below).
+      try {
+        await _ensureAndroidSafPermissions();
+      } catch (e) {
+        SqliteConfigProvider._log.e(
+          'Error checking SAF permissions before scan: $e',
+        );
       }
 
       // On some handhelds launched as the default launcher, Android starts the
@@ -423,6 +489,11 @@ extension SqliteConfigScanning on SqliteConfigProvider {
 
           return false;
         }).toList();
+
+        SqliteConfigProvider._log.i(
+          'AndroidPreFilter: ${allExistingFolders.length} existing subfolder(s); '
+          '${filteredSystems.length} system(s) matched',
+        );
 
         // Android Fix: Combine filtered systems with legacy systems from DB
         // so that deleted systems get a chance to be pruned.
@@ -718,6 +789,11 @@ extension SqliteConfigScanning on SqliteConfigProvider {
         _config.romFolders,
         ignoreHiddenFiles: _config.ignoreHiddenFiles,
         rootFoldersMap: rootFoldersMap,
+      );
+
+      SqliteConfigProvider._log.i(
+        'ScanResult[${system.realName}]: added=${summary.added} '
+        'removed=${summary.removed} total=${summary.total}',
       );
 
       // Update ROM count in system


### PR DESCRIPTION
# Description

A user could not see their **Switch games** when they were stored on a **second storage volume** and the folder was added **without a persistent SAF grant**. The Android scan silently walked such folders as empty, every game inside was dropped, and the system was pruned from the library.

On Android, each configured ROM root must hold its own persistent SAF grant for the scan to read it. Without one, the scan falls back to the SAF walk, which fails with `Permission Denial: requires ACTION_OPEN_DOCUMENT` and reports zero entries.

The field log confirmed the root cause:

```
[E] Error listing SAF files: Permission Denial: reading
    .../tree/primary%3Aswitch/document/primary%3Aswitch/children
    requires that you obtain access using ACTION_OPEN_DOCUMENT or related APIs
...
Scan[Nintendo Switch]: walked .../4A21-0000%3AROMs/document/...%2Fswitch -> 0 entries
ScanResult[Nintendo Switch]: added=0 removed=0 total=0
```

The folder held `.nsp` files but the app had no access to read them.

## Changes

**`lib/providers/sqlite_config_provider/scanning.dart`** — add `_ensureAndroidSafPermissions()`, run at the start of `scanSystems()` on Android. It detects configured `content://` ROM folders that lack a persisted SAF grant via `SafDirectoryService.hasPermission()` and raises a **bell notification** pointing at Settings > Directories.

I deliberately did **not** auto-open the system picker from inside the scan: that risks a hung scan if the activity is recreated while the picker is up, and re-prompts on every scan because a re-picked parent rarely matches the stored URI. The bell tells the user what is wrong, and the re-grant happens on a screen where a picker can never stall the scan. Every configured root is checked even when All-Files-Access is held, because the fast walk only covers the primary volume on API 30+ — SD/USB folders still need their own grant.

**Diagnostic logging (always-on, concise)** — makes scan failures diagnosable without a device:
- `Scan[<system>]: N target(s) resolved`, `walked <dir> -> N entries`, `N raw entries before dedup/filter`.
- `ScanResult[<system>]: added=.. removed=.. total=..` per system.
- `AndroidPreFilter: N existing subfolder(s); N system(s) matched`.
- `SafScan[<folder>]: fast walk found N entries` (info — one line per system) and `SAF walk returned N items` (**debug** — the SAF walk recurses per directory, so it is kept off the production log to avoid rotating away the very context these logs exist to capture).

Closes the field report: the diagnostic logs surface the folders missing a grant, and re-granting access in Settings > Directories restores the Switch games (verified on-device by the reporter).

## Steps to Verify

**Preconditions:** an Android device with a ROM library split across two storage volumes, where at least one folder is configured without a persistent SAF grant.

1. Install the build; open NeoStation (it scans on startup).
2. When the scan detects folders without storage access, a **bell notification** appears: "ROM folder(s) missing storage access".
3. Go to **Settings > Directories** and re-grant access to the folder holding your games (or remove duplicate/extra folders and re-add the main ROM folder via the picker).
4. Rescan; confirm the games now appear.
5. (Diagnostic) Delete the old `app.log`, rescan, and confirm lines like `SAF permission missing for N ROM folder(s)` and `AndroidPreFilter` appear.

## Tested on

- [x] Android — device: AYN Thor (verified by reporter) + developer handheld
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (pre-existing failure in `rom_scan_symlink_alias_test.dart` is unrelated and present on `main`)
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [ ] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [x] No hardcoded UI strings — everything goes through `AppLocale` (this change only logs internally and uses the existing bell-notification pattern with no new UI text)

**The database**
- [ ] Column added to the versioned migration in `sqlite_migrations.dart` **and** the `CREATE TABLE` in `sqlite_service.dart`
- [ ] Migration number is above every slot in use on any open branch, not just `main` + 1
- [ ] Migration is idempotent (`PRAGMA table_info` guard) and has a test
- [ ] `_databaseVersion` bumped; new column selected in *every* system-loading query

**Navigation or a new screen**
- [ ] Every interactive element is reachable by D-pad, not just touch/mouse
- [ ] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()`
- [ ] B cancels / goes back, including out of a focused text field

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths
- [x] Verified on a device, not only on desktop

**`assets/systems/` or emulator launching**
- [ ] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible
- [ ] `assets/manifest.json` version bumped if this should reach existing installs OTA

</details>

## Screenshots / video

N/A (log + behavior fix, no visual change).
