### PR TITLE
feat(ra): match new ROMs against RetroAchievements on startup

### DIFF
--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -256,6 +256,12 @@ class SqliteConfigService {
                 ) ??
                 0) ==
             1,
+        raMatchOnStartup:
+            (int.tryParse(
+                  userConfig?['ra_match_on_startup']?.toString() ?? '0',
+                ) ??
+                0) ==
+            1,
       );
     } catch (e) {
       _log.e('Error applying configuration in loadConfig: $e');
@@ -317,6 +323,7 @@ class SqliteConfigService {
         fanartDimLevel: config.fanartDimLevel,
         esdeFolderPath: config.esdeFolderPath,
         showAchievementsBadge: config.showAchievementsBadge ? 1 : 0,
+        raMatchOnStartup: config.raMatchOnStartup ? 1 : 0,
       );
 
       await SqliteService.saveUserRomFolders(config.romFolders);

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -507,6 +507,13 @@ class SqliteMigrations {
       case 138:
         await _migrateToVersion138(db);
         break;
+      // 139 and 140 are claimed by another branch that is not merged yet.
+      // Taking the next free number instead of the next sequential one is
+      // deliberate: a shared slot with different contents is skipped silently
+      // on any device that already migrated past it.
+      case 141:
+        await _migrateToVersion141(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -6354,6 +6361,36 @@ class SqliteMigrations {
       _log.i('Migration v134 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v134: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v141: Adds `user_config.ra_match_on_startup`, the opt-in for
+  /// running the RetroAchievements match pass after the startup folder scan.
+  ///
+  /// Defaults to 0 — off. On a library that has never been matched the first
+  /// pass hashes every ROM, which takes minutes; that is a cost the user opts
+  /// into, not one imposed on an upgrade.
+  ///
+  /// Idempotent — the column is added only when absent.
+  static Future<void> _migrateToVersion141(Database db) async {
+    _log.i('Migration v141: Adding ra_match_on_startup to user_config');
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_config)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+      if (!columns.contains('ra_match_on_startup')) {
+        db.execute(
+          'ALTER TABLE user_config ADD COLUMN ra_match_on_startup '
+          'INTEGER DEFAULT 0',
+        );
+        _log.i('Column ra_match_on_startup added via v141');
+      } else {
+        _log.i('Column ra_match_on_startup already exists');
+      }
+      _log.i('Migration v141 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v141: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -458,7 +458,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 138;
+  static const int _databaseVersion = 141;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -1894,7 +1894,8 @@ class SqliteService {
         now_playing_dim_level INTEGER DEFAULT 100,
         fanart_dim_level INTEGER DEFAULT 25,
         esde_folder_path TEXT DEFAULT '',
-        show_achievements_badge INTEGER DEFAULT 0
+        show_achievements_badge INTEGER DEFAULT 0,
+        ra_match_on_startup INTEGER DEFAULT 0
       );
       ''',
       '''
@@ -2710,6 +2711,7 @@ class SqliteService {
     int? fanartDimLevel,
     String? esdeFolderPath,
     int? showAchievementsBadge,
+    int? raMatchOnStartup,
   }) async {
     final db = await instance.database;
 
@@ -2841,6 +2843,10 @@ class SqliteService {
     if (esdeFolderPath != null) {
       updates['esde_folder_path'] = esdeFolderPath;
     }
+    if (raMatchOnStartup != null) {
+      updates['ra_match_on_startup'] = raMatchOnStartup;
+    }
+
     if (showAchievementsBadge != null) {
       updates['show_achievements_badge'] = showAchievementsBadge;
     }
@@ -3124,6 +3130,12 @@ class SqliteService {
   /// Configures whether the application should automatically scan for games on startup.
   static Future<void> updateScanOnStartup(int value) async {
     await saveUserConfig(scanOnStartup: value);
+  }
+
+  /// Configures whether the startup scan is followed by a RetroAchievements
+  /// match pass over the ROMs it added.
+  static Future<void> updateRaMatchOnStartup(int value) async {
+    await saveUserConfig(raMatchOnStartup: value);
   }
 
   // ==========================================

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -5258,6 +5258,15 @@ class SqliteService {
   /// with the database on an NVMe, and it ran on every single launch. The stamp
   /// is only written after the seed succeeds, so a failed seed retries next
   /// launch rather than being cached as done.
+  /// Whether this launch actually rebuilt `app_ra_game_list`.
+  ///
+  /// The lookup-only match pass exists to recover matches after the bundled
+  /// RetroAchievements database changes. When it has not changed, walking every
+  /// hashed-but-unmatched ROM again cannot produce a different answer than it
+  /// did last launch — those ROMs are simply not in the list — so an unattended
+  /// pass has nothing to gain from it.
+  static bool raSeedChangedThisLaunch = false;
+
   Future<void> refreshRetroAchievementsData() async {
     try {
       final db = await database;
@@ -5287,7 +5296,7 @@ class SqliteService {
             'RetroAchievements seed unchanged ($assetStamp, $count rows) - '
             'skipping re-seed.',
           );
-          return;
+          return; // raSeedChangedThisLaunch stays false: nothing to re-look-up.
         }
         _log.w(
           'RetroAchievements seed stamp matched but table is empty - '
@@ -5315,6 +5324,7 @@ class SqliteService {
           _log.w('Could not record the RA seed stamp: $e');
         }
       }
+      raSeedChangedThisLaunch = true;
       _log.i('RetroAchievements database synchronized successfully.');
     } catch (e, stackTrace) {
       _log.e(

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -178,6 +178,10 @@ mixin AppLocale {
   static const String showAchievementsBadge = 'show_achievements_badge';
   static const String showAchievementsBadgeSubtitle =
       'show_achievements_badge_subtitle';
+  static const String raMatchOnStartup = 'ra_match_on_startup';
+  static const String raMatchOnStartupSubtitle = 'ra_match_on_startup_subtitle';
+  static const String raMatchOnStartupBacklogWarning =
+      'ra_match_on_startup_backlog_warning';
   static const String fullscreenMode = 'fullscreen_mode';
   static const String fullscreenModeSubtitle = 'fullscreen_mode_subtitle';
   static const String allFilesAccess = 'all_files_access';

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -182,6 +182,7 @@ mixin AppLocale {
   static const String raMatchOnStartupSubtitle = 'ra_match_on_startup_subtitle';
   static const String raMatchOnStartupBacklogWarning =
       'ra_match_on_startup_backlog_warning';
+  static const String raMatchNotificationTitle = 'ra_match_notification_title';
   static const String fullscreenMode = 'fullscreen_mode';
   static const String fullscreenModeSubtitle = 'fullscreen_mode_subtitle';
   static const String allFilesAccess = 'all_files_access';

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -183,6 +183,8 @@ mixin AppLocale {
   static const String raMatchOnStartupBacklogWarning =
       'ra_match_on_startup_backlog_warning';
   static const String raMatchNotificationTitle = 'ra_match_notification_title';
+  static const String raMatchProgressBusy = 'ra_match_progress_busy';
+  static const String raMatchProgressCounted = 'ra_match_progress_counted';
   static const String fullscreenMode = 'fullscreen_mode';
   static const String fullscreenModeSubtitle = 'fullscreen_mode_subtitle';
   static const String allFilesAccess = 'all_files_access';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -175,6 +175,9 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} Spiele wurden noch nie geprüft. Sie alle beim nächsten Start zuzuordnen, kann mehrere Minuten dauern. Führen Sie stattdessen RetroAchievements-Spiele zuordnen unter Werkzeuge aus, mit sichtbarem Fortschritt.',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: 'RetroAchievements werden abgeglichen...',
+  AppLocale.raMatchProgressCounted:
+      'RetroAchievements werden abgeglichen... {done}/{total}',
   AppLocale.fullscreenMode: 'Vollbildmodus',
   AppLocale.fullscreenModeSubtitle: 'Zeigt die App im Vollbildmodus an',
   AppLocale.allFilesAccess: 'Zugriff auf alle Dateien',
@@ -268,7 +271,7 @@ const Map<String, dynamic> appLocaleDe = {
       'Der Abgleich läuft auch im abgemeldeten Zustand, aber du musst dich bei RetroAchievements anmelden, um die Ergebnisse zu sehen.',
   AppLocale.rematchAchievementsLookingUp:
       'Bereits gehashte Spiele werden geprüft ...',
-  AppLocale.rematchAchievementsHashing: '{filename} wird identifiziert',
+  AppLocale.rematchAchievementsHashing: 'Abgleich {done} von {total}',
   AppLocale.rematchAchievementsDone:
       'Fertig: {matched} Spiel(e) zugeordnet, {hashed} neu identifiziert.',
   AppLocale.rematchAchievementsNothingToDo:

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -174,6 +174,7 @@ const Map<String, dynamic> appLocaleDe = {
       'Ordnet neue ROMs nach dem Start-Scan zu. Für eine ganze Bibliothek zuerst RetroAchievements-Spiele zuordnen unter Werkzeuge ausführen.',
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} Spiele wurden noch nie geprüft. Sie alle beim nächsten Start zuzuordnen, kann mehrere Minuten dauern. Führen Sie stattdessen RetroAchievements-Spiele zuordnen unter Werkzeuge aus, mit sichtbarem Fortschritt.',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: 'Vollbildmodus',
   AppLocale.fullscreenModeSubtitle: 'Zeigt die App im Vollbildmodus an',
   AppLocale.allFilesAccess: 'Zugriff auf alle Dateien',

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -169,6 +169,11 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.showAchievementsBadge: 'Erfolgs-Abzeichen',
   AppLocale.showAchievementsBadgeSubtitle:
       'Die Anzahl der Erfolge auf Spielen anzeigen, die RetroAchievements zugeordnet sind',
+  AppLocale.raMatchOnStartup: 'Erfolge beim Start zuordnen',
+  AppLocale.raMatchOnStartupSubtitle:
+      'Ordnet neue ROMs nach dem Start-Scan zu. Für eine ganze Bibliothek zuerst RetroAchievements-Spiele zuordnen unter Werkzeuge ausführen.',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '{count} Spiele wurden noch nie geprüft. Sie alle beim nächsten Start zuzuordnen, kann mehrere Minuten dauern. Führen Sie stattdessen RetroAchievements-Spiele zuordnen unter Werkzeuge aus, mit sichtbarem Fortschritt.',
   AppLocale.fullscreenMode: 'Vollbildmodus',
   AppLocale.fullscreenModeSubtitle: 'Zeigt die App im Vollbildmodus an',
   AppLocale.allFilesAccess: 'Zugriff auf alle Dateien',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -164,6 +164,11 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.showAchievementsBadge: 'Achievement Badges',
   AppLocale.showAchievementsBadgeSubtitle:
       'Show the achievement count on games matched to RetroAchievements',
+  AppLocale.raMatchOnStartup: 'Match achievements on Startup',
+  AppLocale.raMatchOnStartupSubtitle:
+      'Matches new ROMs after the startup scan. To match a whole library, run Match RetroAchievements Games in Tools first.',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '{count} games have never been checked. Matching them all on the next start can take several minutes. Run Match RetroAchievements Games in Tools to do it now instead, with progress you can watch.',
   AppLocale.fullscreenMode: 'Fullscreen Mode',
   AppLocale.fullscreenModeSubtitle: 'Display the app in fullscreen mode',
   AppLocale.allFilesAccess: 'All Files Access',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -170,6 +170,9 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} games have never been checked. Matching them all on the next start can take several minutes. Run Match RetroAchievements Games in Tools to do it now instead, with progress you can watch.',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: 'Matching RetroAchievements...',
+  AppLocale.raMatchProgressCounted:
+      'Matching RetroAchievements... {done}/{total}',
   AppLocale.fullscreenMode: 'Fullscreen Mode',
   AppLocale.fullscreenModeSubtitle: 'Display the app in fullscreen mode',
   AppLocale.allFilesAccess: 'All Files Access',
@@ -257,7 +260,7 @@ const Map<String, dynamic> appLocaleEn = {
       'Matching runs while you are signed out, but you need to sign in to RetroAchievements to see the results.',
   AppLocale.rematchAchievementsLookingUp:
       'Looking up games that are already hashed...',
-  AppLocale.rematchAchievementsHashing: 'Identifying {filename}',
+  AppLocale.rematchAchievementsHashing: 'Matching {done} of {total}',
   AppLocale.rematchAchievementsDone:
       'Done: {matched} game(s) matched, {hashed} newly identified.',
   AppLocale.rematchAchievementsNothingToDo:

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -169,6 +169,7 @@ const Map<String, dynamic> appLocaleEn = {
       'Matches new ROMs after the startup scan. To match a whole library, run Match RetroAchievements Games in Tools first.',
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} games have never been checked. Matching them all on the next start can take several minutes. Run Match RetroAchievements Games in Tools to do it now instead, with progress you can watch.',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: 'Fullscreen Mode',
   AppLocale.fullscreenModeSubtitle: 'Display the app in fullscreen mode',
   AppLocale.allFilesAccess: 'All Files Access',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -170,6 +170,11 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.showAchievementsBadge: 'Insignias de logros',
   AppLocale.showAchievementsBadgeSubtitle:
       'Mostrar el número de logros en los juegos asociados con RetroAchievements',
+  AppLocale.raMatchOnStartup: 'Asociar logros al iniciar',
+  AppLocale.raMatchOnStartupSubtitle:
+      'Empareja ROMs nuevas tras el escaneo inicial. Para toda una biblioteca, ejecuta antes Emparejar juegos de RetroAchievements en Herramientas.',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '{count} juegos nunca se han comprobado. Emparejarlos todos en el próximo inicio puede tardar varios minutos. Ejecuta Emparejar juegos de RetroAchievements en Herramientas para hacerlo ahora, con progreso visible.',
   AppLocale.fullscreenMode: 'Modo Pantalla Completa',
   AppLocale.fullscreenModeSubtitle:
       'Mostrar la aplicación en pantalla completa',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -175,6 +175,7 @@ const Map<String, dynamic> appLocaleEs = {
       'Empareja ROMs nuevas tras el escaneo inicial. Para toda una biblioteca, ejecuta antes Emparejar juegos de RetroAchievements en Herramientas.',
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} juegos nunca se han comprobado. Emparejarlos todos en el próximo inicio puede tardar varios minutos. Ejecuta Emparejar juegos de RetroAchievements en Herramientas para hacerlo ahora, con progreso visible.',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: 'Modo Pantalla Completa',
   AppLocale.fullscreenModeSubtitle:
       'Mostrar la aplicación en pantalla completa',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -176,6 +176,9 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} juegos nunca se han comprobado. Emparejarlos todos en el próximo inicio puede tardar varios minutos. Ejecuta Emparejar juegos de RetroAchievements en Herramientas para hacerlo ahora, con progreso visible.',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: 'Emparejando RetroAchievements...',
+  AppLocale.raMatchProgressCounted:
+      'Emparejando RetroAchievements... {done}/{total}',
   AppLocale.fullscreenMode: 'Modo Pantalla Completa',
   AppLocale.fullscreenModeSubtitle:
       'Mostrar la aplicación en pantalla completa',
@@ -269,7 +272,7 @@ const Map<String, dynamic> appLocaleEs = {
       'La coincidencia funciona sin haber iniciado sesión, pero necesitas iniciar sesión en RetroAchievements para ver los resultados.',
   AppLocale.rematchAchievementsLookingUp:
       'Comprobando los juegos que ya tienen hash...',
-  AppLocale.rematchAchievementsHashing: 'Identificando {filename}',
+  AppLocale.rematchAchievementsHashing: 'Emparejando {done} de {total}',
   AppLocale.rematchAchievementsDone:
       'Listo: {matched} juego(s) emparejado(s), {hashed} identificado(s) por primera vez.',
   AppLocale.rematchAchievementsNothingToDo:

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -181,6 +181,9 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} jeux n’ont jamais été vérifiés. Les associer tous au prochain démarrage peut prendre plusieurs minutes. Lancez plutôt Associer les jeux RetroAchievements dans Outils, avec une progression visible.',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: 'Correspondance RetroAchievements...',
+  AppLocale.raMatchProgressCounted:
+      'Correspondance RetroAchievements... {done}/{total}',
   AppLocale.fullscreenMode: 'Mode Plein Écran',
   AppLocale.fullscreenModeSubtitle: 'Affiche l’application en plein écran',
   AppLocale.allFilesAccess: 'Accès à Tous les Fichiers',
@@ -273,7 +276,7 @@ const Map<String, dynamic> appLocaleFr = {
       'La correspondance fonctionne même déconnecté, mais vous devez vous connecter à RetroAchievements pour voir les résultats.',
   AppLocale.rematchAchievementsLookingUp:
       'Vérification des jeux déjà hachés...',
-  AppLocale.rematchAchievementsHashing: 'Identification de {filename}',
+  AppLocale.rematchAchievementsHashing: 'Correspondance {done} sur {total}',
   AppLocale.rematchAchievementsDone:
       'Terminé : {matched} jeu(x) associé(s), {hashed} nouvellement identifié(s).',
   AppLocale.rematchAchievementsNothingToDo:

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -175,6 +175,11 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.showAchievementsBadge: 'Badges de succès',
   AppLocale.showAchievementsBadgeSubtitle:
       'Afficher le nombre de succès sur les jeux associés à RetroAchievements',
+  AppLocale.raMatchOnStartup: 'Associer les succès au démarrage',
+  AppLocale.raMatchOnStartupSubtitle:
+      'Associe les nouvelles ROMs après le scan de démarrage. Pour toute une bibliothèque, lancez d’abord Associer les jeux RetroAchievements dans Outils.',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '{count} jeux n’ont jamais été vérifiés. Les associer tous au prochain démarrage peut prendre plusieurs minutes. Lancez plutôt Associer les jeux RetroAchievements dans Outils, avec une progression visible.',
   AppLocale.fullscreenMode: 'Mode Plein Écran',
   AppLocale.fullscreenModeSubtitle: 'Affiche l’application en plein écran',
   AppLocale.allFilesAccess: 'Accès à Tous les Fichiers',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -180,6 +180,7 @@ const Map<String, dynamic> appLocaleFr = {
       'Associe les nouvelles ROMs après le scan de démarrage. Pour toute une bibliothèque, lancez d’abord Associer les jeux RetroAchievements dans Outils.',
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} jeux n’ont jamais été vérifiés. Les associer tous au prochain démarrage peut prendre plusieurs minutes. Lancez plutôt Associer les jeux RetroAchievements dans Outils, avec une progression visible.',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: 'Mode Plein Écran',
   AppLocale.fullscreenModeSubtitle: 'Affiche l’application en plein écran',
   AppLocale.allFilesAccess: 'Accès à Tous les Fichiers',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -173,6 +173,9 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} gim belum pernah diperiksa. Mencocokkan semuanya saat mulai berikutnya bisa memakan waktu beberapa menit. Jalankan Cocokkan Game RetroAchievements di Alat untuk melakukannya sekarang, dengan kemajuan yang terlihat.',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: 'Mencocokkan RetroAchievements...',
+  AppLocale.raMatchProgressCounted:
+      'Mencocokkan RetroAchievements... {done}/{total}',
   AppLocale.fullscreenMode: 'Mode Layar Penuh',
   AppLocale.fullscreenModeSubtitle: 'Tampilkan aplikasi dalam mode layar penuh',
   AppLocale.allFilesAccess: 'Akses Semua File',
@@ -257,7 +260,7 @@ const Map<String, dynamic> appLocaleId = {
       'Pencocokan tetap berjalan saat Anda keluar, tetapi Anda perlu masuk ke RetroAchievements untuk melihat hasilnya.',
   AppLocale.rematchAchievementsLookingUp:
       'Memeriksa game yang sudah memiliki hash...',
-  AppLocale.rematchAchievementsHashing: 'Mengidentifikasi {filename}',
+  AppLocale.rematchAchievementsHashing: 'Mencocokkan {done} dari {total}',
   AppLocale.rematchAchievementsDone:
       'Selesai: {matched} game cocok, {hashed} baru diidentifikasi.',
   AppLocale.rematchAchievementsNothingToDo:

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -172,6 +172,7 @@ const Map<String, dynamic> appLocaleId = {
       'Mencocokkan ROM baru setelah pemindaian awal. Untuk seluruh pustaka, jalankan Cocokkan Game RetroAchievements di Alat terlebih dahulu.',
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} gim belum pernah diperiksa. Mencocokkan semuanya saat mulai berikutnya bisa memakan waktu beberapa menit. Jalankan Cocokkan Game RetroAchievements di Alat untuk melakukannya sekarang, dengan kemajuan yang terlihat.',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: 'Mode Layar Penuh',
   AppLocale.fullscreenModeSubtitle: 'Tampilkan aplikasi dalam mode layar penuh',
   AppLocale.allFilesAccess: 'Akses Semua File',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -167,6 +167,11 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.showAchievementsBadge: 'Lencana Prestasi',
   AppLocale.showAchievementsBadgeSubtitle:
       'Tampilkan jumlah prestasi pada gim yang cocok dengan RetroAchievements',
+  AppLocale.raMatchOnStartup: 'Cocokkan prestasi saat mulai',
+  AppLocale.raMatchOnStartupSubtitle:
+      'Mencocokkan ROM baru setelah pemindaian awal. Untuk seluruh pustaka, jalankan Cocokkan Game RetroAchievements di Alat terlebih dahulu.',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '{count} gim belum pernah diperiksa. Mencocokkan semuanya saat mulai berikutnya bisa memakan waktu beberapa menit. Jalankan Cocokkan Game RetroAchievements di Alat untuk melakukannya sekarang, dengan kemajuan yang terlihat.',
   AppLocale.fullscreenMode: 'Mode Layar Penuh',
   AppLocale.fullscreenModeSubtitle: 'Tampilkan aplikasi dalam mode layar penuh',
   AppLocale.allFilesAccess: 'Akses Semua File',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -177,6 +177,7 @@ const Map<String, dynamic> appLocaleIt = {
       'Abbina le nuove ROM dopo la scansione iniziale. Per un’intera libreria, esegui prima Abbina i giochi RetroAchievements in Strumenti.',
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} giochi non sono mai stati controllati. Abbinarli tutti al prossimo avvio può richiedere diversi minuti. Esegui invece Abbina i giochi RetroAchievements in Strumenti, con un avanzamento visibile.',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: 'Modalità Schermo Intero',
   AppLocale.fullscreenModeSubtitle: 'Visualizza l’app a schermo intero',
   AppLocale.allFilesAccess: 'Accesso a Tutti i File',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -172,6 +172,11 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.showAchievementsBadge: 'Badge obiettivi',
   AppLocale.showAchievementsBadgeSubtitle:
       'Mostra il numero di obiettivi sui giochi associati a RetroAchievements',
+  AppLocale.raMatchOnStartup: 'Associa obiettivi all\'avvio',
+  AppLocale.raMatchOnStartupSubtitle:
+      'Abbina le nuove ROM dopo la scansione iniziale. Per un’intera libreria, esegui prima Abbina i giochi RetroAchievements in Strumenti.',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '{count} giochi non sono mai stati controllati. Abbinarli tutti al prossimo avvio può richiedere diversi minuti. Esegui invece Abbina i giochi RetroAchievements in Strumenti, con un avanzamento visibile.',
   AppLocale.fullscreenMode: 'Modalità Schermo Intero',
   AppLocale.fullscreenModeSubtitle: 'Visualizza l’app a schermo intero',
   AppLocale.allFilesAccess: 'Accesso a Tutti i File',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -178,6 +178,9 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} giochi non sono mai stati controllati. Abbinarli tutti al prossimo avvio può richiedere diversi minuti. Esegui invece Abbina i giochi RetroAchievements in Strumenti, con un avanzamento visibile.',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: 'Abbinamento RetroAchievements...',
+  AppLocale.raMatchProgressCounted:
+      'Abbinamento RetroAchievements... {done}/{total}',
   AppLocale.fullscreenMode: 'Modalità Schermo Intero',
   AppLocale.fullscreenModeSubtitle: 'Visualizza l’app a schermo intero',
   AppLocale.allFilesAccess: 'Accesso a Tutti i File',
@@ -267,7 +270,7 @@ const Map<String, dynamic> appLocaleIt = {
       'L\'abbinamento funziona anche senza aver effettuato l\'accesso, ma devi accedere a RetroAchievements per vedere i risultati.',
   AppLocale.rematchAchievementsLookingUp:
       'Controllo dei giochi già sottoposti ad hash...',
-  AppLocale.rematchAchievementsHashing: 'Identificazione di {filename}',
+  AppLocale.rematchAchievementsHashing: 'Abbinamento {done} di {total}',
   AppLocale.rematchAchievementsDone:
       'Fatto: {matched} gioco/giochi abbinati, {hashed} identificati per la prima volta.',
   AppLocale.rematchAchievementsNothingToDo:

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -149,6 +149,7 @@ const Map<String, dynamic> appLocaleJa = {
       '起動時スキャンの後、新しい ROM を照合します。ライブラリ全体を照合するには、先にツールの「RetroAchievements のゲームを照合」を実行してください。',
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} 本のゲームがまだ確認されていません。次回の起動ですべてを照合すると数分かかることがあります。代わりにツールの「RetroAchievements のゲームを照合」を実行すると、進捗を見ながら行えます。',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: 'フルスクリーンモード',
   AppLocale.fullscreenModeSubtitle: 'アプリをフルスクリーンで表示',
   AppLocale.allFilesAccess: 'すべてのファイルへのアクセス',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -150,6 +150,8 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} 本のゲームがまだ確認されていません。次回の起動ですべてを照合すると数分かかることがあります。代わりにツールの「RetroAchievements のゲームを照合」を実行すると、進捗を見ながら行えます。',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: 'RetroAchievements を照合中...',
+  AppLocale.raMatchProgressCounted: 'RetroAchievements を照合中... {done}/{total}',
   AppLocale.fullscreenMode: 'フルスクリーンモード',
   AppLocale.fullscreenModeSubtitle: 'アプリをフルスクリーンで表示',
   AppLocale.allFilesAccess: 'すべてのファイルへのアクセス',
@@ -221,7 +223,7 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.rematchAchievementsSignedOut:
       'ログアウトしていても照合は実行されますが、結果を見るには RetroAchievements にログインする必要があります。',
   AppLocale.rematchAchievementsLookingUp: 'ハッシュ済みのゲームを確認中...',
-  AppLocale.rematchAchievementsHashing: '{filename} を識別中',
+  AppLocale.rematchAchievementsHashing: '{total} 件中 {done} 件を照合中',
   AppLocale.rematchAchievementsDone:
       '完了: {matched} 本を照合し、{hashed} 本を新たに識別しました。',
   AppLocale.rematchAchievementsNothingToDo: '対応するゲームはすべて確認済みです。',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -144,6 +144,11 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.showAchievementsBadge: '実績バッジ',
   AppLocale.showAchievementsBadgeSubtitle:
       'RetroAchievements と一致したゲームに実績数を表示します',
+  AppLocale.raMatchOnStartup: '起動時に実績を照合',
+  AppLocale.raMatchOnStartupSubtitle:
+      '起動時スキャンの後、新しい ROM を照合します。ライブラリ全体を照合するには、先にツールの「RetroAchievements のゲームを照合」を実行してください。',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '{count} 本のゲームがまだ確認されていません。次回の起動ですべてを照合すると数分かかることがあります。代わりにツールの「RetroAchievements のゲームを照合」を実行すると、進捗を見ながら行えます。',
   AppLocale.fullscreenMode: 'フルスクリーンモード',
   AppLocale.fullscreenModeSubtitle: 'アプリをフルスクリーンで表示',
   AppLocale.allFilesAccess: 'すべてのファイルへのアクセス',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -143,6 +143,11 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.showAchievementsBadge: '업적 배지',
   AppLocale.showAchievementsBadgeSubtitle:
       'RetroAchievements와 일치한 게임에 업적 개수를 표시합니다',
+  AppLocale.raMatchOnStartup: '시작할 때 업적 일치',
+  AppLocale.raMatchOnStartupSubtitle:
+      '시작 스캔 후 새 ROM을 매칭합니다. 라이브러리 전체를 매칭하려면 먼저 도구의 "RetroAchievements 게임 매칭"을(를) 실행하세요.',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '{count}개의 게임이 아직 확인되지 않았습니다. 다음 시작 시 모두 매칭하면 몇 분이 걸릴 수 있습니다. 대신 도구의 "RetroAchievements 게임 매칭"을(를) 실행하면 진행 상황을 보면서 처리할 수 있습니다.',
   AppLocale.fullscreenMode: '전체 화면 모드',
   AppLocale.fullscreenModeSubtitle: '앱을 전체 화면으로 표시합니다',
   AppLocale.allFilesAccess: '모든 파일 액세스',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -149,6 +149,8 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count}개의 게임이 아직 확인되지 않았습니다. 다음 시작 시 모두 매칭하면 몇 분이 걸릴 수 있습니다. 대신 도구의 "RetroAchievements 게임 매칭"을(를) 실행하면 진행 상황을 보면서 처리할 수 있습니다.',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: 'RetroAchievements 매칭 중...',
+  AppLocale.raMatchProgressCounted: 'RetroAchievements 매칭 중... {done}/{total}',
   AppLocale.fullscreenMode: '전체 화면 모드',
   AppLocale.fullscreenModeSubtitle: '앱을 전체 화면으로 표시합니다',
   AppLocale.allFilesAccess: '모든 파일 액세스',
@@ -220,7 +222,7 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.rematchAchievementsSignedOut:
       '로그아웃 상태에서도 매칭은 실행되지만, 결과를 보려면 RetroAchievements에 로그인해야 합니다.',
   AppLocale.rematchAchievementsLookingUp: '이미 해시된 게임을 확인하는 중...',
-  AppLocale.rematchAchievementsHashing: '{filename} 식별 중',
+  AppLocale.rematchAchievementsHashing: '{total}개 중 {done}개 매칭 중',
   AppLocale.rematchAchievementsDone: '완료: {matched}개 매칭, {hashed}개 새로 식별했습니다.',
   AppLocale.rematchAchievementsNothingToDo: '지원되는 게임은 모두 확인했습니다.',
   AppLocale.rematchAchievementsPaused:

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -148,6 +148,7 @@ const Map<String, dynamic> appLocaleKo = {
       '시작 스캔 후 새 ROM을 매칭합니다. 라이브러리 전체를 매칭하려면 먼저 도구의 "RetroAchievements 게임 매칭"을(를) 실행하세요.',
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count}개의 게임이 아직 확인되지 않았습니다. 다음 시작 시 모두 매칭하면 몇 분이 걸릴 수 있습니다. 대신 도구의 "RetroAchievements 게임 매칭"을(를) 실행하면 진행 상황을 보면서 처리할 수 있습니다.',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: '전체 화면 모드',
   AppLocale.fullscreenModeSubtitle: '앱을 전체 화면으로 표시합니다',
   AppLocale.allFilesAccess: '모든 파일 액세스',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -177,6 +177,9 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} jogos nunca foram verificados. Associá-los todos no próximo arranque pode demorar vários minutos. Execute Associar jogos do RetroAchievements em Ferramentas para o fazer agora, com progresso visível.',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: 'A associar RetroAchievements...',
+  AppLocale.raMatchProgressCounted:
+      'A associar RetroAchievements... {done}/{total}',
   AppLocale.fullscreenMode: 'Modo Tela Cheia',
   AppLocale.fullscreenModeSubtitle: 'Exibe o aplicativo em tela cheia',
   AppLocale.allFilesAccess: 'Acesso a Todos os Arquivos',
@@ -265,7 +268,7 @@ const Map<String, dynamic> appLocalePt = {
       'A correspondência funciona sem sessão iniciada, mas é preciso iniciar sessão no RetroAchievements para ver os resultados.',
   AppLocale.rematchAchievementsLookingUp:
       'A verificar jogos que já têm hash...',
-  AppLocale.rematchAchievementsHashing: 'A identificar {filename}',
+  AppLocale.rematchAchievementsHashing: 'A associar {done} de {total}',
   AppLocale.rematchAchievementsDone:
       'Concluído: {matched} jogo(s) associado(s), {hashed} identificado(s) pela primeira vez.',
   AppLocale.rematchAchievementsNothingToDo:

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -176,6 +176,7 @@ const Map<String, dynamic> appLocalePt = {
       'Associa novas ROMs após a análise inicial. Para uma biblioteca inteira, execute primeiro Associar jogos do RetroAchievements em Ferramentas.',
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} jogos nunca foram verificados. Associá-los todos no próximo arranque pode demorar vários minutos. Execute Associar jogos do RetroAchievements em Ferramentas para o fazer agora, com progresso visível.',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: 'Modo Tela Cheia',
   AppLocale.fullscreenModeSubtitle: 'Exibe o aplicativo em tela cheia',
   AppLocale.allFilesAccess: 'Acesso a Todos os Arquivos',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -171,6 +171,11 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.showAchievementsBadge: 'Emblemas de conquistas',
   AppLocale.showAchievementsBadgeSubtitle:
       'Mostrar o número de conquistas nos jogos associados ao RetroAchievements',
+  AppLocale.raMatchOnStartup: 'Associar conquistas ao iniciar',
+  AppLocale.raMatchOnStartupSubtitle:
+      'Associa novas ROMs após a análise inicial. Para uma biblioteca inteira, execute primeiro Associar jogos do RetroAchievements em Ferramentas.',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '{count} jogos nunca foram verificados. Associá-los todos no próximo arranque pode demorar vários minutos. Execute Associar jogos do RetroAchievements em Ferramentas para o fazer agora, com progresso visível.',
   AppLocale.fullscreenMode: 'Modo Tela Cheia',
   AppLocale.fullscreenModeSubtitle: 'Exibe o aplicativo em tela cheia',
   AppLocale.allFilesAccess: 'Acesso a Todos os Arquivos',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -168,6 +168,11 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.showAchievementsBadge: 'Значки достижений',
   AppLocale.showAchievementsBadgeSubtitle:
       'Показывать количество достижений на играх, сопоставленных с RetroAchievements',
+  AppLocale.raMatchOnStartup: 'Сопоставлять достижения при запуске',
+  AppLocale.raMatchOnStartupSubtitle:
+      'Сопоставляет новые ROM после стартового сканирования. Для всей библиотеки сначала запустите «Сопоставить игры RetroAchievements» в разделе «Инструменты».',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '{count} игр ещё ни разу не проверялись. Сопоставление их всех при следующем запуске может занять несколько минут. Вместо этого запустите «Сопоставить игры RetroAchievements» в разделе «Инструменты» — с видимым прогрессом.',
   AppLocale.fullscreenMode: 'Полноэкранный режим',
   AppLocale.fullscreenModeSubtitle:
       'Отображать приложение в полноэкранном режиме',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -174,6 +174,9 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} игр ещё ни разу не проверялись. Сопоставление их всех при следующем запуске может занять несколько минут. Вместо этого запустите «Сопоставить игры RetroAchievements» в разделе «Инструменты» — с видимым прогрессом.',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: 'Сопоставление RetroAchievements...',
+  AppLocale.raMatchProgressCounted:
+      'Сопоставление RetroAchievements... {done}/{total}',
   AppLocale.fullscreenMode: 'Полноэкранный режим',
   AppLocale.fullscreenModeSubtitle:
       'Отображать приложение в полноэкранном режиме',
@@ -263,7 +266,7 @@ const Map<String, dynamic> appLocaleRu = {
       'Сопоставление работает и без входа в аккаунт, но чтобы увидеть результаты, нужно войти в RetroAchievements.',
   AppLocale.rematchAchievementsLookingUp:
       'Проверка игр, для которых уже есть хеш...',
-  AppLocale.rematchAchievementsHashing: 'Опознаётся {filename}',
+  AppLocale.rematchAchievementsHashing: 'Сопоставление {done} из {total}',
   AppLocale.rematchAchievementsDone:
       'Готово: сопоставлено игр — {matched}, впервые опознано — {hashed}.',
   AppLocale.rematchAchievementsNothingToDo:

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -173,6 +173,7 @@ const Map<String, dynamic> appLocaleRu = {
       'Сопоставляет новые ROM после стартового сканирования. Для всей библиотеки сначала запустите «Сопоставить игры RetroAchievements» в разделе «Инструменты».',
   AppLocale.raMatchOnStartupBacklogWarning:
       '{count} игр ещё ни разу не проверялись. Сопоставление их всех при следующем запуске может занять несколько минут. Вместо этого запустите «Сопоставить игры RetroAchievements» в разделе «Инструменты» — с видимым прогрессом.',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: 'Полноэкранный режим',
   AppLocale.fullscreenModeSubtitle:
       'Отображать приложение в полноэкранном режиме',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -141,6 +141,11 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.use12HourClockSubtitle: '以 12 小时制（AM/PM）显示时间，而非 24 小时制',
   AppLocale.showAchievementsBadge: '成就徽章',
   AppLocale.showAchievementsBadgeSubtitle: '在已匹配 RetroAchievements 的游戏上显示成就数量',
+  AppLocale.raMatchOnStartup: '启动时匹配成就',
+  AppLocale.raMatchOnStartupSubtitle:
+      '在启动扫描后匹配新的 ROM。若要匹配整个游戏库，请先在工具中运行“匹配 RetroAchievements 游戏”。',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '有 {count} 个游戏从未检查过。在下次启动时全部匹配可能需要几分钟。建议改为在工具中运行“匹配 RetroAchievements 游戏”，可以看到进度。',
   AppLocale.fullscreenMode: '全屏模式',
   AppLocale.fullscreenModeSubtitle: '以全屏模式显示应用',
   AppLocale.allFilesAccess: '所有文件访问权限',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -146,6 +146,7 @@ const Map<String, dynamic> appLocaleZh = {
       '在启动扫描后匹配新的 ROM。若要匹配整个游戏库，请先在工具中运行“匹配 RetroAchievements 游戏”。',
   AppLocale.raMatchOnStartupBacklogWarning:
       '有 {count} 个游戏从未检查过。在下次启动时全部匹配可能需要几分钟。建议改为在工具中运行“匹配 RetroAchievements 游戏”，可以看到进度。',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: '全屏模式',
   AppLocale.fullscreenModeSubtitle: '以全屏模式显示应用',
   AppLocale.allFilesAccess: '所有文件访问权限',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -147,6 +147,8 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '有 {count} 个游戏从未检查过。在下次启动时全部匹配可能需要几分钟。建议改为在工具中运行“匹配 RetroAchievements 游戏”，可以看到进度。',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: '正在匹配 RetroAchievements...',
+  AppLocale.raMatchProgressCounted: '正在匹配 RetroAchievements... {done}/{total}',
   AppLocale.fullscreenMode: '全屏模式',
   AppLocale.fullscreenModeSubtitle: '以全屏模式显示应用',
   AppLocale.allFilesAccess: '所有文件访问权限',
@@ -216,7 +218,7 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.rematchAchievementsSignedOut:
       '未登录时也会进行匹配，但需要登录 RetroAchievements 才能查看结果。',
   AppLocale.rematchAchievementsLookingUp: '正在检查已有哈希的游戏…',
-  AppLocale.rematchAchievementsHashing: '正在识别 {filename}',
+  AppLocale.rematchAchievementsHashing: '正在匹配 {done}/{total}',
   AppLocale.rematchAchievementsDone: '完成：匹配 {matched} 个游戏，新识别 {hashed} 个。',
   AppLocale.rematchAchievementsNothingToDo: '所有受支持的游戏都已检查过。',
   AppLocale.rematchAchievementsPaused: '已暂停：目前已匹配 {matched} 个游戏。再次运行即可继续。',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -141,6 +141,11 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.use12HourClockSubtitle: '以 12 小時制（AM/PM）顯示時間，而非 24 小時制',
   AppLocale.showAchievementsBadge: '成就徽章',
   AppLocale.showAchievementsBadgeSubtitle: '在已比對 RetroAchievements 的遊戲上顯示成就數量',
+  AppLocale.raMatchOnStartup: '啟動時比對成就',
+  AppLocale.raMatchOnStartupSubtitle:
+      '在啟動掃描後比對新的 ROM。若要比對整個遊戲庫，請先在工具中執行「比對 RetroAchievements 遊戲」。',
+  AppLocale.raMatchOnStartupBacklogWarning:
+      '有 {count} 個遊戲從未檢查過。在下次啟動時全部比對可能需要幾分鐘。建議改為在工具中執行「比對 RetroAchievements 遊戲」，可以看到進度。',
   AppLocale.fullscreenMode: '全螢幕模式',
   AppLocale.fullscreenModeSubtitle: '以全螢幕模式顯示應用程式',
   AppLocale.allFilesAccess: '所有檔案存取權限',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -147,6 +147,8 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.raMatchOnStartupBacklogWarning:
       '有 {count} 個遊戲從未檢查過。在下次啟動時全部比對可能需要幾分鐘。建議改為在工具中執行「比對 RetroAchievements 遊戲」，可以看到進度。',
   AppLocale.raMatchNotificationTitle: 'RetroAchievements',
+  AppLocale.raMatchProgressBusy: '正在比對 RetroAchievements...',
+  AppLocale.raMatchProgressCounted: '正在比對 RetroAchievements... {done}/{total}',
   AppLocale.fullscreenMode: '全螢幕模式',
   AppLocale.fullscreenModeSubtitle: '以全螢幕模式顯示應用程式',
   AppLocale.allFilesAccess: '所有檔案存取權限',
@@ -216,7 +218,7 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.rematchAchievementsSignedOut:
       '未登入時仍會進行比對，但需要登入 RetroAchievements 才能查看結果。',
   AppLocale.rematchAchievementsLookingUp: '正在檢查已有雜湊值的遊戲…',
-  AppLocale.rematchAchievementsHashing: '正在辨識 {filename}',
+  AppLocale.rematchAchievementsHashing: '正在比對 {done}/{total}',
   AppLocale.rematchAchievementsDone: '完成：比對 {matched} 個遊戲，新辨識 {hashed} 個。',
   AppLocale.rematchAchievementsNothingToDo: '所有支援的遊戲都已檢查過。',
   AppLocale.rematchAchievementsPaused: '已暫停：目前已比對 {matched} 個遊戲。再次執行即可繼續。',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -146,6 +146,7 @@ const Map<String, dynamic> appLocaleZhHant = {
       '在啟動掃描後比對新的 ROM。若要比對整個遊戲庫，請先在工具中執行「比對 RetroAchievements 遊戲」。',
   AppLocale.raMatchOnStartupBacklogWarning:
       '有 {count} 個遊戲從未檢查過。在下次啟動時全部比對可能需要幾分鐘。建議改為在工具中執行「比對 RetroAchievements 遊戲」，可以看到進度。',
+  AppLocale.raMatchNotificationTitle: 'RetroAchievements',
   AppLocale.fullscreenMode: '全螢幕模式',
   AppLocale.fullscreenModeSubtitle: '以全螢幕模式顯示應用程式',
   AppLocale.allFilesAccess: '所有檔案存取權限',

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -187,6 +187,14 @@ class ConfigModel {
   /// empty one.
   final bool showAchievementsBadge;
 
+  /// Whether the startup folder scan is followed by a RetroAchievements match
+  /// pass over whatever it just added.
+  ///
+  /// Off by default: on a library that has never been matched the first run is
+  /// a long one, and that is not a cost to impose on a user who has not asked
+  /// for it.
+  final bool raMatchOnStartup;
+
   const ConfigModel({
     this.romFolders = const [],
     this.detectedSystems = const [],
@@ -230,6 +238,7 @@ class ConfigModel {
     this.dockSlotCount = 3,
     this.esdeFolderPath = '',
     this.showAchievementsBadge = false,
+    this.raMatchOnStartup = false,
   });
 
   /// Convenience getter that returns the primary ROM folder, if any are configured.
@@ -424,6 +433,13 @@ class ConfigModel {
               '1' ||
           (json['showAchievementsBadge'] ?? false).toString().toLowerCase() ==
               'true',
+      // Same reasoning: absent => 0 => off, matching the column default.
+      raMatchOnStartup:
+          (json['raMatchOnStartup'] ?? json['ra_match_on_startup'] ?? 0)
+                  .toString() ==
+              '1' ||
+          (json['raMatchOnStartup'] ?? false).toString().toLowerCase() ==
+              'true',
     );
   }
 
@@ -477,6 +493,7 @@ class ConfigModel {
       'dockSlotCount': dockSlotCount,
       'esdeFolderPath': esdeFolderPath,
       'showAchievementsBadge': showAchievementsBadge,
+      'raMatchOnStartup': raMatchOnStartup,
     };
   }
 
@@ -524,6 +541,7 @@ class ConfigModel {
     int? dockSlotCount,
     String? esdeFolderPath,
     bool? showAchievementsBadge,
+    bool? raMatchOnStartup,
   }) {
     return ConfigModel(
       romFolders: romFolders ?? this.romFolders,
@@ -570,6 +588,7 @@ class ConfigModel {
       esdeFolderPath: esdeFolderPath ?? this.esdeFolderPath,
       showAchievementsBadge:
           showAchievementsBadge ?? this.showAchievementsBadge,
+      raMatchOnStartup: raMatchOnStartup ?? this.raMatchOnStartup,
     );
   }
 

--- a/lib/providers/sqlite_config_provider/mutators.dart
+++ b/lib/providers/sqlite_config_provider/mutators.dart
@@ -148,6 +148,14 @@ extension SqliteConfigMutators on SqliteConfigProvider {
     _notify();
   }
 
+  /// Persists whether the startup scan is followed by a RetroAchievements
+  /// match pass over the ROMs it added.
+  Future<void> updateRaMatchOnStartup(bool value) async {
+    _config = _config.copyWith(raMatchOnStartup: value);
+    await SqliteConfigService.saveConfig(_config);
+    _notify();
+  }
+
   /// Updates whether hidden files/folders are ignored during ROM scans.
   Future<void> updateIgnoreHiddenFiles(bool ignoreHiddenFiles) async {
     _config = _config.copyWith(ignoreHiddenFiles: ignoreHiddenFiles);

--- a/lib/repositories/retro_achievements_repository.dart
+++ b/lib/repositories/retro_achievements_repository.dart
@@ -50,6 +50,15 @@ class RetroAchievementsRepository {
   }
 
   /// Returns the persisted RA username, or null if not set.
+  /// Whether this launch rebuilt the bundled RetroAchievements game list.
+  ///
+  /// The lookup-only pass exists to recover matches after that list changes.
+  /// When it has not, re-walking every hashed-but-unmatched ROM cannot answer
+  /// differently than it did last launch, because those ROMs are not in the
+  /// list at all.
+  static bool get raSeedChangedThisLaunch =>
+      SqliteService.raSeedChangedThisLaunch;
+
   static Future<String?> getRAUser() async {
     final config = await SqliteService.getUserConfig();
     final value = config?['ra_user']?.toString();

--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -9,6 +9,11 @@ import 'package:neostation/services/systems_update_service.dart';
 import 'package:neostation/widgets/update_dialog.dart';
 import 'package:neostation/widgets/systems_update_dialog.dart';
 import 'package:neostation/services/logger_service.dart';
+import 'package:neostation/services/game/game_session_manager.dart';
+import 'package:neostation/services/ra_library_match_runner.dart';
+import 'package:neostation/services/retroachievements_hash_service.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:flutter_localization/flutter_localization.dart';
 import '../widgets/fixed_header.dart';
 import 'systems_screen/system_content.dart';
 import 'systems_screen/my_systems_section/initial_setup_widget.dart';
@@ -103,6 +108,15 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
 
   ThemeProvider? _themeProvider;
 
+  /// Whether the startup RetroAchievements pass stopped before it finished.
+  ///
+  /// The pass is paused when a game launches, so the common reason it is set
+  /// is the user starting a game partway through a first, long run. Resumed
+  /// once the session ends, which is what lets an unmatched library seed
+  /// itself across several sessions instead of demanding one long supervised
+  /// run.
+  bool _raMatchInterrupted = false;
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -124,6 +138,7 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
     super.initState();
     _currentInstance = this;
     WidgetsBinding.instance.addObserver(this);
+    GameSessionManager.addSessionEndListener(_onGameSessionEnded);
 
     // Initialize the navigation bridge with core application callbacks.
     _gamepadNav = GamepadNavigation(
@@ -208,15 +223,84 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
     }
 
     // Systems/emulator config update check (network).
+    Future<void>? systemsRescan;
     if (configProvider.config.autoUpdateSystems) {
       final systemsUpdated = await _checkAndShowSystemsUpdate(configProvider);
       if (systemsUpdated && mounted) {
         // New definitions were applied — re-scan to reflect them. Wait for the
         // initial scan to settle first, since scanSystems ignores concurrent calls.
         await initialScan;
-        if (mounted) configProvider.scanSystems();
+        if (mounted) systemsRescan = configProvider.scanSystems();
       }
     }
+
+    // Match whatever the scan just added. After the scan, never before it: the
+    // candidate set is "ROMs with no hash", and before the scan settles the new
+    // ROMs are not in it yet. That includes the systems-update re-scan, which
+    // can bring a system into RA range for the first time.
+    await initialScan;
+    await systemsRescan;
+    await _runStartupRaMatch(configProvider);
+  }
+
+  /// Runs the RetroAchievements match pass over ROMs the startup scan added.
+  ///
+  /// Opt-in, and silent when there is nothing to do. Hashing is otherwise only
+  /// ever triggered by the user opening a game or walking to Tools, so a ROM
+  /// added last week carries no match and no badge until somebody remembers to
+  /// press a button.
+  Future<void> _runStartupRaMatch(SqliteConfigProvider configProvider) async {
+    if (!mounted) return;
+    if (!configProvider.config.raMatchOnStartup) return;
+
+    // Nothing to walk, and nothing the user would see if we did.
+    if (configProvider.config.romFolders.isEmpty) return;
+
+    // The Tools button may already be running one; it is single-flight anyway,
+    // but starting a pass that immediately refuses itself would log a warning
+    // on every launch.
+    if (RetroAchievementsHashService.isRematchRunning) return;
+
+    // Deliberately not gated on being signed in to RetroAchievements. The pass
+    // hashes locally and resolves against the bundled RA database, so it needs
+    // no account, and what it produces — the match, and the achievement count
+    // behind the library badge — is visible without one. Tools takes the same
+    // view: signed out it warns and still runs, rather than refusing.
+
+    final strings = _raMatchStrings();
+    if (strings == null) return;
+
+    _raMatchInterrupted = await RaLibraryMatchRunner.run(
+      strings: strings,
+      trigger: RaMatchTrigger.automatic,
+    );
+  }
+
+  /// Picks the startup pass back up after a game session, when it was stopped
+  /// by that session starting.
+  void _onGameSessionEnded() {
+    if (!_raMatchInterrupted || !mounted) return;
+    final configProvider = Provider.of<SqliteConfigProvider>(
+      context,
+      listen: false,
+    );
+    // Fire and forget: this runs on the game-exit path, which already has UI
+    // waiting on it.
+    unawaited(_runStartupRaMatch(configProvider));
+  }
+
+  /// Resolves the runner's strings, or null when there is no context to
+  /// resolve them against.
+  RaMatchStrings? _raMatchStrings() {
+    if (!mounted) return null;
+    return RaMatchStrings(
+      lookingUp: AppLocale.rematchAchievementsLookingUp.getString(context),
+      hashing: AppLocale.rematchAchievementsHashing.getString(context),
+      done: AppLocale.rematchAchievementsDone.getString(context),
+      nothingToDo: AppLocale.rematchAchievementsNothingToDo.getString(context),
+      paused: AppLocale.rematchAchievementsPaused.getString(context),
+      failed: AppLocale.rematchAchievementsFailed.getString(context),
+    );
   }
 
   /// Detects which RetroArch variant the user has installed on Android and sets
@@ -298,6 +382,7 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
   @override
   void dispose() {
     _currentInstance = null;
+    GameSessionManager.removeSessionEndListener(_onGameSessionEnded);
     WidgetsBinding.instance.removeObserver(this);
     _themeProvider?.removeListener(_onThemeChanged);
     GamepadNavigationManager.popLayer('app_screen');

--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -240,7 +240,7 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
     // can bring a system into RA range for the first time.
     await initialScan;
     await systemsRescan;
-    await _runStartupRaMatch(configProvider);
+    await _runStartupRaMatch(configProvider, holdsSplash: true);
   }
 
   /// Runs the RetroAchievements match pass over ROMs the startup scan added.
@@ -249,7 +249,15 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
   /// ever triggered by the user opening a game or walking to Tools, so a ROM
   /// added last week carries no match and no badge until somebody remembers to
   /// press a button.
-  Future<void> _runStartupRaMatch(SqliteConfigProvider configProvider) async {
+  ///
+  /// [holdsSplash] is set only by the startup sequence, which keeps the startup
+  /// screen up until the pass finishes so the user is told what is happening
+  /// rather than watching a library appear mid-work. The resume-after-a-game
+  /// path leaves it false: that library is already on screen.
+  Future<void> _runStartupRaMatch(
+    SqliteConfigProvider configProvider, {
+    bool holdsSplash = false,
+  }) async {
     if (!mounted) return;
     if (!configProvider.config.raMatchOnStartup) return;
 
@@ -273,6 +281,7 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
     _raMatchInterrupted = await RaLibraryMatchRunner.run(
       strings: strings,
       trigger: RaMatchTrigger.automatic,
+      holdsSplash: holdsSplash,
     );
   }
 

--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -294,6 +294,7 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
   RaMatchStrings? _raMatchStrings() {
     if (!mounted) return null;
     return RaMatchStrings(
+      title: AppLocale.raMatchNotificationTitle.getString(context),
       lookingUp: AppLocale.rematchAchievementsLookingUp.getString(context),
       hashing: AppLocale.rematchAchievementsHashing.getString(context),
       done: AppLocale.rematchAchievementsDone.getString(context),

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -14,6 +14,8 @@ import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/utils/adaptive_scroll.dart';
 import 'package:neostation/utils/nav_tabs.dart';
 import '../../../providers/sqlite_config_provider.dart';
+import '../../../repositories/retro_achievements_repository.dart';
+import '../../../widgets/info_dialog.dart';
 import '../../../widgets/custom_toggle_switch.dart';
 import 'settings_title.dart';
 import 'widgets/setting_row.dart';
@@ -73,7 +75,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
 
     // Pre-allocate keys for maximum theoretical setting items (the fixed rows
     // plus one per navigation tab that can be toggled).
-    for (int i = 0; i < 14 + NavTab.values.length; i++) {
+    for (int i = 0; i < 15 + NavTab.values.length; i++) {
       _itemKeys.add(GlobalKey());
     }
   }
@@ -203,6 +205,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
     count++; // SFX volume (dimmed, but still navigable, while SFX are off)
     count++; // 12-Hour Clock
     count++; // Achievement badges on game tiles
+    count++; // Match RetroAchievements on startup
     count += hidableNavTabs().length; // Navigation tab visibility
     count++; // Language
     if (!kIsWeb &&
@@ -221,6 +224,46 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
   }
 
   /// Selection Dispatcher: Executes the action associated with the specified setting index.
+  /// ROMs left to hash before the startup pass is worth warning about.
+  ///
+  /// The pass runs at roughly 20-60 ROMs a second depending on how large the
+  /// files are, so a few hundred is a few seconds and not worth interrupting
+  /// anyone for. Thousands is minutes, and minutes of it is what the Tools
+  /// matcher exists to do properly, with a progress bar and somebody watching.
+  static const int _raBacklogWarnThreshold = 500;
+
+  /// Writes the startup-match toggle, warning first when switching it on would
+  /// leave a large backlog for the next launch.
+  ///
+  /// The toggle is for keeping an already-matched library up to date as ROMs
+  /// are added. Enabling it on a library that has never been matched instead
+  /// hands the next launch the whole job, so this points at the Tools matcher
+  /// rather than letting people discover the cost on their next start. It is
+  /// advice, not a gate: the setting is written either way.
+  Future<void> _setRaMatchOnStartup(bool value) async {
+    final configProvider = context.read<SqliteConfigProvider>();
+    if (!value) {
+      configProvider.updateRaMatchOnStartup(false);
+      return;
+    }
+
+    final coverage = await RetroAchievementsRepository.getRaHashCoverage();
+    final backlog = coverage.eligible - coverage.hashed;
+    if (!mounted) return;
+    configProvider.updateRaMatchOnStartup(true);
+
+    if (backlog < _raBacklogWarnThreshold) return;
+    await InfoDialog.show(
+      context,
+      title: AppLocale.raMatchOnStartup.getString(context),
+      body: AppLocale.raMatchOnStartupBacklogWarning
+          .getString(context)
+          .replaceFirst('{count}', backlog.toString()),
+      okLabel: AppLocale.ok.getString(context),
+      icon: Symbols.trophy_rounded,
+    );
+  }
+
   void selectItem(int index) {
     SfxService().playNavSound();
     int currentItemIndex = 0;
@@ -300,6 +343,13 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
       configProvider.updateShowAchievementsBadge(
         !configProvider.config.showAchievementsBadge,
       );
+      return;
+    }
+    currentItemIndex++;
+
+    // Protocol: Match RetroAchievements after the startup scan.
+    if (index == currentItemIndex) {
+      _setRaMatchOnStartup(!configProvider.config.raMatchOnStartup);
       return;
     }
     currentItemIndex++;
@@ -651,6 +701,28 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                             .read<SqliteConfigProvider>()
                             .updateShowAchievementsBadge(value);
                       },
+                      activeColor: theme.colorScheme.primary,
+                    ),
+                  );
+                }(),
+
+                // Setting: Match RetroAchievements after the startup scan.
+                SizedBox(height: 12.r),
+                () {
+                  final index = currentItemIdx++;
+                  return SettingRow(
+                    key: _itemKeys[index],
+                    onTap: () => selectItem(index),
+                    focused:
+                        widget.isContentFocused &&
+                        widget.selectedContentIndex == index,
+                    title: AppLocale.raMatchOnStartup.getString(context),
+                    subtitle: AppLocale.raMatchOnStartupSubtitle.getString(
+                      context,
+                    ),
+                    trailing: CustomToggleSwitch(
+                      value: config.raMatchOnStartup,
+                      onChanged: _setRaMatchOnStartup,
                       activeColor: theme.colorScheme.primary,
                     ),
                   );

--- a/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
@@ -430,6 +430,7 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
           '${AppLocale.rematchAchievementsSignedOut.getString(context)}';
     }
     final strings = RaMatchStrings(
+      title: AppLocale.raMatchNotificationTitle.getString(context),
       lookingUp: AppLocale.rematchAchievementsLookingUp.getString(context),
       hashing: AppLocale.rematchAchievementsHashing.getString(context),
       done: AppLocale.rematchAchievementsDone.getString(context),

--- a/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
@@ -9,10 +9,10 @@ import 'package:neostation/providers/file_provider.dart';
 import 'package:neostation/providers/retro_achievements_provider.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/repositories/config_repository.dart';
-import 'package:neostation/repositories/retro_achievements_repository.dart';
 import 'package:neostation/repositories/system_repository.dart';
 import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/services/global_notification_service.dart';
+import 'package:neostation/services/ra_library_match_runner.dart';
 import 'package:neostation/services/metadata_cleanup_service.dart';
 import 'package:neostation/services/retroachievements_hash_service.dart';
 import 'package:neostation/services/rom_folder_organizer_service.dart';
@@ -429,17 +429,14 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
           '$localeWarning\n\n'
           '${AppLocale.rematchAchievementsSignedOut.getString(context)}';
     }
-    final localeLookingUp = AppLocale.rematchAchievementsLookingUp.getString(
-      context,
+    final strings = RaMatchStrings(
+      lookingUp: AppLocale.rematchAchievementsLookingUp.getString(context),
+      hashing: AppLocale.rematchAchievementsHashing.getString(context),
+      done: AppLocale.rematchAchievementsDone.getString(context),
+      nothingToDo: AppLocale.rematchAchievementsNothingToDo.getString(context),
+      paused: AppLocale.rematchAchievementsPaused.getString(context),
+      failed: AppLocale.rematchAchievementsFailed.getString(context),
     );
-    final localeHashing = AppLocale.rematchAchievementsHashing.getString(
-      context,
-    );
-    final localeDone = AppLocale.rematchAchievementsDone.getString(context);
-    final localeNothingToDo = AppLocale.rematchAchievementsNothingToDo
-        .getString(context);
-    final localePaused = AppLocale.rematchAchievementsPaused.getString(context);
-    final localeFailed = AppLocale.rematchAchievementsFailed.getString(context);
     final localeConfirm = AppLocale.confirm.getString(context);
 
     final confirmed = await ConfirmActionDialog.show(
@@ -452,109 +449,15 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
     );
     if (confirmed != true || !mounted) return;
 
-    String? completionMessage;
-    NotificationType? completionType;
-    const notificationId = 'rematch_achievements';
+    // Redraw so the row renders as "stop" for the duration of the run.
+    setState(() {});
 
-    try {
-      setState(() {});
-
-      GlobalNotificationService().show(
-        id: notificationId,
-        message: localeLookingUp,
-        type: GlobalNotificationType.info,
-        progress: 0,
-      );
-
-      // The pass resumes: hashed ROMs are excluded from the candidate query, so
-      // a stopped run picks up where it left off. Report progress against the
-      // whole hashable library rather than the work left in this run, or the
-      // bar restarts at 0% every time and reads as if nothing was kept.
-      final coverage = await RetroAchievementsRepository.getRaHashCoverage();
-      final alreadyHashed = coverage.hashed;
-      final eligible = coverage.eligible;
-
-      // Cheap pass: no file I/O, just retry the local lookup for ROMs that
-      // already carry a hash.
-      final lookup = await RetroAchievementsHashService.rematchLibrary(
-        mode: RaRematchMode.lookupOnly,
-
-        onProgress: (processed, total, _) {
-          if (total == 0) return;
-          GlobalNotificationService().update(
-            id: notificationId,
-            message: localeLookingUp,
-            type: GlobalNotificationType.info,
-            progress: eligible > 0 ? alreadyHashed / eligible : null,
-          );
-        },
-      );
-
-      // Expensive pass: hash the ROMs that have never been hashed.
-      final hashPass = lookup.cancelled
-          ? null
-          : await RetroAchievementsHashService.rematchLibrary(
-              onProgress: (processed, total, label) {
-                if (total == 0) return;
-                GlobalNotificationService().update(
-                  id: notificationId,
-                  message: localeHashing.replaceFirst('{filename}', label),
-                  type: GlobalNotificationType.info,
-                  progress: eligible > 0
-                      ? ((alreadyHashed + processed) / eligible).clamp(0.0, 1.0)
-                      : processed / total,
-                );
-              },
-            );
-
-      final matched = lookup.matched + (hashPass?.matched ?? 0);
-      final hashed = hashPass?.hashed ?? 0;
-      final cancelled = lookup.cancelled || (hashPass?.cancelled ?? false);
-      final examined = lookup.total + (hashPass?.total ?? 0);
-
-      if (cancelled) {
-        completionMessage = localePaused.replaceFirst(
-          '{matched}',
-          matched.toString(),
-        );
-        completionType = NotificationType.info;
-      } else if (examined == 0) {
-        completionMessage = localeNothingToDo;
-        completionType = NotificationType.info;
-      } else {
-        completionMessage = localeDone
-            .replaceFirst('{matched}', matched.toString())
-            .replaceFirst('{hashed}', hashed.toString());
-        completionType = matched > 0
-            ? NotificationType.success
-            : NotificationType.info;
-      }
-    } catch (e, stackTrace) {
-      _log.e(
-        'Failed to re-match RetroAchievements: $e',
-        stackTrace: stackTrace,
-      );
-      completionMessage = localeFailed.replaceFirst('{error}', e.toString());
-      completionType = NotificationType.error;
-    } finally {
-      if (mounted) {
-        setState(() {});
-        if (completionMessage != null && completionType != null) {
-          GlobalNotificationService().update(
-            id: notificationId,
-            message: completionMessage,
-            type: completionType == NotificationType.success
-                ? GlobalNotificationType.success
-                : completionType == NotificationType.error
-                ? GlobalNotificationType.error
-                : GlobalNotificationType.info,
-            progress: null,
-          );
-        }
-      } else {
-        GlobalNotificationService().dismiss(notificationId);
-      }
-    }
+    await RaLibraryMatchRunner.run(
+      strings: strings,
+      onProgressStateChanged: () {
+        if (mounted) setState(() {});
+      },
+    );
   }
 
   @override

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -22,6 +22,7 @@ import '../../game_screen/my_games_list.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'grid_geometry.dart';
 import 'widgets/grid_loading_state.dart';
+import '../../../services/ra_library_match_runner.dart';
 import 'widgets/grid_empty_state.dart';
 import 'my_systems_carousel.dart';
 import 'package:neostation/widgets/custom_notification.dart';
@@ -120,20 +121,40 @@ class MySystems extends StatelessWidget {
             systemsWidget = _buildSystemsGrid(context, configProvider);
           }
 
-          // If a non-blocking background scan is active, overlay a progress toast.
-          if (configProvider.isScanning) {
-            return Column(
-              children: [
-                const Padding(
-                  padding: EdgeInsets.all(8.0),
-                  child: SystemScanProgressWidget(),
-                ),
-                Expanded(child: systemsWidget),
-              ],
-            );
-          }
-
-          return systemsWidget;
+          // If a non-blocking background scan is active, overlay a progress
+          // toast. The RetroAchievements pass that runs after the scan gets the
+          // same treatment: it is the other half of "the library is still
+          // settling", and it is deliberately on this branch and not the
+          // isGlobalScanning one above, so it never blocks the grid.
+          return ValueListenableBuilder<RaMatchProgress?>(
+            valueListenable: RaLibraryMatchRunner.progress,
+            builder: (context, raProgress, _) {
+              // A splash-holding pass is never seen here — the startup screen
+              // is still up. This row is for the pass that resumes after a game
+              // session, which runs against a library already on screen.
+              final showRaRow = raProgress != null && !raProgress.holdsSplash;
+              if (!configProvider.isScanning && !showRaRow) {
+                return systemsWidget;
+              }
+              return Column(
+                children: [
+                  if (configProvider.isScanning)
+                    const Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: SystemScanProgressWidget(),
+                    ),
+                  Expanded(child: systemsWidget),
+                  // Below the grid, not above it: the header floats over the
+                  // top of this column and would clip the row out of sight.
+                  if (showRaRow)
+                    const Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: SystemScanProgressWidget(),
+                    ),
+                ],
+              );
+            },
+          );
         },
       ),
     );

--- a/lib/screens/systems_screen/system_content.dart
+++ b/lib/screens/systems_screen/system_content.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import '../../services/ra_library_match_runner.dart';
 
 import 'package:flutter/material.dart';
 import 'package:neostation/l10n/app_locale.dart';
@@ -71,59 +72,80 @@ class _SystemContentState extends State<SystemContent> {
   Widget build(BuildContext context) {
     return Consumer2<SqliteConfigProvider, ThemeProvider>(
       builder: (context, configProvider, themeProvider, child) {
-        // Determine the current operational state of the library.
-        final isLoading = configProvider.isLoading || configProvider.isScanning;
-        final showSplash = isLoading || _holdSplash(isLoading);
-
-        // Show setup wizard if scan is finished but no systems were resolved.
-        final showInitialSetup =
-            !showSplash &&
-            !configProvider.hasDetectedSystems &&
-            configProvider.scanCompleted;
-
-        // Show primary library content only when initialization and scanning are complete.
-        final showContent =
-            !showSplash && configProvider.scanCompleted && !showInitialSetup;
-
-        // PHASE 1: Loading and Initialization — a shimmering NeoStation logo
-        // with a thin progress bar and the current scan step as quiet detail.
-        // PHASE 2: First-Run Experience / Initial Setup.
-        // PHASE 3: Primary System Library.
-        final Widget phase;
-        if (showSplash) {
-          phase = KeyedSubtree(
-            key: const ValueKey('splash'),
-            child: _buildSplash(context, configProvider),
-          );
-        } else if (showInitialSetup) {
-          phase = KeyedSubtree(
-            key: const ValueKey('setup'),
-            child: InitialSetupWidget(),
-          );
-        } else if (showContent) {
-          phase = KeyedSubtree(
-            key: const ValueKey('content'),
-            child: MySystems(
-              selectedIndex: widget.selectedIndex,
-              onCardTapped: widget.onCardTapped,
-            ),
-          );
-        } else {
-          phase = const SizedBox.shrink(key: ValueKey('empty'));
-        }
-
-        // Cross-fade the splash into the library instead of a hard cut.
-        return AnimatedSwitcher(
-          duration: const Duration(milliseconds: 400),
-          child: phase,
+        return ValueListenableBuilder<RaMatchProgress?>(
+          valueListenable: RaLibraryMatchRunner.progress,
+          builder: (context, raProgress, _) =>
+              _buildPhase(context, configProvider, raProgress),
         );
       },
+    );
+  }
+
+  Widget _buildPhase(
+    BuildContext context,
+    SqliteConfigProvider configProvider,
+    RaMatchProgress? raProgress,
+  ) {
+    // The RetroAchievements pass the startup sequence fires is part of getting
+    // the library ready, so the startup screen waits for it exactly as it waits
+    // for the ROM scan, rather than handing over a library that is still being
+    // matched behind the user's back. Only the startup pass sets this — the one
+    // that resumes after a game session must never pull the splash back up.
+    final raHoldsSplash = raProgress?.holdsSplash ?? false;
+
+    // Determine the current operational state of the library.
+    final isLoading =
+        configProvider.isLoading || configProvider.isScanning || raHoldsSplash;
+    final showSplash = isLoading || _holdSplash(isLoading);
+
+    // Show setup wizard if scan is finished but no systems were resolved.
+    final showInitialSetup =
+        !showSplash &&
+        !configProvider.hasDetectedSystems &&
+        configProvider.scanCompleted;
+
+    // Show primary library content only when initialization and scanning are complete.
+    final showContent =
+        !showSplash && configProvider.scanCompleted && !showInitialSetup;
+
+    // PHASE 1: Loading and Initialization — a shimmering NeoStation logo
+    // with a thin progress bar and the current scan step as quiet detail.
+    // PHASE 2: First-Run Experience / Initial Setup.
+    // PHASE 3: Primary System Library.
+    final Widget phase;
+    if (showSplash) {
+      phase = KeyedSubtree(
+        key: const ValueKey('splash'),
+        child: _buildSplash(context, configProvider, raProgress),
+      );
+    } else if (showInitialSetup) {
+      phase = KeyedSubtree(
+        key: const ValueKey('setup'),
+        child: InitialSetupWidget(),
+      );
+    } else if (showContent) {
+      phase = KeyedSubtree(
+        key: const ValueKey('content'),
+        child: MySystems(
+          selectedIndex: widget.selectedIndex,
+          onCardTapped: widget.onCardTapped,
+        ),
+      );
+    } else {
+      phase = const SizedBox.shrink(key: ValueKey('empty'));
+    }
+
+    // Cross-fade the splash into the library instead of a hard cut.
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 400),
+      child: phase,
     );
   }
 
   Widget _buildSplash(
     BuildContext context,
     SqliteConfigProvider configProvider,
+    RaMatchProgress? raProgress,
   ) {
     // The logo sits at the exact screen centre — the same spot it occupies on
     // the native splash and the startup screens — with the progress detail
@@ -133,11 +155,52 @@ class _SystemContentState extends State<SystemContent> {
       // waiting-for-storage phase progress sits at 0, which would park the
       // glint off-screen and leave the logo frozen for up to 30s — keep the
       // ambient sweep running until there's real movement.
-      progress: configProvider.isScanning && configProvider.scanProgress > 0
-          ? configProvider.scanProgress
-          : null,
+      progress: raProgress != null
+          ? (raProgress.total != null && raProgress.total! > 0
+                ? (raProgress.done ?? 0) / raProgress.total!
+                : null)
+          : (configProvider.isScanning && configProvider.scanProgress > 0
+                ? configProvider.scanProgress
+                : null),
       children: [
-        if (configProvider.isScanning) ...[
+        // The RetroAchievements line replaces the per-system scan line rather
+        // than stacking under it: by the time it runs the systems are all in,
+        // and one calm line is the whole point.
+        if (raProgress != null) ...[
+          SizedBox(
+            width: 220,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(2),
+              child: LinearProgressIndicator(
+                value: raProgress.total != null && raProgress.total! > 0
+                    ? (raProgress.done ?? 0) / raProgress.total!
+                    : null,
+                minHeight: 3,
+                backgroundColor: Theme.of(
+                  context,
+                ).colorScheme.onSurface.withValues(alpha: 0.12),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            raProgress.done != null && raProgress.total != null
+                ? AppLocale.raMatchProgressCounted
+                      .getString(context)
+                      .replaceFirst('{done}', raProgress.done.toString())
+                      .replaceFirst('{total}', raProgress.total.toString())
+                : AppLocale.raMatchProgressBusy.getString(context),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              fontSize: 17,
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ] else if (configProvider.isScanning) ...[
           SizedBox(
             width: 220,
             child: ClipRRect(

--- a/lib/screens/systems_screen/system_content.dart
+++ b/lib/screens/systems_screen/system_content.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import '../../services/ra_library_match_runner.dart';
 
 import 'package:flutter/material.dart';
@@ -29,45 +28,6 @@ class SystemContent extends StatefulWidget {
 }
 
 class _SystemContentState extends State<SystemContent> {
-  /// Minimum time the splash stays visible once shown. A fast scan (sub-second
-  /// on a warm library) would otherwise blink the logo away before the shine
-  /// animation is even perceptible.
-  static const _minSplashDuration = Duration(milliseconds: 2500);
-
-  /// When the splash first appeared; null once it has been released.
-  DateTime? _splashShownAt;
-
-  Timer? _releaseTimer;
-
-  @override
-  void dispose() {
-    _releaseTimer?.cancel();
-    super.dispose();
-  }
-
-  /// Returns whether the splash must stay up even though loading has finished,
-  /// arming a one-shot timer that rebuilds when the minimum time is served.
-  bool _holdSplash(bool isLoading) {
-    if (isLoading) {
-      _splashShownAt ??= DateTime.now();
-      _releaseTimer?.cancel();
-      _releaseTimer = null;
-      return false;
-    }
-    final shownAt = _splashShownAt;
-    if (shownAt == null) return false;
-
-    final remaining = _minSplashDuration - DateTime.now().difference(shownAt);
-    if (remaining <= Duration.zero) {
-      _splashShownAt = null;
-      return false;
-    }
-    _releaseTimer ??= Timer(remaining, () {
-      if (mounted) setState(() => _splashShownAt = null);
-    });
-    return true;
-  }
-
   @override
   Widget build(BuildContext context) {
     return Consumer2<SqliteConfigProvider, ThemeProvider>(
@@ -96,7 +56,11 @@ class _SystemContentState extends State<SystemContent> {
     // Determine the current operational state of the library.
     final isLoading =
         configProvider.isLoading || configProvider.isScanning || raHoldsSplash;
-    final showSplash = isLoading || _holdSplash(isLoading);
+    // No minimum display time: a fast scan is a fast start, and holding the
+    // logo up after the library is ready only makes the app feel slower than
+    // it is. The 400 ms cross-fade below is what keeps a quick one from
+    // reading as a flicker.
+    final showSplash = isLoading;
 
     // Show setup wizard if scan is finished but no systems were resolved.
     final showInitialSetup =

--- a/lib/services/game/game_session_manager.dart
+++ b/lib/services/game/game_session_manager.dart
@@ -8,6 +8,7 @@ import '../../repositories/game_repository.dart';
 import '../../repositories/system_repository.dart';
 import '../../sync/sync_manager.dart';
 import '../game_session_persistence.dart';
+import '../retroachievements_hash_service.dart';
 import '../romm_playtime_service.dart';
 
 /// Owns the game-session lifecycle and its mutable tracking state.
@@ -42,7 +43,22 @@ class GameSessionManager {
   /// Opens the launch-pending window. Call when a launch is initiated, before
   /// the emulator handoff. Cleared by [registerGameLaunch] on success or
   /// [clearLaunchPending] on failure.
-  static void beginLaunchPending() => _launchPending = true;
+  static void beginLaunchPending() {
+    _launchPending = true;
+    _pauseBackgroundHashing();
+  }
+
+  /// Stops a library-wide RetroAchievements pass for the duration of a game.
+  ///
+  /// Hashing reads whole ROMs off storage; on a handheld, doing that while an
+  /// emulator is running is a worse trade than finishing the pass later. The
+  /// pass is resumable by construction, so nothing is lost: whoever started it
+  /// picks it up from where it stopped. A no-op when no pass is running.
+  static void _pauseBackgroundHashing() {
+    if (!RetroAchievementsHashService.isRematchRunning) return;
+    _log.i('Pausing RA match pass for the duration of the game session');
+    RetroAchievementsHashService.requestRematchPause();
+  }
 
   /// Closes the launch-pending window (e.g. on launch failure).
   static void clearLaunchPending() => _launchPending = false;
@@ -179,6 +195,9 @@ class GameSessionManager {
   ]) {
     _isGameLaunched = true;
     _launchPending = false;
+    // Also here, not only in beginLaunchPending: a launch path that never
+    // opened the pending window would otherwise leave the pass running.
+    _pauseBackgroundHashing();
     _gameLaunchTime = DateTime.now();
     _lastPlaytimeSave = _gameLaunchTime;
     _launchedEmulatorExe = emulatorExeName;

--- a/lib/services/ra_library_match_runner.dart
+++ b/lib/services/ra_library_match_runner.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/foundation.dart';
+
+import '../repositories/retro_achievements_repository.dart';
+import 'global_notification_service.dart';
+import 'logger_service.dart';
+import 'retroachievements_hash_service.dart';
+
+/// What started a library-wide RetroAchievements pass. The two triggers want
+/// genuinely different behaviour, so this is the switch rather than three
+/// booleans the callers would have to keep in sync.
+enum RaMatchTrigger {
+  /// The user pressed Tools -> Match RetroAchievements Games. Reports itself
+  /// the moment it starts, says so when there was nothing to do, and reopens
+  /// ROMs parked as unhashable — they asked for a retry, so give them one.
+  manual,
+
+  /// The startup pass, running unattended after the folder scan. Stays silent
+  /// unless it finds real work, and never reopens parked ROMs: on a matched
+  /// library that would re-read every unhashable file on every single launch.
+  automatic,
+}
+
+/// The runner's user-facing strings, resolved by the caller.
+///
+/// Localization belongs to the UI layer and this is a service, so the strings
+/// come in already translated instead of the service reaching for a
+/// [BuildContext] it has no business holding.
+class RaMatchStrings {
+  /// Shown during the cheap lookup-only pass.
+  final String lookingUp;
+
+  /// Shown per ROM during the hashing pass. Contains `{filename}`.
+  final String hashing;
+
+  /// Completion message. Contains `{matched}` and `{hashed}`.
+  final String done;
+
+  /// Shown when the pass found nothing to do at all.
+  final String nothingToDo;
+
+  /// Shown when the pass was stopped early. Contains `{matched}`.
+  final String paused;
+
+  /// Shown when the pass threw. Contains `{error}`.
+  final String failed;
+
+  const RaMatchStrings({
+    required this.lookingUp,
+    required this.hashing,
+    required this.done,
+    required this.nothingToDo,
+    required this.paused,
+    required this.failed,
+  });
+}
+
+/// Runs the two-pass library-wide RetroAchievements match and reports it
+/// through [GlobalNotificationService].
+///
+/// Lifted out of the Tools screen so the startup pass can share it: the
+/// ordering of the two passes, the progress denominator and the completion
+/// wording are policy, not widget code, and duplicating them would let the two
+/// entry points drift apart.
+class RaLibraryMatchRunner {
+  RaLibraryMatchRunner._();
+
+  static final _log = LoggerService.instance;
+
+  /// Notification id, shared by both triggers on purpose: only one pass can be
+  /// in flight at a time (the service is single-flight), so they can never
+  /// need two bars.
+  static const String notificationId = 'rematch_achievements';
+
+  /// Runs the cheap lookup pass, then the hashing pass.
+  ///
+  /// Returns true when the run was stopped before it finished — the caller may
+  /// want to pick it up again, which is how the startup pass survives the user
+  /// launching a game halfway through it.
+  ///
+  /// Never throws: a failure is reported through the notification and reported
+  /// back as "not cancelled", because there is nothing left to resume.
+  static Future<bool> run({
+    required RaMatchStrings strings,
+    RaMatchTrigger trigger = RaMatchTrigger.manual,
+    VoidCallback? onProgressStateChanged,
+  }) async {
+    final manual = trigger == RaMatchTrigger.manual;
+    var notificationShown = false;
+
+    void showOrUpdate({
+      required String message,
+      required GlobalNotificationType type,
+      double? progress,
+    }) {
+      if (notificationShown) {
+        GlobalNotificationService().update(
+          id: notificationId,
+          message: message,
+          type: type,
+          progress: progress,
+        );
+      } else {
+        notificationShown = true;
+        GlobalNotificationService().show(
+          id: notificationId,
+          message: message,
+          type: type,
+          progress: progress,
+        );
+      }
+    }
+
+    try {
+      if (manual) {
+        // The user just pressed a button; acknowledge it before the first
+        // query, rather than after. The automatic pass has nobody waiting on
+        // it, so it stays quiet until it knows it has work.
+        showOrUpdate(
+          message: strings.lookingUp,
+          type: GlobalNotificationType.info,
+          progress: 0,
+        );
+      }
+
+      // The pass resumes: hashed ROMs are excluded from the candidate query, so
+      // a stopped run picks up where it left off. Report progress against the
+      // whole hashable library rather than the work left in this run, or the
+      // bar restarts at 0% every time and reads as if nothing was kept.
+      final coverage = await RetroAchievementsRepository.getRaHashCoverage();
+      final alreadyHashed = coverage.hashed;
+      final eligible = coverage.eligible;
+
+      // Cheap pass: no file I/O, just retry the local lookup for ROMs that
+      // already carry a hash.
+      final lookup = await RetroAchievementsHashService.rematchLibrary(
+        mode: RaRematchMode.lookupOnly,
+        reopenSkipped: manual,
+        onProgress: (processed, total, _) {
+          if (total == 0) return;
+          showOrUpdate(
+            message: strings.lookingUp,
+            type: GlobalNotificationType.info,
+            progress: eligible > 0 ? alreadyHashed / eligible : null,
+          );
+        },
+      );
+
+      // Expensive pass: hash the ROMs that have never been hashed.
+      final hashPass = lookup.cancelled
+          ? null
+          : await RetroAchievementsHashService.rematchLibrary(
+              reopenSkipped: manual,
+              onProgress: (processed, total, label) {
+                if (total == 0) return;
+                showOrUpdate(
+                  message: strings.hashing.replaceFirst('{filename}', label),
+                  type: GlobalNotificationType.info,
+                  progress: eligible > 0
+                      ? ((alreadyHashed + processed) / eligible).clamp(0.0, 1.0)
+                      : processed / total,
+                );
+              },
+            );
+
+      final matched = lookup.matched + (hashPass?.matched ?? 0);
+      final hashed = hashPass?.hashed ?? 0;
+      final cancelled = lookup.cancelled || (hashPass?.cancelled ?? false);
+      final examined = lookup.total + (hashPass?.total ?? 0);
+
+      if (cancelled) {
+        _finish(
+          message: strings.paused.replaceFirst('{matched}', matched.toString()),
+          type: GlobalNotificationType.info,
+          notificationShown: notificationShown,
+        );
+      } else if (!manual && matched == 0 && hashed == 0) {
+        // An automatic pass that produced nothing says nothing.
+        //
+        // Deliberately keyed on what was *found*, not on how many rows were
+        // examined: the lookup pass re-walks every hashed-but-unmatched ROM on
+        // every launch and legitimately finds nothing, because those ROMs are
+        // not in the bundled RA database at all. On a real library that is
+        // thousands of candidates, so `examined == 0` never happens and keying
+        // on it posted "Done: 0 game(s) matched, 0 newly identified" on every
+        // single launch — exactly the noise this trigger exists to avoid.
+        GlobalNotificationService().dismiss(notificationId);
+      } else if (examined == 0) {
+        // The user pressed a button and deserves an answer, even when the
+        // answer is that there was nothing left to check.
+        _finish(
+          message: strings.nothingToDo,
+          type: GlobalNotificationType.info,
+          notificationShown: notificationShown,
+        );
+      } else {
+        _finish(
+          message: strings.done
+              .replaceFirst('{matched}', matched.toString())
+              .replaceFirst('{hashed}', hashed.toString()),
+          type: matched > 0
+              ? GlobalNotificationType.success
+              : GlobalNotificationType.info,
+          notificationShown: notificationShown,
+        );
+      }
+
+      return cancelled;
+    } catch (e, stackTrace) {
+      _log.e(
+        'Failed to re-match RetroAchievements: $e',
+        stackTrace: stackTrace,
+      );
+      _finish(
+        message: strings.failed.replaceFirst('{error}', e.toString()),
+        type: GlobalNotificationType.error,
+        notificationShown: notificationShown,
+      );
+      return false;
+    } finally {
+      onProgressStateChanged?.call();
+    }
+  }
+
+  /// Writes the completion message, showing the notification first if the run
+  /// never got far enough to raise one.
+  static void _finish({
+    required String message,
+    required GlobalNotificationType type,
+    required bool notificationShown,
+  }) {
+    if (notificationShown) {
+      GlobalNotificationService().update(
+        id: notificationId,
+        message: message,
+        type: type,
+        progress: null,
+      );
+    } else {
+      GlobalNotificationService().show(
+        id: notificationId,
+        message: message,
+        type: type,
+      );
+    }
+  }
+}

--- a/lib/services/ra_library_match_runner.dart
+++ b/lib/services/ra_library_match_runner.dart
@@ -26,6 +26,12 @@ enum RaMatchTrigger {
 /// come in already translated instead of the service reaching for a
 /// [BuildContext] it has no business holding.
 class RaMatchStrings {
+  /// Names the job in the notification bell. The pass can run unattended, so
+  /// the per-ROM message alone ("Identifying Game.zip") never says what the
+  /// identifying is *for*; the title is what makes an unprompted notification
+  /// legible.
+  final String title;
+
   /// Shown during the cheap lookup-only pass.
   final String lookingUp;
 
@@ -45,6 +51,7 @@ class RaMatchStrings {
   final String failed;
 
   const RaMatchStrings({
+    required this.title,
     required this.lookingUp,
     required this.hashing,
     required this.done,
@@ -103,6 +110,7 @@ class RaLibraryMatchRunner {
         notificationShown = true;
         GlobalNotificationService().show(
           id: notificationId,
+          title: strings.title,
           message: message,
           type: type,
           progress: progress,
@@ -169,6 +177,7 @@ class RaLibraryMatchRunner {
 
       if (cancelled) {
         _finish(
+          title: strings.title,
           message: strings.paused.replaceFirst('{matched}', matched.toString()),
           type: GlobalNotificationType.info,
           notificationShown: notificationShown,
@@ -188,12 +197,14 @@ class RaLibraryMatchRunner {
         // The user pressed a button and deserves an answer, even when the
         // answer is that there was nothing left to check.
         _finish(
+          title: strings.title,
           message: strings.nothingToDo,
           type: GlobalNotificationType.info,
           notificationShown: notificationShown,
         );
       } else {
         _finish(
+          title: strings.title,
           message: strings.done
               .replaceFirst('{matched}', matched.toString())
               .replaceFirst('{hashed}', hashed.toString()),
@@ -211,6 +222,7 @@ class RaLibraryMatchRunner {
         stackTrace: stackTrace,
       );
       _finish(
+        title: strings.title,
         message: strings.failed.replaceFirst('{error}', e.toString()),
         type: GlobalNotificationType.error,
         notificationShown: notificationShown,
@@ -224,6 +236,7 @@ class RaLibraryMatchRunner {
   /// Writes the completion message, showing the notification first if the run
   /// never got far enough to raise one.
   static void _finish({
+    required String title,
     required String message,
     required GlobalNotificationType type,
     required bool notificationShown,
@@ -238,6 +251,7 @@ class RaLibraryMatchRunner {
     } else {
       GlobalNotificationService().show(
         id: notificationId,
+        title: title,
         message: message,
         type: type,
       );

--- a/lib/services/ra_library_match_runner.dart
+++ b/lib/services/ra_library_match_runner.dart
@@ -35,7 +35,10 @@ class RaMatchStrings {
   /// Shown during the cheap lookup-only pass.
   final String lookingUp;
 
-  /// Shown per ROM during the hashing pass. Contains `{filename}`.
+  /// Shown during the hashing pass. Contains `{done}` and `{total}`.
+  ///
+  /// Counted rather than per-ROM: the filename changed tens of times a second
+  /// and told the user nothing they could act on.
   final String hashing;
 
   /// Completion message. Contains `{matched}` and `{hashed}`.
@@ -68,10 +71,39 @@ class RaMatchStrings {
 /// ordering of the two passes, the progress denominator and the completion
 /// wording are policy, not widget code, and duplicating them would let the two
 /// entry points drift apart.
+/// Live progress of a running pass, for UI that wants to show it in place
+/// rather than in the notification bell.
+///
+/// [done] and [total] are null during the cheap lookup pass: it walks every
+/// hashed-but-unmatched ROM on every launch and finding nothing is its normal
+/// outcome, so counting it out loud would be a large number that means nothing
+/// to the user.
+class RaMatchProgress {
+  final int? done;
+  final int? total;
+
+  /// True only for the pass that runs as part of the startup sequence, which
+  /// the startup screen waits for.
+  ///
+  /// The pass that resumes after a game session must NOT set this: it runs
+  /// against a library the user is already looking at, and throwing them back
+  /// to a splash screen on returning from a game would be a bug, not progress.
+  final bool holdsSplash;
+
+  const RaMatchProgress({this.done, this.total, this.holdsSplash = false});
+}
+
 class RaLibraryMatchRunner {
   RaLibraryMatchRunner._();
 
   static final _log = LoggerService.instance;
+
+  /// Non-null exactly while a pass is running. The systems grid shows this as
+  /// a row above the (still usable) library, the same way it shows the ROM
+  /// scan — which is where someone actually looks when the app has just
+  /// started, unlike a bell that has to be clicked.
+  static final ValueNotifier<RaMatchProgress?> progress =
+      ValueNotifier<RaMatchProgress?>(null);
 
   /// Notification id, shared by both triggers on purpose: only one pass can be
   /// in flight at a time (the service is single-flight), so they can never
@@ -89,10 +121,24 @@ class RaLibraryMatchRunner {
   static Future<bool> run({
     required RaMatchStrings strings,
     RaMatchTrigger trigger = RaMatchTrigger.manual,
+    bool holdsSplash = false,
     VoidCallback? onProgressStateChanged,
   }) async {
     final manual = trigger == RaMatchTrigger.manual;
     var notificationShown = false;
+
+    // The automatic pass reports through `progress` and the systems grid row.
+    // It deliberately does NOT post a running notification: it starts on its
+    // own, so a bell pulsing for minutes with a filename churning behind it is
+    // noise nobody asked for. Its completion message still goes to the bell.
+    // The manual pass keeps its notification — Tools' own inline bar reads the
+    // notification's progress, so removing it would blank that row.
+    void publish({int? done, int? total}) => progress.value = RaMatchProgress(
+      done: done,
+      total: total,
+      holdsSplash: holdsSplash,
+    );
+    publish();
 
     void showOrUpdate({
       required String message,
@@ -145,6 +191,8 @@ class RaLibraryMatchRunner {
         reopenSkipped: manual,
         onProgress: (processed, total, _) {
           if (total == 0) return;
+          publish();
+          if (!manual) return;
           showOrUpdate(
             message: strings.lookingUp,
             type: GlobalNotificationType.info,
@@ -158,10 +206,14 @@ class RaLibraryMatchRunner {
           ? null
           : await RetroAchievementsHashService.rematchLibrary(
               reopenSkipped: manual,
-              onProgress: (processed, total, label) {
+              onProgress: (processed, total, _) {
                 if (total == 0) return;
+                publish(done: processed, total: total);
+                if (!manual) return;
                 showOrUpdate(
-                  message: strings.hashing.replaceFirst('{filename}', label),
+                  message: strings.hashing
+                      .replaceFirst('{done}', processed.toString())
+                      .replaceFirst('{total}', total.toString()),
                   type: GlobalNotificationType.info,
                   progress: eligible > 0
                       ? ((alreadyHashed + processed) / eligible).clamp(0.0, 1.0)
@@ -229,6 +281,7 @@ class RaLibraryMatchRunner {
       );
       return false;
     } finally {
+      progress.value = null;
       onProgressStateChanged?.call();
     }
   }

--- a/lib/services/ra_library_match_runner.dart
+++ b/lib/services/ra_library_match_runner.dart
@@ -186,20 +186,39 @@ class RaLibraryMatchRunner {
 
       // Cheap pass: no file I/O, just retry the local lookup for ROMs that
       // already carry a hash.
-      final lookup = await RetroAchievementsHashService.rematchLibrary(
-        mode: RaRematchMode.lookupOnly,
-        reopenSkipped: manual,
-        onProgress: (processed, total, _) {
-          if (total == 0) return;
-          publish();
-          if (!manual) return;
-          showOrUpdate(
-            message: strings.lookingUp,
-            type: GlobalNotificationType.info,
-            progress: eligible > 0 ? alreadyHashed / eligible : null,
-          );
-        },
-      );
+      //
+      // "Cheap" is relative: it walks every hashed-but-unmatched ROM, which on
+      // a real library is thousands of rows and a couple of seconds, and it
+      // finds nothing every time by construction — those ROMs are not in the
+      // bundled RA database. It is worth doing after that database changes and
+      // pointless otherwise, so an unattended pass runs it only then. The user
+      // pressing the Tools button always gets it: they may be trying to repair
+      // exactly this.
+      final runLookup =
+          manual || RetroAchievementsRepository.raSeedChangedThisLaunch;
+      final lookup = !runLookup
+          ? const RaRematchResult(
+              total: 0,
+              processed: 0,
+              hashed: 0,
+              matched: 0,
+              skipped: 0,
+              cancelled: false,
+            )
+          : await RetroAchievementsHashService.rematchLibrary(
+              mode: RaRematchMode.lookupOnly,
+              reopenSkipped: manual,
+              onProgress: (processed, total, _) {
+                if (total == 0) return;
+                publish();
+                if (!manual) return;
+                showOrUpdate(
+                  message: strings.lookingUp,
+                  type: GlobalNotificationType.info,
+                  progress: eligible > 0 ? alreadyHashed / eligible : null,
+                );
+              },
+            );
 
       // Expensive pass: hash the ROMs that have never been hashed.
       final hashPass = lookup.cancelled

--- a/lib/services/retroachievements_hash_service.dart
+++ b/lib/services/retroachievements_hash_service.dart
@@ -234,7 +234,20 @@ class RetroAchievementsHashService {
 
     _log.i('RA re-match (${mode.name}): $total candidate ROMs');
 
+    // Every `await` below can complete synchronously — sqlite goes through
+    // FFI, and a lookup that hits nothing touches no file at all. Awaiting a
+    // future that is already done only drains the microtask queue, and Flutter
+    // renders from the event loop, so a pass over thousands of rows would run
+    // start to finish without a single frame: the UI froze on whatever it had
+    // last painted, which on startup is the final system of the ROM scan. A
+    // real yield every few candidates costs nothing and keeps frames coming.
+    const yieldEvery = 32;
+
     for (final candidate in candidates) {
+      if (processed % yieldEvery == 0) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
       if (cancelled()) {
         _log.i('RA re-match cancelled after $processed of $total');
         return RaRematchResult(

--- a/lib/services/retroachievements_hash_service.dart
+++ b/lib/services/retroachievements_hash_service.dart
@@ -155,8 +155,14 @@ class RetroAchievementsHashService {
   ///
   /// Rows the user matched by hand are never overwritten — the write guard
   /// lives in [RetroAchievementsRepository].
+  ///
+  /// [reopenSkipped] controls what happens once nothing hashable is left: a
+  /// pass the user asked for reopens the ROMs parked as unhashable and tries
+  /// them again, because they may have replaced a bad dump since. An
+  /// unattended pass must not — see [_runRematch].
   static Future<RaRematchResult> rematchLibrary({
     RaRematchMode mode = RaRematchMode.hashMissing,
+    bool reopenSkipped = true,
     void Function(int processed, int total, String label)? onProgress,
     bool Function()? isCancelled,
   }) async {
@@ -178,6 +184,7 @@ class RetroAchievementsHashService {
     try {
       return await _runRematch(
         mode: mode,
+        reopenSkipped: reopenSkipped,
         onProgress: onProgress,
         isCancelled: isCancelled,
       );
@@ -189,6 +196,7 @@ class RetroAchievementsHashService {
 
   static Future<RaRematchResult> _runRematch({
     required RaRematchMode mode,
+    required bool reopenSkipped,
     void Function(int processed, int total, String label)? onProgress,
     bool Function()? isCancelled,
   }) async {
@@ -203,7 +211,14 @@ class RetroAchievementsHashService {
     // an earlier run. Give those one more go — the user may have restored a
     // missing file or replaced a bad dump since — rather than leaving them
     // permanently invisible.
-    if (mode == RaRematchMode.hashMissing && candidates.isEmpty) {
+    //
+    // Only when a human asked for this pass. Unattended, it is the opposite of
+    // what the caller wants: on a fully matched library every parked ROM is
+    // reopened and re-read on *every* run, always failing again. A shelf of
+    // .gdi and .rvz discs is hundreds of pointless file reads per launch.
+    if (reopenSkipped &&
+        mode == RaRematchMode.hashMissing &&
+        candidates.isEmpty) {
       final reopened = await RetroAchievementsRepository.clearRaHashSkips();
       if (reopened > 0) {
         _log.i('RA re-match: retrying $reopened previously skipped ROMs');

--- a/lib/services/retroachievements_hash_service.dart
+++ b/lib/services/retroachievements_hash_service.dart
@@ -241,7 +241,10 @@ class RetroAchievementsHashService {
     // start to finish without a single frame: the UI froze on whatever it had
     // last painted, which on startup is the final system of the ROM scan. A
     // real yield every few candidates costs nothing and keeps frames coming.
-    const yieldEvery = 32;
+    // The lookup pass does nothing but hit the database, so its iterations are
+    // short and a coarse interval leaves the bar visibly stuttering; the hash
+    // pass does real file work per ROM and needs far fewer.
+    final yieldEvery = mode == RaRematchMode.lookupOnly ? 8 : 32;
 
     for (final candidate in candidates) {
       if (processed % yieldEvery == 0) {

--- a/lib/utils/disc/binary_disc_image.dart
+++ b/lib/utils/disc/binary_disc_image.dart
@@ -12,7 +12,26 @@ import 'disc_paths.dart';
 /// No native code is involved — the only thing that varies is where a sector's
 /// 2048 user bytes sit inside whatever the file stores per sector.
 class BinaryDiscImage extends DiscImage {
+  /// How many raw sectors one read pulls in.
+  ///
+  /// Sector reads used to go out one at a time, and on Android every one of
+  /// them is a platform-channel round trip for 2 KB. That is invisible for the
+  /// systems that hash a boot executable or a 512-byte header, and brutal for
+  /// PSP, which hashes the whole of `EBOOT.BIN`: 5.6 MB is ~2,900 round trips,
+  /// measured at ~5.3 s per game on an AYN Thor. CHD images never had the
+  /// problem — libchdr reads and caches whole hunks behind one open handle.
+  ///
+  /// Reads here are sequential by construction (walk the ISO9660 tree, then
+  /// stream one file), so a window is fetched once and sliced.
+  static const int _windowSectors = 256;
+
   final List<_BinaryTrack> _tracks;
+
+  /// The window: raw bytes as stored, so slicing still has to apply the
+  /// track's own sector size and data offset.
+  Uint8List? _window;
+  int _windowTrack = -1;
+  int _windowFirstSector = -1;
 
   BinaryDiscImage._(this._tracks);
 
@@ -116,19 +135,58 @@ class BinaryDiscImage extends DiscImage {
     final withinTrack = lba - track.info.startLba;
     if (withinTrack < 0) return null;
 
-    final offset =
-        (track.fileStartSector + withinTrack) * track.sectorSize +
-        track.dataOffset;
+    final rawSector = track.fileStartSector + withinTrack;
+    final cached = _sliceFromWindow(trackIndex, track, rawSector);
+    if (cached != null) return cached;
+
+    // The window starts at the sector asked for rather than on a fixed grid:
+    // reads run forwards from wherever a file begins, so this keeps every
+    // sector of that file in as few reads as possible.
     final bytes = await OptimizedMd5Utils.readRange(
       track.path,
-      offset,
-      discSectorSize,
+      rawSector * track.sectorSize,
+      _windowSectors * track.sectorSize,
     );
-    return bytes.length == discSectorSize ? bytes : null;
+    if (bytes.length < track.dataOffset + discSectorSize) {
+      // Too short to hold even the sector that was asked for. Near the end of
+      // a file a partial window is still usable, so this only fails the read
+      // when the sector itself is not there.
+      return null;
+    }
+    _window = bytes;
+    _windowTrack = trackIndex;
+    _windowFirstSector = rawSector;
+    return _sliceFromWindow(trackIndex, track, rawSector);
+  }
+
+  /// The user bytes of [rawSector] if the current window covers it.
+  ///
+  /// Returns a view, not a copy. Windows are never written to and a refill
+  /// allocates a new buffer, so views handed out earlier stay valid.
+  Uint8List? _sliceFromWindow(
+    int trackIndex,
+    _BinaryTrack track,
+    int rawSector,
+  ) {
+    final window = _window;
+    if (window == null || _windowTrack != trackIndex) return null;
+
+    final index = rawSector - _windowFirstSector;
+    if (index < 0 || index >= _windowSectors) return null;
+
+    final begin = index * track.sectorSize + track.dataOffset;
+    final end = begin + discSectorSize;
+    if (end > window.length) return null;
+
+    return Uint8List.sublistView(window, begin, end);
   }
 
   @override
-  Future<void> close() async {}
+  Future<void> close() async {
+    _window = null;
+    _windowTrack = -1;
+    _windowFirstSector = -1;
+  }
 
   /// Finds the sector layout by looking for the ISO9660 volume descriptor that
   /// every one of these images has at sector 16.

--- a/lib/widgets/system_scan_progress_widget.dart
+++ b/lib/widgets/system_scan_progress_widget.dart
@@ -4,6 +4,7 @@ import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:provider/provider.dart';
 import '../providers/sqlite_config_provider.dart';
+import '../services/ra_library_match_runner.dart';
 
 class SystemScanProgressWidget extends StatelessWidget {
   const SystemScanProgressWidget({super.key});
@@ -13,7 +14,19 @@ class SystemScanProgressWidget extends StatelessWidget {
     return Consumer<SqliteConfigProvider>(
       builder: (context, configProvider, child) {
         if (!configProvider.isScanning) {
-          return SizedBox.shrink();
+          // The ROM scan is done, but the RetroAchievements pass it feeds runs
+          // on afterwards. It gets the same row rather than only a bell nobody
+          // clicks: this is where someone is already looking when the app has
+          // just started. One calm line — never the per-ROM churn, and never
+          // holding the library up, since this branch renders above a grid the
+          // user can already use.
+          return ValueListenableBuilder<RaMatchProgress?>(
+            valueListenable: RaLibraryMatchRunner.progress,
+            builder: (context, raProgress, _) {
+              if (raProgress == null) return const SizedBox.shrink();
+              return _buildRaMatchRow(context, raProgress);
+            },
+          );
         }
 
         return Container(
@@ -125,6 +138,49 @@ class SystemScanProgressWidget extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+
+  /// The one-line form used while the RetroAchievements pass runs.
+  Widget _buildRaMatchRow(BuildContext context, RaMatchProgress raProgress) {
+    final counted = raProgress.done != null && raProgress.total != null;
+    final label = counted
+        ? AppLocale.raMatchProgressCounted
+              .getString(context)
+              .replaceFirst('{done}', raProgress.done.toString())
+              .replaceFirst('{total}', raProgress.total.toString())
+        : AppLocale.raMatchProgressBusy.getString(context);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+        ),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              label,
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/test/binary_disc_image_windowed_read_test.dart
+++ b/test/binary_disc_image_windowed_read_test.dart
@@ -1,0 +1,147 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/disc/binary_disc_image.dart';
+import 'package:neostation/utils/disc/disc_image.dart';
+
+/// Every sector carries a byte pattern derived from its own number, so a read
+/// that lands one sector — or one `dataOffset` — out of place cannot match.
+int _byteFor(int lba, int index) => (lba * 7 + index * 31) & 0xFF;
+
+const _descriptor = [0x01, 0x43, 0x44, 0x30, 0x30, 0x31]; // \x01 CD001
+
+/// Sector 16 holds the volume descriptor the layout probe looks for, so its
+/// user bytes are the pattern with that stamped over the front.
+Uint8List _userBytes(int lba) {
+  final bytes = Uint8List.fromList(
+    List<int>.generate(discSectorSize, (i) => _byteFor(lba, i)),
+  );
+  if (lba == 16) bytes.setRange(0, _descriptor.length, _descriptor);
+  return bytes;
+}
+
+/// Writes an image whose sectors are [sectorSize] bytes with the user data
+/// [dataOffset] in, and a `CD001` volume descriptor at sector 16 so the layout
+/// probe picks exactly this shape.
+File _writeImage(
+  Directory dir,
+  String name, {
+  required int sectorSize,
+  required int dataOffset,
+  required int sectors,
+}) {
+  final bytes = Uint8List(sectorSize * sectors);
+  for (var lba = 0; lba < sectors; lba++) {
+    final base = lba * sectorSize + dataOffset;
+    // The gap before the user data is filled with something *different*, so a
+    // slice that forgets dataOffset reads noise rather than a lucky zero.
+    for (var i = 0; i < dataOffset; i++) {
+      bytes[lba * sectorSize + i] = 0xA5;
+    }
+    bytes.setRange(base, base + discSectorSize, _userBytes(lba));
+  }
+
+  final file = File('${dir.path}/$name')..writeAsBytesSync(bytes);
+  return file;
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() => tempDir = Directory.systemTemp.createTempSync('binary_disc'));
+  tearDown(() => tempDir.deleteSync(recursive: true));
+
+  // 256 sectors to a window, so 600 crosses two boundaries.
+  const sectorCount = 600;
+
+  for (final layout in const [
+    (name: 'a flat 2048 .iso', sectorSize: 2048, dataOffset: 0),
+    (name: 'MODE2/2352 sectors', sectorSize: 2352, dataOffset: 24),
+    (name: 'MODE1/2352 sectors', sectorSize: 2352, dataOffset: 16),
+  ]) {
+    group(layout.name, () {
+      test('reads every sector correctly across window refills', () async {
+        final file = _writeImage(
+          tempDir,
+          'image.iso',
+          sectorSize: layout.sectorSize,
+          dataOffset: layout.dataOffset,
+          sectors: sectorCount,
+        );
+
+        final image = await BinaryDiscImage.openImage(file.path);
+        expect(image, isNotNull, reason: 'the layout probe should match');
+
+        for (var lba = 0; lba < sectorCount; lba++) {
+          final sector = await image!.readSector(0, lba);
+          expect(sector, isNotNull, reason: 'sector $lba should be readable');
+          expect(
+            sector,
+            _userBytes(lba),
+            reason:
+                'sector $lba came back wrong — a windowed read is off by a '
+                'sector or is ignoring dataOffset',
+          );
+        }
+        await image!.close();
+      });
+
+      test(
+        'a sector read out of order still lands on the right bytes',
+        () async {
+          final file = _writeImage(
+            tempDir,
+            'image.iso',
+            sectorSize: layout.sectorSize,
+            dataOffset: layout.dataOffset,
+            sectors: sectorCount,
+          );
+
+          final image = await BinaryDiscImage.openImage(file.path);
+
+          // Forwards into a window, then backwards out of it: the ISO9660 walk
+          // jumps around before any file is streamed, so a window that only ever
+          // moves forward would serve stale bytes here.
+          for (final lba in [0, 300, 5, 599, 256, 255, 1]) {
+            expect(
+              await image!.readSector(0, lba),
+              _userBytes(lba),
+              reason: 'sector $lba after an out-of-order jump',
+            );
+          }
+          await image!.close();
+        },
+      );
+
+      test('reads past the end of the image report failure', () async {
+        final file = _writeImage(
+          tempDir,
+          'image.iso',
+          sectorSize: layout.sectorSize,
+          dataOffset: layout.dataOffset,
+          sectors: sectorCount,
+        );
+
+        final image = await BinaryDiscImage.openImage(file.path);
+        expect(await image!.readSector(0, sectorCount + 10), isNull);
+        await image.close();
+      });
+    });
+  }
+
+  test('the last sector is readable even though its window is short', () async {
+    // 260 sectors: the window opened at sector 259 can only be one sector long.
+    final file = _writeImage(
+      tempDir,
+      'image.iso',
+      sectorSize: 2048,
+      dataOffset: 0,
+      sectors: 260,
+    );
+
+    final image = await BinaryDiscImage.openImage(file.path);
+    expect(await image!.readSector(0, 259), _userBytes(259));
+    await image.close();
+  });
+}

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -154,7 +154,8 @@ class DatabaseTestHelper {
         now_playing_dim_delay INTEGER DEFAULT 3,
         now_playing_dim_level INTEGER DEFAULT 100,
         fanart_dim_level INTEGER DEFAULT 25,
-        show_achievements_badge INTEGER DEFAULT 0
+        show_achievements_badge INTEGER DEFAULT 0,
+        ra_match_on_startup INTEGER DEFAULT 0
       )
     ''');
 

--- a/test/ra_match_notification_test.dart
+++ b/test/ra_match_notification_test.dart
@@ -120,6 +120,43 @@ void main() {
       expect(note!.message, contains('done'));
     });
 
+    test('live progress is published, then cleared', () async {
+      expect(RaLibraryMatchRunner.progress.value, isNull);
+
+      await RaLibraryMatchRunner.run(
+        strings: _strings,
+        trigger: RaMatchTrigger.automatic,
+      );
+
+      expect(
+        RaLibraryMatchRunner.progress.value,
+        isNull,
+        reason:
+            'the systems grid shows a row for as long as this is non-null, so '
+            'a run that forgets to clear it leaves that row up forever',
+      );
+    });
+
+    test('only the startup pass holds the startup screen', () async {
+      RaMatchProgress? seen;
+      void capture() => seen ??= RaLibraryMatchRunner.progress.value;
+      RaLibraryMatchRunner.progress.addListener(capture);
+      addTearDown(() => RaLibraryMatchRunner.progress.removeListener(capture));
+
+      await RaLibraryMatchRunner.run(
+        strings: _strings,
+        trigger: RaMatchTrigger.automatic,
+      );
+
+      expect(
+        seen?.holdsSplash,
+        isFalse,
+        reason:
+            'the default is the resume-after-a-game pass, and pulling the '
+            'splash back over a library the user is looking at is a bug',
+      );
+    });
+
     test('the notification names the job it is doing', () async {
       await RaLibraryMatchRunner.run(
         strings: _strings,

--- a/test/ra_match_notification_test.dart
+++ b/test/ra_match_notification_test.dart
@@ -7,6 +7,7 @@ import 'database_test_helper.dart';
 /// Placeholder copy: these tests care about *whether* the runner speaks, not
 /// what it says, so the strings only have to be distinguishable.
 const _strings = RaMatchStrings(
+  title: 'ra-title',
   lookingUp: 'looking-up',
   hashing: 'hashing {filename}',
   done: 'done {matched}/{hashed}',
@@ -117,6 +118,21 @@ void main() {
       final note = _raNotification();
       expect(note, isNotNull);
       expect(note!.message, contains('done'));
+    });
+
+    test('the notification names the job it is doing', () async {
+      await RaLibraryMatchRunner.run(
+        strings: _strings,
+        trigger: RaMatchTrigger.automatic,
+      );
+
+      expect(
+        _raNotification()?.title,
+        'ra-title',
+        reason:
+            'the startup pass runs unprompted, so a bare "Identifying '
+            'Game.nes" never says what the identifying is for',
+      );
     });
   });
 }

--- a/test/ra_match_notification_test.dart
+++ b/test/ra_match_notification_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
 import 'package:neostation/services/global_notification_service.dart';
 import 'package:neostation/services/ra_library_match_runner.dart';
 
@@ -83,11 +84,102 @@ void main() {
     });
   });
 
+  group('the lookup pass is skipped when it cannot find anything new', () {
+    final dbHelper = DatabaseTestHelper();
+    late dynamic db;
+
+    setUp(() async {
+      db = await dbHelper.setUp();
+      GlobalNotificationService().dismiss(RaLibraryMatchRunner.notificationId);
+      await db.execute(
+        "INSERT INTO app_systems (id, real_name, folder_name, ra_id, multidisc)"
+        " VALUES ('nes', 'NES', 'nes', '7', 0)",
+      );
+      // A ROM the lookup pass *could* match, so anything skipping the pass is
+      // visible as the match not happening rather than as an empty library.
+      await db.execute(
+        "INSERT INTO app_ra_game_list (hash, game_id, title, console_id) "
+        "VALUES ('hash0', 42, 'Some Game', 7)",
+      );
+      await db.execute(
+        "INSERT INTO user_roms (filename, rom_path, app_system_id, ra_hash) "
+        "VALUES ('Game0.nes', '/roms/nes/Game0.nes', 'nes', 'hash0')",
+      );
+    });
+
+    tearDown(() async {
+      SqliteService.raSeedChangedThisLaunch = false;
+      GlobalNotificationService().dismiss(RaLibraryMatchRunner.notificationId);
+      await dbHelper.tearDown();
+    });
+
+    test('an unattended pass skips it when the RA list is unchanged', () async {
+      SqliteService.raSeedChangedThisLaunch = false;
+
+      await RaLibraryMatchRunner.run(
+        strings: _strings,
+        trigger: RaMatchTrigger.automatic,
+      );
+
+      final rows = await db.rawQuery(
+        "SELECT id_ra FROM user_roms WHERE filename = 'Game0.nes'",
+      );
+      expect(
+        rows.first['id_ra'],
+        isNull,
+        reason:
+            'walking every hashed-but-unmatched ROM cannot answer differently '
+            'than last launch when the bundled list has not changed, and it '
+            'costs seconds of startup every time',
+      );
+    });
+
+    test('an unattended pass runs it when the RA list changed', () async {
+      SqliteService.raSeedChangedThisLaunch = true;
+
+      await RaLibraryMatchRunner.run(
+        strings: _strings,
+        trigger: RaMatchTrigger.automatic,
+      );
+
+      final rows = await db.rawQuery(
+        "SELECT id_ra FROM user_roms WHERE filename = 'Game0.nes'",
+      );
+      expect(
+        rows.first['id_ra'],
+        42,
+        reason: 'a new list is exactly what the lookup pass exists to pick up',
+      );
+    });
+
+    test('the pass the user asked for always runs it', () async {
+      SqliteService.raSeedChangedThisLaunch = false;
+
+      await RaLibraryMatchRunner.run(
+        strings: _strings,
+        trigger: RaMatchTrigger.manual,
+      );
+
+      final rows = await db.rawQuery(
+        "SELECT id_ra FROM user_roms WHERE filename = 'Game0.nes'",
+      );
+      expect(
+        rows.first['id_ra'],
+        42,
+        reason: 'they may be pressing the button to repair exactly this',
+      );
+    });
+  });
+
   group('an automatic pass that finds something reports it', () {
     final dbHelper = DatabaseTestHelper();
     late dynamic db;
 
     setUp(() async {
+      // These cover what the pass *says*, and the thing it has to say something
+      // about here is a lookup hit. An unattended pass only runs the lookup
+      // when the bundled RA list changed, which is the launch being modelled.
+      SqliteService.raSeedChangedThisLaunch = true;
       db = await dbHelper.setUp();
       GlobalNotificationService().dismiss(RaLibraryMatchRunner.notificationId);
       await db.execute(
@@ -105,6 +197,7 @@ void main() {
     });
 
     tearDown(() async {
+      SqliteService.raSeedChangedThisLaunch = false;
       GlobalNotificationService().dismiss(RaLibraryMatchRunner.notificationId);
       await dbHelper.tearDown();
     });

--- a/test/ra_match_notification_test.dart
+++ b/test/ra_match_notification_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/global_notification_service.dart';
+import 'package:neostation/services/ra_library_match_runner.dart';
+
+import 'database_test_helper.dart';
+
+/// Placeholder copy: these tests care about *whether* the runner speaks, not
+/// what it says, so the strings only have to be distinguishable.
+const _strings = RaMatchStrings(
+  lookingUp: 'looking-up',
+  hashing: 'hashing {filename}',
+  done: 'done {matched}/{hashed}',
+  nothingToDo: 'nothing-to-do',
+  paused: 'paused {matched}',
+  failed: 'failed {error}',
+);
+
+GlobalNotificationData? _raNotification() {
+  final all = GlobalNotificationService().notifier.value;
+  for (final n in all) {
+    if (n.id == RaLibraryMatchRunner.notificationId) return n;
+  }
+  return null;
+}
+
+void main() {
+  group('an automatic pass that finds nothing stays silent', () {
+    final dbHelper = DatabaseTestHelper();
+    late dynamic db;
+
+    setUp(() async {
+      db = await dbHelper.setUp();
+      GlobalNotificationService().dismiss(RaLibraryMatchRunner.notificationId);
+      await db.execute(
+        "INSERT INTO app_systems (id, real_name, folder_name, ra_id, multidisc)"
+        " VALUES ('nes', 'NES', 'nes', '7', 0)",
+      );
+      // The steady state of a matched library: every ROM already carries a
+      // hash, so nothing needs hashing, but the lookup pass still re-walks
+      // them all every launch. None of them resolve, because the bundled RA
+      // database has no row for them.
+      for (var i = 0; i < 3; i++) {
+        await db.execute(
+          "INSERT INTO user_roms (filename, rom_path, app_system_id, ra_hash) "
+          "VALUES ('Game$i.nes', '/roms/nes/Game$i.nes', 'nes', 'hash$i')",
+        );
+      }
+    });
+
+    tearDown(() async {
+      GlobalNotificationService().dismiss(RaLibraryMatchRunner.notificationId);
+      await dbHelper.tearDown();
+    });
+
+    test('posts no notification at all', () async {
+      final interrupted = await RaLibraryMatchRunner.run(
+        strings: _strings,
+        trigger: RaMatchTrigger.automatic,
+      );
+
+      expect(interrupted, isFalse);
+      expect(
+        _raNotification(),
+        isNull,
+        reason:
+            'the lookup pass examines every unmatched ROM on every launch and '
+            'legitimately finds nothing; saying so would be noise each time',
+      );
+    });
+
+    test('the pass the user asked for still answers', () async {
+      await RaLibraryMatchRunner.run(
+        strings: _strings,
+        trigger: RaMatchTrigger.manual,
+      );
+
+      expect(
+        _raNotification(),
+        isNotNull,
+        reason: 'they pressed a button, so silence would read as a hang',
+      );
+    });
+  });
+
+  group('an automatic pass that finds something reports it', () {
+    final dbHelper = DatabaseTestHelper();
+    late dynamic db;
+
+    setUp(() async {
+      db = await dbHelper.setUp();
+      GlobalNotificationService().dismiss(RaLibraryMatchRunner.notificationId);
+      await db.execute(
+        "INSERT INTO app_systems (id, real_name, folder_name, ra_id, multidisc)"
+        " VALUES ('nes', 'NES', 'nes', '7', 0)",
+      );
+      await db.execute(
+        "INSERT INTO app_ra_game_list (hash, game_id, title, console_id) "
+        "VALUES ('hash0', 42, 'Some Game', 7)",
+      );
+      await db.execute(
+        "INSERT INTO user_roms (filename, rom_path, app_system_id, ra_hash) "
+        "VALUES ('Game0.nes', '/roms/nes/Game0.nes', 'nes', 'hash0')",
+      );
+    });
+
+    tearDown(() async {
+      GlobalNotificationService().dismiss(RaLibraryMatchRunner.notificationId);
+      await dbHelper.tearDown();
+    });
+
+    test('a new match is worth a notification', () async {
+      await RaLibraryMatchRunner.run(
+        strings: _strings,
+        trigger: RaMatchTrigger.automatic,
+      );
+
+      final note = _raNotification();
+      expect(note, isNotNull);
+      expect(note!.message, contains('done'));
+    });
+  });
+}

--- a/test/ra_match_on_startup_migration_test.dart
+++ b/test/ra_match_on_startup_migration_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+
+/// Tests for migration v141, which adds `user_config.ra_match_on_startup` —
+/// the opt-in for running the RetroAchievements match pass after the startup
+/// scan.
+///
+/// The default is the point of the test as much as the column is. The first
+/// pass on a library that has never been matched hashes every ROM and takes
+/// minutes; an upgrade that switched that on by itself would look like the app
+/// hanging on launch.
+///
+/// The slot number is not sequential — 139 and 140 belong to an unmerged
+/// branch. Sharing a number with different contents is the failure this
+/// codebase has hit before: the device is already past that version, so the
+/// `case` never runs and the column silently never arrives.
+void main() {
+  late Database db;
+
+  setUp(() {
+    // The "old device" case: user_config without the new column.
+    db = sqlite3.openInMemory();
+    db.execute('''
+      CREATE TABLE user_config (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        game_view_mode TEXT DEFAULT 'list',
+        scan_on_startup INTEGER DEFAULT 1
+      )
+    ''');
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  Future<void> runV141() => SqliteMigrations.migrateToVersion(db, 141);
+
+  List<String> configColumns() => db
+      .select('PRAGMA table_info(user_config)')
+      .map((c) => c['name'].toString())
+      .toList();
+
+  group('migration v141', () {
+    test('adds ra_match_on_startup when the column is missing', () async {
+      expect(configColumns(), isNot(contains('ra_match_on_startup')));
+
+      await runV141();
+
+      expect(configColumns(), contains('ra_match_on_startup'));
+    });
+
+    test('leaves an existing row with the startup pass off', () async {
+      db.execute('INSERT INTO user_config (id) VALUES (1)');
+
+      await runV141();
+
+      final rows = db.select(
+        'SELECT ra_match_on_startup FROM user_config WHERE id = 1',
+      );
+      expect(
+        rows.first['ra_match_on_startup'],
+        0,
+        reason: 'an upgrade must not start hashing the library on its own',
+      );
+    });
+
+    test('a row inserted after the migration also defaults to off', () async {
+      await runV141();
+      db.execute('INSERT INTO user_config (id) VALUES (1)');
+
+      final rows = db.select(
+        'SELECT ra_match_on_startup FROM user_config WHERE id = 1',
+      );
+      expect(rows.first['ra_match_on_startup'], 0);
+    });
+
+    test('is a no-op when the column already exists', () async {
+      db.execute(
+        'ALTER TABLE user_config ADD COLUMN ra_match_on_startup '
+        'INTEGER DEFAULT 0',
+      );
+      db.execute(
+        'INSERT INTO user_config (id, ra_match_on_startup) VALUES (1, 1)',
+      );
+
+      await runV141();
+
+      // A device that already has the column keeps the user's choice.
+      final rows = db.select(
+        'SELECT ra_match_on_startup FROM user_config WHERE id = 1',
+      );
+      expect(rows.first['ra_match_on_startup'], 1);
+      expect(
+        configColumns().where((c) => c == 'ra_match_on_startup').length,
+        1,
+        reason: 'the column must not be added twice',
+      );
+    });
+
+    test('re-running the migration stays a no-op', () async {
+      await runV141();
+      await runV141();
+
+      expect(configColumns(), contains('ra_match_on_startup'));
+    });
+  });
+}

--- a/test/ra_match_on_startup_setting_test.dart
+++ b/test/ra_match_on_startup_setting_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_config_service.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+import 'package:neostation/models/config_model.dart';
+
+import 'database_test_helper.dart';
+
+/// The startup match pass is opt-in, and the toggle is only a feature if the
+/// read path picks it back up. A column that is written and never read has
+/// happened more than once in this area, and in each case the write test
+/// passed on its own.
+void main() {
+  final dbHelper = DatabaseTestHelper();
+
+  setUp(() async => dbHelper.setUp());
+  tearDown(() async => dbHelper.tearDown());
+
+  group('match RetroAchievements on startup setting', () {
+    test('a fresh config has the startup pass off', () {
+      expect(const ConfigModel().raMatchOnStartup, isFalse);
+    });
+
+    test(
+      'a database row written before the setting existed reads as off',
+      () async {
+        // No value ever written for the new column: its default stands in, and
+        // an upgrade must not start hashing the library on its own.
+        await SqliteService.saveUserConfig(appLanguage: 'en');
+
+        final loaded = await SqliteConfigService.loadConfig();
+
+        expect(loaded.raMatchOnStartup, isFalse);
+      },
+    );
+
+    test('turning it on survives a save and reload', () async {
+      await SqliteConfigService.saveConfig(
+        const ConfigModel(raMatchOnStartup: true),
+      );
+
+      final loaded = await SqliteConfigService.loadConfig();
+
+      expect(loaded.raMatchOnStartup, isTrue);
+    });
+
+    test('turning it back off survives a save and reload', () async {
+      await SqliteConfigService.saveConfig(
+        const ConfigModel(raMatchOnStartup: true),
+      );
+      await SqliteConfigService.saveConfig(
+        const ConfigModel(raMatchOnStartup: false),
+      );
+
+      final loaded = await SqliteConfigService.loadConfig();
+
+      expect(loaded.raMatchOnStartup, isFalse);
+    });
+
+    test('it does not disturb the neighbouring startup-scan toggle', () async {
+      await SqliteConfigService.saveConfig(
+        const ConfigModel(raMatchOnStartup: true, scanOnStartup: false),
+      );
+
+      final loaded = await SqliteConfigService.loadConfig();
+
+      expect(loaded.raMatchOnStartup, isTrue);
+      expect(loaded.scanOnStartup, isFalse);
+    });
+
+    test('the setting round-trips through JSON in both key forms', () {
+      final asCamel = ConfigModel.fromJson(const {'raMatchOnStartup': true});
+      final asSnake = ConfigModel.fromJson(const {'ra_match_on_startup': 1});
+
+      expect(asCamel.raMatchOnStartup, isTrue);
+      expect(asSnake.raMatchOnStartup, isTrue);
+      expect(
+        const ConfigModel(raMatchOnStartup: true).toJson()['raMatchOnStartup'],
+        isTrue,
+      );
+      expect(ConfigModel.fromJson(const {}).raMatchOnStartup, isFalse);
+    });
+
+    test('copyWith carries the setting and leaves it alone by default', () {
+      const on = ConfigModel(raMatchOnStartup: true);
+
+      expect(on.copyWith().raMatchOnStartup, isTrue);
+      expect(on.copyWith(raMatchOnStartup: false).raMatchOnStartup, isFalse);
+    });
+  });
+}

--- a/test/ra_match_pauses_for_game_test.dart
+++ b/test/ra_match_pauses_for_game_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/game/game_session_manager.dart';
+import 'package:neostation/services/retroachievements_hash_service.dart';
+
+import 'database_test_helper.dart';
+
+/// Launching a game stops a library-wide RetroAchievements pass.
+///
+/// Hashing reads whole ROMs off storage. On a handheld, doing that while an
+/// emulator is running is a worse trade than finishing the pass later — and
+/// the pass loses nothing by stopping, because its candidates are "ROMs with
+/// no hash", so whoever restarts it picks up exactly where it left off.
+///
+/// This matters most for the startup pass, which the user did not ask for at
+/// that moment and which on an unmatched library runs for minutes.
+void main() {
+  final dbHelper = DatabaseTestHelper();
+  late dynamic db;
+
+  setUp(() async {
+    db = await dbHelper.setUp();
+    await db.execute(
+      "INSERT INTO app_systems (id, real_name, folder_name, ra_id, multidisc)"
+      " VALUES ('nes', 'NES', 'nes', '7', 0)",
+    );
+    for (final name in ['A.nes', 'B.nes', 'C.nes', 'D.nes']) {
+      await db.execute(
+        "INSERT INTO user_roms (filename, rom_path, app_system_id) "
+        "VALUES ('$name', '/roms/nes/$name', 'nes')",
+      );
+    }
+  });
+
+  tearDown(() async {
+    // Global launch state: leave it as we found it or the next test starts
+    // inside a launch window.
+    GameSessionManager.clearLaunchPending();
+    await dbHelper.tearDown();
+  });
+
+  test('a launch stops an in-flight pass after the current ROM', () async {
+    final result = await RetroAchievementsHashService.rematchLibrary(
+      onProgress: (processed, total, label) {
+        // Exactly what the user does: starts a game while the pass is running.
+        if (processed == 0) GameSessionManager.beginLaunchPending();
+      },
+    );
+
+    expect(result.cancelled, isTrue);
+    expect(
+      result.processed,
+      lessThan(result.total),
+      reason: 'the pass should stop, not run to the end of the library',
+    );
+    expect(RetroAchievementsHashService.isRematchRunning, isFalse);
+  });
+
+  test('the stopped pass resumes from where it left off', () async {
+    final firstRun = await RetroAchievementsHashService.rematchLibrary(
+      onProgress: (processed, total, label) {
+        if (processed == 0) GameSessionManager.beginLaunchPending();
+      },
+    );
+    GameSessionManager.clearLaunchPending();
+
+    // The ROMs the first run parked are excluded from the candidate query, so
+    // a second run sees only what is left.
+    final secondRun = await RetroAchievementsHashService.rematchLibrary();
+
+    expect(secondRun.total, firstRun.total - firstRun.processed);
+  });
+
+  test('a launch with no pass running latches nothing', () async {
+    GameSessionManager.beginLaunchPending();
+    GameSessionManager.clearLaunchPending();
+
+    // If the pause request had latched, this pass would abort immediately.
+    final result = await RetroAchievementsHashService.rematchLibrary();
+
+    expect(result.cancelled, isFalse);
+    expect(result.processed, result.total);
+  });
+}

--- a/test/retroachievements_hash_service_test.dart
+++ b/test/retroachievements_hash_service_test.dart
@@ -136,6 +136,85 @@ void main() {
     });
   });
 
+  // The reopen is right for a pass the user asked for and wrong for one that
+  // runs by itself: on a fully matched library it re-reads every unhashable
+  // ROM on every single launch, always failing, forever.
+  group('reopening ROMs parked as unhashable', () {
+    final dbHelper = DatabaseTestHelper();
+    late dynamic db;
+
+    setUp(() async {
+      db = await dbHelper.setUp();
+      await db.execute(
+        "INSERT INTO app_systems (id, real_name, folder_name, ra_id, multidisc)"
+        " VALUES ('nes', 'NES', 'nes', '7', 0)",
+      );
+      // Parked by an earlier run: no hash, and a skip reason recorded.
+      await db.execute(
+        "INSERT INTO user_roms (filename, rom_path, app_system_id, "
+        "ra_hash_skipped) VALUES ('Game.nes', '/roms/nes/Game.nes', 'nes', "
+        "'missing')",
+      );
+    });
+
+    tearDown(() async {
+      await dbHelper.tearDown();
+    });
+
+    test('a pass the user asked for retries them', () async {
+      final result = await RetroAchievementsHashService.rematchLibrary();
+
+      expect(
+        result.total,
+        1,
+        reason: 'the parked ROM should be reopened and walked again',
+      );
+      // Still missing, so it parks again — but it got its retry, which is the
+      // point: the user may have restored the file since.
+      expect(result.skipped, 1);
+    });
+
+    test('an automatic pass leaves them parked', () async {
+      final result = await RetroAchievementsHashService.rematchLibrary(
+        reopenSkipped: false,
+      );
+
+      expect(
+        result.total,
+        0,
+        reason: 'an unattended pass must not re-read unhashable files',
+      );
+      final row = await db.rawQuery(
+        "SELECT ra_hash_skipped FROM user_roms WHERE filename = 'Game.nes'",
+      );
+      expect(
+        row.first['ra_hash_skipped'],
+        'missing',
+        reason: 'the skip marker must survive, or the next run walks it again',
+      );
+    });
+
+    test(
+      'an automatic pass still hashes ROMs that were never parked',
+      () async {
+        await db.execute(
+          "INSERT INTO user_roms (filename, rom_path, app_system_id) "
+          "VALUES ('New.nes', '/roms/nes/New.nes', 'nes')",
+        );
+
+        final result = await RetroAchievementsHashService.rematchLibrary(
+          reopenSkipped: false,
+        );
+
+        expect(
+          result.total,
+          1,
+          reason: 'skipping the reopen must not skip genuinely new ROMs',
+        );
+      },
+    );
+  });
+
   group('the library pass is a singleton', () {
     final dbHelper = DatabaseTestHelper();
 


### PR DESCRIPTION
# Description

Hashing is otherwise lazy: a ROM is only hashed when the user opens it, so a ROM added last week
carries no match and no achievement badge until somebody remembers to walk to Tools and press a
button. This adds an opt-in pass that runs after the startup folder scan and picks up whatever the
scan just added.

**Off by default.** The toggle lives in General settings, directly below the achievement badge:

> **Match achievements on Startup**
> Matches new ROMs after the startup scan. To match a whole library, run Match RetroAchievements
> Games in Tools first.

Switching it on reads the real backlog and, at 500 or more, names the count and points at
**Tools → Match RetroAchievements Games**, which does the same work with a progress bar and somebody
watching. It is advice, not a gate: the setting is written either way. Both toggle paths (gamepad
and touch) route through one method, so the prompt cannot be sidestepped by using the other input.

**It runs after the whole scan, never during.** The candidate set is "ROMs with no hash", so a pass
that started mid-scan simply would not see the ROMs the scan had not inserted yet. It waits for the
initial scan across every configured folder *and* for the systems-update re-scan, which can bring a
system into RA range for the first time.

**The startup screen shows it, and waits for it.** The scan already narrates itself there, naming
each system as it goes; the pass finishes that sentence with one line —
`Matching RetroAchievements... 40/680` — and the library appears when it is done, matched, rather
than settling behind the user's back. Only the startup pass does this. The pass that resumes after a
game session shows as a row under the library instead: it runs against a library already on screen,
and pulling a splash back over it would be a bug.

**The pass runs to completion** rather than being capped. On a large unmatched library that is one
slow start and then never again, because every later launch finds nothing to do. A per-launch budget
was built and measured during this work and then removed: it left ROMs unmatched by design and
turned a first enable into many mediocre launches instead of one. Steering people to Tools at the
toggle is what replaced it.

The two-pass ordering, the progress denominator and the completion wording move out of the Tools
screen into a shared `RaLibraryMatchRunner`, so the two entry points cannot drift apart. Strings
arrive already translated through `RaMatchStrings`, keeping localization in the UI layer and
`BuildContext` out of the service. A `RaMatchTrigger` enum carries the behavioural differences
between a pass the user asked for and an unattended one.

The pass pauses when a game launches and resumes when the session ends, so hashing never competes
with a running emulator for storage.

## Bugs found by testing this on a device

Each of these was a standing problem that only became visible once an unattended pass existed.

- **An automatic pass no longer reopens ROMs parked as unhashable** (`rematchLibrary` gained
  `reopenSkipped`). Reopening is right when a human asks, since they may have replaced a bad dump,
  but on a matched library it re-read every `.gdi` and `.rvz` on every single launch.
- **An automatic pass that finds nothing now says nothing.** The "nothing to do" branch keyed on how
  many rows were *examined*, but the lookup pass re-walks every hashed-but-unmatched ROM on every
  launch and legitimately finds nothing. On a real library that is thousands of rows, so the silent
  branch was unreachable and a fully matched library posted "Done: 0 game(s) matched, 0 newly
  identified" on every launch.
- **The lookup pass no longer runs on every launch.** It walks every hashed-but-unmatched ROM — 4,098
  on the test library — and finds nothing every time by construction: those ROMs are not in the
  bundled RA database at all. It exists to recover matches after that database *changes*, so an
  unattended pass now runs it only when the launch actually rebuilt the list. Tools always runs it.
  Newly added ROMs are unaffected: the hashing pass looks each one up inline as it hashes it.
- **The UI could not paint during a pass.** Every `await` in the candidate loop can complete
  synchronously — sqlite goes through FFI, and a lookup that hits nothing touches no file — and
  awaiting an already-completed future only drains the microtask queue while Flutter renders from the
  event loop. A pass over thousands of rows therefore ran start to finish without producing a frame,
  so the screen froze on whatever it had last painted, which on startup is the final system of the
  ROM scan. It looked exactly like the scan hanging on that system. Fixed by yielding properly.
- **Disc images were read one 2048-byte sector at a time**, and on Android every one of those is a
  platform-channel round trip through SAF. Invisible for systems that hash a boot executable or a
  512-byte header; brutal for PSP, which hashes the whole of `EBOOT.BIN` — 5.6 MB is ~2,900 round
  trips. `BinaryDiscImage` now reads a window of 256 sectors and slices it. CHD images never had the
  problem: libchdr reads and caches whole hunks behind one native handle.

## Also here, and separable

**The 2.5 s minimum splash duration is gone** (added in #281 so a fast scan would not blink the logo
away before its glint animation registered). It trades the user's time for an animation: when the
library is ready in under a second, holding the logo up makes a fast start feel slow. This is the one
change in the PR that is not about RetroAchievements — happy to split it out if you would rather.

## One deliberate deviation

The pass is **not** gated on being signed in to RetroAchievements. It hashes locally against the
bundled database and needs no account, and what it produces (the match, and the count behind the
library badge) is visible without one. Tools takes the same view. Silently doing nothing for a user
who went and enabled the toggle seemed the worse outcome. It is commented as such in
`AppScreen._runStartupRaMatch` and is a one-line reversal if you would rather it no-op'd.

## Steps to Verify

**Preconditions:** an Android device with a large ROM library, signed in to RetroAchievements or not,
and Settings → General → **Match achievements on Startup** switched ON.

1. Add a ROM to a scanned folder while the app is closed. Start the app.
2. After the systems finish scanning, the startup screen shows `Matching RetroAchievements... 1/1`
   and then opens the library. The log reads `RA re-match (hashMissing): 1 candidate ROMs` →
   `1 processed, 1 hashed, 1 matched`.
3. Restart. The startup screen shows no matching line at all, no notification is posted, and the log
   reads `RA re-match (hashMissing): 0 candidate ROMs` with no `lookupOnly` line: the new ROM is not
   walked again, a matched library is silent, and there is no per-launch cost.
4. With a backlog still to do, launch a game mid-pass. The pass stops (`Pausing RA match pass for the
   duration of the game session`, `RA re-match cancelled after N of M`).
5. Quit the game. The pass resumes at exactly the count it had not reached, shown as a row under the
   library rather than a splash, and runs to completion.
6. Switch the toggle on with 500+ ROMs never checked: a dialog names the count and points at Tools.
   Dismissing it still writes the setting.

## Tested on

All on an AYN Thor against a 9,137-ROM library.

**Behaviour**

| check | result |
|---|---|
| a backlog runs to completion in one launch | `980 candidates` → `974 hashed, 473 matched, 6 skipped`, 74 s |
| …and does not come back | next launch `hashMissing: 0` |
| a new ROM is hashed on the next launch | `hashMissing: 1` → `1 processed, 1 hashed, 1 matched` |
| …and only then | the launch after that: `hashMissing: 0` |
| a fully matched library is silent | no notification posted, bell unlit |
| ROMs parked as unhashable are not reopened | the 6 skipped above were not walked again |
| the pass pauses for a game | `cancelled after 1899 of 5108` |
| …and resumes to completion | `hashMissing: 3208` → `3208 hashed, 1699 matched` |
| signed out, the pass still runs | `ra_user` cleared: `747 hashed, 483 matched` |
| a 400-ROM mixed backlog | 120 PS1 + 60 NES + 60 SNES + 40 arcade + 40 GB + 40 Sega CD + 32 DS + 8 PSP |

**Performance**

| | before | after |
|---|---|---|
| 8 PSP ISOs (hashing phase) | 42.8 s (~5.3 s each) | under 1 s |
| 8 PSP ISOs (launch → library) | 52.0 s | 8.2 s |
| frames during a pass | byte-identical for 1.6 s+ | every captured frame differs |
| relaunch on a matched library | ~2 s of "Matching…" with a stuttering bar | no matching line at all |

The PSP runs returned `8 processed, 8 hashed, 6 matched` before and after, so the windowed reads
change no hashes.

- [x] Android — device: AYN Thor, 9,137-ROM library
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1,417)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — strings, the database, and disc reading</b></summary>

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [x] No hardcoded UI strings — everything goes through `AppLocale`. Each translation names the Tools
      row as it appears in that language, rather than leaving an English label mid-sentence

**The database**
- [x] Column added to the versioned migration in `sqlite_migrations.dart` **and** the `CREATE TABLE`
      in `sqlite_service.dart`
- [x] Migration number is above every slot in use on any open branch, not just `main` + 1 — **v141**,
      re-scanned across all worktrees immediately before opening this PR
- [x] Migration is idempotent (`PRAGMA table_info` guard) and has a test
- [x] `_databaseVersion` bumped

Slots 139 and 140 are deliberately left empty: they are held by other unmerged branches, so upgrading
devices will log `No migration defined for version 139/140` twice. That is a warning, not a throw,
and is the price of not colliding.

**Disc reading**
- [x] New test builds real image files in all three sector layouts (flat 2048, MODE1/2352,
      MODE2/2352) and reads every sector across window refills, out of order, past the end, and at a
      final short window. The existing disc tests all use a fake image and never exercised this
      reader

**Navigation**
- [x] The toggle is reachable by D-pad and by touch, and both paths go through the same method

</details>
