### PR TITLE
fix(romm): stop re-sending saves whose bytes never changed

### DIFF
--- a/lib/sync/providers/romm_provider.dart
+++ b/lib/sync/providers/romm_provider.dart
@@ -18,6 +18,7 @@ library;
 import 'dart:async';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as path;
 import 'package:neostation/models/game_model.dart';
@@ -354,6 +355,18 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
         // pull belongs to the pre-launch hook, which knows a game is about to
         // start and has a deadline to answer to.
         if (uploadOnly) continue;
+        // "The server moved on" is a statement about timestamps, not content.
+        // A device that uploaded, then another that pulled and re-uploaded the
+        // identical file, both bump `updated_at` without a byte changing — and
+        // RomM's own `content_hash` says so for free. Hashing the local file
+        // costs a fraction of the transfer it replaces, and settling the pair
+        // here also stops the mtime path re-asking the same question forever.
+        final pullDigest = await _md5OfFile(local.filePath);
+        if (pullDigest != null &&
+            await _serverHoldsSameBytes(match, pullDigest, local)) {
+          await _recordSynced(local, match.updatedAtMs, pullDigest);
+          continue;
+        }
         final r = await _download(
           game,
           match,
@@ -374,7 +387,53 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
         // older local one — so a sweep leaves ties to the hook that can settle
         // them.
         if (uploadOnly && remoteChanged) continue;
-        if (await _upload(romId, local, isState, existing: match)) uploaded++;
+        // `localChanged` is an mtime answer, and mtime lies in the direction
+        // that costs the most: RetroArch rewrites `<game>.state.auto` on every
+        // exit whether or not the bytes moved, so a device with auto-save-state
+        // on re-uploads the same file after every session. Two hashes settle
+        // it — the one recorded at the last sync (which covers states, where
+        // RomM has no `content_hash` of its own) and the server's, which
+        // catches a second device that already pushed these exact bytes.
+        final pushDigest = await _md5OfFile(local.filePath);
+        if (pushDigest != null) {
+          // Both hashes are asked, never short-circuited, because the answers
+          // are not interchangeable: only the server's says anything about the
+          // copy that is actually up there. The recorded hash says this device
+          // has not changed its file, which is reason enough to skip the
+          // upload but no reason at all to claim [match] has been seen — and
+          // recording its stamp would mark a remote copy consumed that nothing
+          // ever compared or fetched, leaving `remoteChanged` false from then
+          // on and stranding the other device's save for good. So the cloud
+          // stamp only moves when [_serverHoldsSameBytes] vouched for it;
+          // otherwise it stays put and the next pass, with the local mtime now
+          // settled, takes the pull branch and collects what is waiting.
+          //
+          // States live on this path exclusively — RomM gives them no
+          // `content_hash` to check — so it carries the ordinary two-device
+          // case, not an exotic one.
+          final serverMatches = await _serverHoldsSameBytes(
+            match,
+            pushDigest,
+            local,
+          );
+          if (serverMatches || pushDigest == recorded?['file_hash']) {
+            await _recordSynced(
+              local,
+              serverMatches ? match.updatedAtMs : recordedCloudMs,
+              pushDigest,
+            );
+            continue;
+          }
+        }
+        if (await _upload(
+          romId,
+          local,
+          isState,
+          existing: match,
+          digest: pushDigest,
+        )) {
+          uploaded++;
+        }
       }
     }
 
@@ -649,6 +708,114 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
   static bool isPermissionDenied(Object e) =>
       e is RommException && e.statusCode == 403;
 
+  /// The local file's first four bytes, as a zip archive would start them.
+  static const List<int> _zipMagic = [0x50, 0x4B, 0x03, 0x04];
+
+  /// MD5 of the file at [filePath], or null when it cannot be read.
+  ///
+  /// MD5 because that is what RomM computes — `hashlib.md5` over the stored
+  /// file, streamed in 8 KiB chunks (`AssetsHandler._compute_file_hash`, RomM
+  /// 5.1.0) — so this value is directly comparable with `content_hash`. It is a
+  /// change detector, never a security check; the comparison it feeds only ever
+  /// decides whether a transfer can be skipped.
+  ///
+  /// Streamed rather than read whole: a PS2 shared memory card is 8 MB and this
+  /// runs on the launch path.
+  static Future<String?> _md5OfFile(String filePath) async {
+    try {
+      final file = File(filePath);
+      if (!await file.exists()) return null;
+      return (await md5.bind(file.openRead()).first).toString();
+    } catch (e) {
+      _log.w('RomM hash failed ($filePath): $e');
+      return null;
+    }
+  }
+
+  /// Whether RomM's own `content_hash` for [asset] provably describes the same
+  /// bytes as [digest], an [_md5OfFile] of [local].
+  ///
+  /// False whenever the comparison cannot be trusted, which keeps every
+  /// uncertain case on the existing transfer path — the worst outcome of a
+  /// "no" here is the redundant upload or download this gate set out to avoid,
+  /// while a wrong "yes" would silently skip a real one. Three cases:
+  ///
+  /// * **States.** RomM's `StateSchema` has no `content_hash` field at all
+  ///   (verified against 5.1.0), so `/api/states` can never answer this. States
+  ///   are covered instead by the hash recorded at the last sync.
+  /// * **No hash.** Older servers, and rows whose file went missing, leave it
+  ///   null; RomM backfills them with a maintenance task on its own schedule.
+  /// * **Zip archives.** RomM hashes a zip entry-wise — MD5 over
+  ///   `"<name>:<md5>"` lines for the sorted entries
+  ///   (`AssetsHandler._compute_zip_hash`) — so its value is not an MD5 of the
+  ///   file's bytes and must never be compared with one.
+  static Future<bool> _serverHoldsSameBytes(
+    RommAsset asset,
+    String digest,
+    LocalSaveFile local,
+  ) async {
+    final remote = asset.contentHash;
+    if (asset.isState || remote == null || remote.isEmpty) return false;
+    if (remote.toLowerCase() != digest) return false;
+    return !await _looksZipped(local.filePath);
+  }
+
+  /// Whether [filePath] opens with a zip archive's local-file-header magic.
+  ///
+  /// Deliberately a header sniff and not a real archive test: it exists only to
+  /// withhold the [_serverHoldsSameBytes] shortcut from files RomM may have
+  /// hashed entry-wise, and a false positive costs one ordinary transfer.
+  static Future<bool> _looksZipped(String filePath) async {
+    try {
+      final handle = await File(filePath).open();
+      try {
+        final head = await handle.read(_zipMagic.length);
+        if (head.length < _zipMagic.length) return false;
+        for (var i = 0; i < _zipMagic.length; i++) {
+          if (head[i] != _zipMagic[i]) return false;
+        }
+        return true;
+      } finally {
+        await handle.close();
+      }
+    } catch (e) {
+      _log.w('RomM zip probe failed ($filePath): $e');
+      return false;
+    }
+  }
+
+  /// Records [local] as settled at [cloudUpdatedAt], no transfer having been
+  /// needed.
+  ///
+  /// [cloudUpdatedAt] is the caller's claim about how much of the server it has
+  /// actually accounted for, which is not always the matched asset's stamp: a
+  /// skip decided from this device's own records leaves it where it was, so the
+  /// remote copy stays unseen and a later pass still pulls it.
+  ///
+  /// Writing this row is the point of the skip, not bookkeeping around it:
+  /// without it the mtime comparison asks the same question on every pass and
+  /// this file pays for a hash forever. The stat is re-read rather than reusing
+  /// the locator's, so the recorded mtime is the one a later pass will see.
+  Future<void> _recordSynced(
+    LocalSaveFile local,
+    int cloudUpdatedAt,
+    String digest,
+  ) async {
+    try {
+      final stat = await File(local.filePath).stat();
+      await SyncRepository.saveSyncState(
+        kProviderId,
+        local.filePath,
+        stat.modified.millisecondsSinceEpoch,
+        cloudUpdatedAt,
+        stat.size,
+        fileHash: digest,
+      );
+    } catch (e) {
+      _log.w('RomM sync-state record failed (${local.filePath}): $e');
+    }
+  }
+
   /// Sends [local] to RomM, updating [existing] in place when the asset is
   /// already there and creating it otherwise.
   ///
@@ -659,6 +826,7 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
     LocalSaveFile local,
     bool isState, {
     RommAsset? existing,
+    String? digest,
   }) async {
     try {
       final file = File(local.filePath);
@@ -674,13 +842,20 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
             : await _svc.uploadSave(romId, file, emulator: _assetLabel);
       }
       final stat = await file.stat();
+      // Record *our* hash of the bytes just sent, not the server's echo of it.
+      // The two agree for an ordinary save, but RomM hashes a zip archive
+      // entry-wise rather than byte-wise, and states carry no `content_hash` at
+      // all — so storing the server's value would leave exactly the files this
+      // gate exists for without one. The reader ([_syncGame]) only ever
+      // compares it against another [_md5OfFile] result, so self-consistency is
+      // what matters.
       await SyncRepository.saveSyncState(
         kProviderId,
         local.filePath,
         stat.modified.millisecondsSinceEpoch,
         asset.updatedAtMs,
         local.fileSize,
-        fileHash: asset.contentHash,
+        fileHash: digest ?? await _md5OfFile(local.filePath),
       );
       return true;
     } catch (e) {
@@ -797,7 +972,9 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
           stat.modified.millisecondsSinceEpoch,
           asset.updatedAtMs,
           bytes.length,
-          fileHash: asset.contentHash,
+          // Ours, for the reason given in [_upload] — and free here, since the
+          // bytes are already in memory.
+          fileHash: md5.convert(bytes).toString(),
         );
         wroteAny = true;
       }

--- a/test/romm_content_hash_gate_test.dart
+++ b/test/romm_content_hash_gate_test.dart
@@ -1,0 +1,553 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/models/neo_sync_models.dart';
+import 'package:neostation/models/romm_asset.dart';
+import 'package:neostation/providers/neo_sync_provider.dart';
+import 'package:neostation/providers/romm_provider.dart';
+import 'package:neostation/repositories/romm_save_map_repository.dart';
+import 'package:neostation/repositories/sync_repository.dart';
+import 'package:neostation/services/neosync/neo_sync_service.dart';
+import 'package:neostation/services/romm_service.dart';
+import 'package:neostation/sync/providers/romm_provider.dart';
+
+import 'database_test_helper.dart';
+
+/// Content-hash gate: no transfer when the bytes are already where they'd go.
+///
+/// The reconcile decides *whether* to move a file from timestamps, and
+/// timestamps overstate change in both directions. Locally, RetroArch rewrites
+/// `<game>.state.auto` on every exit whether or not a byte moved, so a device
+/// with auto-save-state on re-uploads the same file after every session.
+/// Remotely, another device that pulled and pushed the identical file bumps
+/// `updated_at` without changing anything, and this device pulls it back.
+///
+/// RomM answers both for saves with its own `content_hash` — MD5 over the
+/// stored file (`AssetsHandler._compute_file_hash`), verified byte-for-byte
+/// against a live 5.1.0 server. States have no such field, so they are covered
+/// by the hash this provider records for itself at each sync.
+///
+/// Every test here asserts an *absence* — no upload, no download — so each one
+/// is paired with the case that must still transfer, which is the real risk:
+/// a gate that over-matches loses saves silently.
+
+/// In-memory RomM server that models `content_hash` the way RomM computes it.
+class _FakeRommService extends RommService {
+  final Map<int, List<RommAsset>> savesByRom = {};
+  final Map<int, List<RommAsset>> statesByRom = {};
+  final Map<String, List<int>> contentByPath = {};
+
+  final List<String> creates = [];
+  final List<int> updates = [];
+  final List<String> downloads = [];
+
+  int _nextAssetId = 1;
+  int _stampSeq = 0;
+
+  DateTime _stamp() =>
+      DateTime.now().toUtc().add(Duration(seconds: ++_stampSeq));
+
+  /// RomM's plain-file hash: `hashlib.md5` over the bytes as stored.
+  static String hashOf(List<int> bytes) => md5.convert(bytes).toString();
+
+  /// Plants a save as if another client uploaded it. [contentHash] defaults to
+  /// what RomM would compute; pass null for a pre-backfill row.
+  RommAsset seedSave(
+    int romId,
+    String fileName,
+    List<int> bytes, {
+    required DateTime updatedAt,
+    String? slot,
+    String? contentHash = '',
+  }) {
+    final path = 'assets/$romId/${_nextAssetId}_$fileName';
+    final asset = RommAsset(
+      id: _nextAssetId++,
+      fileName: fileName,
+      fileSizeBytes: bytes.length,
+      isState: false,
+      updatedAt: updatedAt,
+      slot: slot,
+      contentHash: contentHash == '' ? hashOf(bytes) : contentHash,
+      downloadPath: path,
+    );
+    contentByPath[path] = List.of(bytes);
+    (savesByRom[romId] ??= []).add(asset);
+    return asset;
+  }
+
+  /// Plants a state. `/api/states` never returns a `content_hash`, so this
+  /// deliberately cannot take one.
+  RommAsset seedState(
+    int romId,
+    String fileName,
+    List<int> bytes, {
+    required DateTime updatedAt,
+  }) {
+    final path = 'assets/$romId/${_nextAssetId}_$fileName';
+    final asset = RommAsset(
+      id: _nextAssetId++,
+      fileName: fileName,
+      fileSizeBytes: bytes.length,
+      isState: true,
+      updatedAt: updatedAt,
+      downloadPath: path,
+    );
+    contentByPath[path] = List.of(bytes);
+    (statesByRom[romId] ??= []).add(asset);
+    return asset;
+  }
+
+  @override
+  bool get playtimeSyncAvailable => false;
+
+  @override
+  Future<List<RommAsset>> listSaves({required int romId}) async =>
+      List.of(savesByRom[romId] ?? const []);
+
+  @override
+  Future<List<RommAsset>> listStates({required int romId}) async =>
+      List.of(statesByRom[romId] ?? const []);
+
+  @override
+  Future<RommAsset> uploadSave(
+    int romId,
+    File file, {
+    String? emulator,
+    String? slot,
+    String? deviceId,
+    bool overwrite = true,
+  }) async {
+    final name = p.basename(file.path);
+    creates.add('$romId/$name');
+    return seedSave(romId, name, await file.readAsBytes(), updatedAt: _stamp());
+  }
+
+  @override
+  Future<RommAsset> uploadState(
+    int romId,
+    File file, {
+    String? emulator,
+    String? slot,
+    String? deviceId,
+    bool overwrite = true,
+  }) async {
+    final name = p.basename(file.path);
+    creates.add('$romId/$name');
+    return seedState(
+      romId,
+      name,
+      await file.readAsBytes(),
+      updatedAt: _stamp(),
+    );
+  }
+
+  @override
+  Future<RommAsset> updateSave(int assetId, File file) =>
+      _update(savesByRom, assetId, file, isState: false);
+
+  @override
+  Future<RommAsset> updateState(int assetId, File file) =>
+      _update(statesByRom, assetId, file, isState: true);
+
+  Future<RommAsset> _update(
+    Map<int, List<RommAsset>> byRom,
+    int assetId,
+    File file, {
+    required bool isState,
+  }) async {
+    for (final entry in byRom.entries) {
+      final i = entry.value.indexWhere((a) => a.id == assetId);
+      if (i < 0) continue;
+      final old = entry.value[i];
+      final bytes = await file.readAsBytes();
+      updates.add(assetId);
+      contentByPath[old.downloadPath!] = List.of(bytes);
+      // RomM's `update_save` re-scans the written file, so the row's hash and
+      // size follow the new bytes; `update_state` has no hash to re-scan.
+      final updated = RommAsset(
+        id: old.id,
+        fileName: old.fileName,
+        fileSizeBytes: bytes.length,
+        isState: old.isState,
+        updatedAt: _stamp(),
+        slot: old.slot,
+        contentHash: isState ? null : hashOf(bytes),
+        downloadPath: old.downloadPath,
+      );
+      entry.value[i] = updated;
+      return updated;
+    }
+    throw StateError('no asset with id $assetId');
+  }
+
+  @override
+  Future<Uint8List> downloadAssetByPath(String downloadPath) async {
+    downloads.add(downloadPath);
+    return Uint8List.fromList(contentByPath[downloadPath]!);
+  }
+
+  @override
+  Future<Uint8List> downloadSaveContent(int assetId) async =>
+      throw UnimplementedError('tests always provide download_path');
+}
+
+class _FakeBrowse extends RommProvider {
+  final RommService fakeService;
+  bool connected = true;
+  _FakeBrowse(this.fakeService);
+
+  @override
+  bool get isConnected => connected;
+
+  @override
+  RommService get service => fakeService;
+}
+
+/// NeoSync path resolution over a temp directory holding both `saves/` and
+/// `states/`, statted live so mtime comparisons see the current file.
+class _TempSavePaths {
+  _TempSavePaths(this.root);
+
+  final String root;
+
+  Future<List<LocalSaveFile>> locate(GameModel game) async {
+    final out = <LocalSaveFile>[];
+    for (final kind in const ['saves', 'states']) {
+      final dir = Directory(p.join(root, kind));
+      if (!dir.existsSync()) continue;
+      for (final f in dir.listSync().whereType<File>()) {
+        final stat = f.statSync();
+        out.add(
+          LocalSaveFile(
+            filePath: f.path,
+            fileName: p.basename(f.path),
+            fileSize: stat.size,
+            lastModified: stat.modified,
+            gameName: game.name,
+            isSynced: false,
+            relativePath: '$kind/${p.basename(f.path)}',
+          ),
+        );
+      }
+    }
+    return out;
+  }
+
+  Future<List<String>> resolveTargets(
+    GameModel game,
+    String relativeName,
+  ) async => [p.join(root, relativeName)];
+}
+
+GameModel _game(String romname) => GameModel(
+  romname: romname,
+  realname: romname,
+  name: p.basenameWithoutExtension(romname),
+  year: '1996',
+  developer: '',
+  publisher: '',
+  genre: '',
+  players: '',
+  rating: 0,
+  romPath: '/roms/nes/$romname',
+  systemFolderName: 'nes',
+  cloudSyncEnabled: true,
+);
+
+void main() {
+  final helper = DatabaseTestHelper();
+  late Directory tempDir;
+  late _FakeRommService svc;
+  late _FakeBrowse browse;
+  late _TempSavePaths paths;
+  late RomMSyncProvider provider;
+
+  final game = _game('Game.nes');
+
+  File localSave() => File(p.join(tempDir.path, 'saves', 'Game.srm'));
+  File localState() => File(p.join(tempDir.path, 'states', 'Game.state.auto'));
+
+  /// Bumps a file's mtime without touching its bytes — what RetroArch does to
+  /// an auto save state on every exit, and well past [_mtimeToleranceMs].
+  Future<void> touch(File f) =>
+      f.setLastModified(DateTime.now().add(const Duration(minutes: 5)));
+
+  setUp(() async {
+    final db = await helper.setUp();
+    await db.execute(SqliteMigrations.createAppRommRomMapTableSql);
+    await db.execute(SqliteMigrations.createAppNeoSyncStateTableSql);
+    tempDir = await Directory.systemTemp.createTemp('romm_hash_gate_test');
+    await Directory(p.join(tempDir.path, 'saves')).create(recursive: true);
+    await Directory(p.join(tempDir.path, 'states')).create(recursive: true);
+
+    await RommSaveMapRepository.putMapping(
+      romname: 'Game.nes',
+      systemFolder: 'nes',
+      rommRomId: 1,
+    );
+
+    svc = _FakeRommService();
+    browse = _FakeBrowse(svc);
+    paths = _TempSavePaths(tempDir.path);
+    provider = RomMSyncProvider(
+      browse,
+      NeoSyncProvider(NeoSyncService()),
+      locateSaves: paths.locate,
+      resolveTargets: paths.resolveTargets,
+      autoSweep: false,
+    );
+  });
+
+  tearDown(() async {
+    await helper.tearDown();
+    await tempDir.delete(recursive: true);
+  });
+
+  group('uploads', () {
+    test('a save whose mtime moved but whose bytes did not is not '
+        're-uploaded', () async {
+      svc.seedSave(
+        1,
+        'Game.srm',
+        'PROGRESS'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+      await localSave().writeAsString('PROGRESS');
+      await touch(localSave());
+
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, isEmpty, reason: 'identical bytes, nothing to send');
+      expect(svc.creates, isEmpty);
+    });
+
+    test('a save whose bytes really changed is still uploaded', () async {
+      svc.seedSave(
+        1,
+        'Game.srm',
+        'PROGRESS'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+      await localSave().writeAsString('MORE-PROGRESS');
+      await touch(localSave());
+
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, [1]);
+      expect(
+        String.fromCharCodes(svc.contentByPath.values.single),
+        'MORE-PROGRESS',
+      );
+    });
+
+    test('a state is gated on the hash recorded at the last sync, since RomM '
+        'has none of its own', () async {
+      // The auto-state churn case: RomM's StateSchema carries no content_hash,
+      // so the only thing that can vouch for these bytes is what this provider
+      // recorded when it last sent them.
+      await localState().writeAsString('STATE-BYTES');
+      await provider.syncGameSavesAfterClose(game);
+      expect(svc.creates, hasLength(1), reason: 'first sync must upload');
+
+      await touch(localState());
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(
+        svc.updates,
+        isEmpty,
+        reason: 'RetroArch rewrote the file; the bytes are unchanged',
+      );
+    });
+
+    test('a changed state is still uploaded', () async {
+      await localState().writeAsString('STATE-BYTES');
+      await provider.syncGameSavesAfterClose(game);
+
+      await localState().writeAsString('LATER-STATE');
+      await touch(localState());
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, hasLength(1));
+    });
+
+    test('a server copy identical to the local one is not overwritten, even '
+        'with no recorded sync state', () async {
+      // Two devices meeting for the first time, or one whose local database
+      // was reset: nothing recorded, mtimes unrelated, bytes the same.
+      svc.seedSave(
+        1,
+        'Game.srm',
+        'IDENTICAL'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+      await localSave().writeAsString('IDENTICAL');
+
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, isEmpty);
+    });
+
+    test('a pre-backfill row with no content_hash still uploads', () async {
+      // RomM backfills content_hash on its own schedule; until it does, the
+      // only safe answer is the transfer we would have made anyway.
+      svc.seedSave(
+        1,
+        'Game.srm',
+        'IDENTICAL'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 1),
+        contentHash: null,
+      );
+      await localSave().writeAsString('IDENTICAL');
+
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, [1]);
+    });
+
+    test('a zip-shaped save is never matched on the server hash', () async {
+      // RomM hashes a zip archive entry-wise, so its content_hash is not an
+      // MD5 of the file's bytes and must not be compared with one. Modelled
+      // here as a server hash that *would* match: only the guard can refuse it.
+      final zipish = <int>[0x50, 0x4B, 0x03, 0x04, 1, 2, 3];
+      svc.seedSave(1, 'Game.srm', zipish, updatedAt: DateTime.utc(2026, 1, 1));
+      await localSave().writeAsBytes(zipish);
+
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, [1]);
+    });
+  });
+
+  group('downloads', () {
+    test(
+      'a newer server timestamp over identical bytes pulls nothing',
+      () async {
+        svc.seedSave(
+          1,
+          'Game.srm',
+          'SAME-BYTES'.codeUnits,
+          updatedAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        );
+        await localSave().writeAsString('SAME-BYTES');
+
+        await provider.syncGameSavesBeforeLaunch(game);
+
+        expect(svc.downloads, isEmpty);
+      },
+    );
+
+    test('a newer server copy with different bytes is still pulled', () async {
+      svc.seedSave(
+        1,
+        'Game.srm',
+        'REMOTE-PROGRESS'.codeUnits,
+        updatedAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+      );
+      await localSave().writeAsString('OLD');
+
+      await provider.syncGameSavesBeforeLaunch(game);
+
+      expect(svc.downloads, hasLength(1));
+      expect(await localSave().readAsString(), 'REMOTE-PROGRESS');
+    });
+
+    test(
+      'the skip records sync state, so the next pass costs nothing',
+      () async {
+        // Without the recorded row the mtime comparison asks the same question
+        // on every launch and this file pays for a hash forever.
+        final asset = svc.seedSave(
+          1,
+          'Game.srm',
+          'SAME-BYTES'.codeUnits,
+          updatedAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        );
+        await localSave().writeAsString('SAME-BYTES');
+
+        await provider.syncGameSavesBeforeLaunch(game);
+        final recorded = await SyncRepository.getSyncState(
+          RomMSyncProvider.kProviderId,
+          localSave().path,
+        );
+
+        expect(svc.downloads, isEmpty, reason: 'the pull was skipped');
+        expect(recorded, isNotNull);
+        expect(
+          recorded!['file_hash'],
+          _FakeRommService.hashOf('SAME-BYTES'.codeUnits),
+        );
+        expect(recorded['cloud_updated_at'], asset.updatedAtMs);
+      },
+    );
+  });
+
+  group('skipping never consumes a remote copy it did not look at', () {
+    test(
+      'a state another device advanced still arrives after a local skip',
+      () async {
+        // The gate's own hazard. A skip taken on the recorded hash proves only
+        // that *this* device stood still; if it banked the matched asset's stamp
+        // it would mark a remote copy seen that nothing compared or fetched, and
+        // `remoteChanged` would read false from then on. States have no server
+        // hash to check, so this is their ordinary two-device case.
+        await localState().writeAsString('STATE-A');
+        await provider.syncGameSavesAfterClose(game);
+
+        // The other device pushes a genuinely newer state.
+        svc.statesByRom[1] = [];
+        svc.seedState(
+          1,
+          'Game.state.auto',
+          'STATE-B'.codeUnits,
+          updatedAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        );
+
+        // RetroArch rewrites the auto-state on exit; the bytes do not move.
+        await touch(localState());
+        await provider.syncGameSavesAfterClose(game);
+        expect(
+          svc.updates,
+          isEmpty,
+          reason: 'unchanged bytes must not be pushed over the newer state',
+        );
+
+        await provider.syncGameSavesBeforeLaunch(game);
+
+        expect(
+          await localState().readAsString(),
+          'STATE-B',
+          reason: 'the skip must leave the newer state there to be pulled',
+        );
+      },
+    );
+
+    test('a save the server vouched for does bank its stamp', () async {
+      // The other half: when [_serverHoldsSameBytes] answered, the remote copy
+      // really has been accounted for, so the stamp moves and the next pass
+      // costs nothing.
+      final asset = svc.seedSave(
+        1,
+        'Game.srm',
+        'IDENTICAL'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+      await localSave().writeAsString('IDENTICAL');
+      await touch(localSave());
+
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, isEmpty);
+      final recorded = await SyncRepository.getSyncState(
+        RomMSyncProvider.kProviderId,
+        localSave().path,
+      );
+      expect(recorded!['cloud_updated_at'], asset.updatedAtMs);
+    });
+  });
+}


### PR DESCRIPTION
# Description

`_syncGame` picks a sync direction from timestamps, and timestamps overstate change in both directions:

- **Locally**, RetroArch rewrites `<game>.state.auto` on every exit whether or not a byte moved, so a device with auto-save-state on re-uploads the same file after every session.
- **Remotely**, a second device that pulled and re-pushed an identical file bumps `updated_at`, and this device pulls it straight back.

Neither transfer moves any data, and both sit on the launch critical path.

This gates both branches on **content** instead. RomM already answers the question for saves: `content_hash` is MD5 over the stored file, verified byte-for-byte against a live 5.1.0 server, so a local MD5 is directly comparable and costs a fraction of the transfer it replaces. States have no such field, so they are gated on the hash the provider records for itself at each sync — and that record is now our own MD5 rather than the server's echo of it. The two agree for an ordinary save, but RomM hashes zip archives entry-wise and returns nothing at all for states, so storing the server's value would leave exactly the files this gate exists for without a usable one.

Every case the comparison cannot vouch for — a state, a null hash on a pre-backfill row, a zip-shaped file — answers "not the same bytes" and falls through to the existing transfer path. The worst outcome of a wrong "no" is the redundant transfer this set out to avoid; a wrong "yes" would silently skip a real one.

The gates sit *after* the existing mtime decision, so the steady state costs nothing and a hash is only computed where a transfer was about to happen.

## It also closes a pre-existing save-loss path

This is the part worth reviewing hardest, and it is a stronger claim than "avoids redundant transfers".

When a second device uploads while you are playing, the post-close pass sees both sides changed and prefers local — so it **uploads the stale local state over the newer remote one and destroys it server-side**. The losing pass reports `1 up, 0 down`, so nothing marks it as a failure.

Verified on hardware, both arms, identical inputs (sequence B below):

| | post-close | server holds afterwards | the other device's state |
|---|---|---|---|
| `main` | `1 up, 0 down` | the stale 4096 B state | **destroyed** |
| this branch | `0 up, 0 down` | the newer 6000 B state | **intact**, pulled on the next launch |

The skip is deliberately careful not to trade one loss for another. It does **not** advance the recorded cloud stamp, because the recorded hash only proves *this device* stood still and says nothing about the copy that is actually on the server. Banking the stamp there would mark a remote copy consumed that nothing ever compared or fetched, leave `remoteChanged` false from then on, and strand the other device's save permanently. The two hashes are therefore asked separately and never short-circuited: the stamp moves only when the server's own hash vouched for it.

## Scope

Builds on #369 (the read-side slot and datetime-tag handling).

**Scope note: this PR does not address #368**, which remains the tracker for the two stages deliberately not adopted — sending a slot on upload, and `POST /api/sync/negotiate`.

<!-- Phrased deliberately without a GitHub closing keyword next to the issue number: the parser
     matches such a keyword even when it is negated, so an earlier revision of this line
     auto-closed that issue on merge. It has since been reopened. -->

No protocol adoption, no schema change, no new scopes: `app_neo_sync_state.file_hash` has existed since v111 and was already being written, just never read by anything.

## Steps to Verify

**Preconditions:**

- An Android device with the app installed, plus any second client that can talk to the same RomM server (a shell with `curl` is enough — it stands in for "another device").
- A RomM **5.1.0** server, and a RomM-linked game with **Cloud sync** enabled. It must genuinely be linked in the RomM save map; a local ROM that merely shares a filename with a server entry will be skipped.
- A local save state for that game at `<RetroArch states dir>/<core>/<Game>.state`. Use `.state` rather than `.state.auto`: RetroArch only auto-rewrites the latter, so `.state` stays under your control across a session.

### A — an unchanged save is no longer re-sent

1. Play the game once and close it, so the save uploads and a sync state is recorded for it.
2. Without playing again, bump only the file's modification time (`touch` it). The bytes are unchanged.
3. Restart the app and wait about 30 seconds for the connect-time upload sweep.
4. The game is a sweep candidate but nothing transfers: `RomM upload sweep: 1 pending, 1 synced` alongside `RomM sync <game>: 0 up, 0 down`, and the asset's `updated_at` on the server is unchanged. **Before this change, this step uploaded the file.**
5. Restart once more. The sweep now reports `nothing pending` — the skip settles the question rather than re-asking it on every pass.
6. Now genuinely change the file's bytes and repeat. It uploads (`1 up, 0 down`). This half matters as much as the first: a gate that over-matches would lose saves silently.

Repeat 1–6 with the state file to exercise the arm that has no server-side hash to lean on.

### B — the save-loss path

1. Get the state file synced: identical bytes on the device and on RomM.
2. Launch the game.
3. **While it is running**, upload a different state for that ROM to RomM as another device would (`PUT /api/states/{id}`). Make it a different size from the local one so the outcome is visible in metadata alone. Then bump the local file's modification time without changing its bytes — this is what RetroArch does on exit.
4. Close the game and watch the post-close pass.
   - **Before this change:** `RomM sync <game>: 1 up, 0 down`. Fetch the state back from RomM and it is the stale local copy; the newer state from step 3 no longer exists on the server or on either device.
   - **With this change:** `0 up, 0 down`, and the server still serves the newer state.
5. Launch the game again. The pre-launch pass reports `0 up, 1 down` and the local file becomes the newer state — it was waiting, not stranded.

States carry no `content_hash`, so confirm which bytes survived by downloading `/api/states/{id}/content?timestamp=…` and hashing what it serves; comparing `file_size_bytes` is enough when the two states differ in size.

## Tested on

- [x] Android — device: AYN Thor (Android 13), against a live RomM 5.1.0 server
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Eight scenarios on hardware covering both gate arms in both directions, each "nothing transferred" assertion paired with the case that must still transfer. Plus the A/B above: the same scripted sequence run against this branch and against `main`'s provider, on the same device, server and game.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1344)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

No user-facing strings, no schema change, and no navigation changes — those sections do not apply. `app_neo_sync_state.file_hash` is an existing column (v111); only the value written to it changes, and legacy rows holding a server hash still compare equal for an ordinary save.

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths — save paths come from the existing RetroArch config resolution, unchanged here
- [x] Verified on a device, not only on desktop

</details>

