### PR TITLE
fix(ra): re-read achievement progress after a game session

### DIFF
--- a/lib/providers/retro_achievements_provider.dart
+++ b/lib/providers/retro_achievements_provider.dart
@@ -11,6 +11,7 @@ import '../models/retro_achievements_dashboard_models.dart';
 import '../models/retro_achievements_game_info.dart';
 import '../models/retro_achievements_gotw.dart';
 import '../models/retro_achievements_user_awards.dart';
+import '../services/game/game_session_manager.dart';
 import 'retro_achievements_credentials.dart';
 
 /// Provider responsible for managing the integration with RetroAchievements.org.
@@ -18,6 +19,16 @@ import 'retro_achievements_credentials.dart';
 /// Handles user authentication, profile synchronization, achievement progress
 /// tracking, and ROM identification via console-specific hashing algorithms.
 class RetroAchievementsProvider extends ChangeNotifier {
+  RetroAchievementsProvider() {
+    GameSessionManager.addSessionEndListener(invalidateCachedReads);
+  }
+
+  @override
+  void dispose() {
+    GameSessionManager.removeSessionEndListener(invalidateCachedReads);
+    super.dispose();
+  }
+
   static const String _dashboardApiKeyError =
       'A RetroAchievements web API key is required for this dashboard data.';
 
@@ -196,6 +207,14 @@ class RetroAchievementsProvider extends ChangeNotifier {
   OwnedWeekGameResolution? get ownedWeekGame => _ownedWeekGame;
   bool get hasResolvedApiKey =>
       RetroAchievementsService.resolveApiKey(_apiKey).trim().isNotEmpty;
+
+  /// Whether any dashboard section is currently in flight.
+  bool get isDashboardLoading =>
+      _recentUnlocksLoading ||
+      _recentlyPlayedLoading ||
+      _userAwardsLoading ||
+      _completionProgressLoading ||
+      _gotwLoading;
 
   bool get dashboardLoaded =>
       _recentUnlocksLoaded &&
@@ -455,6 +474,73 @@ class RetroAchievementsProvider extends ChangeNotifier {
       _log.e('$_error');
       return null;
     }
+  }
+
+  /// Incremented by every [invalidateCachedReads]. A mounted dashboard watches
+  /// this rather than the `*Loaded` flags: the flags cannot distinguish "was
+  /// invalidated" from "the last load failed", so reacting to them would retry
+  /// a failing section forever. A counter changes only when someone actually
+  /// asked for fresh data.
+  int _cacheGeneration = 0;
+  int get cacheGeneration => _cacheGeneration;
+
+  /// How long a dashboard read stays good enough to show without re-fetching.
+  ///
+  /// Entering the RetroAchievements tab re-reads anything older than this, so
+  /// leaving the tab and coming back is the way to refresh — there is no
+  /// refresh control, and a gamepad launcher is a poor place to hunt for one.
+  /// Long enough that walking between tabs costs nothing, short enough that
+  /// achievements earned on another device, or a section that failed the first
+  /// time, are not stuck until the app restarts.
+  static const Duration dashboardStaleAfter = Duration(minutes: 2);
+
+  /// When the dashboard last finished a load *attempt*. Set whether or not the
+  /// sections succeeded, so a failing endpoint is retried on the next entry
+  /// rather than on every entry.
+  DateTime? _dashboardAttemptedAt;
+
+  /// Whether entering the tab should re-read the dashboard.
+  bool get dashboardIsStale =>
+      _dashboardAttemptedAt == null ||
+      DateTime.now().difference(_dashboardAttemptedAt!) > dashboardStaleAfter;
+
+  /// Records that a dashboard load attempt has just finished.
+  void markDashboardAttempted() => _dashboardAttemptedAt = DateTime.now();
+
+  /// Drops every cached RetroAchievements read so the next look re-fetches.
+  ///
+  /// [_gameInfoCache] and the dashboard's `*Loaded` flags both live for the
+  /// whole app session and are only cleared on [disconnect]. That is right
+  /// while browsing the library — it is what stops a grid of tiles hammering
+  /// the API — and wrong the moment the player has actually been playing: the
+  /// emulator submits their unlocks to RetroAchievements, but NeoStation would
+  /// go on showing the pre-session achievement list and the pre-session
+  /// dashboard until the app was restarted.
+  ///
+  /// The whole per-game map goes rather than one entry: mapping the finished
+  /// game back to its RetroAchievements id means a resolve on the game-exit
+  /// path, and the cost of being wrong here (stale progress the user just
+  /// earned) is worse than the cost of being thorough (one re-fetch per game
+  /// they next open).
+  ///
+  /// Also resets the staleness clock, so this beats [dashboardStaleAfter]: a
+  /// session that ended ten seconds ago still forces a re-read.
+  void invalidateCachedReads() {
+    _cacheGeneration++;
+    _dashboardAttemptedAt = null;
+    // Infrequent (a finished session, or a sign-out) and the only trace this
+    // leaves, so it is worth a line: without it there is no way to tell a
+    // dashboard that reloaded because the player just finished a game from one
+    // that reloaded because it aged out.
+    _log.i('RA: cached reads invalidated (generation $_cacheGeneration)');
+    _gameInfoCache.clear();
+    _summaryLoaded = false;
+    _gotwLoaded = false;
+    _userAwardsLoaded = false;
+    _recentUnlocksLoaded = false;
+    _recentlyPlayedLoaded = false;
+    _completionProgressLoaded = false;
+    notifyListeners();
   }
 
   /// Initializes the provider and attempts automatic login with stored credentials.

--- a/lib/screens/retro_achievements_screen/ra_dashboard.dart
+++ b/lib/screens/retro_achievements_screen/ra_dashboard.dart
@@ -39,7 +39,19 @@ class _RADashboardHubState extends State<RADashboardHub> {
   /// is just quickly passing through this tab.
   Timer? _dashboardLoadTimer;
 
+  /// The provider this hub is subscribed to, and the invalidation generation
+  /// it has already acted on. Watching the generation is what makes a refresh
+  /// work while the hub is mounted: [didChangeDependencies] runs once, so a
+  /// finished game session (or the refresh button) would otherwise drop the
+  /// loaded flags with nothing left to notice.
+  RetroAchievementsProvider? _provider;
+  int _seenCacheGeneration = 0;
+
   Future<void> _loadDashboard(RetroAchievementsProvider provider) async {
+    // Stamped up front, not on completion: the five fetches below take a while
+    // and the stamp is what stops a second entry starting a duplicate run
+    // while this one is still going.
+    provider.markDashboardAttempted();
     // Load sequentially rather than with Future.wait: firing all five RA
     // endpoints at once trips the RetroAchievements API rate limiter (HTTP 429),
     // which left sections such as "Recent Masteries" stuck loading. Each section
@@ -55,13 +67,21 @@ class _RADashboardHubState extends State<RADashboardHub> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final provider = context.read<RetroAchievementsProvider>();
+    if (!identical(provider, _provider)) {
+      _provider?.removeListener(_onProviderChanged);
+      _provider = provider;
+      _seenCacheGeneration = provider.cacheGeneration;
+      provider.addListener(_onProviderChanged);
+    }
+    // Entering the tab re-reads anything past its staleness window, which is
+    // what stands in for a refresh control: leaving and coming back is the
+    // gesture. Without it the dashboard was a once-per-app-session snapshot —
+    // a section that failed, an unlock earned on another device, or the
+    // offline banner from a launch with no network, all stuck until restart.
     if (!_requestedInitialLoad &&
         provider.isConnected &&
-        !provider.dashboardLoaded &&
-        !provider.recentUnlocksLoading &&
-        !provider.recentlyPlayedLoading &&
-        !provider.completionProgressLoading &&
-        !provider.gotwLoading) {
+        (!provider.dashboardLoaded || provider.dashboardIsStale) &&
+        !provider.isDashboardLoading) {
       _requestedInitialLoad = true;
       _dashboardLoadTimer?.cancel();
       _dashboardLoadTimer = Timer(const Duration(milliseconds: 300), () {
@@ -70,9 +90,26 @@ class _RADashboardHubState extends State<RADashboardHub> {
     }
   }
 
+  /// Reloads when the cached reads have been invalidated under us — after a
+  /// game session, or when the user pressed refresh. Deliberately keyed to the
+  /// generation counter and not to `dashboardLoaded`: a section that failed
+  /// leaves that flag false too, and retrying on it would loop.
+  void _onProviderChanged() {
+    final provider = _provider;
+    if (provider == null || !mounted) return;
+    if (provider.cacheGeneration == _seenCacheGeneration) return;
+    _seenCacheGeneration = provider.cacheGeneration;
+    if (!provider.isConnected) return;
+    _dashboardLoadTimer?.cancel();
+    _requestedInitialLoad = true;
+    // ignore: unawaited_futures
+    _loadDashboard(provider);
+  }
+
   @override
   void dispose() {
     _dashboardLoadTimer?.cancel();
+    _provider?.removeListener(_onProviderChanged);
     super.dispose();
   }
 

--- a/lib/services/game/game_session_manager.dart
+++ b/lib/services/game/game_session_manager.dart
@@ -90,6 +90,40 @@ class GameSessionManager {
     _onProcessExitCallback = null;
   }
 
+  /// Listeners notified once a session has been finalized.
+  ///
+  /// Separate from [_onProcessExitCallback] and [_onGameReturnedCallback],
+  /// which are single-slot and owned by whichever screen launched the game.
+  /// This is a broadcast for state that is not tied to a launch site — anything
+  /// cached about the player's progress is stale the moment they stop playing,
+  /// whichever screen started the game and whichever platform ended it. Every
+  /// launcher funnels its exit through [endGameSession], so registering here
+  /// covers them all.
+  static final List<VoidCallback> _sessionEndListeners = <VoidCallback>[];
+
+  static void addSessionEndListener(VoidCallback listener) {
+    if (!_sessionEndListeners.contains(listener)) {
+      _sessionEndListeners.add(listener);
+    }
+  }
+
+  static void removeSessionEndListener(VoidCallback listener) {
+    _sessionEndListeners.remove(listener);
+  }
+
+  /// Fires every session-end listener, isolating them from each other: this
+  /// runs on the game-exit path, which already has UI waiting on it, so one
+  /// listener throwing must not skip the rest or fail the teardown.
+  static void _notifySessionEnded() {
+    for (final listener in List<VoidCallback>.from(_sessionEndListeners)) {
+      try {
+        listener();
+      } catch (e) {
+        _log.e('Session-end listener failed: $e');
+      }
+    }
+  }
+
   /// Recovers playtime from a previously interrupted game session.
   ///
   /// Handles cases where the application was terminated by the OS (Android)
@@ -246,6 +280,8 @@ class GameSessionManager {
     _launchedEmulatorExe = null;
     _currentGameSystem = null;
     _currentGame = null;
+
+    _notifySessionEnded();
   }
 
   static Future<void> _savePlayTime(

--- a/test/ra_stale_after_session_test.dart
+++ b/test/ra_stale_after_session_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/models/retro_achievements_game_info.dart';
+import 'package:neostation/models/system_model.dart';
+import 'package:neostation/providers/retro_achievements_provider.dart';
+import 'package:neostation/services/game/game_session_manager.dart';
+
+/// The player earns achievements in the emulator, not in NeoStation, so every
+/// RetroAchievements read the app is holding is stale the moment a session
+/// ends. Both caches that serve those reads live for the whole app session and
+/// were only ever cleared on sign-out, so the achievement list and the
+/// dashboard kept showing pre-session state until the app was restarted.
+void main() {
+  const system = SystemModel(
+    folderName: 'gg',
+    realName: 'Game Gear',
+    iconImage: '',
+    color: '#7E57C2',
+  );
+
+  // romPath stays null so ending the session touches no repository: the
+  // playtime write and the RomM record are both skipped for a session with no
+  // path and no elapsed seconds, which leaves the notification as the only
+  // thing under test.
+  const game = GameModel(
+    romname: 'Sonic The Hedgehog.gg',
+    realname: 'Sonic The Hedgehog',
+    name: 'Sonic The Hedgehog',
+    year: '1991',
+    developer: '',
+    publisher: '',
+    genre: '',
+    players: '1',
+    rating: 0,
+  );
+
+  Future<void> playAndExit() async {
+    GameSessionManager.registerGameLaunch(system, game);
+    await GameSessionManager.endGameSession();
+  }
+
+  group('cached RetroAchievements reads after a game session', () {
+    test('a finished session invalidates the provider', () async {
+      final provider = RetroAchievementsProvider();
+      addTearDown(provider.dispose);
+
+      final before = provider.cacheGeneration;
+      await playAndExit();
+
+      expect(
+        provider.cacheGeneration,
+        greaterThan(before),
+        reason: 'ending a session must drop what the provider cached',
+      );
+    });
+
+    test('the per-game achievement cache is emptied', () async {
+      final provider = RetroAchievementsProvider();
+      addTearDown(provider.dispose);
+
+      // The map is the live cache, so seeding it stands in for having opened a
+      // game's achievements before playing it.
+      provider.gameInfoCache[1516] = GameInfoAndUserProgress.fromJson(const {
+        'ID': 1516,
+        'Title': 'Sonic The Hedgehog',
+      });
+      expect(provider.gameInfoCache, isNotEmpty);
+
+      await playAndExit();
+
+      expect(provider.gameInfoCache, isEmpty);
+    });
+
+    test('a finished session marks the dashboard stale immediately', () async {
+      final provider = RetroAchievementsProvider();
+      addTearDown(provider.dispose);
+
+      provider.markDashboardAttempted();
+      expect(
+        provider.dashboardIsStale,
+        isFalse,
+        reason: 'a load that just finished is inside the staleness window',
+      );
+
+      await playAndExit();
+
+      expect(
+        provider.dashboardIsStale,
+        isTrue,
+        reason:
+            'a finished session has to beat the staleness window, not '
+            'wait it out',
+      );
+    });
+
+    test('an unread dashboard starts stale', () {
+      final provider = RetroAchievementsProvider();
+      addTearDown(provider.dispose);
+
+      expect(provider.dashboardIsStale, isTrue);
+    });
+
+    test('listeners are told, so a mounted dashboard can reload', () async {
+      final provider = RetroAchievementsProvider();
+      addTearDown(provider.dispose);
+
+      var notified = 0;
+      void listener() => notified++;
+      provider.addListener(listener);
+      addTearDown(() => provider.removeListener(listener));
+
+      await playAndExit();
+
+      expect(notified, greaterThan(0));
+    });
+
+    test('a disposed provider is not notified', () async {
+      final provider = RetroAchievementsProvider();
+      provider.dispose();
+
+      // Without the unsubscribe in dispose this throws: notifyListeners on a
+      // disposed ChangeNotifier is an error, and the session manager holds a
+      // static reference that outlives any one provider.
+      await expectLater(playAndExit(), completes);
+    });
+  });
+
+  group('session-end listeners', () {
+    test('one listener throwing does not stop the rest', () async {
+      var second = 0;
+      void bad() => throw StateError('boom');
+      void good() => second++;
+
+      GameSessionManager.addSessionEndListener(bad);
+      GameSessionManager.addSessionEndListener(good);
+      addTearDown(() {
+        GameSessionManager.removeSessionEndListener(bad);
+        GameSessionManager.removeSessionEndListener(good);
+      });
+
+      await playAndExit();
+
+      expect(second, 1);
+    });
+
+    test('a removed listener stops being called', () async {
+      var calls = 0;
+      void listener() => calls++;
+
+      GameSessionManager.addSessionEndListener(listener);
+      await playAndExit();
+      expect(calls, 1);
+
+      GameSessionManager.removeSessionEndListener(listener);
+      await playAndExit();
+      expect(calls, 1);
+    });
+
+    test('registering the same listener twice still calls it once', () async {
+      var calls = 0;
+      void listener() => calls++;
+
+      GameSessionManager.addSessionEndListener(listener);
+      GameSessionManager.addSessionEndListener(listener);
+      addTearDown(() => GameSessionManager.removeSessionEndListener(listener));
+
+      await playAndExit();
+
+      expect(calls, 1);
+    });
+  });
+}


### PR DESCRIPTION
# Description

Achievements are earned in the emulator, not in NeoStation, so everything the app holds about the
player's progress is stale the moment they stop playing. Both caches that serve it lived for the
whole app session and were only ever cleared on sign-out:

- **the per-game map** behind the achievements dialog and the footer pill
  (`RetroAchievementsProvider._gameInfoCache`), which the dialog reads with `forceRefresh: false`;
- **the dashboard**, whose per-section `*Loaded` flags are checked once, when the hub mounts.

So a player could unlock three achievements, exit, open that same game's achievement list and be
shown the state from *before* they played — with Recent Unlocks, points and masteries unchanged on
the dashboard behind it — until the app was restarted. Re-entering the tab did not help: the flags
were still set.

**One invalidation, one path.** Every launcher funnels its exit through
`GameSessionManager.endGameSession`, so that is where a session-end broadcast goes, and the provider
subscribes to it. `invalidateCachedReads()` drops the per-game map and the dashboard flags together
and bumps a generation counter.

**A mounted dashboard reloads on that counter, not on the flags.** A section that failed to load
leaves its flag false too, so reacting to the flags would retry a failing section forever; the
counter moves only when something actually asked for fresh data.

**The invalidation logs a line.** It fires rarely — a finished session, or a sign-out — and it is
the only trace the mechanism leaves, so without it there is no telling a dashboard that reloaded
because the player just finished a game from one that reloaded because it aged out. It is also what
made the device test below conclusive.

**Entering the tab re-reads anything older than two minutes.** That is what stands in for a refresh
control — leaving the tab and coming back is the gesture, and a gamepad launcher is a poor place to
hunt for a button. It covers what a finished session does not:

- a section that failed the first time (rate limited, transient error) — there was no retry
  anywhere short of restarting the app;
- achievements earned on another device;
- the offline banner from #405 after a launch with no network, which otherwise lingers until relaunch.

The stamp is taken when a load *starts*, not when it finishes, so a second entry cannot kick off a
duplicate run; and an invalidation clears it, so a session that just ended beats the window instead
of waiting it out. The existing 300 ms debounce still means walking through the tab costs nothing.

**Deliberately no new notification, and no refresh button.** The plan's original C2 was a toast or
overlay on the main display when the earned-id set grows. That is redundant: RetroArch and the other
RA-enabled emulators already pop their own unlock overlay in-game, which is the moment that matters,
and NeoStation is backgrounded then anyway. A refresh button was in the first draft of this PR and
came out again — it duplicated what the tab-entry check does, and parked one D-pad press away from
logout. (The library tile pill is unaffected throughout: it renders the snapshot's *total* count,
never an earned count, so it has nothing to go stale.)

No schema change, no migration, no new dependency, no new locale key, and no navigation change.

## Steps to Verify

**Preconditions:** signed in to RetroAchievements, and a game matched to a set you can still earn
achievements in.

1. Open the RetroAchievements tab and let the dashboard load. Note Recent Unlocks and the points
   pill.
2. Open the game's achievements dialog and note which are earned. Close it.
3. Launch the game, earn at least one achievement, exit back to NeoStation.
4. Re-open the game's achievements dialog. **Before:** the pre-session list. **After:** the new
   unlock is there.
5. Open the RetroAchievements tab. **Before:** Recent Unlocks and the points pill unchanged until an
   app restart. **After:** both reflect the session.
6. Leave the tab and come straight back — nothing re-fetches (inside the two-minute window). Wait
   two minutes, come back again, and it re-reads.
7. Offline check (needs #405's behaviour): start with no network so the offline banner shows,
   restore the network, then leave the tab and return after the window — the banner clears.

## Tested on

- [x] Android — device: **AYN Thor** (dev channel, release build, md5-verified against the tree)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

What the device run showed, using the seven files in `user-data/ra_cache/` as the evidence (a live
response rewrites them, so their mtimes say whether the app actually went to the API):

| check | result |
| --- | --- |
| leave the RA tab and return **inside** the window (1m52s) | no re-fetch — mtimes unmoved |
| leave and return **past** the window (2m57s) | all five dashboard endpoints re-fetched |
| exit a real RetroArch session | `RA: cached reads invalidated (generation 1)` in logcat, then the next tab visit re-read all five |
| idle on the dashboard | no repeat loads between 22:48:31 and 22:51:11 — the retry loop the generation counter is designed to avoid did not appear |

One honest caveat on the third row: the tab visit after that session landed 2m29s after the previous
load, so *that observation alone* is also consistent with the window firing. The log line is what
makes it conclusive — the invalidation demonstrably ran on the real session-end path, and it nulls
the staleness stamp, so the reload was going to happen either way.

The `profile_*` and `summary_*` files, which are only fetched at login, stayed untouched throughout
— so the reload is scoped to the dashboard, not a blanket re-auth.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1363)
- [x] Tests added or updated — `test/ra_stale_after_session_test.dart`, 9 cases
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**User-facing text**
- [x] No new strings — nothing user-visible was added

**The database**
- [x] N/A — no schema change, `_databaseVersion` untouched

**Navigation**
- [x] N/A — no new interactive element, no route, no change to the D-pad model or to B

**Android**
- [x] No path logic touched

</details>
