### PR TITLE
fix(ra): let a failed disc hash explain itself in the log

### DIFF
--- a/lib/services/logger_service.dart
+++ b/lib/services/logger_service.dart
@@ -18,6 +18,15 @@ class LoggerService {
   Logger _logger;
   bool _initialized = false;
 
+  /// Lines logged in this isolate since [startCapture], or null when nothing
+  /// is collecting.
+  List<String>? _captured;
+
+  /// The most lines one capture holds. A capture exists to explain a single
+  /// failure, and an unbounded list in a background isolate is a memory leak
+  /// waiting for a pathological image.
+  static const int _captureLimit = 64;
+
   /// Whether [init] has run and log output is reaching the file as well as the
   /// console.
   ///
@@ -80,6 +89,57 @@ class LoggerService {
     }
   }
 
+  /// Starts collecting everything this isolate logs, on top of its normal
+  /// output.
+  ///
+  /// For work handed to a background isolate. [init] runs in the main isolate
+  /// only — a spawned one gets its own copy of this singleton with no file
+  /// output, and two isolates holding a [FileOutput] on the same path would
+  /// interleave writes and race the rotation rename, so it cannot simply open
+  /// the file too. Capturing lets it hand its diagnostics back instead: the
+  /// isolate calls this, returns [takeCapture] with its result, and the main
+  /// isolate feeds that to [replayCaptured].
+  void startCapture() => _captured = <String>[];
+
+  /// Everything captured since [startCapture], and stops collecting.
+  ///
+  /// Each line carries a one-character level prefix so [replayCaptured] can
+  /// restore the severity; the encoding is deliberately primitive because the
+  /// list crosses an isolate boundary.
+  List<String> takeCapture() {
+    final captured = _captured ?? const <String>[];
+    _captured = null;
+    return captured;
+  }
+
+  /// Re-logs lines a background isolate captured, so they reach the log file.
+  ///
+  /// Anything already collecting here keeps collecting: replaying goes through
+  /// [log] like any other line.
+  void replayCaptured(Iterable<String> lines) {
+    for (final line in lines) {
+      if (line.length < 2 || line[1] != _captureSeparator) continue;
+      log(line.substring(2), level: _levelForTag(line[0]));
+    }
+  }
+
+  /// Separates a captured line's level tag from its message.
+  static const String _captureSeparator = '|';
+
+  static String _tagForLevel(LogLevel level) => switch (level) {
+    LogLevel.info => 'i',
+    LogLevel.warning => 'w',
+    LogLevel.error => 'e',
+    LogLevel.debug => 'd',
+  };
+
+  static LogLevel _levelForTag(String tag) => switch (tag) {
+    'w' => LogLevel.warning,
+    'e' => LogLevel.error,
+    'd' => LogLevel.debug,
+    _ => LogLevel.info,
+  };
+
   /// Logs a message at the specified [LogLevel].
   void log(
     String message, {
@@ -87,6 +147,12 @@ class LoggerService {
     Object? error,
     StackTrace? stackTrace,
   }) {
+    final captured = _captured;
+    if (captured != null && captured.length < _captureLimit) {
+      final suffix = error == null ? '' : ' $error';
+      captured.add('${_tagForLevel(level)}$_captureSeparator$message$suffix');
+    }
+
     switch (level) {
       case LogLevel.info:
         _logger.i(message, error: error, stackTrace: stackTrace);

--- a/lib/services/retroachievements_hash_service.dart
+++ b/lib/services/retroachievements_hash_service.dart
@@ -104,11 +104,13 @@ class RetroAchievementsHashService {
       await Future.delayed(const Duration(milliseconds: 500));
 
       final isolateToken = RootIsolateToken.instance!;
-      final hash = await compute(_generateHashForSystemIsolate, {
-        'romPath': romPathToProcess,
-        'algo': policy.algo.jsonName,
-        'token': isolateToken,
-      });
+      final hash = _replayIsolateLog(
+        await compute(_generateHashForSystemIsolate, {
+          'romPath': romPathToProcess,
+          'algo': policy.algo.jsonName,
+          'token': isolateToken,
+        }),
+      );
 
       if (isArchive) {
         await ArchiveService.cleanupTempFolder(
@@ -231,6 +233,10 @@ class RetroAchievementsHashService {
     int hashed = 0;
     int matched = 0;
     int skipped = 0;
+    // Why each parked ROM was parked. The count alone reads as a stall; the
+    // reasons say whether the gap is the user's library (a missing file, a
+    // container nothing can read) or ours.
+    final skipReasons = <String, int>{};
 
     _log.i('RA re-match (${mode.name}): $total candidate ROMs');
 
@@ -281,10 +287,13 @@ class RetroAchievementsHashService {
           if (hash == null) {
             // Park it with the reason, so the next run does not walk it again
             // and the gap stays visible instead of looking like a stall.
+            final reason =
+                attempt.skipReason ?? RetroAchievementsRepository.raSkipError;
             await RetroAchievementsRepository.markRomRaHashSkipped(
               candidate.romPath,
-              attempt.skipReason ?? RetroAchievementsRepository.raSkipError,
+              reason,
             );
+            skipReasons[reason] = (skipReasons[reason] ?? 0) + 1;
             skipped++;
           } else {
             hashed++;
@@ -309,6 +318,8 @@ class RetroAchievementsHashService {
             candidate.romPath,
             RetroAchievementsRepository.raSkipError,
           );
+          final reason = RetroAchievementsRepository.raSkipError;
+          skipReasons[reason] = (skipReasons[reason] ?? 0) + 1;
         }
         skipped++;
       }
@@ -319,8 +330,9 @@ class RetroAchievementsHashService {
     onProgress?.call(processed, total, '');
     _log.i(
       'RA re-match finished: $processed processed, $hashed hashed, '
-      '$matched matched, $skipped skipped',
+      '$matched matched, $skipped skipped${_reasonSummary(skipReasons)}',
     );
+    await _logLibrarySkips();
 
     return RaRematchResult(
       total: total,
@@ -330,6 +342,31 @@ class RetroAchievementsHashService {
       skipped: skipped,
       cancelled: false,
     );
+  }
+
+  /// Renders skip reasons as ` (disc 12, missing 1)`, or nothing at all when
+  /// none were parked.
+  static String _reasonSummary(Map<String, int> reasons) {
+    if (reasons.isEmpty) return '';
+    final parts = reasons.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return ' (${parts.map((e) => '${e.key} ${e.value}').join(', ')})';
+  }
+
+  /// Logs how much of the library sits parked, across every run so far.
+  ///
+  /// The per-run summary only covers the ROMs this pass walked, and a pass on
+  /// a settled library walks none of the parked ones at all — so on the run
+  /// where a user notices the gap, the per-run line reads as a clean sweep.
+  static Future<void> _logLibrarySkips() async {
+    try {
+      final counts = await RetroAchievementsRepository.getRaHashSkipCounts();
+      if (counts.isEmpty) return;
+      final total = counts.values.fold(0, (sum, count) => sum + count);
+      _log.i('RA re-match: $total ROM(s) parked${_reasonSummary(counts)}');
+    } catch (e) {
+      _log.w('RA re-match: could not read skip counts: $e');
+    }
   }
 
   /// Hashes a single bulk-pass candidate.
@@ -393,11 +430,13 @@ class RetroAchievementsHashService {
     }
 
     try {
-      final hash = await compute(_generateHashForSystemIsolate, {
-        'romPath': romPathToProcess,
-        'algo': candidate.policy.algo.jsonName,
-        'token': RootIsolateToken.instance!,
-      });
+      final hash = _replayIsolateLog(
+        await compute(_generateHashForSystemIsolate, {
+          'romPath': romPathToProcess,
+          'algo': candidate.policy.algo.jsonName,
+          'token': RootIsolateToken.instance!,
+        }),
+      );
       if (hash == null || hash.isEmpty) {
         return (
           hash: null,
@@ -482,7 +521,15 @@ class RetroAchievementsHashService {
   /// Takes the algorithm by name rather than the system folder: the policy is
   /// resolved on the main isolate, so this side has no database to consult and
   /// there is only one place that decides which algorithm a system gets.
-  static Future<String?> _generateHashForSystemIsolate(
+  ///
+  /// Returns the hash under `hash` and everything this isolate logged under
+  /// `log`, for [_replayIsolateLog] to write out. The disc reader explains a
+  /// failure
+  /// entirely in warnings — an unreadable container, a track it cannot use, a
+  /// disc with no executable on it — and this isolate's logger has no file
+  /// output, so without handing them back the only trace a user's `app.log`
+  /// keeps of a failed hash is the skip count at the end of the pass.
+  static Future<Map<String, Object?>> _generateHashForSystemIsolate(
     Map<String, dynamic> params,
   ) async {
     final token = params['token'] as RootIsolateToken?;
@@ -493,6 +540,22 @@ class RetroAchievementsHashService {
     final romPath = params['romPath'].toString();
     final algo = RaHashAlgo.fromJson(params['algo']?.toString());
 
+    _log.startCapture();
+    try {
+      return {
+        'hash': await _hashInIsolate(algo, romPath),
+        'log': _log.takeCapture(),
+      };
+    } finally {
+      // Belt and braces: a throw that escaped _hashInIsolate would otherwise
+      // leave this isolate collecting for good.
+      _log.takeCapture();
+    }
+  }
+
+  /// The hash itself, so [_generateHashForSystemIsolate] can keep to
+  /// collecting the log around it.
+  static Future<String?> _hashInIsolate(RaHashAlgo algo, String romPath) async {
     try {
       // A disc's hash covers the boot executable inside the image, so it needs
       // the disc reader rather than any transformation of the file's bytes.
@@ -517,6 +580,14 @@ class RetroAchievementsHashService {
       _log.e('Error generating ${algo.jsonName} hash for $romPath: $e');
       return null;
     }
+  }
+
+  /// Writes out what the hashing isolate logged and returns the hash it
+  /// produced.
+  static String? _replayIsolateLog(Map<String, Object?> result) {
+    final lines = result['log'];
+    if (lines is List) _log.replayCaptured(lines.cast<String>());
+    return result['hash'] as String?;
   }
 
   /// Searches for the RetroAchievements Game ID in the local database using the

--- a/test/logger_isolate_capture_test.dart
+++ b/test/logger_isolate_capture_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/logger_service.dart';
+
+/// Tests for the log capture a background isolate uses to hand its diagnostics
+/// back to the isolate that owns the log file.
+///
+/// `compute()` spawns an isolate with its own copy of the [LoggerService]
+/// singleton, and that copy never runs [LoggerService.init] — two isolates
+/// holding a `FileOutput` on one path would interleave writes and race the
+/// rotation rename. So everything the RetroAchievements disc reader logs about
+/// a failed hash went to the console only, and the `app.log` a user sends kept
+/// no trace of it beyond the pass's own skip count.
+void main() {
+  final log = LoggerService.instance;
+
+  tearDown(() {
+    // A capture left running would follow this singleton into the next test.
+    log.takeCapture();
+  });
+
+  group('capturing', () {
+    test('collects nothing until asked', () {
+      log.w('before any capture');
+
+      expect(log.takeCapture(), isEmpty);
+    });
+
+    test('collects a line per level, tagged with its severity', () {
+      log.startCapture();
+      log.i('info line');
+      log.w('warning line');
+      log.e('error line');
+      log.d('debug line');
+
+      expect(log.takeCapture(), [
+        'i|info line',
+        'w|warning line',
+        'e|error line',
+        'd|debug line',
+      ]);
+    });
+
+    test('keeps the error object, which is where the reason usually is', () {
+      log.startCapture();
+      log.e('CHD: failed to open', error: 'PathNotFoundException');
+
+      expect(log.takeCapture(), [
+        'e|CHD: failed to open PathNotFoundException',
+      ]);
+    });
+
+    test('stops collecting once taken', () {
+      log.startCapture();
+      log.w('first');
+      log.takeCapture();
+
+      log.w('second');
+
+      expect(log.takeCapture(), isEmpty);
+    });
+
+    test('bounds what one capture holds', () {
+      // A capture explains a single failure. An unbounded list in a background
+      // isolate is a leak waiting for a pathological image.
+      log.startCapture();
+      for (var i = 0; i < 200; i++) {
+        log.w('line $i');
+      }
+
+      final captured = log.takeCapture();
+
+      expect(captured, hasLength(64));
+      expect(captured.first, 'w|line 0');
+      expect(captured.last, 'w|line 63');
+    });
+  });
+
+  group('replaying', () {
+    test('re-logs each line at the level it was captured at', () {
+      // Replaying goes back through log(), so capturing around it shows what
+      // the file output would have received.
+      log.startCapture();
+      log.replayCaptured([
+        'w|RA disc: could not open game.chd',
+        'e|CHD: no file descriptor',
+        'i|RA disc: SLUS_202.02 has no PS-X EXE marker',
+      ]);
+
+      expect(log.takeCapture(), [
+        'w|RA disc: could not open game.chd',
+        'e|CHD: no file descriptor',
+        'i|RA disc: SLUS_202.02 has no PS-X EXE marker',
+      ]);
+    });
+
+    test('survives a line that carries no level tag', () {
+      log.startCapture();
+      log.replayCaptured(['', 'x', 'no separator here', 'w|kept']);
+
+      expect(log.takeCapture(), ['w|kept']);
+    });
+
+    test('treats an unknown tag as info rather than dropping the line', () {
+      log.startCapture();
+      log.replayCaptured(['?|from a newer build']);
+
+      expect(log.takeCapture(), ['i|from a newer build']);
+    });
+  });
+}


### PR DESCRIPTION
# Description

A user reported that no PlayStation 2 disc in their library matched RetroAchievements and sent an `app.log`. The only trace of the problem in it was the pass's own summary:

```
RA re-match (hashMissing): 50 candidate ROMs
RA re-match finished: 50 processed, 38 hashed, 28 matched, 12 skipped
```

Everything explaining those 12 was lost. Hashing runs under `compute()`, and a spawned isolate gets its own copy of the `LoggerService` singleton which never runs `init()` — so its output is `ConsoleOutput` alone. `CHD: could not open`, `RA disc: no usable track`, `RA disc: could not locate primary executable` all went to logcat, which a user does not have. The isolate cannot simply open the log file too: two isolates holding a `FileOutput` on one path interleave writes and race the rotation rename, which is exactly why the secondary display's engine deliberately skips `init()`.

So the isolate hands its lines back instead. `LoggerService` gains a per-isolate capture (`startCapture` / `takeCapture` / `replayCaptured`), `_generateHashForSystemIsolate` returns what it collected alongside the hash, and the main isolate replays it into the file-backed logger. Replaying goes through `log()` like any other line, so `RedactingPrinter` still strips credentials before anything is written. A capture is capped at 64 lines — it exists to explain a single failure, and an unbounded list in a background isolate is a leak waiting for a pathological image.

The skip count now says why, per run and across the library:

```
RA re-match finished: 50 processed, 38 hashed, 28 matched, 12 skipped (error 12)
RA re-match: 12 ROM(s) parked (error 12)
```

The second line is what finally gives `getRaHashSkipCounts()` a caller, and it earns its place: a pass over a settled library walks none of the parked ROMs, so on the run where a user notices the gap the per-run line reads as a clean sweep.

No behaviour changes — this only makes an existing failure legible. The underlying PS2 report is still open and gets its own PR once a log names the cause.

## Steps to Verify

**Preconditions:** any platform, a library with at least one disc-based system, RetroAchievements signed in.

1. Put a file the disc reader cannot open where a PS2/PSX ROM would go — a `.chd` of zeroes is enough (`head -c 8192 /dev/zero > "Broken (USA).chd"`).
2. Scan so it is picked up, then run the RetroAchievements match pass (Tools → re-match, or launch with match-on-startup enabled).
3. Open `app.log` in the user-data folder.
4. Before this change the file holds only the `... N skipped` summary. After it, the two warnings that used to reach logcat only are in the file:
   ```
   [W]  CHD: ChdException(open): .../Broken (USA).chd
   [W]  RA disc: could not open .../Broken (USA).chd
   ```
5. The summary line now carries a reason breakdown, followed by the library-wide parked count.

## Tested on

- [ ] Android — device:
- [x] Linux — device: CachyOS desktop (`flutter test`, plus a real failing container through `RaDiscHash.compute`)
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: Android not yet exercised. The capture is platform-independent (it sits in `LoggerService.log`, above every I/O path), and the isolate boundary it crosses is the same on every platform, so the risk of a device-only difference here is low. Happy to smoke it on the Thor before merge if preferred.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1423)
- [x] Tests added or updated — `test/logger_isolate_capture_test.dart`, 8 cases: per-level tagging, the error object, the 64-line cap, take-clears-capture, replay round-trip, malformed lines, and an unknown tag from a newer build
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — n/a
