### PR TITLE
feat(settings): apply Show Subfolders to every system from General settings

### DIFF
--- a/lib/constants/system_folder_names.dart
+++ b/lib/constants/system_folder_names.dart
@@ -1,4 +1,18 @@
 class SystemFolderNames {
   static const String favorites = 'favorites';
   static const String all = 'all';
+  static const String music = 'music';
+  static const String android = 'android';
+
+  /// Systems the subfolder view cannot apply to: virtual aggregates that own no
+  /// ROM folder of their own ([all], [favorites]), the music library, and the
+  /// installed-apps grid. The game list skips the setting for these, so the
+  /// global "Show Subfolders" toggle leaves them alone rather than writing a
+  /// flag nothing will ever read.
+  static const Set<String> subfolderViewExcluded = {
+    all,
+    favorites,
+    music,
+    android,
+  };
 }

--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -268,6 +268,12 @@ class SqliteConfigService {
                 ) ??
                 0) ==
             1,
+        subfolderViewAll:
+            (int.tryParse(
+                  userConfig?['subfolder_view_all']?.toString() ?? '0',
+                ) ??
+                0) ==
+            1,
       );
     } catch (e) {
       _log.e('Error applying configuration in loadConfig: $e');
@@ -331,6 +337,7 @@ class SqliteConfigService {
         esdeFolderPath: config.esdeFolderPath,
         showAchievementsBadge: config.showAchievementsBadge ? 1 : 0,
         raMatchOnStartup: config.raMatchOnStartup ? 1 : 0,
+        subfolderViewAll: config.subfolderViewAll ? 1 : 0,
       );
 
       await SqliteService.saveUserRomFolders(config.romFolders);

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -522,6 +522,9 @@ class SqliteMigrations {
       case 146:
         await _migrateToVersion146(db);
         break;
+      case 147:
+        await _migrateToVersion147(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -6484,6 +6487,45 @@ class SqliteMigrations {
       _log.i('Migration v146 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v146: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v147: adds `user_config.subfolder_view_all`.
+  ///
+  /// Remembers the Settings > General "Show Subfolders" master toggle. Flipping
+  /// it stamps every system's own `subfolder_view`, so this column is not what
+  /// the game list reads: it is the remembered choice the switch shows, and the
+  /// value any system added later (a systems update) inherits.
+  ///
+  /// Defaults to 0 — off, matching the per-system column, so an upgrade changes
+  /// nothing until the user asks for it.
+  ///
+  /// Guarded on `PRAGMA table_info` so a database that already carries the
+  /// column (a fresh install, or a device that skipped this case because its
+  /// version was already past 147) is left alone.
+  static Future<void> _migrateToVersion147(Database db) async {
+    _log.i('Migration v147: Adding subfolder_view_all to user_config');
+    try {
+      final columns = db
+          .select('PRAGMA table_info(user_config)')
+          .map((c) => c['name'].toString())
+          .toSet();
+
+      if (!columns.contains('subfolder_view_all')) {
+        db.execute(
+          'ALTER TABLE user_config ADD COLUMN subfolder_view_all '
+          'INTEGER DEFAULT 0',
+        );
+        _log.i('v147: subfolder_view_all column added');
+      } else {
+        _log.i('v147: subfolder_view_all already present, nothing to do');
+      }
+
+      _log.i('Migration v147 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v147: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -13,6 +13,7 @@ import '../../models/emulator_model.dart';
 import '../../models/core_emulator_model.dart';
 // import '../models/neo_sync_models.dart'; // Removido si no se usa directamente aquí
 import '../../models/database_game_model.dart';
+import '../../constants/system_folder_names.dart';
 import '../../utils/cloud_path_builder.dart';
 import '../../utils/semaphore.dart';
 import 'sqlite_migrations.dart';
@@ -458,7 +459,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 146;
+  static const int _databaseVersion = 147;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -531,6 +532,15 @@ class SqliteService {
     final syncedSystems = <SystemModel>[];
     final Set<String> syncedSystemIds = {};
 
+    // The global "Show Subfolders" choice, so a system this sync adds for the
+    // first time (a systems update shipping a new platform) starts out matching
+    // the rest of the library instead of silently opting out of it.
+    final userConfig = await getUserConfig();
+    final subfolderViewAll =
+        (int.tryParse(userConfig?['subfolder_view_all']?.toString() ?? '0') ??
+            0) ==
+        1;
+
     // Cache OS IDs
     final osMap = <String, int>{};
     final osResults = await db.query('app_os');
@@ -595,6 +605,19 @@ class SqliteService {
             'multidisc': jsonSystem.multiDisc ? 1 : 0,
             'neosync_json': json.encode(jsonSystem.neosync.toJson()),
           });
+
+          // Only for a brand-new system: an existing one keeps whatever the
+          // user set on it, and a virtual system never reads the flag.
+          if (subfolderViewAll &&
+              !SystemFolderNames.subfolderViewExcluded.contains(
+                jsonSystem.folderName,
+              )) {
+            await txn.insert('user_system_settings', {
+              'app_system_id': systemId,
+              'subfolder_view': 1,
+              'updated_at': DateTime.now().toIso8601String(),
+            }, conflictAlgorithm: ConflictAlgorithm.ignore);
+          }
         }
 
         // SYNC FOLDERS: Source of Truth is JSON. Overwrite DB.
@@ -1896,7 +1919,8 @@ class SqliteService {
         fanart_dim_level INTEGER DEFAULT 25,
         esde_folder_path TEXT DEFAULT '',
         show_achievements_badge INTEGER DEFAULT 0,
-        ra_match_on_startup INTEGER DEFAULT 0
+        ra_match_on_startup INTEGER DEFAULT 0,
+        subfolder_view_all INTEGER DEFAULT 0
       );
       ''',
       '''
@@ -2714,6 +2738,7 @@ class SqliteService {
     String? esdeFolderPath,
     int? showAchievementsBadge,
     int? raMatchOnStartup,
+    int? subfolderViewAll,
   }) async {
     final db = await instance.database;
 
@@ -2851,6 +2876,9 @@ class SqliteService {
     if (raMatchOnStartup != null) {
       updates['ra_match_on_startup'] = raMatchOnStartup;
     }
+    if (subfolderViewAll != null) {
+      updates['subfolder_view_all'] = subfolderViewAll;
+    }
 
     if (showAchievementsBadge != null) {
       updates['show_achievements_badge'] = showAchievementsBadge;
@@ -2960,6 +2988,78 @@ class SqliteService {
     bool enabled,
   ) async {
     await _updateSystemSetting(systemId, 'subfolder_view', enabled ? 1 : 0);
+  }
+
+  /// The `NOT IN (?, ?, ...)` fragment and arguments that keep a statement off
+  /// the systems the subfolder view cannot apply to.
+  static (String, List<Object?>) get _nonVirtualSystemsFilter {
+    final names = SystemFolderNames.subfolderViewExcluded.toList();
+    final holes = List.filled(names.length, '?').join(', ');
+    return ('s.folder_name NOT IN ($holes)', names);
+  }
+
+  /// How many systems currently carry a `subfolder_view` of their own, i.e. one
+  /// that differs from [globalValue], the last global choice.
+  ///
+  /// This is what the settings screen reports before the global toggle
+  /// overwrites them. Counting rows that *deviate* rather than rows that will
+  /// change is the whole point: on a plain global flip every system moves
+  /// together, and saying so would be noise, not information.
+  ///
+  /// A system with no settings row reads as off, exactly as the game list reads
+  /// it, hence the LEFT JOIN and the COALESCE.
+  static Future<int> countSubfolderViewOverrides(bool globalValue) async {
+    final db = await instance.database;
+    final (filter, args) = _nonVirtualSystemsFilter;
+
+    final result = await db.rawQuery(
+      'SELECT COUNT(*) AS c FROM app_systems s '
+      'LEFT JOIN user_system_settings ss ON s.id = ss.app_system_id '
+      'WHERE $filter AND COALESCE(ss.subfolder_view, 0) != ?',
+      [...args, globalValue ? 1 : 0],
+    );
+
+    return int.tryParse(result.first['c']?.toString() ?? '0') ?? 0;
+  }
+
+  /// Applies "Show Subfolders" to every system in one pass, for the global
+  /// toggle in Settings > General.
+  ///
+  /// Systems the user has never opened the settings dialog for have no
+  /// [user_system_settings] row at all, so the stamp has to create one before
+  /// it can update it. The inserted row names only `subfolder_view`: every
+  /// other column falls back to its table default, which is exactly what the
+  /// absent row already read as, so this adds no behaviour of its own.
+  ///
+  /// Virtual systems are skipped ([SystemFolderNames.subfolderViewExcluded]).
+  /// The game list never reads the flag for them, so writing one would only be
+  /// a value waiting to be believed by some later change.
+  static Future<void> setSubfolderViewForAllSystems(bool enabled) async {
+    final db = await instance.database;
+    final value = enabled ? 1 : 0;
+    final now = DateTime.now().toIso8601String();
+    final (filter, args) = _nonVirtualSystemsFilter;
+
+    await db.transaction((txn) async {
+      await txn.rawInsert(
+        'INSERT INTO user_system_settings '
+        '(app_system_id, subfolder_view, updated_at) '
+        'SELECT s.id, ?, ? FROM app_systems s '
+        'WHERE $filter AND NOT EXISTS ('
+        'SELECT 1 FROM user_system_settings ss WHERE ss.app_system_id = s.id)',
+        [value, now, ...args],
+      );
+      await txn.rawUpdate(
+        'UPDATE user_system_settings SET subfolder_view = ?, updated_at = ? '
+        'WHERE app_system_id IN '
+        '(SELECT s.id FROM app_systems s WHERE $filter)',
+        [value, now, ...args],
+      );
+    });
+
+    // The cached models carry the old per-system flag, and the settings dialog
+    // reads them.
+    _cachedSystems = null;
   }
 
   /// Retrieves the complete configuration for a system.

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -116,6 +116,10 @@ mixin AppLocale {
   static const String recursiveScanDisabled = 'recursive_scan_disabled';
   static const String subfolderView = 'subfolder_view';
   static const String subfolderViewSubtitle = 'subfolder_view_subtitle';
+  static const String subfolderViewAll = 'subfolder_view_all';
+  static const String subfolderViewAllSubtitle = 'subfolder_view_all_subtitle';
+  static const String subfolderViewAllOverridesNotice =
+      'subfolder_view_all_overrides_notice';
   static const String subfolderViewEnabled = 'subfolder_view_enabled';
   static const String subfolderViewDisabled = 'subfolder_view_disabled';
   static const String errorScanningSystem = 'error_scanning_system';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -103,6 +103,11 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.subfolderView: 'Unterordner anzeigen',
   AppLocale.subfolderViewSubtitle:
       'ROMs in Unterordnern als durchsuchbare Ordner gruppieren, statt sie mit Spielen zu vermischen',
+  AppLocale.subfolderViewAll: 'Unterordner in allen Systemen anzeigen',
+  AppLocale.subfolderViewAllSubtitle:
+      'Die Einstellung „Unterordner anzeigen“ auf einmal für alle Systeme übernehmen',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '{count} System(e) hatten eine eigene Einstellung „Unterordner anzeigen“. Alle Systeme folgen jetzt diesem Schalter; du kannst jedes einzelne weiterhin in seinen Systemeinstellungen ändern.',
   AppLocale.subfolderViewEnabled: 'Unterordner werden als Ordner angezeigt',
   AppLocale.subfolderViewDisabled: 'Unterordner mit Spielen vermischt',
   AppLocale.errorScanningSystem: 'Fehler beim Scannen des Systems: {error}',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -100,6 +100,11 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.subfolderView: 'Show Subfolders',
   AppLocale.subfolderViewSubtitle:
       'Group ROMs in subfolders into browsable folders instead of mixing them with games',
+  AppLocale.subfolderViewAll: 'Show Subfolders in Every System',
+  AppLocale.subfolderViewAllSubtitle:
+      'Apply the per-system Show Subfolders setting to every system at once',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '{count} system(s) had their own Show Subfolders setting. All systems now follow this switch; you can still change any of them individually in that system’s settings.',
   AppLocale.subfolderViewEnabled: 'Subfolders shown as folders',
   AppLocale.subfolderViewDisabled: 'Subfolders mixed with games',
   AppLocale.errorScanningSystem: 'Error scanning system: {error}',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -103,6 +103,11 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.subfolderView: 'Mostrar subcarpetas',
   AppLocale.subfolderViewSubtitle:
       'Agrupar las ROMs de subcarpetas en carpetas navegables en lugar de mezclarlas con los juegos',
+  AppLocale.subfolderViewAll: 'Mostrar subcarpetas en todos los sistemas',
+  AppLocale.subfolderViewAllSubtitle:
+      'Aplicar de una vez la opción Mostrar subcarpetas a todos los sistemas',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '{count} sistema(s) tenían su propia opción Mostrar subcarpetas. Ahora todos los sistemas siguen este interruptor; puedes volver a cambiar cualquiera de ellos en los ajustes de ese sistema.',
   AppLocale.subfolderViewEnabled: 'Subcarpetas mostradas como carpetas',
   AppLocale.subfolderViewDisabled: 'Subcarpetas mezcladas con los juegos',
   AppLocale.errorScanningSystem: 'Error al escanear el sistema: {error}',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -106,6 +106,12 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.subfolderView: 'Afficher les sous-dossiers',
   AppLocale.subfolderViewSubtitle:
       'Regrouper les ROMs des sous-dossiers dans des dossiers navigables au lieu de les mélanger avec les jeux',
+  AppLocale.subfolderViewAll:
+      'Afficher les sous-dossiers dans tous les systèmes',
+  AppLocale.subfolderViewAllSubtitle:
+      'Appliquer d’un coup l’option Afficher les sous-dossiers à tous les systèmes',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '{count} système(s) avaient leur propre réglage Afficher les sous-dossiers. Tous les systèmes suivent désormais cet interrupteur ; vous pouvez toujours modifier chacun d’eux dans ses propres réglages.',
   AppLocale.subfolderViewEnabled: 'Sous-dossiers affichés comme dossiers',
   AppLocale.subfolderViewDisabled: 'Sous-dossiers mélangés aux jeux',
   AppLocale.errorScanningSystem:

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -101,6 +101,11 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.subfolderView: 'Tampilkan Subfolder',
   AppLocale.subfolderViewSubtitle:
       'Kelompokkan ROM dalam subfolder menjadi folder yang dapat dijelajahi alih-alih mencampurnya dengan game',
+  AppLocale.subfolderViewAll: 'Tampilkan Subfolder di Semua Sistem',
+  AppLocale.subfolderViewAllSubtitle:
+      'Terapkan pengaturan Tampilkan Subfolder ke semua sistem sekaligus',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '{count} sistem memiliki pengaturan Tampilkan Subfolder sendiri. Kini semua sistem mengikuti sakelar ini; Anda masih dapat mengubahnya satu per satu di pengaturan sistem tersebut.',
   AppLocale.subfolderViewEnabled: 'Subfolder ditampilkan sebagai folder',
   AppLocale.subfolderViewDisabled: 'Subfolder dicampur dengan game',
   AppLocale.errorScanningSystem: 'Kesalahan saat memindai sistem: {error}',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -102,6 +102,11 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.subfolderView: 'Mostra sottocartelle',
   AppLocale.subfolderViewSubtitle:
       'Raggruppa le ROM nelle sottocartelle in cartelle navigabili invece di mescolarle con i giochi',
+  AppLocale.subfolderViewAll: 'Mostra sottocartelle in tutti i sistemi',
+  AppLocale.subfolderViewAllSubtitle:
+      'Applica in una volta l’opzione Mostra sottocartelle a tutti i sistemi',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '{count} sistema/i avevano una propria impostazione Mostra sottocartelle. Ora tutti i sistemi seguono questo interruttore; puoi comunque modificarne ognuno nelle impostazioni di quel sistema.',
   AppLocale.subfolderViewEnabled: 'Sottocartelle mostrate come cartelle',
   AppLocale.subfolderViewDisabled: 'Sottocartelle mescolate ai giochi',
   AppLocale.errorScanningSystem:

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -90,6 +90,10 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.recursiveScanDisabled: '再帰スキャン無効。{name}をスキャン中...',
   AppLocale.subfolderView: 'サブフォルダを表示',
   AppLocale.subfolderViewSubtitle: 'サブフォルダ内のROMをゲームと混在させず、閲覧可能なフォルダにまとめます',
+  AppLocale.subfolderViewAll: 'すべてのシステムでサブフォルダを表示',
+  AppLocale.subfolderViewAllSubtitle: '「サブフォルダを表示」の設定をすべてのシステムに一括で適用します',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '{count} 個のシステムに個別の「サブフォルダを表示」設定がありました。現在はすべてのシステムがこのスイッチに従います。各システムの設定で個別に変更することもできます。',
   AppLocale.subfolderViewEnabled: 'サブフォルダをフォルダとして表示',
   AppLocale.subfolderViewDisabled: 'サブフォルダをゲームと混在',
   AppLocale.errorScanningSystem: 'システムのスキャン中にエラーが発生しました: {error}',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -89,6 +89,10 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.recursiveScanDisabled: '하위 폴더 검색이 비활성화되었습니다. {name} 검색 중...',
   AppLocale.subfolderView: '하위 폴더 표시',
   AppLocale.subfolderViewSubtitle: '하위 폴더의 ROM을 게임 목록에 섞지 않고 탐색 가능한 폴더로 그룹화합니다',
+  AppLocale.subfolderViewAll: '모든 시스템에서 하위 폴더 표시',
+  AppLocale.subfolderViewAllSubtitle: '‘하위 폴더 표시’ 설정을 모든 시스템에 한 번에 적용합니다',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '{count}개 시스템에 자체 ‘하위 폴더 표시’ 설정이 있었습니다. 이제 모든 시스템이 이 스위치를 따릅니다. 각 시스템 설정에서 개별적으로 다시 변경할 수 있습니다.',
   AppLocale.subfolderViewEnabled: '하위 폴더를 폴더로 표시합니다',
   AppLocale.subfolderViewDisabled: '하위 폴더를 게임 목록에 섞어서 표시합니다',
   AppLocale.errorScanningSystem: '시스템 검색 오류: {error}',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -104,6 +104,11 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.subfolderView: 'Mostrar subpastas',
   AppLocale.subfolderViewSubtitle:
       'Agrupar ROMs em subpastas em pastas navegáveis em vez de misturá-las com os jogos',
+  AppLocale.subfolderViewAll: 'Mostrar subpastas em todos os sistemas',
+  AppLocale.subfolderViewAllSubtitle:
+      'Aplicar de uma vez a opção Mostrar subpastas a todos os sistemas',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '{count} sistema(s) tinham a sua própria opção Mostrar subpastas. Agora todos os sistemas seguem este interruptor; ainda é possível alterar qualquer um deles nas definições desse sistema.',
   AppLocale.subfolderViewEnabled: 'Subpastas mostradas como pastas',
   AppLocale.subfolderViewDisabled: 'Subpastas misturadas com os jogos',
   AppLocale.errorScanningSystem: 'Erro ao varrer o sistema: {error}',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -102,6 +102,11 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.subfolderView: 'Показывать подпапки',
   AppLocale.subfolderViewSubtitle:
       'Группировать ROM в подпапках в виде просматриваемых папок, а не смешивать их с играми',
+  AppLocale.subfolderViewAll: 'Показывать подпапки во всех системах',
+  AppLocale.subfolderViewAllSubtitle:
+      'Применить настройку «Показывать подпапки» сразу ко всем системам',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '{count} систем(ы) имели собственную настройку «Показывать подпапки». Теперь все системы следуют этому переключателю; каждую из них по-прежнему можно изменить в её настройках.',
   AppLocale.subfolderViewEnabled: 'Подпапки показаны как папки',
   AppLocale.subfolderViewDisabled: 'Подпапки смешаны с играми',
   AppLocale.errorScanningSystem: 'Ошибка при сканировании системы: {error}',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -89,6 +89,10 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.recursiveScanDisabled: '递归扫描已禁用。正在扫描 {name}...',
   AppLocale.subfolderView: '显示子文件夹',
   AppLocale.subfolderViewSubtitle: '将子文件夹中的 ROM 归入可浏览的文件夹，而不是与游戏混在一起',
+  AppLocale.subfolderViewAll: '在所有系统中显示子文件夹',
+  AppLocale.subfolderViewAllSubtitle: '将“显示子文件夹”设置一次性应用到所有系统',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '有 {count} 个系统使用了各自的“显示子文件夹”设置。现在所有系统都跟随此开关；你仍可在各系统的设置中单独更改。',
   AppLocale.subfolderViewEnabled: '子文件夹显示为文件夹',
   AppLocale.subfolderViewDisabled: '子文件夹与游戏混合',
   AppLocale.errorScanningSystem: '扫描系统时出错: {error}',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -89,6 +89,10 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.recursiveScanDisabled: '遞迴掃描已停用。正在掃描 {name}...',
   AppLocale.subfolderView: '顯示子資料夾',
   AppLocale.subfolderViewSubtitle: '將子資料夾中的 ROM 歸入可瀏覽的資料夾，而非與遊戲混在一起',
+  AppLocale.subfolderViewAll: '在所有系統中顯示子資料夾',
+  AppLocale.subfolderViewAllSubtitle: '將「顯示子資料夾」設定一次套用到所有系統',
+  AppLocale.subfolderViewAllOverridesNotice:
+      '有 {count} 個系統使用了各自的「顯示子資料夾」設定。現在所有系統都跟隨此開關；你仍可在各系統的設定中單獨變更。',
   AppLocale.subfolderViewEnabled: '子資料夾顯示為資料夾',
   AppLocale.subfolderViewDisabled: '子資料夾與遊戲混合',
   AppLocale.errorScanningSystem: '掃描系統時發生錯誤: {error}',

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -200,6 +200,14 @@ class ConfigModel {
   /// for it.
   final bool raMatchOnStartup;
 
+  /// The remembered Settings > General "Show Subfolders" master choice.
+  ///
+  /// Not what the game list reads — flipping the switch stamps every system's
+  /// own subfolder setting, and the per-system toggle stays free to differ
+  /// afterwards. This is the value the switch shows, and the one a system added
+  /// by a later systems update inherits.
+  final bool subfolderViewAll;
+
   const ConfigModel({
     this.romFolders = const [],
     this.detectedSystems = const [],
@@ -245,6 +253,7 @@ class ConfigModel {
     this.esdeFolderPath = '',
     this.showAchievementsBadge = false,
     this.raMatchOnStartup = false,
+    this.subfolderViewAll = false,
   });
 
   /// Convenience getter that returns the primary ROM folder, if any are configured.
@@ -451,6 +460,13 @@ class ConfigModel {
               '1' ||
           (json['raMatchOnStartup'] ?? false).toString().toLowerCase() ==
               'true',
+      // Same reasoning: absent => 0 => off, matching the column default.
+      subfolderViewAll:
+          (json['subfolderViewAll'] ?? json['subfolder_view_all'] ?? 0)
+                  .toString() ==
+              '1' ||
+          (json['subfolderViewAll'] ?? false).toString().toLowerCase() ==
+              'true',
     );
   }
 
@@ -506,6 +522,7 @@ class ConfigModel {
       'esdeFolderPath': esdeFolderPath,
       'showAchievementsBadge': showAchievementsBadge,
       'raMatchOnStartup': raMatchOnStartup,
+      'subfolderViewAll': subfolderViewAll,
     };
   }
 
@@ -555,6 +572,7 @@ class ConfigModel {
     String? esdeFolderPath,
     bool? showAchievementsBadge,
     bool? raMatchOnStartup,
+    bool? subfolderViewAll,
   }) {
     return ConfigModel(
       romFolders: romFolders ?? this.romFolders,
@@ -603,6 +621,7 @@ class ConfigModel {
       showAchievementsBadge:
           showAchievementsBadge ?? this.showAchievementsBadge,
       raMatchOnStartup: raMatchOnStartup ?? this.raMatchOnStartup,
+      subfolderViewAll: subfolderViewAll ?? this.subfolderViewAll,
     );
   }
 

--- a/lib/providers/sqlite_config_provider/mutators.dart
+++ b/lib/providers/sqlite_config_provider/mutators.dart
@@ -164,6 +164,22 @@ extension SqliteConfigMutators on SqliteConfigProvider {
     _notify();
   }
 
+  /// Persists the global "Show Subfolders" choice and applies it to every
+  /// system.
+  ///
+  /// The game list reads the per-system flag, so the stored config value alone
+  /// would change nothing: the stamp is what makes the toggle global. Systems
+  /// keep their own toggle afterwards, and a later flip of this one overwrites
+  /// them again.
+  Future<void> updateSubfolderViewAll(bool value) async {
+    _config = _config.copyWith(subfolderViewAll: value);
+    await SqliteConfigService.saveConfig(_config);
+    await SystemRepository.setSubfolderViewForAll(value);
+    // The in-memory system models still carry the old per-system flag.
+    await refreshDetectedSystems();
+    _notify();
+  }
+
   /// Updates whether hidden files/folders are ignored during ROM scans.
   Future<void> updateIgnoreHiddenFiles(bool ignoreHiddenFiles) async {
     _config = _config.copyWith(ignoreHiddenFiles: ignoreHiddenFiles);

--- a/lib/repositories/system_repository.dart
+++ b/lib/repositories/system_repository.dart
@@ -91,6 +91,17 @@ class SystemRepository {
   static Future<void> setSubfolderView(String systemId, bool value) =>
       SqliteService.setSystemSubfolderView(systemId, value);
 
+  /// Applies "Show Subfolders" to every system at once (the global toggle in
+  /// Settings > General).
+  static Future<void> setSubfolderViewForAll(bool value) =>
+      SqliteService.setSubfolderViewForAllSystems(value);
+
+  /// How many systems carry a "Show Subfolders" setting of their own — one that
+  /// differs from [globalValue], the last global choice — and would therefore
+  /// be overwritten by the next global stamp.
+  static Future<int> countSubfolderViewOverrides(bool globalValue) =>
+      SqliteService.countSubfolderViewOverrides(globalValue);
+
   static Future<void> setHideExtension(String systemId, bool value) =>
       SqliteService.setSystemHideExtension(systemId, value);
 

--- a/lib/screens/game_screen/my_games_list/data_loading.dart
+++ b/lib/screens/game_screen/my_games_list/data_loading.dart
@@ -79,10 +79,7 @@ extension _DataLoading on _SystemGamesListState {
       final sysId = widget.system.id;
       final folderName = widget.system.folderName;
       if (sysId != null &&
-          folderName != 'music' &&
-          folderName != 'all' &&
-          folderName != SystemFolderNames.favorites &&
-          folderName != 'android') {
+          !SystemFolderNames.subfolderViewExcluded.contains(folderName)) {
         final settings = await SystemRepository.getSystemSettings(sysId);
         subfolderView = (settings['subfolder_view'] ?? 0) == 1;
       }

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -15,6 +15,7 @@ import 'package:neostation/utils/adaptive_scroll.dart';
 import 'package:neostation/utils/nav_tabs.dart';
 import '../../../providers/sqlite_config_provider.dart';
 import '../../../repositories/retro_achievements_repository.dart';
+import '../../../repositories/system_repository.dart';
 import '../../../widgets/info_dialog.dart';
 import '../../../widgets/custom_toggle_switch.dart';
 import 'settings_title.dart';
@@ -75,7 +76,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
 
     // Pre-allocate keys for maximum theoretical setting items (the fixed rows
     // plus one per navigation tab that can be toggled).
-    for (int i = 0; i < 15 + NavTab.values.length; i++) {
+    for (int i = 0; i < 16 + NavTab.values.length; i++) {
       _itemKeys.add(GlobalKey());
     }
   }
@@ -204,6 +205,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
     count++; // SFX Sounds
     count++; // SFX volume (dimmed, but still navigable, while SFX are off)
     count++; // 12-Hour Clock
+    count++; // Show subfolders (every system)
     count++; // Achievement badges on game tiles
     count++; // Match RetroAchievements on startup
     count += hidableNavTabs().length; // Navigation tab visibility
@@ -261,6 +263,32 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
           .replaceFirst('{count}', backlog.toString()),
       okLabel: AppLocale.ok.getString(context),
       icon: Symbols.trophy_rounded,
+    );
+  }
+
+  /// Flips the global "Show Subfolders" switch and applies it to every system.
+  ///
+  /// Systems that carried a setting of their own are overwritten by the stamp,
+  /// so they are counted first — after the write every system reads the same
+  /// and the information is gone. Like the RetroAchievements toggle above this
+  /// is advice, not a gate: the setting is written either way.
+  Future<void> _setSubfolderViewAll(bool value) async {
+    final configProvider = context.read<SqliteConfigProvider>();
+    final overridden = await SystemRepository.countSubfolderViewOverrides(
+      configProvider.config.subfolderViewAll,
+    );
+    if (!mounted) return;
+    await configProvider.updateSubfolderViewAll(value);
+    if (!mounted || overridden == 0) return;
+
+    await InfoDialog.show(
+      context,
+      title: AppLocale.subfolderViewAll.getString(context),
+      body: AppLocale.subfolderViewAllOverridesNotice
+          .getString(context)
+          .replaceFirst('{count}', overridden.toString()),
+      okLabel: AppLocale.ok.getString(context),
+      icon: Symbols.folder_rounded,
     );
   }
 
@@ -334,6 +362,13 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
       configProvider.updateUse12HourClock(
         !configProvider.config.use12HourClock,
       );
+      return;
+    }
+    currentItemIndex++;
+
+    // Protocol: Show subfolders, applied to every system.
+    if (index == currentItemIndex) {
+      _setSubfolderViewAll(!configProvider.config.subfolderViewAll);
       return;
     }
     currentItemIndex++;
@@ -675,6 +710,30 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                             .read<SqliteConfigProvider>()
                             .updateUse12HourClock(value);
                       },
+                      activeColor: theme.colorScheme.primary,
+                    ),
+                  );
+                }(),
+
+                // Setting: Show subfolders, applied to every system. The
+                // per-system toggle in a system's settings dialog stays
+                // available; this stamps them all at once.
+                SizedBox(height: 12.r),
+                () {
+                  final index = currentItemIdx++;
+                  return SettingRow(
+                    key: _itemKeys[index],
+                    onTap: () => selectItem(index),
+                    focused:
+                        widget.isContentFocused &&
+                        widget.selectedContentIndex == index,
+                    title: AppLocale.subfolderViewAll.getString(context),
+                    subtitle: AppLocale.subfolderViewAllSubtitle.getString(
+                      context,
+                    ),
+                    trailing: CustomToggleSwitch(
+                      value: config.subfolderViewAll,
+                      onChanged: _setSubfolderViewAll,
                       activeColor: theme.colorScheme.primary,
                     ),
                   );

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -156,7 +156,8 @@ class DatabaseTestHelper {
         now_playing_dim_level INTEGER DEFAULT 100,
         fanart_dim_level INTEGER DEFAULT 25,
         show_achievements_badge INTEGER DEFAULT 0,
-        ra_match_on_startup INTEGER DEFAULT 0
+        ra_match_on_startup INTEGER DEFAULT 0,
+        subfolder_view_all INTEGER DEFAULT 0
       )
     ''');
 

--- a/test/subfolder_view_all_migration_test.dart
+++ b/test/subfolder_view_all_migration_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+
+/// Tests for migration v147, which adds `user_config.subfolder_view_all` — the
+/// remembered state of the global "Show Subfolders" toggle in Settings >
+/// General.
+void main() {
+  late Database db;
+
+  setUp(() {
+    db = sqlite3.openInMemory();
+    // The "old device" case: a user_config without the new column.
+    db.execute('''
+      CREATE TABLE user_config (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        scan_on_startup INTEGER DEFAULT 1,
+        ignore_hidden_files INTEGER DEFAULT 1,
+        ra_match_on_startup INTEGER DEFAULT 0
+      )
+    ''');
+    db.execute('INSERT INTO user_config (id) VALUES (1)');
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  Future<void> runV147() => SqliteMigrations.migrateToVersion(db, 147);
+
+  List<String> configColumns() => db
+      .select('PRAGMA table_info(user_config)')
+      .map((c) => c['name'].toString())
+      .toList();
+
+  group('migration v147', () {
+    test('adds subfolder_view_all when the column is missing', () async {
+      await runV147();
+
+      expect(configColumns(), contains('subfolder_view_all'));
+    });
+
+    test('defaults the new column to off for existing rows', () async {
+      await runV147();
+
+      final row = db.select('SELECT subfolder_view_all FROM user_config').first;
+      expect(row['subfolder_view_all'], 0);
+    });
+
+    test('re-running is a no-op and keeps the stored value', () async {
+      await runV147();
+      db.execute('UPDATE user_config SET subfolder_view_all = 1');
+
+      await runV147();
+
+      final row = db.select('SELECT subfolder_view_all FROM user_config').first;
+      expect(row['subfolder_view_all'], 1);
+    });
+
+    test('leaves the other config columns untouched', () async {
+      await runV147();
+
+      final columns = configColumns();
+      expect(columns, contains('scan_on_startup'));
+      expect(columns, contains('ignore_hidden_files'));
+      expect(columns, contains('ra_match_on_startup'));
+    });
+  });
+}

--- a/test/subfolder_view_all_stamp_test.dart
+++ b/test/subfolder_view_all_stamp_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+import 'package:neostation/repositories/system_repository.dart';
+
+import 'database_test_helper.dart';
+
+/// Tests for the global "Show Subfolders" toggle's write path: one call has to
+/// reach every system, including the ones the user has never opened the
+/// per-system settings dialog for (they have no user_system_settings row yet).
+void main() {
+  final dbHelper = DatabaseTestHelper();
+  late DatabaseAdapter db;
+
+  setUp(() async {
+    db = await dbHelper.setUp();
+    // The last four are virtual: the game list never reads the subfolder flag
+    // for them, so the stamp has to leave them alone.
+    for (final id in [
+      'nes',
+      'snes',
+      'psx',
+      'all',
+      'favorites',
+      'music',
+      'android',
+    ]) {
+      await db.insert('app_systems', {
+        'id': id,
+        'real_name': id.toUpperCase(),
+        'folder_name': id,
+      });
+    }
+  });
+
+  tearDown(() async {
+    await dbHelper.tearDown();
+  });
+
+  Future<List<Map<String, Object?>>> settingsRows() =>
+      db.query('user_system_settings', orderBy: 'app_system_id');
+
+  group('setSubfolderViewForAll', () {
+    test('enables it on systems that have no settings row yet', () async {
+      expect(await settingsRows(), isEmpty);
+
+      await SystemRepository.setSubfolderViewForAll(true);
+
+      final rows = await settingsRows();
+      expect(rows.length, 3);
+      expect(rows.every((r) => r['subfolder_view'] == 1), isTrue);
+    });
+
+    test('writes no row at all for virtual systems', () async {
+      await SystemRepository.setSubfolderViewForAll(true);
+
+      final ids = (await settingsRows()).map((r) => r['app_system_id']);
+      expect(ids, containsAll(['nes', 'snes', 'psx']));
+      expect(ids, isNot(contains('all')));
+      expect(ids, isNot(contains('favorites')));
+      expect(ids, isNot(contains('music')));
+      expect(ids, isNot(contains('android')));
+    });
+
+    test('leaves an existing virtual-system row untouched', () async {
+      // A row can pre-date the exclusion (an early build stamped them).
+      await SystemRepository.setSubfolderView('music', true);
+
+      await SystemRepository.setSubfolderViewForAll(false);
+
+      final rows = await settingsRows();
+      final byId = {for (final r in rows) r['app_system_id']: r};
+      expect(byId['music']!['subfolder_view'], 1);
+      expect(byId['nes']!['subfolder_view'], 0);
+    });
+
+    test('overwrites a system that was configured by hand', () async {
+      await SystemRepository.setSubfolderView('nes', true);
+
+      await SystemRepository.setSubfolderViewForAll(false);
+
+      final rows = await settingsRows();
+      expect(rows.length, 3);
+      expect(rows.every((r) => r['subfolder_view'] == 0), isTrue);
+    });
+
+    test('a system keeps its own toggle after the global stamp', () async {
+      await SystemRepository.setSubfolderViewForAll(true);
+      await SystemRepository.setSubfolderView('snes', false);
+
+      final rows = await settingsRows();
+      final byId = {for (final r in rows) r['app_system_id']: r};
+      expect(byId['nes']!['subfolder_view'], 1);
+      expect(byId['snes']!['subfolder_view'], 0);
+      expect(byId['psx']!['subfolder_view'], 1);
+    });
+
+    test('leaves the other per-system settings at their defaults', () async {
+      await SystemRepository.setSubfolderViewForAll(true);
+
+      final row = (await settingsRows()).first;
+      // The inserted row names only subfolder_view, so everything else has to
+      // read exactly as the absent row did.
+      expect(row['recursive_scan'], 1);
+      expect(row['hide_extension'], 1);
+      expect(row['hide_parentheses'], 1);
+      expect(row['hide_brackets'], 1);
+      expect(row['hide_logo'], 0);
+      expect(row['prefer_file_name'], 0);
+    });
+
+    test('re-stamping the same value is idempotent', () async {
+      await SystemRepository.setSubfolderViewForAll(true);
+      await SystemRepository.setSubfolderViewForAll(true);
+
+      final rows = await settingsRows();
+      expect(rows.length, 3);
+      expect(rows.every((r) => r['subfolder_view'] == 1), isTrue);
+    });
+  });
+
+  group('countSubfolderViewOverrides', () {
+    test('counts nothing when every system agrees with the global', () async {
+      expect(await SystemRepository.countSubfolderViewOverrides(false), 0);
+
+      await SystemRepository.setSubfolderViewForAll(true);
+
+      expect(await SystemRepository.countSubfolderViewOverrides(true), 0);
+    });
+
+    test('counts a system set by hand against a global that is off', () async {
+      await SystemRepository.setSubfolderView('nes', true);
+
+      expect(await SystemRepository.countSubfolderViewOverrides(false), 1);
+    });
+
+    test('counts a system turned off under a global that is on', () async {
+      await SystemRepository.setSubfolderViewForAll(true);
+      await SystemRepository.setSubfolderView('snes', false);
+
+      expect(await SystemRepository.countSubfolderViewOverrides(true), 1);
+    });
+
+    test('a system with no row counts as off, not as a deviation', () async {
+      // Nothing has ever been written, so no system deviates from "off" — but
+      // every one of them deviates from "on".
+      expect(await SystemRepository.countSubfolderViewOverrides(false), 0);
+      expect(await SystemRepository.countSubfolderViewOverrides(true), 3);
+    });
+
+    test('never counts a virtual system', () async {
+      await SystemRepository.setSubfolderView('music', true);
+      await SystemRepository.setSubfolderView('all', true);
+
+      expect(await SystemRepository.countSubfolderViewOverrides(false), 0);
+    });
+  });
+}


### PR DESCRIPTION
# Description

Show Subfolders could only be enabled one system at a time. Settings > General now carries a switch that applies the choice to every system at once, and each system keeps its own toggle to deviate afterwards.

**How it works.** The game list reads the per-system `subfolder_view` flag, so the global switch stamps that flag on every system rather than introducing a second source of truth into every read path. The remembered choice lives in `user_config.subfolder_view_all` (migration v147); that value is also what a system added by a later systems update inherits, so a new platform does not silently opt out of a library-wide choice.

**Virtual systems are excluded.** `all`, `favorites`, `music` and `android` are skipped by the stamp, by the count and by the seeding: the game list never reads the flag for them. The excluded set lives in `SystemFolderNames.subfolderViewExcluded`, and the game list's own guard in `data_loading.dart` now reads the same constant, so the two cannot drift apart.

**Overwriting is reported, not silent.** Flipping the switch first counts the systems that carry a setting of their own, applies the change, and then says how many were overwritten. The count deliberately names systems that *deviated* from the previous global value rather than systems that changed: on a plain flip every system moves together, and reporting 121 of them would be noise. Zero deviations means no dialog. This follows the existing `_setRaMatchOnStartup` precedent: advice, not a gate, and it fires on both the touch and the gamepad path.

**Note for review:** migration v147 was free across `origin/main` and every open worktree at the time of writing (highest in use: 146). Worth re-checking before merge, because there is no `_ensureUserConfigColumns` safety net for this table and `saveUserConfig` writes all named columns in one statement, so a device that skipped the migration would fail *every* settings write, not just this one.

## Steps to Verify

**Preconditions:** a library with ROMs in subfolders under at least one system, on a database created before this branch (so the v146 to v147 upgrade path runs).

1. Launch the app. The log shows `Migration v147: Adding subfolder_view_all to user_config` followed by `Migration v147 completed`.
2. Go to Settings > General and turn on **Show Subfolders in Every System**.
3. Open a system whose ROMs live in subfolders. The subfolders appear as navigable folders.
4. Open that system's own settings dialog and turn **Show Subfolders** off. Only that system reverts; the others still show folders.
5. Return to Settings > General and flip the global switch off, then on again. A dialog reports that 1 system had its own setting, and every system now follows the switch again.
6. Check `all`, `favorites` and `music`: none of them gained a folder level.

## Tested on

- [x] Android — device: AYN Thor (dev channel, 9138-ROM library, real v146 database upgraded in place)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

On device: the migration ran on a real 9138-ROM database; the global stamp wrote every system in one transaction (a single shared `updated_at`); folders rendered; the switch off cleared all of them; a per-system override applied afterwards survived and was the only row left on. Rows created by the stamp came out at the table defaults (`recursive_scan`, `hide_extension`, `hide_parentheses`, `hide_brackets` at 1, `hide_logo` and `prefer_file_name` at 0), so systems that had never been configured were not otherwise disturbed.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1471)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [x] No hardcoded UI strings — everything goes through `AppLocale`

**The database**
- [x] Column added to the versioned migration in `sqlite_migrations.dart` **and** the `CREATE TABLE` in `sqlite_service.dart`
- [x] Migration number is above every slot in use on any open branch, not just `main` + 1 (checked against `origin/main` and all 24 local worktrees; highest in use was 146)
- [x] Migration is idempotent (`PRAGMA table_info` guard) and has a test
- [x] `_databaseVersion` bumped; new column selected in *every* system-loading query (not applicable: the column is on `user_config`, read through `getUserConfig`)

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse (the new row is in `selectItem` and `getItemCount`, and the notice fires from both paths)
- [x] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()` (no new route)
- [x] B cancels / goes back, including out of a focused text field (unchanged)

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths (no new path parsing; the existing `normalizeRomPath` tree builder is untouched)
- [x] Verified on a device, not only on desktop

</details>

## Notes

One path is not covered by a test: the `syncSystems` seeding that gives a brand-new system the global value. There is no test harness for `syncSystems` in the repo, and exercising it needs a systems update that adds a platform, so it rests on review rather than on a test or a device run.
