### PR TITLE
fix(ra): hash DVD-format CHDs, which is most of a PS2 library

### DIFF
--- a/packages/flutter_chd/README.md
+++ b/packages/flutter_chd/README.md
@@ -1,7 +1,11 @@
 # flutter_chd
 
-Reads CD tracks and sectors out of CHD disc images, so RetroAchievements hashing
+Reads tracks and sectors out of CHD disc images, so RetroAchievements hashing
 can reach the executable inside a disc's filesystem.
+
+Both CHD layouts a game library holds are read: a CD image, whose tracks are
+listed in metadata and whose frames wrap their user data in sector headers, and
+a DVD image, which has neither and is one flat run of 2048-byte sectors.
 
 RetroAchievements identifies a disc game by hashing its primary executable, not
 the container, so a plain MD5 of a `.chd` matches nothing in RA's database. This

--- a/packages/flutter_chd/lib/flutter_chd.dart
+++ b/packages/flutter_chd/lib/flutter_chd.dart
@@ -1,4 +1,4 @@
-/// Reads CD tracks and sectors out of a CHD disc image.
+/// Reads tracks and sectors out of a CHD disc image.
 ///
 /// CHD is how essentially every disc-based ROM in a real library is stored, and
 /// RetroAchievements identifies a disc game by hashing the executable inside its
@@ -77,7 +77,8 @@ enum ChdOpenError {
   /// The file is missing, unreadable, or not a CHD at all.
   open,
 
-  /// A CHD, but one with no CD track metadata — a hard-disk or DVD image.
+  /// A CHD, but one describing no readable track — a hard-disk image, or a
+  /// disc whose sectors are neither CD frames nor plain 2048-byte ones.
   noTracks,
 
   /// Compressed with a codec this build cannot decode.

--- a/packages/flutter_chd/pubspec.yaml
+++ b/packages/flutter_chd/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chd
 resolution: workspace
-description: "Reads CD tracks and sectors out of CHD disc images, over a vendored libchdr."
+description: "Reads tracks and sectors out of CD and DVD CHD disc images, over a vendored libchdr."
 version: 0.0.1
 homepage:
 

--- a/packages/flutter_chd/src/flutter_chd.c
+++ b/packages/flutter_chd/src/flutter_chd.c
@@ -34,6 +34,7 @@ typedef struct {
   uint32_t pregap;    /* leading frames that are gap rather than track data */
   uint32_t start;     /* first physical frame of the track within the CHD */
   uint32_t start_lba; /* first sector of the track as the disc addresses it */
+  int32_t flat;       /* frames are bare user data, with no sector header */
 } nchd_track;
 
 struct nchd_disc {
@@ -129,6 +130,42 @@ static uint32_t nchd_read_track_metadata(chd_file *chd, uint32_t index,
   return track->frames + nchd_padding_frames(track->frames);
 }
 
+/* Describes a DVD image as the single flat track it is, returning 1 when the
+ * CHD is one.
+ *
+ * A DVD carries none of the metadata above. `chdman createdvd` writes no track
+ * entry at all — only a `DVD ` tag with an empty payload — and stores the image
+ * as an unbroken run of 2048-byte sectors with no sync pattern, no header and
+ * no subheader. There is nothing to enumerate, so the layout comes from the
+ * header instead: one data track covering every sector in the file.
+ *
+ * The unit size is what decides it rather than the tag. A unit of exactly one
+ * sector's worth of user data can hold nothing but user data, the tag says no
+ * more than that, and not every writer leaves one behind. A container that
+ * turns out to carry no filesystem then fails where it already did, in the
+ * ISO9660 probe above this. */
+static int32_t nchd_add_dvd_track(const chd_header *header, nchd_disc *disc) {
+  uint64_t frames;
+  nchd_track *track;
+
+  if (header->unitbytes != NCHD_SECTOR_SIZE) return 0;
+
+  frames = header->logicalbytes / header->unitbytes;
+  if (frames == 0) return 0;
+  /* Sector numbers cross the FFI boundary as int32; a dual-layer DVD is about
+   * four million sectors, so this only ever bites a malformed header. */
+  if (frames > (uint64_t)0x7FFFFFFF) frames = (uint64_t)0x7FFFFFFF;
+
+  track = &disc->tracks[0];
+  memset(track, 0, sizeof(*track));
+  track->number = 1;
+  track->mode = NCHD_MODE_MODE1;
+  track->frames = (uint32_t)frames;
+  track->flat = 1;
+  disc->track_count = 1;
+  return 1;
+}
+
 static nchd_disc *nchd_create(chd_file *chd, FILE *fp, int32_t *out_error) {
   const chd_header *header = chd_get_header(chd);
   nchd_disc *disc;
@@ -173,7 +210,7 @@ static nchd_disc *nchd_create(chd_file *chd, FILE *fp, int32_t *out_error) {
     start_lba = track.start_lba + (track.frames - track.pregap);
   }
 
-  if (disc->track_count == 0) {
+  if (disc->track_count == 0 && !nchd_add_dvd_track(header, disc)) {
     free(disc->hunk);
     free(disc);
     if (out_error != NULL) *out_error = NCHD_ERR_NO_TRACKS;
@@ -359,7 +396,10 @@ FFI_PLUGIN_EXPORT int32_t nchd_read_sector(nchd_disc *disc, int32_t track_index,
   if (!nchd_load_hunk(disc, hunk_number)) return -2;
 
   sector = disc->hunk + frame_offset;
-  data_offset = nchd_sector_data_offset(sector, track->mode);
+  /* A flat track's frame *is* the user data: there is no header to step over,
+   * and looking for one would both drop the first 16 bytes of the sector and
+   * run past the end of the frame. */
+  data_offset = track->flat ? 0 : nchd_sector_data_offset(sector, track->mode);
   if ((uint32_t)data_offset + NCHD_SECTOR_SIZE > disc->unit_bytes) return -3;
 
   memcpy(out, sector + data_offset, NCHD_SECTOR_SIZE);

--- a/packages/flutter_chd/src/flutter_chd.h
+++ b/packages/flutter_chd/src/flutter_chd.h
@@ -1,4 +1,4 @@
-/* A minimal CD-image reader over libchdr.
+/* A minimal disc-image reader over libchdr.
  *
  * The Dart side needs one primitive to hash a disc the way RetroAchievements
  * does: "give me the 2048 user-data bytes of logical sector N of track T".
@@ -43,7 +43,9 @@ extern "C" {
  * that is not the first one has to subtract this. */
 #define NCHD_FIELD_START_LBA 3
 
-/* Track modes. Anything that is not audio carries a filesystem. */
+/* Track modes. Anything that is not audio carries a filesystem. A DVD image
+ * has no track metadata to take a mode from and no sector headers either, so
+ * it is reported as the plain data track it reads as. */
 #define NCHD_MODE_AUDIO 0
 #define NCHD_MODE_MODE1 1
 #define NCHD_MODE_MODE2 2
@@ -52,7 +54,7 @@ extern "C" {
  * codec is a build problem to fix, a bad file is a ROM problem to report. */
 #define NCHD_OK 0
 #define NCHD_ERR_OPEN 1        /* the file could not be opened or is not a CHD */
-#define NCHD_ERR_NO_TRACKS 2   /* opened, but carries no CD track metadata */
+#define NCHD_ERR_NO_TRACKS 2   /* opened, but describes no readable track */
 #define NCHD_ERR_UNSUPPORTED 3 /* a codec this build cannot decompress */
 #define NCHD_ERR_MEMORY 4
 

--- a/test/chd_disc_image_test.dart
+++ b/test/chd_disc_image_test.dart
@@ -190,6 +190,67 @@ void main() {
     }, skip: skip);
   });
 
+  group('reading a DVD CHD', () {
+    test('reads a DVD image as the one flat track it is', () {
+      // `chdman createdvd` writes no track metadata at all and no sector
+      // headers either: frame N of the file is sector N of the disc, and its
+      // 2048 bytes are the user data. Reading one as a CD frame would drop the
+      // first 16 bytes of every sector and then run off the end of the frame —
+      // which is why every DVD-format PS2 CHD came back unhashed.
+      final payload = Uint8List.fromList(
+        List.generate(2048, (index) => index & 0xFF),
+      );
+      final disc = ChdDisc.open(
+        write(buildDvdChd(sectors: 40, data: {0: payload, 39: payload})),
+      );
+
+      expect(disc.tracks, hasLength(1));
+      expect(disc.tracks.single.number, 1);
+      expect(disc.tracks.single.isData, isTrue);
+      expect(disc.tracks.single.isMode2, isFalse);
+      expect(disc.tracks.single.sectors, 40);
+      expect(disc.tracks.single.startLba, 0);
+      // Byte for byte, including the 16 a CD sector would spend on a header.
+      expect(disc.readSector(0, 0), payload);
+      expect(disc.readSector(0, 39), payload);
+      expect(disc.readSector(0, 40), isNull, reason: 'past the disc');
+
+      disc.close();
+    }, skip: skip);
+
+    test('takes a 2048-byte unit as a DVD even with no tag', () {
+      // The tag says DVD, but a unit that is exactly one sector of user data
+      // already means the frames hold user data and nothing else. Requiring
+      // the tag would leave any image written without one unreadable.
+      final payload = Uint8List.fromList(List.filled(2048, 0x6D));
+      final disc = ChdDisc.open(
+        write(buildDvdChd(sectors: 8, data: {3: payload}, tagged: false)),
+      );
+
+      expect(disc.tracks, hasLength(1));
+      expect(disc.readSector(0, 3), payload);
+
+      disc.close();
+    }, skip: skip);
+
+    test('still reports a CHD that describes no track at all', () {
+      // A hard-disk image, or anything else with neither CD frames nor plain
+      // sectors, has to stay an open failure rather than be read as a disc.
+      expect(
+        () => ChdDisc.open(
+          write(buildDvdChd(sectors: 8, tagged: false, unitBytes: 2448)),
+        ),
+        throwsA(
+          isA<ChdException>().having(
+            (e) => e.error,
+            'error',
+            ChdOpenError.noTracks,
+          ),
+        ),
+      );
+    }, skip: skip);
+  });
+
   group('hashing a CHD end to end', () {
     test('produces the PlayStation hash from inside the image', () async {
       // The whole chain over a real container: hunk decompression, track
@@ -225,6 +286,40 @@ void main() {
           ...exeHeader,
           ...payload,
         ]).toString(),
+      );
+    }, skip: skip);
+
+    test('produces the PlayStation 2 hash from a DVD image', () async {
+      // The format most of a PS2 library is actually stored in. Everything
+      // above the reader is unchanged — the ISO9660 probe already expects flat
+      // 2048-byte sectors — so this is the container path end to end.
+      final executable = sector([0x7F, 0x45, 0x4C, 0x46]);
+      final path = write(
+        buildDvdChd(
+          sectors: 32,
+          data: {
+            16: volumeDescriptor(rootSector: 20, rootSize: 2048),
+            20: directory({
+              'SYSTEM.CNF;1': [22, 100],
+              'SLUS_202.02;1': [24, 2048],
+            }).first,
+            22: sector(
+              'BOOT2 = cdrom0:\\SLUS_202.02;1\r\nVER=1.00\r\n'.codeUnits,
+            ),
+            24: executable,
+          },
+        ),
+      );
+
+      final hash = await RaDiscHash.compute(RaHashAlgo.ps2, path);
+
+      expect(
+        hash,
+        crypto.md5
+            .convert(
+              ['SLUS_202.02'.codeUnits, executable].expand((e) => e).toList(),
+            )
+            .toString(),
       );
     }, skip: skip);
 
@@ -407,6 +502,69 @@ Uint8List buildChd({
   sectors.forEach((frame, data) {
     final start = dataStart + frame * _frameSize;
     bytes.setRange(start, start + data.length, data);
+  });
+
+  return bytes;
+}
+
+// --- Building a DVD CHD -----------------------------------------------------
+//
+// The other layout a CHD can hold, and the one `chdman createdvd` writes: no
+// track metadata, a `DVD ` tag with an empty payload, and the image stored as
+// an unbroken run of 2048-byte sectors.
+
+/// Builds an uncompressed DVD-format CHD of [sectors] sectors, with [data]
+/// placed by sector number.
+///
+/// [tagged] and [unitBytes] exist to cover what the reader has to decide from
+/// the header alone: an image written without the tag is still a DVD, and one
+/// whose unit is not a sector of user data is not.
+Uint8List buildDvdChd({
+  required int sectors,
+  Map<int, Uint8List> data = const {},
+  bool tagged = true,
+  int unitBytes = 2048,
+}) {
+  // Two sectors to a hunk, as `chdman createdvd` writes them: a 4096-byte
+  // hunk over a 2048-byte unit.
+  const framesPerHunk = 2;
+  final hunkBytes = unitBytes * framesPerHunk;
+  final logicalBytes = sectors * unitBytes;
+  final hunkCount = (logicalBytes + hunkBytes - 1) ~/ hunkBytes;
+
+  final dataStart = hunkBytes;
+  final bytes = Uint8List(dataStart + hunkCount * hunkBytes);
+  final view = ByteData.sublistView(bytes);
+
+  var offset = 124;
+  final metaOffset = offset;
+  if (tagged) {
+    // chdman writes the tag with an empty string, so the payload is that
+    // string's terminator and nothing else.
+    view.setUint32(offset, 0x44564420); // 'DVD '
+    view.setUint32(offset + 4, 1); // flags 0, length 1
+    view.setUint64(offset + 8, 0); // no entry after this one
+    bytes[offset + 16] = 0;
+    offset += 17;
+  }
+
+  final mapOffset = offset;
+  for (var hunk = 0; hunk < hunkCount; hunk++) {
+    view.setUint32(mapOffset + hunk * 4, hunk + 1);
+  }
+
+  bytes.setRange(0, 8, 'MComprHD'.codeUnits);
+  view.setUint32(8, 124); // header length
+  view.setUint32(12, 5); // version
+  view.setUint64(32, logicalBytes);
+  view.setUint64(40, mapOffset);
+  view.setUint64(48, tagged ? metaOffset : 0);
+  view.setUint32(56, hunkBytes);
+  view.setUint32(60, unitBytes);
+
+  data.forEach((sector, content) {
+    final start = dataStart + sector * unitBytes;
+    bytes.setRange(start, start + content.length, content);
   });
 
   return bytes;


### PR DESCRIPTION
# Description

A CHD holds one of two layouts, and the reader only understood the CD one. It enumerated
tracks from `CDROM_TRACK_METADATA2` / `CDROM_TRACK_METADATA` / `GDROM_TRACK_METADATA`, and a
DVD image carries none of those: `chdman createdvd` writes no track entry at all, only a
`DVD ` tag with an empty payload, and stores the disc as an unbroken run of 2048-byte sectors
with no sync pattern and no header.

So index 0 came back empty, the track count stayed at 0, the open failed with
`NCHD_ERR_NO_TRACKS`, and `RaDiscHash` logged "could not open" and gave up. Every DVD-format
PS2 CHD in a library was left unhashed and matched nothing. CD-format PS2 CHDs were correct
all along, which is why this got through #380: both PS2 discs in the test library happen to be
CD-format, so a DVD sample was never in the set.

There was a second half to it. Even with a track, `nchd_sector_data_offset` would have looked
for a sync pattern in a bare 2048-byte sector, not found one, returned 16 for mode 1, and then
tripped the `data_offset + 2048 > unit_bytes` guard and returned -3.

`nchd_add_dvd_track` now describes a DVD as the single flat track it is: one data track
spanning `logicalbytes / unitbytes` sectors, flagged `flat` so `nchd_read_sector` reads it
with no header to step over.

**The unit size decides it, not `DVD_METADATA_TAG`.** A unit of exactly one sector's worth of
user data can hold nothing but user data, the tag says no more than that, and not every writer
leaves one behind. Consulting the tag as well would be dead code: it cannot change the answer.
A container that turns out to carry no filesystem still fails where it already did, in the
ISO9660 probe.

Nothing above the reader changes. `hashPlaystation2` only ever asks a track for sectors and
the ISO9660 probe already expects flat 2048-byte ones, so this is container-level: PSP UMD
images stored the same way are covered by the same fix. Of the six disc algorithms (`psx`,
`ps2`, `psp`, `segacd`, `saturn`, `pcecd`), those two are the only ones that can present a DVD
layout, and both go through this reader.

**No migration, deliberately.** Precedent v134 had to un-park ROMs an earlier pass had marked
unhashable, since `getRomsNeedingRaHash` skips parked rows and would never revisit them. That
argument does not apply here: #380 has never shipped (newest tag `v0.10.0+125` is 2026-08-15,
the merge is 2026-08-18), so no user has run the disc hash pass in a release build and nobody
has DVD CHDs parked from it. Anyone on a dev or feature channel is covered by the existing
self-heal, which clears every skip when the candidate list comes up empty.

Related: #346. Follows #380.

## Steps to Verify

**Preconditions:** a PS2 system with at least one DVD-format `.chd`, i.e. one built with
`chdman createdvd` rather than `chdman createcd`. `chdman info` on it reports `Unit Size:
2,048` and `Metadata: Tag='DVD '` with no track entry; a CD-format one reports `Unit Size:
2,448` and one `CHT2` entry per track. Signed in to RetroAchievements.

1. Open the PS2 system and select the DVD-format game in the list.
2. Its achievement count appears in the detail panel instead of nothing.
3. Check the row: `ra_hash` is set, `ra_hash_skipped` is null, and `ra_match_source` is `hash`.
4. Confirm no `ChdException(noTracks)` or `RA disc: could not open` in `app.log`.
5. Repeat on a CD-format PS2 `.chd` to confirm it still matches as before.

On this branch, before the fix, step 2 shows nothing and step 4 finds the exception.

## Tested on

- [x] Android, device: AYN Thor (dev channel, release build)
- [ ] Linux, device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested, why:

Two real DVD-format PS2 CHDs on the Thor, both zstd-compressed, both previously unhashed:

| ROM | Hash | Matched |
| --- | --- | --- |
| `Burnout (USA).chd` (866 MB) | `3a66d06ceddac2fb4085eb495515915a` | RA 2693 "Burnout", 10 achievements |
| `Kuon (USA).chd` (855 MB) | `4d066b1c36d124505c0e5deca2d92118` | RA 19259 "Kuon", 92 achievements |

Both via the lazy per-ROM path, `ra_match_source = hash`, `ra_hash_skipped` null, nothing in
`app.log`. Header check on device first: unit `0x0800`, hunk `0x1000`, generic `zstd/zlib/huff/
flac` codecs, so a genuine DVD layout. The two CD-format PS2 CHDs already in that library
(`cdlz`, unit `0x0990`) keep their original hashes and matches.

Also verified locally against a `chdman createdvd` image built with MAME 0.289 (LZMA, 280 MB
source): the old library raises `ChdException(noTracks)`, the new one reports one track of
136,864 sectors matching chdman's own `Total Units`, and the PSP hash read out of the CHD is
identical to the one read out of the source ISO. Real CD-format CHDs re-checked for regression:
`Ace Combat 2` (psx) and `Lords of Thunder` (pcecd) both hash to a value present in
`assets/data/ra_insert.sql`.

## Checklist

- [x] `dart format .`, no diff
- [x] `flutter analyze`, clean (no errors *or* warnings)
- [x] `flutter test`, all passing (1350)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses (no new assets)

Tests live in `test/chd_disc_image_test.dart`: a `buildDvdChd` builder mirroring what chdman
actually writes (1-byte `DVD ` payload at metaoffset 124, 4096-byte hunks over 2048-byte
units), then a flat-track read asserting the sector comes back byte for byte including the 16 a
CD frame would spend on a header, the untagged-but-2048 case, a non-2048 unit still reporting
`noTracks`, and a PS2 hash end to end over a DVD container.

No schema change, no new user-facing strings, no `assets/systems/` or manifest change, no
navigation change, so the extra-checks sections do not apply beyond Android, covered above.
