### PR TITLE
fix(romm): stop pulling conflict backups down from the server

### DIFF
--- a/lib/sync/providers/romm_provider.dart
+++ b/lib/sync/providers/romm_provider.dart
@@ -313,8 +313,12 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
       ]);
       // Collapse a slot's version history before anything looks at the listing,
       // so the pairing loop and the remote-only pass below agree on which asset
-      // represents each local file.
-      remote = latestPerLocalName([...results[0], ...results[1]]);
+      // represents each local file. Conflict backups are dropped first: they
+      // must never reach the pairing loop, and filtering them here is cheaper
+      // than deduping them and discarding the survivor.
+      remote = latestPerLocalName(
+        syncableRemote([...results[0], ...results[1]]),
+      );
     } catch (e) {
       _log.e('RomM listSaves/listStates failed for ${game.romname}: $e');
       return GameSyncStatus.error;
@@ -670,6 +674,31 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
   static String localNameForAsset(RommAsset asset) => asset.isState
       ? asset.fileName
       : asset.fileName.replaceAll(_datetimeTag, '');
+
+  /// Drops remote assets that are conflict backups.
+  ///
+  /// [syncableSaves] refuses to *upload* a local file carrying
+  /// [conflictBackupMarker]. Without the same rule on the way down the guard is
+  /// one-directional: an asset named `<game>.state.romm-conflict-<stamp>` has no
+  /// local counterpart to pair with, so the remote-only pass downloads it, and
+  /// every device that syncs the game acquires a permanent copy the upload side
+  /// then refuses to touch — unreconcilable and unremovable from the app.
+  ///
+  /// A backup is by definition a copy this system kept for a person to inspect
+  /// *locally*, never something to distribute, so its own marker is the whole
+  /// test. Deliberately checked against the raw `file_name` rather than
+  /// [localNameForAsset]: the marker survives tag-stripping, but the point is to
+  /// reject the asset before anything derives a local name from it.
+  @visibleForTesting
+  static List<RommAsset> syncableRemote(List<RommAsset> remote) {
+    return remote.where((a) {
+      if (a.fileName.toLowerCase().contains(conflictBackupMarker)) {
+        _log.i('RomM: skipping remote conflict backup ${a.fileName}');
+        return false;
+      }
+      return true;
+    }).toList();
+  }
 
   /// Collapses a remote listing to one asset per local filename, newest first.
   ///

--- a/lib/sync/providers/romm_provider.dart
+++ b/lib/sync/providers/romm_provider.dart
@@ -1352,7 +1352,11 @@ class RomMSyncProvider extends ChangeNotifier implements ISyncProvider {
         _svc.listSaves(romId: romId),
         _svc.listStates(romId: romId),
       ]);
-      final assets = [...results[0], ...results[1]];
+      // Conflict backups are filtered here too, not just in [_syncGame]. This
+      // reports what a caller may sync, not an inventory of the server, and a
+      // backup is never syncable in either direction — leaving it in would put
+      // the download gap back the moment anything transfers from this listing.
+      final assets = syncableRemote([...results[0], ...results[1]]);
       return assets
           .map(
             (a) => SyncFile(

--- a/test/romm_conflict_backup_test.dart
+++ b/test/romm_conflict_backup_test.dart
@@ -354,6 +354,76 @@ void main() {
     await tempDir.delete(recursive: true);
   });
 
+  group('a conflict backup on the server is never pulled down', () {
+    test('syncableRemote drops it and keeps everything else', () {
+      final backup = svc.seedState(
+        1,
+        'Game.state.auto${RomMSyncProvider.conflictBackupMarker}'
+        '2026-08-21_20-00-21',
+        'OTHER DEVICE'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+      final ordinary = svc.seedState(
+        1,
+        'Game.state.auto',
+        'REAL'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+
+      final kept = RomMSyncProvider.syncableRemote([backup, ordinary]);
+
+      expect(kept, [ordinary]);
+    });
+
+    test('the pre-launch pass downloads the real state but not the backup '
+        'sitting beside it', () async {
+      svc.seedState(
+        1,
+        'Game.state.auto${RomMSyncProvider.conflictBackupMarker}'
+        '2026-08-21_20-00-21',
+        'OTHER DEVICE'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+      svc.seedState(
+        1,
+        'Game.state.auto',
+        'REAL'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+
+      await provider.syncGameSavesBeforeLaunch(game);
+
+      expect(
+        await localState().readAsString(),
+        'REAL',
+        reason: 'the ordinary state still syncs',
+      );
+      expect(
+        backupsIn('states'),
+        isEmpty,
+        reason: 'the marker must not survive a round trip through the server',
+      );
+    });
+
+    test(
+      'a backup is not resurrected after the local copy is deleted',
+      () async {
+        svc.seedState(
+          1,
+          'Game.state.auto${RomMSyncProvider.conflictBackupMarker}'
+          '2026-08-21_20-00-21',
+          'OTHER DEVICE'.codeUnits,
+          updatedAt: DateTime.utc(2026, 1, 2),
+        );
+
+        await provider.syncGameSavesBeforeLaunch(game);
+        await provider.syncGameSavesBeforeLaunch(game);
+
+        expect(backupsIn('states'), isEmpty);
+      },
+    );
+  });
+
   group('a genuine both-sides change keeps the copy it replaces', () {
     test('a save the other device advanced is preserved before the local '
         'one overwrites it', () async {

--- a/test/romm_conflict_backup_test.dart
+++ b/test/romm_conflict_backup_test.dart
@@ -405,6 +405,28 @@ void main() {
       );
     });
 
+    test('the provider listing does not offer it either', () async {
+      svc.seedState(
+        1,
+        'Game.state.auto${RomMSyncProvider.conflictBackupMarker}'
+        '2026-08-21_20-00-21',
+        'OTHER DEVICE'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+      svc.seedState(
+        1,
+        'Game.state.auto',
+        'REAL'.codeUnits,
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+
+      final listed = await provider.listSaves(gameId: '1');
+
+      expect(listed.map((f) => f.fileName), [
+        'Game.state.auto',
+      ], reason: 'the listing reports what may sync, not a server inventory');
+    });
+
     test(
       'a backup is not resurrected after the local copy is deleted',
       () async {


### PR DESCRIPTION
# Description

#406 kept the remote bytes a conflicting upload would otherwise have destroyed, writing them beside the local file as `<name>.romm-conflict-<stamp>`, and guarded them from being uploaded again — `syncableSaves` drops any local file carrying the marker.

**That guard is one-directional.** `_syncGame` passed the remote listing only through `latestPerLocalName`, which dedupes a slot's version history and nothing else. An asset named `<game>.state.romm-conflict-<stamp>` therefore had no local counterpart to pair with, so the remote-only pass downloaded it — and every device syncing that game acquired a permanent copy that the upload side then refuses to touch. Unreconcilable, and unremovable from the app: deleting it locally didn't help, because the next pre-launch pass pulled it straight back.

This filters the remote listing by the same marker, before the dedup and before anything derives a local name from the asset.

The second commit applies the same filter to `RomMSyncProvider.listSaves`, the `ISyncProvider` contract listing. Nothing consumes that method today, so it is not a live second instance of the bug — but it is the same gap left open, and anything that later transferred from that listing would reintroduce it.

Fixes #409

### Reachability

No released build can have uploaded such an asset — #406 shipped the backup writer and the upload guard in the same commit. But a dev build made during its development can, and did: the asset that turned this up carries `emulator='neostation'`, so NeoStation put it there. Narrow window, permanent consequence, which is the wrong way round.

## Steps to Verify

**Preconditions:** a RomM server, a game with an `app_romm_rom_map` row and a local save state, and an asset on the server whose filename contains `.romm-conflict-`.

1. Confirm the server holds both the real state and an asset named `<game>.state.romm-conflict-<stamp>`.
2. Delete the local copy of that backup from the device's RetroArch states folder, so only the real state remains.
3. Launch the game, so the pre-launch (download-only) pass runs.
4. Check the states folder.

Before this change the backup is downloaded again and reappears. After it, the folder is unchanged and the log reads `RomM: skipping remote conflict backup <name>`.

## Tested on

- [x] Android — device: AYN Thor (dev channel, release build)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Observed on device after the fix:

```
RomM: skipping remote conflict backup RoboCop 2.state.romm-conflict-2026-08-21_20-00-21
RomM sync RoboCop 2: 0 up, 0 down (2 local, 2 remote)
```

`2 remote` rather than 3 is the filter working — the backup never reached the pairing loop — and the states folder still held only `RoboCop 2.state`.

All three behavioural tests were also run against unfixed code and each fails there, so they pin the regression rather than merely describing the fix.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1378)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — n/a, no assets

<details>
<summary><b>Extra checks</b></summary>

**User-facing text** — n/a, no new strings; the only new string is a log line, which is exempt.

**The database** — n/a, no schema change.

**Android**
- [x] Verified on a device, not only on desktop
- Path logic untouched; this filters a remote listing, not a local path.

</details>
