### PR TITLE
fix(romm): keep the save a conflicting upload replaces

### DIFF
--- a/lib/sync/providers/romm_provider.dart
+++ b/lib/sync/providers/romm_provider.dart
@@ -52,6 +52,22 @@ typedef ResolveSaveTargets =
 /// Enumerates the local library, for the pending-upload sweep.
 typedef ListLocalGames = Future<List<GameModel>> Function();
 
+/// Outcome of the pre-upload check that protects a remote copy the local one is
+/// about to replace.
+enum _RemoteGuard {
+  /// The server holds nothing this device has not already accounted for, so the
+  /// upload is an ordinary one-sided change.
+  clear,
+
+  /// Both sides genuinely changed and the remote bytes were saved beside the
+  /// local file before the upload overwrote them.
+  preserved,
+
+  /// The remote copy could not be read, so it could not be protected. The
+  /// upload is abandoned for this pass rather than performed blind.
+  unreadable,
+}
+
 class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
   static const String kProviderId = 'romm';
 
@@ -292,6 +308,7 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
     final matchedRemote = <String>{};
     String remoteKey(RommAsset a) => '${a.isState ? 's' : 'f'}:${a.id}';
     int uploaded = 0, downloaded = 0, coreMismatched = 0;
+    int conflictsPreserved = 0;
     bool anyLocal = localFiles.isNotEmpty;
     bool anyRemote = remote.isNotEmpty;
 
@@ -425,6 +442,30 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
             continue;
           }
         }
+        // Both sides moved since this device last agreed with the server, and
+        // the gate above has ruled out the false alarms (identical bytes, an
+        // untouched local file). What is left is a real conflict, and pushing
+        // over it is what destroyed another device's state on `main`. The
+        // outcome still prefers local — the session that just ended wins — but
+        // the copy it replaces is kept first.
+        if (remoteChanged) {
+          final guard = await _guardDivergedRemote(
+            match,
+            local,
+            recordedHash: recorded?['file_hash'] as String?,
+            pushDigest: pushDigest,
+          );
+          if (guard == _RemoteGuard.unreadable) {
+            // Nothing recorded: the file stays pending and the next pass asks
+            // again, which is the non-destructive way to fail.
+            _log.w(
+              'RomM: leaving ${path.basename(local.filePath)} pending — the '
+              'remote copy it would replace could not be read',
+            );
+            continue;
+          }
+          if (guard == _RemoteGuard.preserved) conflictsPreserved++;
+        }
         if (await _upload(
           romId,
           local,
@@ -454,7 +495,8 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
     _log.i(
       'RomM sync ${game.romname}: $uploaded up, $downloaded down '
       '(${localFiles.length} local, ${remote.length} remote)'
-      '${coreMismatched > 0 ? ', $coreMismatched kept (different core)' : ''}',
+      '${coreMismatched > 0 ? ', $coreMismatched kept (different core)' : ''}'
+      '${conflictsPreserved > 0 ? ', $conflictsPreserved conflict backup(s)' : ''}',
     );
 
     // Playtime rides along with the upload-capable passes only. The pre-launch
@@ -515,7 +557,7 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
   /// saves matched by title id, neither of which carries the game's name in the
   /// filename — so it is left alone and tightened here, at RomM's door.
   ///
-  /// Two things get dropped:
+  /// Three things get dropped:
   ///
   /// * **Thumbnails.** A `.state.png` was being uploaded to RomM as a save
   ///   state. Confirmed on device: one play session produced four "states",
@@ -538,6 +580,15 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
     return found.where((f) {
       final name = path.basename(f.filePath);
       final lower = name.toLowerCase();
+
+      // Our own conflict backups. They begin with the game's name and continue
+      // with a dot, so every other rule here reads them as ordinary save data —
+      // and uploading a copy kept precisely because it was *not* this device's
+      // truth would undo the point of keeping it.
+      if (lower.contains(conflictBackupMarker)) {
+        _log.i('RomM: skipping conflict backup $name');
+        return false;
+      }
 
       if (_thumbnailExtensions.contains(path.extension(lower))) {
         _log.i('RomM: skipping thumbnail $name');
@@ -711,6 +762,14 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
   /// The local file's first four bytes, as a zip archive would start them.
   static const List<int> _zipMagic = [0x50, 0x4B, 0x03, 0x04];
 
+  /// Infix marking a conflict backup written by [_guardDivergedRemote].
+  ///
+  /// Deliberately not a plain extension swap: the file sits next to the save it
+  /// came from so the user can find it, and the full original name stays
+  /// visible in front of the marker (`Game.srm.romm-conflict-<stamp>`).
+  @visibleForTesting
+  static const String conflictBackupMarker = '.romm-conflict-';
+
   /// MD5 of the file at [filePath], or null when it cannot be read.
   ///
   /// MD5 because that is what RomM computes — `hashlib.md5` over the stored
@@ -782,6 +841,115 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
       _log.w('RomM zip probe failed ($filePath): $e');
       return false;
     }
+  }
+
+  /// Protects the server's copy of [match] from an upload of [local] that would
+  /// replace bytes this device has never seen.
+  ///
+  /// This is the narrowing of the "prefer local" tie-break. The branch that
+  /// calls it has always resolved a both-sides-changed pair by pushing the
+  /// local file over the remote one, on the reasoning that a session just
+  /// ended here. That reasoning is sound and is kept — what was wrong was the
+  /// *evidence*: "both changed" was an mtime answer, and the loser was
+  /// destroyed with no copy left anywhere. A hardware A/B confirmed it, a
+  /// second device's save state ceasing to exist on the server and on both
+  /// devices while the pass reported `1 up, 0 down`.
+  ///
+  /// So the question asked here is byte-level, and the answer only ever costs
+  /// the remote copy a read:
+  ///
+  /// * **[_RemoteGuard.clear]** — the server holds the very bytes this device
+  ///   recorded at its last sync, so nothing has diverged and the upload is an
+  ///   ordinary one-sided change. Also the answer when the server turns out to
+  ///   hold *our* new bytes already, which the upload would only rewrite.
+  /// * **[_RemoteGuard.preserved]** — the two really do differ. The remote
+  ///   bytes are written beside [local] under [conflictBackupMarker] and the
+  ///   upload then proceeds, so the outcome the user sees is unchanged and the
+  ///   copy that used to be destroyed is recoverable by hand.
+  /// * **[_RemoteGuard.unreadable]** — the remote copy could not be fetched.
+  ///   The caller abandons the upload for this pass; nothing is recorded, so
+  ///   the file stays pending and the next pass asks again. Non-destructive,
+  ///   which a blind overwrite would not be.
+  ///
+  /// [recordedHash] is the digest banked at the last sync and is the whole
+  /// basis for "has the *remote* moved": since #403 that column holds a hash
+  /// this provider computed, so it is comparable both with RomM's `content_hash`
+  /// for an ordinary save and with an MD5 of freshly fetched bytes. Without one
+  /// (a pair this device has never synced) nothing can be ruled out, and the
+  /// remote copy is preserved rather than assumed stale.
+  ///
+  /// The fetch is what makes this cover **states**, where RomM exposes no
+  /// `content_hash` at all and a zipped save's is entry-wise. Only the
+  /// post-close pass reaches here — the sweep bails on `uploadOnly &&
+  /// remoteChanged` before this point and the pre-launch pass never takes the
+  /// upload branch — so there is no launch deadline to spend it against.
+  Future<_RemoteGuard> _guardDivergedRemote(
+    RommAsset match,
+    LocalSaveFile local, {
+    required String? recordedHash,
+    required String? pushDigest,
+  }) async {
+    // Cheap path: RomM's own hash can rule divergence out without a transfer,
+    // but only where it is an MD5 of the stored bytes. States have none and a
+    // zip's is computed entry-wise, so both fall through to the fetch. Only
+    // equality is trusted here; "different" still needs the bytes, to keep.
+    final serverHash = match.contentHash;
+    if (recordedHash != null &&
+        recordedHash.isNotEmpty &&
+        !match.isState &&
+        serverHash != null &&
+        serverHash.isNotEmpty &&
+        serverHash.toLowerCase() == recordedHash &&
+        !await _looksZipped(local.filePath)) {
+      return _RemoteGuard.clear;
+    }
+
+    final Uint8List? bytes;
+    try {
+      bytes = await _fetchAssetBytes(match);
+    } catch (e) {
+      if (isPermissionDenied(e)) rethrow;
+      _log.e('RomM conflict guard: cannot read ${match.fileName}: $e');
+      return _RemoteGuard.unreadable;
+    }
+    if (bytes == null) return _RemoteGuard.unreadable;
+
+    final remoteDigest = md5.convert(bytes).toString();
+    // Unchanged since this device last agreed with the server, or already the
+    // bytes about to be pushed. Neither is a conflict.
+    if (remoteDigest == recordedHash || remoteDigest == pushDigest) {
+      return _RemoteGuard.clear;
+    }
+
+    try {
+      final backup = File(
+        '${local.filePath}$conflictBackupMarker${_backupStamp()}',
+      );
+      await backup.parent.create(recursive: true);
+      await backup.writeAsBytes(bytes, flush: true);
+      _log.w(
+        'RomM conflict: ${path.basename(local.filePath)} and the server both '
+        'changed since the last sync — kept the remote copy as '
+        '${path.basename(backup.path)} before uploading the local one',
+      );
+      return _RemoteGuard.preserved;
+    } catch (e) {
+      _log.e(
+        'RomM conflict guard: cannot write backup for ${local.filePath}: $e',
+      );
+      return _RemoteGuard.unreadable;
+    }
+  }
+
+  /// `2026-08-21_19-30-00`, for a conflict backup's filename.
+  ///
+  /// Local time, colon-free and sortable: it is read by a person looking in
+  /// their saves folder, not parsed by anything.
+  static String _backupStamp() {
+    final n = DateTime.now();
+    String p2(int v) => v.toString().padLeft(2, '0');
+    return '${n.year}-${p2(n.month)}-${p2(n.day)}_'
+        '${p2(n.hour)}-${p2(n.minute)}-${p2(n.second)}';
   }
 
   /// Records [local] as settled at [cloudUpdatedAt], no transfer having been
@@ -872,6 +1040,20 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
   /// written by a different core (see the guard below). Everything else — no
   /// target, an expired deadline, a newer local copy — is a routine `wrote:
   /// false`.
+  /// The bytes RomM holds for [asset], or null when they cannot be fetched.
+  ///
+  /// Both saves and states download via the asset's `download_path`; only saves
+  /// have the `/content` convenience route, used as a fallback. A state with no
+  /// `download_path` is unreadable, which is a server-side data problem rather
+  /// than something a caller can retry differently.
+  Future<Uint8List?> _fetchAssetBytes(RommAsset asset) async {
+    final dp = asset.downloadPath;
+    if (dp != null && dp.isNotEmpty) return _svc.downloadAssetByPath(dp);
+    if (!asset.isState) return _svc.downloadSaveContent(asset.id);
+    _log.w('RomM download: state ${asset.fileName} has no download_path');
+    return null;
+  }
+
   Future<({bool wrote, bool coreMismatch})> _download(
     GameModel game,
     RommAsset asset, {
@@ -898,18 +1080,8 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
         _log.w('RomM download: no local target for ${asset.fileName}');
         return (wrote: false, coreMismatch: false);
       }
-      // Both saves and states download via the asset's download_path; only
-      // saves have the /content convenience route (used as a fallback).
-      final Uint8List bytes;
-      final dp = asset.downloadPath;
-      if (dp != null && dp.isNotEmpty) {
-        bytes = await _svc.downloadAssetByPath(dp);
-      } else if (!asset.isState) {
-        bytes = await _svc.downloadSaveContent(asset.id);
-      } else {
-        _log.w('RomM download: state ${asset.fileName} has no download_path');
-        return (wrote: false, coreMismatch: false);
-      }
+      final bytes = await _fetchAssetBytes(asset);
+      if (bytes == null) return (wrote: false, coreMismatch: false);
 
       // Pre-launch deadline guard: the network fetch is done, but if the
       // launch-blocking wait has already elapsed the game is running on the

--- a/test/romm_conflict_backup_test.dart
+++ b/test/romm_conflict_backup_test.dart
@@ -1,0 +1,627 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/models/neo_sync_models.dart';
+import 'package:neostation/models/romm_asset.dart';
+import 'package:neostation/providers/neo_sync_provider.dart';
+import 'package:neostation/providers/romm_provider.dart';
+import 'package:neostation/repositories/romm_save_map_repository.dart';
+import 'package:neostation/repositories/sync_repository.dart';
+import 'package:neostation/services/neosync/neo_sync_service.dart';
+import 'package:neostation/services/romm_service.dart';
+import 'package:neostation/sync/providers/romm_provider.dart';
+
+import 'database_test_helper.dart';
+
+/// Narrowing the "prefer local" tie-break to genuine byte-level conflicts.
+///
+/// The post-close reconcile resolves a both-sides-changed pair by pushing the
+/// local file over the remote one, on the reasoning that a session just ended
+/// here. That outcome is kept. What was wrong was the evidence and the cost:
+/// "both changed" was an mtime answer, and the loser was destroyed with no copy
+/// anywhere. A hardware A/B confirmed it — a second device's save state ceased
+/// to exist on the server *and* on both devices while the pass reported
+/// `1 up, 0 down`.
+///
+/// So the question is asked at byte level, using the digest this provider now
+/// records for itself, and a remote copy that really has diverged is written
+/// beside the local file before the upload replaces it.
+///
+/// Each "a backup was written" assertion is paired with a case that must *not*
+/// write one, because a guard that over-fires turns every ordinary upload into
+/// litter in the user's saves folder.
+
+/// In-memory RomM server that models `content_hash` the way RomM computes it.
+class _FakeRommService extends RommService {
+  final Map<int, List<RommAsset>> savesByRom = {};
+  final Map<int, List<RommAsset>> statesByRom = {};
+  final Map<String, List<int>> contentByPath = {};
+
+  final List<String> creates = [];
+  final List<int> updates = [];
+  final List<String> downloads = [];
+
+  /// Makes every asset read fail, modelling a server that is reachable enough
+  /// to list but not to fetch from.
+  bool failDownloads = false;
+
+  int _nextAssetId = 1;
+  int _stampSeq = 0;
+
+  DateTime _stamp() =>
+      DateTime.now().toUtc().add(Duration(seconds: ++_stampSeq));
+
+  /// RomM's plain-file hash: `hashlib.md5` over the bytes as stored.
+  static String hashOf(List<int> bytes) => md5.convert(bytes).toString();
+
+  /// Plants a save as if another client uploaded it. [contentHash] defaults to
+  /// what RomM would compute; pass null for a pre-backfill row.
+  RommAsset seedSave(
+    int romId,
+    String fileName,
+    List<int> bytes, {
+    required DateTime updatedAt,
+    String? slot,
+    String? contentHash = '',
+  }) {
+    final path = 'assets/$romId/${_nextAssetId}_$fileName';
+    final asset = RommAsset(
+      id: _nextAssetId++,
+      fileName: fileName,
+      fileSizeBytes: bytes.length,
+      isState: false,
+      updatedAt: updatedAt,
+      slot: slot,
+      contentHash: contentHash == '' ? hashOf(bytes) : contentHash,
+      downloadPath: path,
+    );
+    contentByPath[path] = List.of(bytes);
+    (savesByRom[romId] ??= []).add(asset);
+    return asset;
+  }
+
+  /// Plants a state. `/api/states` never returns a `content_hash`, so this
+  /// deliberately cannot take one.
+  RommAsset seedState(
+    int romId,
+    String fileName,
+    List<int> bytes, {
+    required DateTime updatedAt,
+  }) {
+    final path = 'assets/$romId/${_nextAssetId}_$fileName';
+    final asset = RommAsset(
+      id: _nextAssetId++,
+      fileName: fileName,
+      fileSizeBytes: bytes.length,
+      isState: true,
+      updatedAt: updatedAt,
+      downloadPath: path,
+    );
+    contentByPath[path] = List.of(bytes);
+    (statesByRom[romId] ??= []).add(asset);
+    return asset;
+  }
+
+  /// Replaces the server's copy of [asset] as a second device would, moving
+  /// both the bytes and the stamp.
+  RommAsset otherDevicePut(int romId, RommAsset asset, List<int> bytes) {
+    final byRom = asset.isState ? statesByRom : savesByRom;
+    final list = byRom[romId]!;
+    final i = list.indexWhere((a) => a.id == asset.id);
+    final updated = RommAsset(
+      id: asset.id,
+      fileName: asset.fileName,
+      fileSizeBytes: bytes.length,
+      isState: asset.isState,
+      updatedAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+      slot: asset.slot,
+      contentHash: asset.isState ? null : hashOf(bytes),
+      downloadPath: asset.downloadPath,
+    );
+    contentByPath[asset.downloadPath!] = List.of(bytes);
+    list[i] = updated;
+    return updated;
+  }
+
+  /// Bumps a row's stamp without changing a byte — what a device that pulled
+  /// and re-pushed an unchanged file leaves behind.
+  RommAsset otherDeviceTouched(int romId, RommAsset asset) =>
+      otherDevicePut(romId, asset, contentByPath[asset.downloadPath!]!);
+
+  @override
+  bool get playtimeSyncAvailable => false;
+
+  @override
+  Future<List<RommAsset>> listSaves({required int romId}) async =>
+      List.of(savesByRom[romId] ?? const []);
+
+  @override
+  Future<List<RommAsset>> listStates({required int romId}) async =>
+      List.of(statesByRom[romId] ?? const []);
+
+  @override
+  Future<RommAsset> uploadSave(
+    int romId,
+    File file, {
+    String? emulator,
+    String? slot,
+    String? deviceId,
+    bool overwrite = true,
+  }) async {
+    final name = p.basename(file.path);
+    creates.add('$romId/$name');
+    return seedSave(romId, name, await file.readAsBytes(), updatedAt: _stamp());
+  }
+
+  @override
+  Future<RommAsset> uploadState(
+    int romId,
+    File file, {
+    String? emulator,
+    String? slot,
+    String? deviceId,
+    bool overwrite = true,
+  }) async {
+    final name = p.basename(file.path);
+    creates.add('$romId/$name');
+    return seedState(
+      romId,
+      name,
+      await file.readAsBytes(),
+      updatedAt: _stamp(),
+    );
+  }
+
+  @override
+  Future<RommAsset> updateSave(int assetId, File file) =>
+      _update(savesByRom, assetId, file, isState: false);
+
+  @override
+  Future<RommAsset> updateState(int assetId, File file) =>
+      _update(statesByRom, assetId, file, isState: true);
+
+  Future<RommAsset> _update(
+    Map<int, List<RommAsset>> byRom,
+    int assetId,
+    File file, {
+    required bool isState,
+  }) async {
+    for (final entry in byRom.entries) {
+      final i = entry.value.indexWhere((a) => a.id == assetId);
+      if (i < 0) continue;
+      final old = entry.value[i];
+      final bytes = await file.readAsBytes();
+      updates.add(assetId);
+      contentByPath[old.downloadPath!] = List.of(bytes);
+      // RomM's `update_save` re-scans the written file, so the row's hash and
+      // size follow the new bytes; `update_state` has no hash to re-scan.
+      final updated = RommAsset(
+        id: old.id,
+        fileName: old.fileName,
+        fileSizeBytes: bytes.length,
+        isState: old.isState,
+        updatedAt: _stamp(),
+        slot: old.slot,
+        contentHash: isState ? null : hashOf(bytes),
+        downloadPath: old.downloadPath,
+      );
+      entry.value[i] = updated;
+      return updated;
+    }
+    throw StateError('no asset with id $assetId');
+  }
+
+  @override
+  Future<Uint8List> downloadAssetByPath(String downloadPath) async {
+    if (failDownloads) throw const SocketException('server unreachable');
+    downloads.add(downloadPath);
+    return Uint8List.fromList(contentByPath[downloadPath]!);
+  }
+
+  @override
+  Future<Uint8List> downloadSaveContent(int assetId) async =>
+      throw UnimplementedError('tests always provide download_path');
+}
+
+class _FakeBrowse extends RommProvider {
+  final RommService fakeService;
+  bool connected = true;
+  _FakeBrowse(this.fakeService);
+
+  @override
+  bool get isConnected => connected;
+
+  @override
+  RommService get service => fakeService;
+}
+
+/// NeoSync path resolution over a temp directory holding both `saves/` and
+/// `states/`, statted live so mtime comparisons see the current file.
+class _TempSavePaths {
+  _TempSavePaths(this.root);
+
+  final String root;
+
+  Future<List<LocalSaveFile>> locate(GameModel game) async {
+    final out = <LocalSaveFile>[];
+    for (final kind in const ['saves', 'states']) {
+      final dir = Directory(p.join(root, kind));
+      if (!dir.existsSync()) continue;
+      for (final f in dir.listSync().whereType<File>()) {
+        final stat = f.statSync();
+        out.add(
+          LocalSaveFile(
+            filePath: f.path,
+            fileName: p.basename(f.path),
+            fileSize: stat.size,
+            lastModified: stat.modified,
+            gameName: game.name,
+            isSynced: false,
+            relativePath: '$kind/${p.basename(f.path)}',
+          ),
+        );
+      }
+    }
+    return RomMSyncProvider.syncableSaves(game, out);
+  }
+
+  Future<List<String>> resolveTargets(
+    GameModel game,
+    String relativeName,
+  ) async => [p.join(root, relativeName)];
+}
+
+GameModel _game(String romname) => GameModel(
+  romname: romname,
+  realname: romname,
+  name: p.basenameWithoutExtension(romname),
+  year: '1996',
+  developer: '',
+  publisher: '',
+  genre: '',
+  players: '',
+  rating: 0,
+  romPath: '/roms/nes/$romname',
+  systemFolderName: 'nes',
+  cloudSyncEnabled: true,
+);
+
+void main() {
+  final helper = DatabaseTestHelper();
+  late Directory tempDir;
+  late _FakeRommService svc;
+  late _FakeBrowse browse;
+  late _TempSavePaths paths;
+  late RomMSyncProvider provider;
+
+  final game = _game('Game.nes');
+
+  File localSave() => File(p.join(tempDir.path, 'saves', 'Game.srm'));
+  File localState() => File(p.join(tempDir.path, 'states', 'Game.state.auto'));
+
+  /// The conflict backups sitting beside a local file, newest name last.
+  List<File> backupsIn(String kind) =>
+      Directory(p.join(tempDir.path, kind))
+          .listSync()
+          .whereType<File>()
+          .where(
+            (f) => p
+                .basename(f.path)
+                .contains(RomMSyncProvider.conflictBackupMarker),
+          )
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+  /// Bumps a file's mtime without touching its bytes — what RetroArch does to
+  /// an auto save state on every exit, and well past the mtime tolerance.
+  Future<void> touch(File f) =>
+      f.setLastModified(DateTime.now().add(const Duration(minutes: 5)));
+
+  setUp(() async {
+    final db = await helper.setUp();
+    await db.execute(SqliteMigrations.createAppRommRomMapTableSql);
+    await db.execute(SqliteMigrations.createAppNeoSyncStateTableSql);
+    tempDir = await Directory.systemTemp.createTemp('romm_conflict_test');
+    await Directory(p.join(tempDir.path, 'saves')).create(recursive: true);
+    await Directory(p.join(tempDir.path, 'states')).create(recursive: true);
+
+    await RommSaveMapRepository.putMapping(
+      romname: 'Game.nes',
+      systemFolder: 'nes',
+      rommRomId: 1,
+    );
+
+    svc = _FakeRommService();
+    browse = _FakeBrowse(svc);
+    paths = _TempSavePaths(tempDir.path);
+    provider = RomMSyncProvider(
+      browse,
+      NeoSyncProvider(NeoSyncService()),
+      locateSaves: paths.locate,
+      resolveTargets: paths.resolveTargets,
+      listGames: () async => [game],
+      autoSweep: false,
+    );
+  });
+
+  tearDown(() async {
+    await helper.tearDown();
+    await tempDir.delete(recursive: true);
+  });
+
+  group('a genuine both-sides change keeps the copy it replaces', () {
+    test('a save the other device advanced is preserved before the local '
+        'one overwrites it', () async {
+      final asset = svc.seedSave(
+        1,
+        'Game.srm',
+        'SHARED'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+      await localSave().writeAsString('SHARED');
+      await provider.syncGameSavesAfterClose(game);
+
+      // While this device played, another finished its own session.
+      svc.otherDevicePut(1, asset, 'REMOTE-PROGRESS'.codeUnits);
+      await localSave().writeAsString('LOCAL-PROGRESS');
+      await touch(localSave());
+
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, [
+        asset.id,
+      ], reason: 'the session that just ended still wins');
+      expect(
+        String.fromCharCodes(svc.contentByPath[asset.downloadPath!]!),
+        'LOCAL-PROGRESS',
+      );
+
+      final backups = backupsIn('saves');
+      expect(backups, hasLength(1), reason: 'the loser must survive somewhere');
+      expect(await backups.single.readAsString(), 'REMOTE-PROGRESS');
+      expect(
+        p.basename(backups.single.path),
+        startsWith('Game.srm${RomMSyncProvider.conflictBackupMarker}'),
+        reason: 'the original name stays readable in front of the marker',
+      );
+    });
+
+    test('a state is covered too, which is where RomM offers no hash at '
+        'all', () async {
+      // The A/B case. `StateSchema` carries no content_hash, so the only way to
+      // know whether the server has moved is to read the bytes back.
+      await localState().writeAsString('STATE-A');
+      await provider.syncGameSavesAfterClose(game);
+      final asset = svc.statesByRom[1]!.single;
+
+      svc.otherDevicePut(1, asset, 'STATE-D-FROM-THE-OTHER-DEVICE'.codeUnits);
+      await localState().writeAsString('STATE-B');
+      await touch(localState());
+
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, [asset.id]);
+      final backups = backupsIn('states');
+      expect(backups, hasLength(1));
+      expect(
+        await backups.single.readAsString(),
+        'STATE-D-FROM-THE-OTHER-DEVICE',
+      );
+    });
+
+    test('a zip-shaped save is preserved on the fetched bytes, its server '
+        'hash being entry-wise', () async {
+      // RomM hashes an archive entry-wise, so the cheap comparison is refused
+      // and the guard must still reach the right answer via the download.
+      final zipA = <int>[0x50, 0x4B, 0x03, 0x04, 1, 2, 3];
+      final zipRemote = <int>[0x50, 0x4B, 0x03, 0x04, 9, 9, 9];
+      final zipLocal = <int>[0x50, 0x4B, 0x03, 0x04, 7, 7, 7];
+      final asset = svc.seedSave(
+        1,
+        'Game.srm',
+        zipA,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+      await localSave().writeAsBytes(zipA);
+      await provider.syncGameSavesAfterClose(game);
+
+      svc.otherDevicePut(1, asset, zipRemote);
+      await localSave().writeAsBytes(zipLocal);
+      await touch(localSave());
+
+      await provider.syncGameSavesAfterClose(game);
+
+      final backups = backupsIn('saves');
+      expect(backups, hasLength(1));
+      expect(await backups.single.readAsBytes(), zipRemote);
+    });
+  });
+
+  group('an ordinary upload writes no backup', () {
+    test(
+      'when the server holds exactly what this device last synced',
+      () async {
+        final asset = svc.seedSave(
+          1,
+          'Game.srm',
+          'SHARED'.codeUnits,
+          updatedAt: DateTime.utc(2026, 1, 1),
+        );
+        await localSave().writeAsString('SHARED');
+        await provider.syncGameSavesAfterClose(game);
+
+        // Only this device played.
+        await localSave().writeAsString('LOCAL-PROGRESS');
+        await touch(localSave());
+        await provider.syncGameSavesAfterClose(game);
+
+        expect(svc.updates, [asset.id]);
+        expect(backupsIn('saves'), isEmpty);
+      },
+    );
+
+    test('when the remote stamp moved but its bytes did not', () async {
+      // A device that pulled and re-pushed an unchanged file bumps updated_at
+      // and nothing else. That is not a conflict, and RomM's own hash says so
+      // without spending a download.
+      final asset = svc.seedSave(
+        1,
+        'Game.srm',
+        'SHARED'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+      await localSave().writeAsString('SHARED');
+      await provider.syncGameSavesAfterClose(game);
+
+      svc.otherDeviceTouched(1, asset);
+      await localSave().writeAsString('LOCAL-PROGRESS');
+      await touch(localSave());
+      svc.downloads.clear();
+
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, [asset.id]);
+      expect(backupsIn('saves'), isEmpty);
+      expect(
+        svc.downloads,
+        isEmpty,
+        reason: "RomM's content_hash answers this without a transfer",
+      );
+    });
+
+    test(
+      'when the server copy already holds the bytes about to be sent',
+      () async {
+        // Two devices that made the same move. There is nothing to preserve, and
+        // the earlier content-hash gate should have skipped the push anyway.
+        final asset = svc.seedSave(
+          1,
+          'Game.srm',
+          'SHARED'.codeUnits,
+          updatedAt: DateTime.utc(2026, 1, 1),
+        );
+        await localSave().writeAsString('SHARED');
+        await provider.syncGameSavesAfterClose(game);
+
+        svc.otherDevicePut(1, asset, 'SAME-MOVE'.codeUnits);
+        await localSave().writeAsString('SAME-MOVE');
+        await touch(localSave());
+
+        await provider.syncGameSavesAfterClose(game);
+
+        expect(backupsIn('saves'), isEmpty);
+      },
+    );
+  });
+
+  group('failing to protect the remote copy abandons the upload', () {
+    test('nothing is pushed, nothing is recorded, and the next pass '
+        'retries', () async {
+      final asset = svc.seedSave(
+        1,
+        'Game.srm',
+        'SHARED'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+      await localSave().writeAsString('SHARED');
+      await provider.syncGameSavesAfterClose(game);
+      final settled = await SyncRepository.getSyncState(
+        RomMSyncProvider.kProviderId,
+        localSave().path,
+      );
+
+      svc.otherDevicePut(1, asset, 'REMOTE-PROGRESS'.codeUnits);
+      await localSave().writeAsString('LOCAL-PROGRESS');
+      await touch(localSave());
+      svc.failDownloads = true;
+
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(
+        svc.updates,
+        isEmpty,
+        reason:
+            'a blind overwrite is the one thing '
+            'this must not do',
+      );
+      expect(
+        String.fromCharCodes(svc.contentByPath[asset.downloadPath!]!),
+        'REMOTE-PROGRESS',
+      );
+      expect(backupsIn('saves'), isEmpty);
+      final after = await SyncRepository.getSyncState(
+        RomMSyncProvider.kProviderId,
+        localSave().path,
+      );
+      expect(
+        after!['local_modified_at'],
+        settled!['local_modified_at'],
+        reason: 'recording the skip would settle a question nothing answered',
+      );
+
+      // The server comes back.
+      svc.failDownloads = false;
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(svc.updates, [asset.id]);
+      expect(backupsIn('saves'), hasLength(1));
+    });
+  });
+
+  group('the guard is scoped to the pass that has the authority', () {
+    test('the connect sweep leaves a contested file alone rather than '
+        'preserving and pushing it', () async {
+      // A sweep runs on connect with nothing to say the local copy is the newer
+      // *session*, so it defers to the post-close hook instead of resolving.
+      final asset = svc.seedSave(
+        1,
+        'Game.srm',
+        'SHARED'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+      await localSave().writeAsString('SHARED');
+      await provider.syncGameSavesAfterClose(game);
+
+      svc.otherDevicePut(1, asset, 'REMOTE-PROGRESS'.codeUnits);
+      await localSave().writeAsString('LOCAL-PROGRESS');
+      await touch(localSave());
+
+      await provider.retryPendingUploads();
+
+      expect(svc.updates, isEmpty);
+      expect(backupsIn('saves'), isEmpty);
+    });
+
+    test('a backup is never itself synced', () async {
+      final asset = svc.seedSave(
+        1,
+        'Game.srm',
+        'SHARED'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+      await localSave().writeAsString('SHARED');
+      await provider.syncGameSavesAfterClose(game);
+
+      svc.otherDevicePut(1, asset, 'REMOTE-PROGRESS'.codeUnits);
+      await localSave().writeAsString('LOCAL-PROGRESS');
+      await touch(localSave());
+      await provider.syncGameSavesAfterClose(game);
+      expect(backupsIn('saves'), hasLength(1));
+
+      svc.creates.clear();
+      await provider.syncGameSavesAfterClose(game);
+
+      expect(
+        svc.creates,
+        isEmpty,
+        reason: 'uploading the copy kept as the loser would undo the point',
+      );
+      expect(svc.savesByRom[1], hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
# Description

When a local save and the server's copy have both moved since this device last synced, the post-close reconcile pushes the local file over the remote one. That outcome is right: the session that just ended wins. The problem was the evidence and the cost. "Both changed" was an mtime comparison, and the losing copy was destroyed with nothing left anywhere.

A hardware A/B caught it on `main`: a second device's save state ceased to exist on the server *and* on both devices, while the pass reported `1 up, 0 down` as though it had succeeded.

#403 removed the false alarms (a file whose mtime moved but whose bytes did not) and so stopped the common case reaching this branch at all. It did not change what happens when both sides really have changed, which is the case that loses data. This PR does.

The question is now asked at byte level, using the digest #403 started recording, and the copy an upload replaces is kept:

- **RomM's own `content_hash` rules divergence out with no transfer** when it matches the hash banked at the last sync. Only equality is trusted: states have no `content_hash` and a zip's is computed entry-wise, so both fall through.
- **Otherwise the remote bytes are fetched and compared.** Different from both the recorded digest and the one about to be pushed means a real conflict, so they are written beside the local file as `<name>.romm-conflict-<stamp>` and the upload then proceeds.
- **If the remote copy cannot be read, the upload is abandoned** for that pass and nothing is recorded, so the file stays pending and the next pass asks again. A blind overwrite is the one thing this must not do.

The fetch is what makes this cover **save states**, where RomM exposes no `content_hash` at all. Only the post-close pass reaches it: the sweep already defers a contested file to the hook with the authority to settle it, and the pre-launch pass never takes the upload branch, so there is no launch deadline to spend the read against.

`syncableSaves` now drops these backups. They begin with the game's name and continue with a dot, so every other rule there read them as ordinary save data and would have uploaded the copy kept precisely because it was not this device's truth.

Background: this narrows the `localChanged && !downloadOnly` tie-break that #368 proposed removing by adopting `/sync/negotiate`. It gets that benefit without the protocol, the extra scopes or the whole-library round trip, and unlike `negotiate` it covers states.

No schema change, no new scopes, no migration. `app_neo_sync_state.file_hash` has held our own digest since #403.

## Steps to Reproduce

**Preconditions:** a RomM-linked game with a local save state and a server-side state asset (a real `app_romm_rom_map` row is required, or the game is silently skipped), plus a second client able to `PUT` to the same asset.

1. Sync the game so both sides hold identical state bytes **A** and a pass reports `0 up, 0 down`.
2. Launch the game.
3. While it runs, have the second device `PUT` state **D** to the server, and change the local state's bytes to **B** (a genuine change, not just a `touch`).
4. Close the game and let the post-close sync run.

On `main`: `1 up, 0 down`, the server ends on B, and **D no longer exists anywhere**.

## Steps to Verify

**Preconditions:** as above.

1. Repeat steps 1-4.
2. The post-close pass logs `1 up, 0 down (…), 1 conflict backup(s)` and a `RomM conflict:` warning naming the file it kept.
3. The server ends on **B** (local still wins, unchanged behaviour).
4. A file `<name>.romm-conflict-<stamp>` sits beside the local state and is byte-identical to **D**.
5. Restart the app and let the connect sweep run: it logs `skipping conflict backup <name>` and `nothing pending`, and the server still holds exactly the assets it had. The backup is never itself synced.

Also worth checking that it does **not** over-fire: with only the local side changed, or with the remote's timestamp moved but its bytes unchanged, the upload happens with no backup written and no download spent.

## Tested on

- [x] Android — device: AYN Thor (dev channel), against a live RomM 5.1.0 server
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Device run, both sides genuinely changed:

| | post-close | server after | the other device's state survives? |
|---|---|---|---|
| build without the guard | `1 up, 0 down` | local bytes | **no, destroyed** |
| this PR | `1 up, 0 down`, `1 conflict backup(s)` | local bytes | **yes**, on disk byte-exact |

`app_neo_sync_state` settles correctly afterwards (size and `file_hash` follow the uploaded bytes, cloud stamp advanced), so the pair is not left stranded.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1361)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**User-facing text**
- No new UI strings. The conflict is reported through `_log` only, which is exempt.

**The database**
- No schema change. `app_neo_sync_state.file_hash` has existed since v111 and has held a digest we compute since #403.

**Android**
- [x] Verified on a device, not only on desktop
- The backup path is built from the local file's own path, so it inherits whatever form that already had; no new path parsing.

</details>

## Tests

`test/romm_conflict_backup_test.dart`, 9 tests against an in-memory RomM that models `content_hash` the way RomM computes it. Every "a backup was written" case is paired with one that must **not** write one, because a guard that over-fires litters the user's saves folder.

Covered: a save, a state and a zip-shaped save all preserved before the local copy overwrites them; no backup when the server holds what was last synced, when the remote stamp moved but its bytes did not (asserting no download is spent there), or when the server already holds the bytes being pushed; the unreadable-remote case end to end, including that nothing is recorded and the next pass retries; the sweep deferring instead of resolving; and a backup never being synced itself.

Neutralising the guard fails exactly the five conflict tests and leaves the four over-fire guards passing.
