### PR TITLE
feat(ra): keep RetroAchievements signed in when the network is unreachable

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -645,6 +645,7 @@ mixin AppLocale {
   static const String cancelScan = 'cancel_scan';
   static const String progress = 'progress';
   static const String raLogin = 'ra_login';
+  static const String raOfflineBanner = 'ra_offline_banner';
   static const String raWhatIs = 'ra_what_is';
   static const String raDescription = 'ra_description';
   static const String raEarnPoints = 'ra_earn_points';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -664,6 +664,8 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.cancelScan: 'Suche abbrechen',
   AppLocale.progress: 'Fortschritt',
   AppLocale.raLogin: 'RetroAchievements Login',
+  AppLocale.raOfflineBanner:
+      'Offline – zeigt deine zuletzt synchronisierten Erfolge',
   AppLocale.raWhatIs: 'Was ist RetroAchievements?',
   AppLocale.raDescription:
       'RetroAchievements ist eine Community, die Erfolge für klassische Spiele über Emulation anbietet.',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -642,6 +642,7 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.cancelScan: 'Cancel Scan',
   AppLocale.progress: 'Progress',
   AppLocale.raLogin: 'RetroAchievements Login',
+  AppLocale.raOfflineBanner: 'Offline — showing your last synced achievements',
   AppLocale.raWhatIs: 'What is RetroAchievements?',
   AppLocale.raDescription:
       'RetroAchievements is a community effort to provide achievements for classic games using emulators.',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -662,6 +662,8 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.cancelScan: 'Cancelar escaneo',
   AppLocale.progress: 'Progreso',
   AppLocale.raLogin: 'Login de RetroAchievements',
+  AppLocale.raOfflineBanner:
+      'Sin conexión: mostrando tus últimos logros sincronizados',
   AppLocale.raWhatIs: '¿Qué es RetroAchievements?',
   AppLocale.raDescription:
       'RetroAchievements es un esfuerzo comunitario para proporcionar logros en juegos clásicos mediante emuladores.',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -670,6 +670,8 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.cancelScan: 'Annuler l’Analyse',
   AppLocale.progress: 'Progression',
   AppLocale.raLogin: 'Connexion RetroAchievements',
+  AppLocale.raOfflineBanner:
+      'Hors ligne — affichage de vos derniers succès synchronisés',
   AppLocale.raWhatIs: 'Qu’est-ce que RetroAchievements ?',
   AppLocale.raDescription:
       'RetroAchievements est une communauté qui propose des succès pour les jeux classiques via l’émulation.',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -645,6 +645,8 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.cancelScan: 'Batalkan Pemindaian',
   AppLocale.progress: 'Kemajuan',
   AppLocale.raLogin: 'Login RetroAchievements',
+  AppLocale.raOfflineBanner:
+      'Offline — menampilkan pencapaian terakhir yang disinkronkan',
   AppLocale.raWhatIs: 'Apa itu RetroAchievements?',
   AppLocale.raDescription:
       'RetroAchievements adalah komunitas yang menawarkan pencapaian untuk game klasik melalui emulasi.',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -661,6 +661,8 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.cancelScan: 'Annulla Scansione',
   AppLocale.progress: 'Progresso',
   AppLocale.raLogin: 'Login RetroAchievements',
+  AppLocale.raOfflineBanner:
+      'Offline — mostra i tuoi ultimi obiettivi sincronizzati',
   AppLocale.raWhatIs: 'Cos’è RetroAchievements ?',
   AppLocale.raDescription:
       'RetroAchievements è una community che offre obiettivi per i giochi classici tramite emulazione.',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -582,6 +582,7 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.cancelScan: 'スキャンキャンセル',
   AppLocale.progress: '進捗',
   AppLocale.raLogin: 'RetroAchievementsログイン',
+  AppLocale.raOfflineBanner: 'オフライン — 最後に同期した実績を表示しています',
   AppLocale.raWhatIs: 'RetroAchievementsとは？',
   AppLocale.raDescription:
       'RetroAchievementsは、エミュレーションを通じてクラシックゲームに実績を提供するコミュニティです。',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -588,6 +588,7 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.cancelScan: '스캔 취소',
   AppLocale.progress: '진행상황',
   AppLocale.raLogin: 'RetroAchievements 로그인',
+  AppLocale.raOfflineBanner: '오프라인 — 마지막으로 동기화된 업적을 표시합니다',
   AppLocale.raWhatIs: 'RetroAchievements란?',
   AppLocale.raDescription:
       'RetroAchievements는 에뮬레이터로 즐기는 고전 게임에 업적 기능을 제공하는 커뮤니티 서비스입니다.',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -654,6 +654,8 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.cancelScan: 'Cancelar Varredura',
   AppLocale.progress: 'Progresso',
   AppLocale.raLogin: 'Login RetroAchievements',
+  AppLocale.raOfflineBanner:
+      'Offline — a mostrar as suas últimas conquistas sincronizadas',
   AppLocale.raWhatIs: 'O que é RetroAchievements?',
   AppLocale.raDescription:
       'RetroAchievements é uma comunidade que oferece conquistas para jogos clássicos via emulação.',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -652,6 +652,8 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.cancelScan: 'Отмена',
   AppLocale.progress: 'Прогресс',
   AppLocale.raLogin: 'Вход в RetroAchievements',
+  AppLocale.raOfflineBanner:
+      'Не в сети — показаны последние синхронизированные достижения',
   AppLocale.raWhatIs: 'Что такое RetroAchievements?',
   AppLocale.raDescription:
       'RetroAchievements — это сообщество, добавляющее достижения в классические игры.',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -573,6 +573,7 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.cancelScan: '取消扫描',
   AppLocale.progress: '进度',
   AppLocale.raLogin: 'RetroAchievements 登录',
+  AppLocale.raOfflineBanner: '离线 — 显示上次同步的成就',
   AppLocale.raWhatIs: '什么是 RetroAchievements？',
   AppLocale.raDescription: 'RetroAchievements 是一个通过模拟器为经典游戏提供成就的社区。',
   AppLocale.raEarnPoints: '赚取硬核积分并展示成就',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -573,6 +573,7 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.cancelScan: '取消掃描',
   AppLocale.progress: '進度',
   AppLocale.raLogin: 'RetroAchievements 登入',
+  AppLocale.raOfflineBanner: '離線 — 顯示上次同步的成就',
   AppLocale.raWhatIs: '什麼是 RetroAchievements？',
   AppLocale.raDescription: 'RetroAchievements 是一個透過模擬器為經典遊戲提供成就的社群。',
   AppLocale.raEarnPoints: '賺取硬核積分並展示成就',

--- a/lib/providers/retro_achievements_provider.dart
+++ b/lib/providers/retro_achievements_provider.dart
@@ -5,6 +5,7 @@ import 'package:neostation/services/logger_service.dart';
 import '../models/retro_achievements_user.dart';
 import '../models/retro_achievements_summary.dart';
 import '../services/retro_achievements_service.dart';
+import '../services/retro_achievements_cache.dart';
 import '../repositories/retro_achievements_repository.dart';
 import '../models/retro_achievements_dashboard_models.dart';
 import '../models/retro_achievements_game_info.dart';
@@ -127,6 +128,13 @@ class RetroAchievementsProvider extends ChangeNotifier {
   RetroAchievementsUser? get user => _user;
   bool get isLoading => _isLoading;
   bool get isConnected => _isConnected;
+
+  /// True while any part of the signed-in dashboard is being served from the
+  /// offline cache, so the UI can say the data is stale. Derived rather than
+  /// latched: each endpoint drops out of it the moment the API answers that
+  /// endpoint live again.
+  bool get isOffline =>
+      _isConnected && RetroAchievementsCache.anyServedFromCache;
   String? get error => _error;
   String get username => _username;
   String get apiKey => _apiKey;
@@ -570,6 +578,8 @@ class RetroAchievementsProvider extends ChangeNotifier {
     if (clearSavedUser) {
       _clearRAUserFromConfig();
       _clearRAApiKeyFromConfig();
+      // Drop cached API payloads so a different user can't see stale data.
+      unawaited(RetroAchievementsCache.clear());
     }
 
     notifyListeners();

--- a/lib/screens/retro_achievements_screen/ra_content.dart
+++ b/lib/screens/retro_achievements_screen/ra_content.dart
@@ -3,6 +3,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:provider/provider.dart';
 import '../../providers/retro_achievements_provider.dart';
+import '../../repositories/retro_achievements_repository.dart';
 import '../../widgets/confirm_action_dialog.dart';
 import '../../widgets/custom_notification.dart';
 import '../../responsive.dart';
@@ -60,6 +61,17 @@ class _RAContentState extends State<RAContent>
     attachFocusSelectionListeners();
     _dashboardScrollController.addListener(_releaseLogoutOnScroll);
     _initControllerNavigation();
+    _prefillUsername();
+  }
+
+  /// Pre-populates the username field with the last saved user so the form is
+  /// not blank after a failed auto-login (e.g. when the device is offline).
+  Future<void> _prefillUsername() async {
+    final saved = await RetroAchievementsRepository.getRAUser();
+    if (!mounted || saved == null || saved.isEmpty) return;
+    if (_usernameController.text.isEmpty) {
+      _usernameController.text = saved;
+    }
   }
 
   void _initControllerNavigation() {
@@ -309,6 +321,7 @@ class _RAContentState extends State<RAContent>
               ),
             ),
           ] else ...[
+            if (raProvider.isOffline) _buildOfflineBanner(context),
             Expanded(
               child: RepaintBoundary(
                 child: RADashboardHub(
@@ -319,6 +332,43 @@ class _RAContentState extends State<RAContent>
               ),
             ),
           ],
+        ],
+      ),
+    );
+  }
+
+  /// Slim banner shown above the dashboard when the session was signed in from
+  /// cached data because the network was unreachable at launch.
+  Widget _buildOfflineBanner(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: EdgeInsets.symmetric(horizontal: 16.r).copyWith(bottom: 8.r),
+      padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 8.r),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer.withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(10.r),
+        border: Border.all(
+          color: theme.colorScheme.secondary.withValues(alpha: 0.3),
+          width: 1.r,
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Symbols.cloud_off_rounded,
+            color: theme.colorScheme.secondary,
+            size: 18.r,
+          ),
+          SizedBox(width: 10.r),
+          Expanded(
+            child: Text(
+              AppLocale.raOfflineBanner.getString(context),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSecondaryContainer,
+                fontSize: 12.r,
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/services/retro_achievements_cache.dart
+++ b/lib/services/retro_achievements_cache.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as path;
+import 'package:neostation/services/config_service.dart';
+import 'package:neostation/services/logger_service.dart';
+
+/// On-disk cache of raw RetroAchievements API responses.
+///
+/// Each successful fetch stores the decoded JSON payload keyed by endpoint +
+/// username. When the network is unavailable the service layer replays the
+/// stored payload through the same `fromJson` parsers, so a signed-in user
+/// keeps a fully-populated (if stale) dashboard offline instead of being
+/// bounced back to the login form.
+///
+/// Only data that is safe to show while offline is cached here — never the
+/// API key (that lives in secure storage).
+class RetroAchievementsCache {
+  RetroAchievementsCache._();
+
+  static final _log = LoggerService.instance;
+  static String? _cachedDir;
+
+  /// Keys whose most recent cache-aware fetch was served from disk rather than
+  /// the live API. Tracked per key, not as a single "last fetch" flag: the
+  /// dashboard fires several endpoints concurrently, so a shared flag would
+  /// report whichever request happened to finish last.
+  static final Set<String> _servedFromCache = <String>{};
+
+  /// Whether the last completed fetch for [key] came from the offline cache.
+  static bool servedFromCache(String key) => _servedFromCache.contains(key);
+
+  /// Whether anything on screen is currently stale: true while at least one
+  /// endpoint's most recent fetch was replayed from disk. A live response
+  /// drops its own key, so this clears itself endpoint by endpoint as the
+  /// network comes back, without anyone having to reset a flag.
+  static bool get anyServedFromCache => _servedFromCache.isNotEmpty;
+
+  static void markServedFromCache(String key) => _servedFromCache.add(key);
+  static void markServedLive(String key) => _servedFromCache.remove(key);
+
+  static Future<String> _dir() async {
+    if (_cachedDir != null) return _cachedDir!;
+    final base = await ConfigService.getUserDataPath();
+    _cachedDir = path.join(base, 'ra_cache');
+    return _cachedDir!;
+  }
+
+  /// Points the cache at [directory] and forgets which keys were replayed.
+  /// Tests use this to exercise the store without a platform user-data path.
+  @visibleForTesting
+  static void setDirectoryForTesting(String? directory) {
+    _cachedDir = directory;
+    _servedFromCache.clear();
+  }
+
+  /// Filesystem-safe filename for a cache key.
+  static String _sanitize(String key) =>
+      key.replaceAll(RegExp(r'[^A-Za-z0-9_.-]'), '_');
+
+  static Future<File> _fileFor(String key) async {
+    final dir = await _dir();
+    return File(path.join(dir, '${_sanitize(key)}.json'));
+  }
+
+  /// Persists a decoded JSON [payload] under [key], overwriting any prior copy.
+  static Future<void> save(String key, dynamic payload) async {
+    try {
+      final file = await _fileFor(key);
+      await file.parent.create(recursive: true);
+      await file.writeAsString(json.encode(payload));
+    } catch (e) {
+      // A cache write failure must never break a live fetch — just log it.
+      _log.w('RA cache: failed to save "$key": $e');
+    }
+  }
+
+  /// Returns the decoded JSON payload stored under [key], or null if absent
+  /// or unreadable.
+  static Future<dynamic> load(String key) async {
+    try {
+      final file = await _fileFor(key);
+      if (!await file.exists()) return null;
+      return json.decode(await file.readAsString());
+    } catch (e) {
+      _log.w('RA cache: failed to load "$key": $e');
+      return null;
+    }
+  }
+
+  /// Removes every cached response (used when the user disconnects).
+  static Future<void> clear() async {
+    _servedFromCache.clear();
+    try {
+      final dir = Directory(await _dir());
+      if (await dir.exists()) await dir.delete(recursive: true);
+    } catch (e) {
+      _log.w('RA cache: failed to clear: $e');
+    }
+  }
+}

--- a/lib/services/retro_achievements_service.dart
+++ b/lib/services/retro_achievements_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:neostation/services/logger_service.dart';
+import 'retro_achievements_cache.dart';
 import '../models/retro_achievements_user.dart';
 import '../models/retro_achievements_summary.dart';
 import '../models/retro_achievements_game_info.dart';
@@ -28,6 +29,74 @@ class RetroAchievementsService {
 
   static final _log = LoggerService.instance;
 
+  /// Runs a cache-aware GET.
+  ///
+  /// On a successful (200) response the decoded body is stored under
+  /// [cacheKey] and parsed via [parse].
+  ///
+  /// The fallback is deliberately narrow: only a transport failure (offline,
+  /// DNS, timeout) or a 5xx replays the last cached body for [cacheKey]
+  /// through [parse]. A 4xx is an answer from the API, not an absence of
+  /// network — in particular 429 (Cloudflare rate limiting, which the
+  /// provider detects by the `(429)` in the thrown message) must reach the
+  /// caller rather than being masked by stale data that looks live.
+  ///
+  /// [onMiss] produces the caller's normal "nothing here" result (return null,
+  /// throw, etc.) and receives the status code when there was one, so error
+  /// messages keep carrying it. A bounded [timeout] keeps an unreachable
+  /// network from stalling the caller.
+  static Future<T> _fetchWithCache<T>({
+    required String cacheKey,
+    required Future<http.Response> Function() send,
+    required T Function(dynamic decoded) parse,
+    required T Function(int? statusCode) onMiss,
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    int? statusCode;
+    dynamic live;
+    var haveLive = false;
+    var apiAnswered = false;
+
+    // Nothing that decides the outcome may run inside this try: `onMiss` and
+    // `parse` both throw for several callers, and a throw caught here would
+    // silently divert them into the offline fallback.
+    try {
+      final response = await send().timeout(timeout);
+      statusCode = response.statusCode;
+      if (statusCode == 200) {
+        live = json.decode(response.body);
+        haveLive = true;
+      } else if (statusCode < 500) {
+        // Rate limiting, auth failures and not-found are real answers; let the
+        // caller surface them exactly as it did before caching existed.
+        _log.w('RA[$cacheKey] HTTP $statusCode; not serving cache');
+        apiAnswered = true;
+      } else {
+        _log.w('RA[$cacheKey] HTTP $statusCode; trying offline cache');
+      }
+    } catch (e) {
+      _log.w('RA[$cacheKey] request failed ($e); trying offline cache');
+    }
+
+    if (haveLive) {
+      // Parse before storing, so a body this build cannot read is never left
+      // behind to be replayed (and to fail again) the next time we go offline.
+      final result = parse(live);
+      await RetroAchievementsCache.save(cacheKey, live);
+      RetroAchievementsCache.markServedLive(cacheKey);
+      return result;
+    }
+    if (apiAnswered) return onMiss(statusCode);
+
+    final cached = await RetroAchievementsCache.load(cacheKey);
+    if (cached != null) {
+      _log.i('RA[$cacheKey] served from offline cache');
+      RetroAchievementsCache.markServedFromCache(cacheKey);
+      return parse(cached);
+    }
+    return onMiss(statusCode);
+  }
+
   /// Fetches the "Achievement of the Week" (GOTW) data.
   ///
   /// Optionally takes a [username] to include user-specific progress toward the achievement.
@@ -44,25 +113,25 @@ class RetroAchievementsService {
       '$_baseUrl/API_GetAchievementOfTheWeek.php',
     ).replace(queryParameters: {'y': effectiveApiKey});
 
-    final response = await http.get(
-      url,
-      headers: {'User-Agent': 'NeoStation/1.0', 'Accept': 'application/json'},
+    return _fetchWithCache<RetroAchievementsGOTW?>(
+      cacheKey: 'gotw',
+      send: () => http.get(
+        url,
+        headers: {'User-Agent': 'NeoStation/1.0', 'Accept': 'application/json'},
+      ),
+      parse: (data) {
+        if (data != null && data['Achievement'] != null) {
+          return RetroAchievementsGOTW.fromJson(data);
+        }
+        if (data != null && data['Error'] != null) {
+          _log.e('API Error: ${data['Error']}');
+        }
+        return null;
+      },
+      onMiss: (statusCode) => throw HttpException(
+        'RetroAchievements achievement of the week request failed (${statusCode ?? 'offline'})',
+      ),
     );
-
-    if (response.statusCode != 200) {
-      throw HttpException(
-        'RetroAchievements achievement of the week request failed (${response.statusCode})',
-      );
-    }
-
-    final data = json.decode(response.body);
-    if (data != null && data['Achievement'] != null) {
-      return RetroAchievementsGOTW.fromJson(data);
-    }
-    if (data != null && data['Error'] != null) {
-      _log.e('API Error: ${data['Error']}');
-    }
-    return null;
   }
 
   /// Mapping of NeoStation system identifiers to RetroAchievements console IDs.
@@ -103,33 +172,25 @@ class RetroAchievementsService {
     String username, {
     String? apiKey,
   }) async {
-    try {
-      final url = Uri.parse(
-        '$_baseUrl/API_GetUserProfile.php',
-      ).replace(queryParameters: {'u': username, 'y': resolveApiKey(apiKey)});
+    final url = Uri.parse(
+      '$_baseUrl/API_GetUserProfile.php',
+    ).replace(queryParameters: {'u': username, 'y': resolveApiKey(apiKey)});
 
-      final response = await http.get(
+    return _fetchWithCache<RetroAchievementsUser?>(
+      cacheKey: 'profile_$username',
+      send: () => http.get(
         url,
         headers: {'User-Agent': 'NeoStation/1.0', 'Accept': 'application/json'},
-      );
-
-      if (response.statusCode == 200) {
-        final data = json.decode(response.body);
-
-        if (data['User'] != null) {
+      ),
+      parse: (data) {
+        if (data != null && data['User'] != null) {
           return RetroAchievementsUser.fromJson(data);
-        } else {
-          _log.e('User not found: $username');
-          return null;
         }
-      } else {
-        _log.e('HTTP error ${response.statusCode}: ${response.body}');
+        _log.e('User not found: $username');
         return null;
-      }
-    } catch (e) {
-      _log.e('Error getting user profile: $e');
-      return null;
-    }
+      },
+      onMiss: (_) => null,
+    );
   }
 
   /// Checks if a username is registered on RetroAchievements.
@@ -145,19 +206,20 @@ class RetroAchievementsService {
     String username, {
     String? apiKey,
   }) async {
-    try {
-      final timestamp = DateTime.now().millisecondsSinceEpoch;
-      final url = Uri.parse('$_baseUrl/API_GetUserSummary.php').replace(
-        queryParameters: {
-          'u': username,
-          'g': '1', // Include recent games
-          'a': '2', // Include recent achievements
-          'y': resolveApiKey(apiKey),
-          '_t': timestamp.toString(),
-        },
-      );
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final url = Uri.parse('$_baseUrl/API_GetUserSummary.php').replace(
+      queryParameters: {
+        'u': username,
+        'g': '1', // Include recent games
+        'a': '2', // Include recent achievements
+        'y': resolveApiKey(apiKey),
+        '_t': timestamp.toString(),
+      },
+    );
 
-      final response = await http.get(
+    return _fetchWithCache<RetroAchievementsUserSummary?>(
+      cacheKey: 'summary_$username',
+      send: () => http.get(
         url,
         headers: {
           'User-Agent': 'NeoStation/1.0',
@@ -166,11 +228,8 @@ class RetroAchievementsService {
           'Pragma': 'no-cache',
           'Expires': '0',
         },
-      );
-
-      if (response.statusCode == 200) {
-        final data = json.decode(response.body);
-
+      ),
+      parse: (data) {
         if (data is Map && data['User'] != null) {
           return RetroAchievementsUserSummary.fromJson(
             data as Map<String, dynamic>,
@@ -184,18 +243,12 @@ class RetroAchievementsService {
           }
           _log.e('Unexpected response: list without valid data');
           return null;
-        } else {
-          _log.e('User not found or invalid response: $username');
-          return null;
         }
-      } else {
-        _log.e('HTTP error ${response.statusCode}: ${response.body}');
+        _log.e('User not found or invalid response: $username');
         return null;
-      }
-    } catch (e) {
-      _log.e('Error getting user summary: $e');
-      return null;
-    }
+      },
+      onMiss: (_) => null,
+    );
   }
 
   /// Retrieves detailed information for a specific game and the user's progress.
@@ -337,30 +390,30 @@ class RetroAchievementsService {
       'User-Agent': 'NeoStation/1.0',
       'Accept': 'application/json',
     };
-    final response = client == null
-        ? await http.get(url, headers: headers)
-        : await client.get(url, headers: headers);
 
-    if (response.statusCode != 200) {
-      throw HttpException(
-        'RetroAchievements recent achievements request failed (${response.statusCode})',
-      );
-    }
-
-    final decoded = json.decode(response.body);
-    if (decoded is! List) {
-      throw const FormatException(
-        'Invalid RetroAchievements recent achievements response',
-      );
-    }
-
-    return decoded
-        .map(
-          (item) => RetroAchievementRecentUnlockItem.fromJson(
-            Map<String, dynamic>.from(item as Map),
-          ),
-        )
-        .toList();
+    return _fetchWithCache<List<RetroAchievementRecentUnlockItem>>(
+      cacheKey: 'recent_unlocks_$username',
+      send: () => client == null
+          ? http.get(url, headers: headers)
+          : client.get(url, headers: headers),
+      parse: (decoded) {
+        if (decoded is! List) {
+          throw const FormatException(
+            'Invalid RetroAchievements recent achievements response',
+          );
+        }
+        return decoded
+            .map(
+              (item) => RetroAchievementRecentUnlockItem.fromJson(
+                Map<String, dynamic>.from(item as Map),
+              ),
+            )
+            .toList();
+      },
+      onMiss: (statusCode) => throw HttpException(
+        'RetroAchievements recent achievements request failed (${statusCode ?? 'offline'})',
+      ),
+    );
   }
 
   static Future<List<RetroAchievementRecentlyPlayedGameItem>>
@@ -385,30 +438,30 @@ class RetroAchievementsService {
       'User-Agent': 'NeoStation/1.0',
       'Accept': 'application/json',
     };
-    final response = client == null
-        ? await http.get(url, headers: headers)
-        : await client.get(url, headers: headers);
 
-    if (response.statusCode != 200) {
-      throw HttpException(
-        'RetroAchievements recently played request failed (${response.statusCode})',
-      );
-    }
-
-    final decoded = json.decode(response.body);
-    if (decoded is! List) {
-      throw const FormatException(
-        'Invalid RetroAchievements recently played response',
-      );
-    }
-
-    return decoded
-        .map(
-          (item) => RetroAchievementRecentlyPlayedGameItem.fromJson(
-            Map<String, dynamic>.from(item as Map),
-          ),
-        )
-        .toList();
+    return _fetchWithCache<List<RetroAchievementRecentlyPlayedGameItem>>(
+      cacheKey: 'recently_played_$username',
+      send: () => client == null
+          ? http.get(url, headers: headers)
+          : client.get(url, headers: headers),
+      parse: (decoded) {
+        if (decoded is! List) {
+          throw const FormatException(
+            'Invalid RetroAchievements recently played response',
+          );
+        }
+        return decoded
+            .map(
+              (item) => RetroAchievementRecentlyPlayedGameItem.fromJson(
+                Map<String, dynamic>.from(item as Map),
+              ),
+            )
+            .toList();
+      },
+      onMiss: (statusCode) => throw HttpException(
+        'RetroAchievements recently played request failed (${statusCode ?? 'offline'})',
+      ),
+    );
   }
 
   static Future<RetroAchievementCompletionProgressSummary>
@@ -433,25 +486,25 @@ class RetroAchievementsService {
       'User-Agent': 'NeoStation/1.0',
       'Accept': 'application/json',
     };
-    final response = client == null
-        ? await http.get(url, headers: headers)
-        : await client.get(url, headers: headers);
 
-    if (response.statusCode != 200) {
-      throw HttpException(
-        'RetroAchievements completion progress request failed (${response.statusCode})',
-      );
-    }
-
-    final decoded = json.decode(response.body);
-    if (decoded is! Map) {
-      throw const FormatException(
-        'Invalid RetroAchievements completion progress response',
-      );
-    }
-
-    return RetroAchievementCompletionProgressSummary.fromJson(
-      Map<String, dynamic>.from(decoded),
+    return _fetchWithCache<RetroAchievementCompletionProgressSummary>(
+      cacheKey: 'completion_$username',
+      send: () => client == null
+          ? http.get(url, headers: headers)
+          : client.get(url, headers: headers),
+      parse: (decoded) {
+        if (decoded is! Map) {
+          throw const FormatException(
+            'Invalid RetroAchievements completion progress response',
+          );
+        }
+        return RetroAchievementCompletionProgressSummary.fromJson(
+          Map<String, dynamic>.from(decoded),
+        );
+      },
+      onMiss: (statusCode) => throw HttpException(
+        'RetroAchievements completion progress request failed (${statusCode ?? 'offline'})',
+      ),
     );
   }
 
@@ -474,25 +527,23 @@ class RetroAchievementsService {
       },
     );
 
-    final response = await http.get(
-      url,
-      headers: {
-        'User-Agent': 'NeoStation/1.0',
-        'Accept': 'application/json',
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Pragma': 'no-cache',
-        'Expires': '0',
-      },
+    return _fetchWithCache<Map<String, dynamic>?>(
+      cacheKey: 'awards_$username',
+      send: () => http.get(
+        url,
+        headers: {
+          'User-Agent': 'NeoStation/1.0',
+          'Accept': 'application/json',
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0',
+        },
+      ),
+      parse: (data) => data as Map<String, dynamic>,
+      onMiss: (statusCode) => throw HttpException(
+        'RetroAchievements user awards request failed (${statusCode ?? 'offline'})',
+      ),
     );
-
-    if (response.statusCode != 200) {
-      throw HttpException(
-        'RetroAchievements user awards request failed (${response.statusCode})',
-      );
-    }
-
-    final data = json.decode(response.body);
-    return data as Map<String, dynamic>;
   }
 
   /// Searches for games by name within a specific console category.

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -37,8 +37,12 @@ class UpdateService {
       // 1. Resolve local versioning from the application manifest.
       final currentVersion = await _getAppVersion();
 
-      // 2. Poll GitHub API for the latest release metadata.
-      final response = await http.get(Uri.parse(_githubApiUrl));
+      // 2. Poll GitHub API for the latest release metadata. A bounded timeout
+      // keeps an offline/unreachable network from stalling the startup
+      // sequence, which defers the ROM scan until the update checks finish.
+      final response = await http
+          .get(Uri.parse(_githubApiUrl))
+          .timeout(const Duration(seconds: 10));
 
       if (response.statusCode != 200) {
         _log.e('UpdateService: API failure (Status: ${response.statusCode})');

--- a/test/retro_achievements_service_test.dart
+++ b/test/retro_achievements_service_test.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:neostation/models/retro_achievements_user_awards.dart';
+import 'package:neostation/services/retro_achievements_cache.dart';
 import 'package:neostation/services/retro_achievements_service.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -215,5 +218,143 @@ void main() {
         expect(completions.single.title, 'Softcore Game');
       },
     );
+
+    group('offline cache policy', () {
+      // One real API payload, reused so each test differs only in what the
+      // network does the second time round.
+      const recentlyPlayedBody =
+          '[{"GameID":11332,"ConsoleID":12,"ConsoleName":"PlayStation",'
+          '"Title":"Final Fantasy Origins","ImageIcon":"/Images/060249.png",'
+          '"ImageTitle":"/Images/026707.png",'
+          '"ImageIngame":"/Images/026708.png",'
+          '"ImageBoxArt":"/Images/046257.png",'
+          '"LastPlayed":"2023-10-27 00:30:04","AchievementsTotal":119,'
+          '"NumPossibleAchievements":119,"PossibleScore":945,'
+          '"NumAchieved":38,"ScoreAchieved":382,'
+          '"NumAchievedHardcore":38,"ScoreAchievedHardcore":382}]';
+
+      late Directory cacheDir;
+
+      setUp(() {
+        cacheDir = Directory.systemTemp.createTempSync('ra_cache_test');
+        RetroAchievementsCache.setDirectoryForTesting(cacheDir.path);
+      });
+
+      tearDown(() {
+        RetroAchievementsCache.setDirectoryForTesting(null);
+        if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
+      });
+
+      Future<void> primeCache(String username) async {
+        await RetroAchievementsService.getUserRecentlyPlayedGames(
+          username,
+          apiKey: 'secret-key',
+          client: MockClient(
+            (request) async => http.Response(recentlyPlayedBody, 200),
+          ),
+        );
+      }
+
+      test('replays the last good response when the network drops', () async {
+        await primeCache('Cached');
+        expect(
+          RetroAchievementsCache.servedFromCache('recently_played_Cached'),
+          isFalse,
+        );
+
+        final offline =
+            await RetroAchievementsService.getUserRecentlyPlayedGames(
+              'Cached',
+              apiKey: 'secret-key',
+              client: MockClient(
+                (request) async =>
+                    throw const SocketException('Network is unreachable'),
+              ),
+            );
+
+        expect(offline.single.title, 'Final Fantasy Origins');
+        expect(
+          RetroAchievementsCache.servedFromCache('recently_played_Cached'),
+          isTrue,
+        );
+      });
+
+      test('falls back to the cached copy on a 5xx', () async {
+        await primeCache('Flaky');
+
+        final served =
+            await RetroAchievementsService.getUserRecentlyPlayedGames(
+              'Flaky',
+              apiKey: 'secret-key',
+              client: MockClient(
+                (request) async => http.Response('Bad Gateway', 502),
+              ),
+            );
+
+        expect(served.single.gameId, 11332);
+        expect(
+          RetroAchievementsCache.servedFromCache('recently_played_Flaky'),
+          isTrue,
+        );
+      });
+
+      test(
+        'a rate-limited (429) reaches the caller even with a cached copy',
+        () async {
+          // The regression this guards: `onMiss` throws, so throwing it from
+          // inside the fallback's own try block sent 429s into the cache path
+          // and answered them with stale data that looked live. The provider
+          // recognises rate limiting by the "(429)" in the message, so the
+          // status code has to survive the cache layer.
+          await primeCache('Limited');
+
+          await expectLater(
+            RetroAchievementsService.getUserRecentlyPlayedGames(
+              'Limited',
+              apiKey: 'secret-key',
+              client: MockClient(
+                (request) async => http.Response('Too Many Requests', 429),
+              ),
+            ),
+            throwsA(
+              isA<HttpException>().having(
+                (e) => e.message,
+                'message',
+                contains('(429)'),
+              ),
+            ),
+          );
+          expect(
+            RetroAchievementsCache.servedFromCache('recently_played_Limited'),
+            isFalse,
+          );
+        },
+      );
+
+      test(
+        'a transport failure with no cached copy reports itself as offline',
+        () async {
+          final client = MockClient(
+            (request) async =>
+                throw const SocketException('Network is unreachable'),
+          );
+
+          await expectLater(
+            RetroAchievementsService.getUserRecentlyPlayedGames(
+              'Scott',
+              apiKey: 'secret-key',
+              client: client,
+            ),
+            throwsA(
+              isA<HttpException>().having(
+                (e) => e.message,
+                'message',
+                contains('(offline)'),
+              ),
+            ),
+          );
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
# Description

A signed-in RetroAchievements user was bounced back to the login form whenever the device had no
network at launch. It is most visible when NeoStation is the home launcher and cold-starts at boot,
before wifi associates: the RA tab shows the sign-in card, as if the account had been forgotten.

The dashboard's seven endpoints (profile, summary, recent unlocks, recently played, completion
progress, awards and Game of the Week) now go through one cache-aware fetch. Each successful
response is stored under `user-data/ra_cache/`, keyed by endpoint and username, and replayed
through the same `fromJson` parsers when the request cannot reach the API — so the session stays
signed in with a fully populated, if stale, dashboard.

**The fallback is deliberately narrow.** Only a transport failure (offline, DNS, timeout) or a 5xx
serves cached data. A 4xx is an answer from the API, so **429 still reaches the caller** rather than
being masked by stale data that looks live: the provider detects Cloudflare rate limiting by the
`(429)` in the thrown message, and losing that turns a visible "you are rate limited" into a
dashboard that quietly stops updating.

Alongside:

- **A banner above the dashboard while any of it is stale.** The state is derived from the cache
  rather than latched at login: an endpoint drops out of the stale set the moment the API answers
  it live, so the banner clears itself as the network returns instead of needing a flag reset. It
  is tracked per cache key, not as one "last fetch" flag, because the dashboard loads several
  endpoints in a row and a shared flag would report whichever finished last.
- **The login form pre-fills the last saved username**, so a failed auto-login does not leave it
  blank.
- **A bounded 10 s timeout on the update check.** Without it an unreachable network stalls the
  startup sequence, which defers the ROM scan until the update checks finish.

**Not cached, on purpose:** per-game info/progress and the achievement comment pages. Those are
per-title rather than a fixed set, so caching them wants a TTL and a bound on how many entries are
kept — follow-up work rather than something to bolt on here.

**Known limit, worth stating:** the dashboard loads once per session today, so in practice the
banner lasts until the next launch even if wifi associates a minute later. Clearing it sooner needs
a refresh affordance, which does not exist yet and is queued with the TTL work.

No schema change, no migration.

## Steps to Verify

**Preconditions:** an Android device signed in to RetroAchievements, with the RA dashboard having
loaded at least once while online.

1. Open the RetroAchievements tab while online and let the dashboard populate, then leave the tab.
   `user-data/ra_cache/` now holds seven JSON files.
2. Put the device in airplane mode.
3. Kill NeoStation and cold-start it.
4. Open the RetroAchievements tab. **Before:** the sign-in card, as though the account had been
   forgotten. **After:** the dashboard, populated from the last sync, under an
   "Offline — showing your last synced achievements" banner. Remote avatar and badge images fall
   back to placeholders, since those are network images.
5. Turn airplane mode off and relaunch. The dashboard loads live and the banner is gone.
6. Sign out. `user-data/ra_cache/` is deleted, so the next user cannot be shown the previous one's
   data.

Rate limiting is covered by tests rather than by hand — `test/retro_achievements_service_test.dart`,
"a rate-limited (429) reaches the caller even with a cached copy". That case is the one worth
guarding: the miss handler throws for several endpoints, so throwing it from inside the fetch's own
`try` sent 429s down the offline path and answered them with the cache.

## Tested on

- [x] Android — device: AYN Thor (dev channel, release build, md5-verified against the tree)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1352)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**User-facing text**
- [x] New key `raOfflineBanner` in `lib/l10n/app_locale.dart` and a value in all 12
  `app_locale_<lang>.dart` files
- [x] No hardcoded UI strings — everything goes through `AppLocale`

**The database**
- [x] N/A — no schema change, no migration, `_databaseVersion` untouched

**Navigation or a new screen**
- [x] N/A — the banner is non-interactive; no route and no focusable element added

**Android**
- [x] No path parsing changed; the cache directory comes from `ConfigService.getUserDataPath()`,
  the same resolver every other user-data file uses
- [x] Verified on a device

</details>
