### PR TITLE
docs: initial wiki pages added

### DIFF
--- a/docs/configuration/configuring-emulators.md
+++ b/docs/configuration/configuring-emulators.md
@@ -1,0 +1,30 @@
+# Configuring Emulators
+
+NeoStation uses the bundled system definitions to decide which emulators are available for each system. Available choices depend on your platform and installed software.
+
+## RetroArch
+
+If you use RetroArch, configure it as the emulator for a system and make sure the required core is installed. When a launch fails, NeoStation can report that RetroArch, its executable, core directory, or selected core is missing.
+
+## Standalone Emulators
+
+On desktop platforms, NeoStation can ask you to select the executable for a standalone emulator.
+
+1. Open **Settings → Emulators**.
+2. Open **Standalone Emulators**.
+3. Select a system, then the emulator you want to configure.
+4. Select its executable:
+   - Windows: choose the emulator's `.exe` file.
+   - Linux: use the executable picker.
+   - macOS: choose the emulator executable.
+
+NeoStation stores the selected path for that emulator. Repeat this for each standalone emulator you use.
+
+## Android
+
+Android launches supported standalone emulators using their configured application integration. There is no desktop executable-picker step on Android.
+
+## Related Pages
+
+- [Getting Started](../getting-started/getting-started.md)
+- [Troubleshooting](../troubleshooting.md)

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -21,7 +21,7 @@ We are open to other scraping sources, but ScreenScraper is currently hard to be
 
 You can create application themes with the [NeoStation Theme Designer](https://neostation.dev/theme-designer/).
 
-For system art themes, we welcome submissions through the Discord server or through the [Neostation Assets Github Repo](https://github.com/misobadev/neostation-assets). Assets must adhere to the rules set out in the aforementioned repo.
+For system art themes, we will be launching a way for users to submit themes shortly. Stay tuned...
 
 ## Another frontend has a feature. Why doesn’t NeoStation?
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,0 +1,36 @@
+
+# FAQs
+
+## Will NeoStation add social features, such as Discord integration?
+
+Never say never, but there are currently no plans to add social features.
+
+NeoStation is primarily designed around the individual user experience. Features such as user profiles, friends, messaging, comments or public activity feeds would introduce a significant additional layer of development and ongoing responsibility, particularly around privacy, security, moderation and safeguarding.
+
+There are also regulatory considerations. Within the EU, services that host and distribute user-generated content can potentially fall within the scope of legislation such as the Digital Services Act (DSA), while the GDPR introduces requirements around the collection, storage and processing of personal information. Services accessible to children and teenagers can have additional privacy and safeguarding obligations.
+
+For those reasons, we don't want to add social functionality simply because we can. Any future social features would need to provide a clear benefit to NeoStation users while being designed with privacy and security from the outset.
+
+As an icon of retro gaming often puts it: “The juice isn’t worth the squeeze.”
+
+## Will you add more scrapers, such as SteamGridDB?
+
+We are open to other scraping sources, but ScreenScraper is currently hard to beat for metadata coverage, language support, and the amount of artwork, videos and user manuals that it provides. We are aware that other scrapers provide metadata for more modern games and systems, so it is something that we are openly exploring.
+
+## Will you add more themes?
+
+You can create application themes with the [NeoStation Theme Designer](https://neostation.dev/theme-designer/).
+
+For system art themes, we welcome submissions through the Discord server or through the [Neostation Assets Github Repo](https://github.com/misobadev/neostation-assets). Assets must adhere to the rules set out in the aforementioned repo.
+
+## Another frontend has a feature. Why doesn’t NeoStation?
+
+Whilst we are more than happy to take suggestions for new features (which you can raise via Github), the priority of NeoStation is to provide a frontend that is intuitive, user-friendly and robust. As we support multiple platforms, we take pride in ensuring that any new features are implemented in a way that doesn't diminish the user experience across those platforms.
+
+## Is NeoStation “vibecoded”?
+
+No.
+
+We use AI as an assistant for work such as automating tests and tracking down bugs, which leaves more time for new features and improving the experience of using NeoStation. All development decisions are made by the lead developers, who between them have over 30 years of software-engineering experience across multiple industries (and countries!).
+
+NeoStation is open source. You can read the code, inspect the changes, and decide for yourself. All pull requests are reviewed both agentically and manually to ensure that all guidelines are followed. If any PR fails to meet the standards of NeoStation, it is rejected.

--- a/docs/features/neosync.md
+++ b/docs/features/neosync.md
@@ -1,0 +1,36 @@
+# NeoSync
+
+NeoSync synchronises game saves and states through your NeoSync account. It includes account registration, email verification, password recovery, cloud-save browsing, quota information, and custom save folders for standalone emulators.
+
+## Sign In or Create an Account
+
+Open the **NeoSync** tab. You can register a new account or sign in with an existing account. New registrations require email verification; NeoStation can also resend the verification email and start password recovery.
+
+If the NeoSync tab is not visible, enable **Show NeoSync tab** in the General settings.
+
+## Save Synchronisation
+
+Once signed in, NeoSync tracks local and cloud save files and can show synchronisation progress and errors. The **Save List** lets you browse and refresh your online saves.
+
+> **Note:** Only one save-sync provider is active at a time. If another connected provider owns save synchronisation, NeoSync remains available for its account and cloud-save views but does not run active save sync.
+
+## Custom Save Folders
+
+Use **Custom Save Folders** when a standalone emulator stores saves in a location NeoStation cannot discover automatically.
+
+1. Open **Custom Save Folders** in the NeoSync area.
+2. Choose a system and emulator.
+3. Select the save folder.
+4. Select **Configure**, then use **Sync now** when needed.
+
+Removing a custom save folder unlinks it from synchronisation; it does not delete the local files.
+
+## Delete a Cloud Save
+
+NeoSync asks for confirmation before deleting a cloud save.
+
+> **Warning:** Deleting a cloud save is permanent. If you need a local copy first, use the available download option before deleting it.
+
+## Related Pages
+
+- [Troubleshooting](../troubleshooting.md)

--- a/docs/features/retroachievements.md
+++ b/docs/features/retroachievements.md
@@ -1,0 +1,36 @@
+# RetroAchievements
+
+Connect your RetroAchievements account to view supported-game information, achievement progress, recent unlocks, completions, masteries, and leaderboards in NeoStation.
+
+## Sign In
+
+1. Open the **RetroAchievements** tab.
+2. Enter your RetroAchievements username.
+3. Enter your personal Web API key.
+4. Select **Login**.
+
+Use **Get API Key** in NeoStation to open the RetroAchievements control panel, where you can obtain your personal key. NeoStation does not use a shared build-time RetroAchievements key.
+
+## Match Your Library
+
+NeoStation can match new ROMs after the startup scan. To process your whole library with visible progress:
+
+1. Open **Settings → Tools**.
+2. Select **Match RetroAchievements Games**.
+
+Matching reads unmatched ROMs to identify them. It can take several minutes for a large library. Selecting the tool again pauses it; completed matches are kept and a later run continues. Disc images are sampled, but NeoStation does not move or delete files while matching.
+
+You can run matching while signed out, but you must sign in to see results. When a match needs correcting, NeoStation provides a RetroAchievements title search for a manual match.
+
+## Offline Use
+
+If NeoStation starts without a network connection but has cached sign-in data, it can show an offline banner. Reconnect to refresh online data.
+
+## Sign Out
+
+Disconnecting signs you out and removes the saved RetroAchievements credentials from that device.
+
+## Related Pages
+
+- [Adding Your Games](../library/adding-your-games.md)
+- [Troubleshooting](../troubleshooting.md)

--- a/docs/features/scraping-and-metadata.md
+++ b/docs/features/scraping-and-metadata.md
@@ -1,0 +1,35 @@
+# Scraping & Metadata
+
+NeoStation can use ScreenScraper to obtain game metadata and media for your local library.
+
+## Sign In
+
+1. Open the **Scraping** tab.
+2. Sign in with your ScreenScraper account.
+3. Open the scraper options to manage the account later.
+
+NeoStation stores the saved account credentials on the device. You can sign out from the **Account** section of the scraper options.
+
+## Configure Scraping
+
+The scraper options include these sections:
+
+- **Scraping**
+- **Scrape Mode** — choose **New Content Only** or **All Content**.
+- **Media** — enable the media types you want downloaded.
+- **Region**
+- **Language**
+- **Systems**
+
+You can start scraping from a game as well as from the scraping workflow. A game can also be re-scraped from its settings.
+
+## If a Game Does Not Scrape
+
+NeoStation may report that you are not signed in, the system is not mapped to ScreenScraper, the game was not found, or that media downloads failed after metadata was saved. Check your account, system mapping, and network connection, then try again.
+
+> **Note:** Scraping is unavailable for Android apps. It applies to ROM games.
+
+## Related Pages
+
+- [Adding Your Games](../library/adding-your-games.md)
+- [Troubleshooting](../troubleshooting.md)

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -1,0 +1,30 @@
+# Getting Started
+
+Set up a local game library by adding one or more ROM folders, scanning them, and selecting an emulator for each system you want to play.
+
+## Before You Start
+
+- Install NeoStation for your platform.
+- Install the emulator(s) you intend to use. NeoStation launches RetroArch or supported standalone emulators; it does not include them.
+- Keep your ROMs in folders you can browse from the device.
+
+## Add a ROM Folder
+
+1. Open **Settings → Directories**.
+2. Select **Add ROM Folder**.
+3. Choose the folder that contains your ROM library.
+4. NeoStation scans the folder and makes recognised systems available.
+
+You can configure up to five ROM folders. Use **Rescan All ROM Folders** in the same screen after adding or changing files.
+
+> **Note:** Removing a ROM folder from NeoStation removes it as a library source only. It does not delete the files in that folder.
+
+## Choose an Emulator
+
+Open a system, then use its emulator settings to choose from the emulators available for that system. If a standalone emulator needs its executable selected, see [Configuring Emulators](../configuration/configuring-emulators.md).
+
+## Next Steps
+
+- [Adding Your Games](../library/adding-your-games.md)
+- [Scraping & Metadata](../features/scraping-and-metadata.md)
+- [RetroAchievements](../features/retroachievements.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ NeoStation is a landscape, gamepad-driven emulation frontend for Windows, Linux,
 - [Steam Deck & SteamOS](platforms/steam-deck-and-steamos.md) — run the AppImage through Steam for proper controller input.
 
 ## Help and contributions
-
+- [FAQS](faqs.md)
 - [Troubleshooting](troubleshooting.md)
 - [Contributing](https://github.com/misobadev/neostation-frontend/blob/main/CONTRIBUTING.md)
 - [Report an issue](https://github.com/misobadev/neostation-frontend/issues)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,26 @@
+# NeoStation Wiki
+
+NeoStation is a landscape, gamepad-driven emulation frontend for Windows, Linux, macOS, Android, and Android TV.
+
+## Get started
+
+- [Getting Started](getting-started/getting-started.md) — add a ROM folder, scan it, and choose an emulator.
+- [Adding Your Games](library/adding-your-games.md) — ROM folders, scans, subfolders, and Android storage access.
+- [Configuring Emulators](configuration/configuring-emulators.md) — configure RetroArch or a standalone emulator.
+
+## Library features
+
+- [Multi-Disc Games](library/multi-disc-games.md) — organise recognised disc sets into folders and `.m3u` playlists.
+- [Scraping & Metadata](features/scraping-and-metadata.md) — connect ScreenScraper and choose what to download.
+- [RetroAchievements](features/retroachievements.md) — sign in, match your library, and view progress.
+- [NeoSync](features/neosync.md) — sign in and manage cloud save synchronisation.
+
+## Platform guides
+
+- [Steam Deck & SteamOS](platforms/steam-deck-and-steamos.md) — run the AppImage through Steam for proper controller input.
+
+## Help and contributions
+
+- [Troubleshooting](troubleshooting.md)
+- [Contributing](https://github.com/misobadev/neostation-frontend/blob/main/CONTRIBUTING.md)
+- [Report an issue](https://github.com/misobadev/neostation-frontend/issues)

--- a/docs/library/adding-your-games.md
+++ b/docs/library/adding-your-games.md
@@ -1,0 +1,33 @@
+# Adding Your Games
+
+NeoStation builds your local library from the folders listed in **Settings → Directories**.
+
+## Add and Rescan Folders
+
+1. Open **Settings → Directories**.
+2. Select **Add ROM Folder** and choose a folder.
+3. To update the library later, select **Rescan All ROM Folders**.
+
+NeoStation supports a maximum of five ROM folders. Removing a configured folder does not remove any ROM files from storage.
+
+## Subfolders
+
+The **Show Subfolders** setting controls whether games in subfolders are shown in a system. **Show Subfolders in Every System** applies the current setting across systems; you can still change an individual system afterwards.
+
+## Android and Android TV
+
+On Android, choose ROM folders through the system folder picker. NeoStation uses Android's Storage Access Framework, so ROM locations may be represented as storage-provider locations rather than ordinary desktop paths.
+
+On Android TV, NeoStation uses its TV directory picker. If a folder cannot be opened, choose a location Android permits the app to access.
+
+## Remove a Folder
+
+Open **Settings → Directories**, select a configured ROM folder, and confirm **Remove**.
+
+> **Note:** This removes the folder from scanning only. Your ROM files remain in place.
+
+## Related Pages
+
+- [Getting Started](../getting-started/getting-started.md)
+- [Multi-Disc Games](multi-disc-games.md)
+- [Troubleshooting](../troubleshooting.md)

--- a/docs/library/multi-disc-games.md
+++ b/docs/library/multi-disc-games.md
@@ -1,0 +1,40 @@
+# Multi-Disc Games
+
+**Organize Multi-Disc Games** finds recognised disc sets, puts each set in a game folder, and creates an `.m3u` playlist for emulators that use one.
+
+## Before You Start
+
+Back up your ROM library if you do not want NeoStation to rearrange it. This tool moves files.
+
+NeoStation only processes recognised ROM extensions for configured systems.
+
+## Organise Your Library
+
+1. Open **Settings → Tools**.
+2. Select **Organize Multi-Disc Games**.
+3. Wait for the scan and completion message.
+
+The tool searches configured ROM folders, including the relevant system folders, and supports both desktop folders and Android Storage Access Framework locations.
+
+## Recognised Names
+
+The filename must contain a `Disc`, `Disk`, or `CD` marker followed by a number. For example:
+
+- `Example Game (Disc 1).chd`
+- `Example Game (Disk 2).chd`
+- `Example Game CD 03.iso`
+
+For each set, NeoStation creates a folder named after the game, moves the disc files into it, and writes a playlist named `<game>.m3u`. Playlist entries use the moved filenames.
+
+Existing `.m3u` files are moved into the game folder when appropriate. A directory whose own name ends in `.m3u`, or which is inside one, is skipped to avoid reprocessing a playlist directory.
+
+## Limitations
+
+- Sets without one of the recognised markers are not grouped.
+- The organiser does not delete disc images.
+- A missing or inaccessible configured folder is skipped and reported in the result.
+
+## Related Pages
+
+- [Adding Your Games](adding-your-games.md)
+- [Troubleshooting](../troubleshooting.md)

--- a/docs/platforms/steam-deck-and-steamos.md
+++ b/docs/platforms/steam-deck-and-steamos.md
@@ -1,0 +1,23 @@
+# Steam Deck & SteamOS
+
+NeoStation's Linux build supports Steam Deck. Run its AppImage through Steam so Steam Input presents the Deck controls as a gamepad.
+
+## Add NeoStation to Steam
+
+In Desktop Mode:
+
+1. Download the x86_64 NeoStation AppImage.
+2. In Steam, open **Games → Add a Non-Steam Game to My Library**.
+3. Select **Browse** and change the file filter to **All Files**; the picker normally hides `.AppImage` files.
+4. Select the AppImage.
+5. Launch NeoStation from your Steam library, either in Game Mode or with Steam running in Desktop Mode.
+
+## Why Steam Matters
+
+Outside Steam, the Deck may use lizard mode: it presents controls as keyboard and mouse input. This can leave a mouse cursor visible, make A/B behave as Enter/Escape, and leave the bumpers without input. Launching through Steam gives NeoStation a virtual gamepad instead.
+
+## Related Pages
+
+- [Getting Started](../getting-started/getting-started.md)
+- [Configuring Emulators](../configuration/configuring-emulators.md)
+- [Troubleshooting](../troubleshooting.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,34 @@
+# Troubleshooting
+
+## My games do not appear
+
+1. Open **Settings → Directories** and confirm the ROM folder is listed.
+2. Select **Rescan All ROM Folders**.
+3. Check that the games are in a supported format for the detected system.
+4. On Android, grant access again by choosing the ROM folder through the system picker.
+
+## A game will not launch
+
+Check the emulator configured for that system. NeoStation can report missing RetroArch, a missing RetroArch executable or core directory, a missing core, a missing standalone executable, or an unconfigured emulator. Configure or reinstall the item named in the message, then try again.
+
+## Scraping fails
+
+Confirm that you are signed in to ScreenScraper and that the game system is mapped. A successful metadata request can still have failed media downloads; retry after checking your connection.
+
+## RetroAchievements has no matches
+
+Run **Settings → Tools → Match RetroAchievements Games**. Matching a large library can take time and may be paused and resumed. Sign in to the RetroAchievements tab to view results.
+
+## Steam Deck controls feel wrong
+
+Launch NeoStation from Steam. See [Steam Deck & SteamOS](platforms/steam-deck-and-steamos.md) for the lizard-mode symptoms and setup.
+
+## Collecting Useful Information
+
+When opening an issue, include your platform, NeoStation version, the system and emulator involved, the exact error message, and whether the problem happens after a rescan or restart. Do not share account passwords or API keys.
+
+## Related Pages
+
+- [Getting Started](getting-started/getting-started.md)
+- [Configuring Emulators](configuration/configuring-emulators.md)
+- [Scraping & Metadata](features/scraping-and-metadata.md)


### PR DESCRIPTION
# Description

  Adds the initial user documentation set under `docs/`, organised by category with kebab-case filenames.

  Includes guides for:

  - Getting started and adding ROM folders
  - Emulator configuration
  - Multi-disc game organisation
  - ScreenScraper metadata
  - RetroAchievements
  - NeoSync
  - Steam Deck / SteamOS
  - Troubleshooting

  Adds `docs/index.md` as the documentation entry point and uses relative links between pages.

  AI-assisted: Codex (GPT-5).

  ## Steps to Verify

  **Preconditions:**

  1. Check out `docs/wiki-v1`.

  1. Open `docs/index.md`.
  2. Follow each internal Markdown link.
  3. Confirm every linked page exists within `docs/`.
  4. Confirm filenames and category directories use kebab-case.

  ## Tested on

  - [ ] Android — device:
  - [ ] Linux — device:
  - [ ] Windows
  - [ ] macOS
  - [x] Not runtime-tested — documentation-only change; all internal Markdown links were validated.

  ## Checklist

  - [ ] `dart format .` — no diff
  - [ ] `flutter analyze` — clean (no errors *or* warnings)
  - [ ] `flutter test` — all passing
  - [ ] Tests added or updated
  - [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)