### PR TITLE
fix(secondary): apply the UI sound settings to the bottom screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -796,6 +796,17 @@ Future<void> subDisplay() async {
       initLang = rawConfig['app_language'].toString();
     }
     initThemeName = rawConfig?['theme_name']?.toString();
+    // Same story for UI sounds: this engine has its own SfxService singleton,
+    // so the main engine's setEnabled/setVolume never reach it. The main engine
+    // also pushes these through the shared state, but that can land after the
+    // first tap — seed from the same config row so the very first sound already
+    // respects the setting.
+    SfxService().setEnabled(
+      (int.tryParse(rawConfig?['sfx_enabled']?.toString() ?? '1') ?? 1) == 1,
+    );
+    SfxService().setVolume(
+      double.tryParse(rawConfig?['sfx_volume']?.toString() ?? '0.75') ?? 0.75,
+    );
   } catch (e) {
     debugPrint('Secondary display could not load saved config: $e');
   }

--- a/lib/models/secondary_display_state.dart
+++ b/lib/models/secondary_display_state.dart
@@ -213,6 +213,17 @@ class SecondaryDisplayStateData {
   /// picked a ROM folder.
   final bool setupWizardActive;
 
+  /// Whether UI navigation sounds are enabled. User setting, pushed by the main
+  /// engine. The secondary display runs its own engine/isolate with its own
+  /// [SfxService] singleton, so the main engine's `setEnabled` never reaches it
+  /// — without this the bottom screen kept clicking after the user turned UI
+  /// sounds off.
+  final bool sfxEnabled;
+
+  /// UI navigation sound volume (0.0–[SfxService.maxVolume]). User setting,
+  /// pushed by the main engine for the same cross-engine reason as [sfxEnabled].
+  final double sfxVolume;
+
   SecondaryDisplayStateData({
     required this.systemName,
     this.gameFanart,
@@ -277,6 +288,11 @@ class SecondaryDisplayStateData {
     this.dockSlotCount = 3,
     this.appReady = false,
     this.setupWizardActive = false,
+    // Mirror the config defaults (sfx_enabled DEFAULT 1, sfx_volume DEFAULT
+    // 0.75) so a snapshot built before the main engine's seed lands behaves
+    // like the persisted setting rather than silently muting or blasting.
+    this.sfxEnabled = true,
+    this.sfxVolume = 0.75,
   });
 
   /// Returns a new instance with the specified properties updated.
@@ -355,6 +371,8 @@ class SecondaryDisplayStateData {
     int? dockSlotCount,
     bool? appReady,
     bool? setupWizardActive,
+    bool? sfxEnabled,
+    double? sfxVolume,
   }) {
     return SecondaryDisplayStateData(
       systemName: systemName ?? this.systemName,
@@ -434,6 +452,8 @@ class SecondaryDisplayStateData {
       dockSlotCount: dockSlotCount ?? this.dockSlotCount,
       appReady: appReady ?? this.appReady,
       setupWizardActive: setupWizardActive ?? this.setupWizardActive,
+      sfxEnabled: sfxEnabled ?? this.sfxEnabled,
+      sfxVolume: sfxVolume ?? this.sfxVolume,
     );
   }
 
@@ -515,6 +535,8 @@ class SecondaryDisplayStateData {
       dockSlotCount: (json['dockSlotCount'] as num?)?.toInt() ?? 3,
       appReady: json['appReady'] as bool? ?? false,
       setupWizardActive: json['setupWizardActive'] as bool? ?? false,
+      sfxEnabled: json['sfxEnabled'] as bool? ?? true,
+      sfxVolume: (json['sfxVolume'] as num?)?.toDouble() ?? 0.75,
     );
   }
 
@@ -579,6 +601,8 @@ class SecondaryDisplayStateData {
       'dockSlotCount': dockSlotCount,
       'appReady': appReady,
       'setupWizardActive': setupWizardActive,
+      'sfxEnabled': sfxEnabled,
+      'sfxVolume': sfxVolume,
     };
   }
 }
@@ -693,6 +717,8 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
     int? dockSlotCount,
     bool? appReady,
     bool? setupWizardActive,
+    bool? sfxEnabled,
+    double? sfxVolume,
   }) async {
     if (!Platform.isAndroid) return;
 
@@ -776,6 +802,8 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
           dockSlotCount: dockSlotCount,
           appReady: appReady,
           setupWizardActive: setupWizardActive,
+          sfxEnabled: sfxEnabled,
+          sfxVolume: sfxVolume,
         ),
       );
     } catch (e) {

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -294,6 +294,8 @@ class SqliteConfigProvider extends ChangeNotifier with WidgetsBindingObserver {
           nowPlayingDimDelay: _config.nowPlayingDimDelay,
           nowPlayingDimLevel: _config.nowPlayingDimLevel,
           fanartDimLevel: _config.fanartDimLevel,
+          sfxEnabled: _config.sfxEnabled,
+          sfxVolume: _config.sfxVolume,
         );
       }
 

--- a/lib/providers/sqlite_config_provider/mutators.dart
+++ b/lib/providers/sqlite_config_provider/mutators.dart
@@ -200,6 +200,9 @@ extension SqliteConfigMutators on SqliteConfigProvider {
     await SqliteConfigService.saveConfig(_config);
     // Apply immediately to the running service — no restart needed.
     SfxService().setEnabled(value);
+    // The secondary display runs its own engine with its own SfxService
+    // singleton, so it has to be told separately or it keeps playing.
+    _secondaryDisplayState?.updateState(sfxEnabled: value);
     _notify();
   }
 
@@ -210,6 +213,8 @@ extension SqliteConfigMutators on SqliteConfigProvider {
     _config = _config.copyWith(sfxVolume: volume);
     // Apply immediately to the running service — no restart needed.
     SfxService().setVolume(volume);
+    // Mirror it to the secondary engine's own SfxService (see updateSfxEnabled).
+    _secondaryDisplayState?.updateState(sfxVolume: volume);
     _notify();
     unawaited(SfxService().playVolumePreview());
     await SqliteConfigService.saveConfig(_config);

--- a/lib/providers/sqlite_config_provider/secondary_display.dart
+++ b/lib/providers/sqlite_config_provider/secondary_display.dart
@@ -98,6 +98,8 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
         dockApps: _config.dockApps,
         dockEnabled: _config.dockEnabled,
         dockSlotCount: _config.dockSlotCount,
+        sfxEnabled: _config.sfxEnabled,
+        sfxVolume: _config.sfxVolume,
         // If the main UI is already up (e.g. a display hot-connected after
         // launch), carry the ready latch so the dock slides in on connect;
         // during cold boot this is still false and the dock stays parked until
@@ -193,6 +195,8 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
               state.nowPlayingDimDelay != _config.nowPlayingDimDelay ||
               state.nowPlayingDimLevel != _config.nowPlayingDimLevel ||
               state.fanartDimLevel != _config.fanartDimLevel ||
+              state.sfxEnabled != _config.sfxEnabled ||
+              state.sfxVolume != _config.sfxVolume ||
               (ScreenshotService.lastKnownAccess != null &&
                   state.screenshotAccessEnabled !=
                       ScreenshotService.lastKnownAccess))) {
@@ -221,6 +225,8 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
           nowPlayingDimDelay: _config.nowPlayingDimDelay,
           nowPlayingDimLevel: _config.nowPlayingDimLevel,
           fanartDimLevel: _config.fanartDimLevel,
+          sfxEnabled: _config.sfxEnabled,
+          sfxVolume: _config.sfxVolume,
           screenshotAccessEnabled: ScreenshotService.lastKnownAccess,
         );
       }

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -219,6 +219,12 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     final state = _secondaryDisplayState?.value;
     if (state == null) return;
 
+    // This engine has its own SfxService singleton, so the main engine's
+    // setEnabled/setVolume never reach it — the UI-sounds setting arrives only
+    // as pushed state. Without this the bottom screen kept clicking after the
+    // user turned UI sounds off in General settings.
+    _applySfxSettings(state);
+
     // Warm the app list + dock icons exactly once, only after the dock has
     // revealed. Gating on `appReady` keeps this heavy work off the cold-boot
     // reveal path so it can't perturb the cross-engine dock-reveal race — and
@@ -282,6 +288,16 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
         _videoController!.setVolume(state.isVideoMuted ? 0.0 : 1.0);
       }
     }
+  }
+
+  /// Mirrors the pushed UI-sound settings onto this engine's [SfxService].
+  ///
+  /// Cheap enough to run on every state push: [SfxService] only stores the
+  /// values, and skipping the unchanged case keeps the log quiet.
+  void _applySfxSettings(SecondaryDisplayStateData state) {
+    final sfx = SfxService();
+    if (sfx.isEnabled != state.sfxEnabled) sfx.setEnabled(state.sfxEnabled);
+    if (sfx.volume != state.sfxVolume) sfx.setVolume(state.sfxVolume);
   }
 
   /// Whether the device screen is on, according to *both* signals that carry

--- a/test/secondary_display_state_test.dart
+++ b/test/secondary_display_state_test.dart
@@ -91,6 +91,10 @@ void main() {
       // same value and the comparison passes regardless.
       appReady: true,
       setupWizardActive: true,
+      // Both non-default: the secondary engine has its own SfxService, so these
+      // are the only way the UI-sound setting crosses the engine boundary.
+      sfxEnabled: false,
+      sfxVolume: 0.25,
     );
 
     test('round-trips every field through toJson/fromJson', () {
@@ -145,6 +149,11 @@ void main() {
       // must not read as "wizard running" — that would park the dock forever.
       expect(restored.appReady, isFalse);
       expect(restored.setupWizardActive, isFalse);
+      // Mirror the config defaults (sfx_enabled DEFAULT 1, sfx_volume DEFAULT
+      // 0.75) so a snapshot predating these fields sounds like the persisted
+      // setting rather than silently muting the bottom screen.
+      expect(restored.sfxEnabled, isTrue);
+      expect(restored.sfxVolume, 0.75);
     });
 
     test('coerces numeric fields delivered as doubles', () {
@@ -154,12 +163,15 @@ void main() {
         'lastPlayedMillis': 1700000000000.0,
         'nowPlayingDimLevel': 75.0,
         'dockSlotCount': 5.0,
+        'sfxVolume': 0,
       });
 
       expect(restored.playTimeSeconds, 120);
       expect(restored.lastPlayedMillis, 1700000000000);
       expect(restored.nowPlayingDimLevel, 75);
       expect(restored.dockSlotCount, 5);
+      // An int-valued volume must not blow up the double cast.
+      expect(restored.sfxVolume, 0.0);
     });
   });
 
@@ -245,6 +257,31 @@ void main() {
         inWizard.copyWith(setupWizardActive: false).setupWizardActive,
         isFalse,
       );
+    });
+
+    test('a partial update that omits the SFX settings preserves them', () {
+      // UI sounds off is pushed once, from General settings. Every later push
+      // from either engine — a mute toggle, a screen-power edge, an art change
+      // — must carry it through, or the bottom screen starts clicking again.
+      final muted = SecondaryDisplayStateData(
+        systemName: 'snes',
+        sfxEnabled: false,
+        sfxVolume: 0.25,
+      );
+
+      final next = muted.copyWith(isVideoMuted: true, deviceScreenOn: false);
+
+      expect(next.sfxEnabled, isFalse);
+      expect(next.sfxVolume, 0.25);
+    });
+
+    test('an explicit sfxEnabled: false clears it (sounds turned off)', () {
+      // How the setting reaches the secondary engine: the mutator pushes the
+      // toggle, and the secondary applies it to its own SfxService.
+      final loud = SecondaryDisplayStateData(systemName: 'snes');
+
+      expect(loud.sfxEnabled, isTrue);
+      expect(loud.copyWith(sfxEnabled: false).sfxEnabled, isFalse);
     });
   });
 }


### PR DESCRIPTION
# Description

The secondary display runs its own Flutter engine, so it has its own `SfxService` singleton. Only `main()` ever called `setEnabled`/`setVolume`, which left the bottom-screen engine at the service defaults: UI sounds kept playing on the bottom screen after the user turned them off in General settings, and always at full volume regardless of the chosen level.

This carries both settings across the engine boundary on the shared `SecondaryDisplayState`, alongside the other main-owned settings:

- seeded at boot and on display connect, and re-asserted by the stale-echo drift correction;
- pushed live from `updateSfxEnabled` / `updateSfxVolume` (no restart needed);
- mirrored onto the secondary engine's `SfxService` on every state change (`_applySfxSettings`);
- `subDisplay()` also seeds them from the same `user_config` row it already reads for language and theme, so the very first tap after a cold boot obeys the setting before the main engine's push lands.

Snapshots that predate the new fields decode to the config defaults (enabled, 0.75), so an old persisted state never mutes or blasts the bottom screen.

## Steps to Verify

**Preconditions:** a dual-screen device (AYN Thor) with at least one game selected so the bottom screen shows the preview / dock.

1. Settings → General → turn **UI Navigation Sounds** off.
2. On the bottom screen tap an empty dock slot (or the preview's mute button).
3. Before: a nav click plays. After: silence (in logcat there is no `[SfxService] nav[...]` line from the tap).
4. Turn UI Navigation Sounds back on; the bottom-screen tap clicks again.
5. Cycle **UI Sounds Volume** Low → Medium → High; bottom-screen clicks follow the level without a restart.

## Tested on

- [x] Android — device: AYN Thor (dev channel; steps above driven over adb, logcat confirmed no nav sound within ~300 ms of the toggle, and the volume pushes land live)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files (n/a, no new strings)
- [x] No hardcoded UI strings — everything goes through `AppLocale`

**The database**
- [x] n/a — no schema change; reads the existing `sfx_enabled` / `sfx_volume` columns

**Navigation or a new screen**
- [x] n/a

**Android**
- [x] Path logic handles SAF `content://` URIs (n/a)
- [x] Verified on a device, not only on desktop

**`assets/systems/` or emulator launching**
- [x] n/a

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
