### PR TITLE
fix(credentials): keep NeoSync and RetroAchievements logins on SteamOS

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -686,6 +686,11 @@ mixin AppLocale {
   static const String totalRA = 'total_ra';
   static const String awardedOn = 'awarded_on';
   static const String successConnectedRA = 'success_connected_ra';
+
+  /// Shown when a sign-in worked but the credential could not be stored,
+  /// which is what an unusable Linux keyring looks like to the user.
+  static const String credentialStorageUnavailable =
+      'credential_storage_unavailable';
   static const String connect = 'connect';
   static const String enterUsername = 'enter_username';
   static const String pleaseCompleteAllFields = 'please_complete_all_fields';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -711,6 +711,8 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.totalRA: 'Gesamt',
   AppLocale.awardedOn: 'Verliehen am',
   AppLocale.successConnectedRA: 'Erfolgreich mit RetroAchievements verbunden!',
+  AppLocale.credentialStorageUnavailable:
+      'Anmeldung erfolgreich, aber dieses Gerät konnte deine Anmeldedaten nicht speichern. Beim nächsten Mal musst du dich erneut anmelden.',
   AppLocale.connect: 'Verbinden',
   AppLocale.enterUsername: 'Gib deinen Benutzernamen ein',
   AppLocale.pleaseCompleteAllFields: 'Bitte fülle alle Felder aus',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -688,6 +688,8 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.totalRA: 'TOTAL',
   AppLocale.awardedOn: 'Awarded on ',
   AppLocale.successConnectedRA: 'Successfully connected to RetroAchievements!',
+  AppLocale.credentialStorageUnavailable:
+      'Signed in, but this device could not save your login. You will need to sign in again next time.',
   AppLocale.connect: 'Connect',
   AppLocale.enterUsername: 'Enter your username',
   AppLocale.pleaseCompleteAllFields: 'Please complete all fields',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -710,6 +710,8 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.totalRA: 'TOTAL',
   AppLocale.awardedOn: 'Premiado el ',
   AppLocale.successConnectedRA: '¡Conectado con éxito a RetroAchievements!',
+  AppLocale.credentialStorageUnavailable:
+      'Sesión iniciada, pero este dispositivo no pudo guardar tus credenciales. Tendrás que iniciar sesión de nuevo la próxima vez.',
   AppLocale.connect: 'Conectar',
   AppLocale.enterUsername: 'Introduce tu usuario',
   AppLocale.pleaseCompleteAllFields: 'Por favor, completa todos los campos',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -718,6 +718,8 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.totalRA: 'Total',
   AppLocale.awardedOn: 'Décerné le',
   AppLocale.successConnectedRA: 'Connecté à RetroAchievements avec succès !',
+  AppLocale.credentialStorageUnavailable:
+      'Connexion réussie, mais cet appareil n\'a pas pu enregistrer vos identifiants. Vous devrez vous reconnecter la prochaine fois.',
   AppLocale.connect: 'Connecter',
   AppLocale.enterUsername: 'Entrez votre utilisateur',
   AppLocale.pleaseCompleteAllFields: 'Veuillez remplir tous les champs',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -691,6 +691,8 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.totalRA: 'Total',
   AppLocale.awardedOn: 'Diberikan pada',
   AppLocale.successConnectedRA: 'Berhasil terhubung ke RetroAchievements!',
+  AppLocale.credentialStorageUnavailable:
+      'Berhasil masuk, tetapi perangkat ini tidak dapat menyimpan info masuk Anda. Anda harus masuk lagi lain kali.',
   AppLocale.connect: 'Hubungkan',
   AppLocale.enterUsername: 'Masukkan nama pengguna Anda',
   AppLocale.pleaseCompleteAllFields: 'Harap lengkapi semua bidang',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -708,6 +708,8 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.totalRA: 'Totale',
   AppLocale.awardedOn: 'Premiato il',
   AppLocale.successConnectedRA: 'Connesso a RetroAchievements con successo !',
+  AppLocale.credentialStorageUnavailable:
+      'Accesso eseguito, ma questo dispositivo non è riuscito a salvare le credenziali. Dovrai accedere di nuovo la prossima volta.',
   AppLocale.connect: 'Connetti',
   AppLocale.enterUsername: 'Inserisci il tuo utente',
   AppLocale.pleaseCompleteAllFields: 'Per favore, completa tutti i campi',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -625,6 +625,8 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.totalRA: '合計',
   AppLocale.awardedOn: '受賞日',
   AppLocale.successConnectedRA: 'RetroAchievementsに正常に接続されました！',
+  AppLocale.credentialStorageUnavailable:
+      'ログインしましたが、このデバイスにログイン情報を保存できませんでした。次回は再度ログインが必要です。',
   AppLocale.connect: '接続',
   AppLocale.enterUsername: 'ユーザー名を入力',
   AppLocale.pleaseCompleteAllFields: 'すべての項目を入力してください',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -631,6 +631,8 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.totalRA: '합계',
   AppLocale.awardedOn: '획득일: ',
   AppLocale.successConnectedRA: 'RetroAchievements에 성공적으로 연결되었습니다!',
+  AppLocale.credentialStorageUnavailable:
+      '로그인했지만 이 기기에 로그인 정보를 저장하지 못했습니다. 다음에 다시 로그인해야 합니다.',
   AppLocale.connect: '연결',
   AppLocale.enterUsername: '사용자 이름을 입력하세요',
   AppLocale.pleaseCompleteAllFields: '모든 항목을 작성해 주세요',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -701,6 +701,8 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.totalRA: 'Total',
   AppLocale.awardedOn: 'Premiado em',
   AppLocale.successConnectedRA: 'Conectado ao RetroAchievements com sucesso!',
+  AppLocale.credentialStorageUnavailable:
+      'Sessão iniciada, mas este dispositivo não conseguiu guardar as suas credenciais. Terá de iniciar sessão novamente da próxima vez.',
   AppLocale.connect: 'Conectar',
   AppLocale.enterUsername: 'Digite seu usuário',
   AppLocale.pleaseCompleteAllFields: 'Por favor, preencha todos os campos',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -699,6 +699,8 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.totalRA: 'ВСЕГО',
   AppLocale.awardedOn: 'Награжден ',
   AppLocale.successConnectedRA: 'Успешное подключение к RetroAchievements!',
+  AppLocale.credentialStorageUnavailable:
+      'Вход выполнен, но это устройство не смогло сохранить данные для входа. В следующий раз потребуется войти снова.',
   AppLocale.connect: 'Подключить',
   AppLocale.enterUsername: 'Введите имя пользователя',
   AppLocale.pleaseCompleteAllFields: 'Пожалуйста, заполните все поля',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -615,6 +615,7 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.totalRA: '总计',
   AppLocale.awardedOn: '授予日期 ',
   AppLocale.successConnectedRA: '成功连接到 RetroAchievements！',
+  AppLocale.credentialStorageUnavailable: '已登录，但此设备无法保存登录信息。下次启动时需要重新登录。',
   AppLocale.connect: '连接',
   AppLocale.enterUsername: '输入用户名',
   AppLocale.pleaseCompleteAllFields: '请填写所有字段',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -615,6 +615,7 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.totalRA: '總計',
   AppLocale.awardedOn: '授予日期 ',
   AppLocale.successConnectedRA: '成功連線到 RetroAchievements！',
+  AppLocale.credentialStorageUnavailable: '已登入，但此裝置無法儲存登入資訊。下次啟動時需要重新登入。',
   AppLocale.connect: '連線',
   AppLocale.enterUsername: '輸入使用者名稱',
   AppLocale.pleaseCompleteAllFields: '請填寫所有欄位',

--- a/lib/providers/retro_achievements_provider.dart
+++ b/lib/providers/retro_achievements_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:neostation/services/credential_store.dart';
 import 'package:neostation/services/logger_service.dart';
 import '../models/retro_achievements_user.dart';
 import '../models/retro_achievements_summary.dart';
@@ -52,6 +53,10 @@ class RetroAchievementsProvider extends ChangeNotifier {
 
   /// Current RetroAchievements API key used for requests.
   String _apiKey = '';
+
+  /// Whether the last successful [connect] managed to store the API key.
+  /// False means this session is signed in but the next launch will not be.
+  bool _credentialsPersisted = true;
 
   static final _log = LoggerService.instance;
 
@@ -208,6 +213,9 @@ class RetroAchievementsProvider extends ChangeNotifier {
   bool get hasResolvedApiKey =>
       RetroAchievementsService.resolveApiKey(_apiKey).trim().isNotEmpty;
 
+  /// False when the credentials for the current session could not be saved.
+  bool get credentialsPersisted => _credentialsPersisted;
+
   /// Whether any dashboard section is currently in flight.
   bool get isDashboardLoading =>
       _recentUnlocksLoading ||
@@ -258,7 +266,7 @@ class RetroAchievementsProvider extends ChangeNotifier {
         _isConnected = true;
 
         await _saveRAUserToConfig(_username);
-        await _saveRAApiKeyToConfig(_apiKey);
+        _credentialsPersisted = await _saveRAApiKeyToConfig(_apiKey);
         await loadLocalStats();
         unawaited(loadUserSummary());
 
@@ -714,11 +722,17 @@ class RetroAchievementsProvider extends ChangeNotifier {
   }
 
   /// Persists the RetroAchievements API key to secure storage.
-  Future<void> _saveRAApiKeyToConfig(String apiKey) async {
+  ///
+  /// Returns false when the key only lives in memory, which is what happens on
+  /// a Linux install with no working keyring: the session works, but the next
+  /// launch starts signed out unless the user is told.
+  Future<bool> _saveRAApiKeyToConfig(String apiKey) async {
     try {
-      await RetroAchievementsRepository.saveRAApiKey(apiKey);
+      final outcome = await RetroAchievementsRepository.saveRAApiKey(apiKey);
+      return outcome != CredentialWriteOutcome.sessionOnly;
     } catch (e) {
       _log.e('Error saving RA API key: $e');
+      return false;
     }
   }
 

--- a/lib/repositories/retro_achievements_repository.dart
+++ b/lib/repositories/retro_achievements_repository.dart
@@ -1,10 +1,10 @@
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../data/datasources/sqlite_service.dart';
 import '../models/database_game_model.dart';
 import '../models/ra_game_list_entry.dart';
 import '../models/ra_hash_policy.dart';
 import '../models/ra_match_candidate.dart';
 import '../models/retro_achievements_dashboard_models.dart';
+import '../services/credential_store.dart';
 import '../services/logger_service.dart';
 
 /// Repository for RetroAchievements data access.
@@ -12,17 +12,6 @@ class RetroAchievementsRepository {
   static final _log = LoggerService.instance;
 
   static const String _raApiKeyStorageKey = 'ra_api_key';
-  // Do not let a transient Android Keystore error erase credentials. This can
-  // happen during cold boot on some launchers, and the default resetOnError
-  // behaviour turns a temporary read failure into a permanent logout.
-  static const FlutterSecureStorage _storage = FlutterSecureStorage(
-    aOptions: AndroidOptions(resetOnError: false, migrateWithBackup: true),
-    // NeoStation's macOS builds are also distributed outside the App Store.
-    // The classic Keychain remains encrypted by macOS without requiring the
-    // restricted Keychain Sharing entitlement used by the data-protection
-    // Keychain, so ad-hoc-signed builds can persist the API key securely.
-    mOptions: MacOsOptions(usesDataProtectionKeychain: false),
-  );
 
   /// Returns local ROM counts: total and RA-compatible (has ra_hash).
   static Future<({int totalRoms, int raCompatibleRoms})>
@@ -69,19 +58,20 @@ class RetroAchievementsRepository {
   static Future<void> saveRAUser(String username) =>
       SqliteService.updateRAUser(username);
 
-  /// Persists the RA API key securely.
-  static Future<void> saveRAApiKey(String apiKey) async {
-    await _storage.write(key: _raApiKeyStorageKey, value: apiKey);
+  /// Persists the RA API key securely, reporting where it ended up so the
+  /// caller can tell the user when it will not survive a restart.
+  static Future<CredentialWriteOutcome> saveRAApiKey(String apiKey) {
+    return CredentialStore.write(_raApiKeyStorageKey, apiKey);
   }
 
   /// Returns the persisted RA API key, or null if not set.
-  static Future<String?> getRAApiKey() async {
-    return _storage.read(key: _raApiKeyStorageKey);
+  static Future<String?> getRAApiKey() {
+    return CredentialStore.read(_raApiKeyStorageKey);
   }
 
   /// Clears the stored RA API key.
-  static Future<void> clearRAApiKey() async {
-    await _storage.delete(key: _raApiKeyStorageKey);
+  static Future<void> clearRAApiKey() {
+    return CredentialStore.delete(_raApiKeyStorageKey);
   }
 
   /// Clears the stored RA username.

--- a/lib/screens/retro_achievements_screen/ra_content.dart
+++ b/lib/screens/retro_achievements_screen/ra_content.dart
@@ -170,10 +170,16 @@ class _RAContentState extends State<RAContent>
     );
     if (!mounted) return;
     if (success) {
+      // A login that could not be stored still works for this session, so say
+      // so rather than reporting a plain success the next launch contradicts.
       AppNotification.showNotification(
         context,
-        AppLocale.successConnectedRA.getString(context),
-        type: NotificationType.success,
+        raProvider.credentialsPersisted
+            ? AppLocale.successConnectedRA.getString(context)
+            : AppLocale.credentialStorageUnavailable.getString(context),
+        type: raProvider.credentialsPersisted
+            ? NotificationType.success
+            : NotificationType.info,
       );
     } else if (raProvider.error != null) {
       AppNotification.showNotification(

--- a/lib/services/credential_backend.dart
+++ b/lib/services/credential_backend.dart
@@ -1,0 +1,15 @@
+/// A place a credential can be kept.
+///
+/// Implemented by the platform keychain wrapper and by the app's own encrypted
+/// file, so [CredentialStore] can try them in order without caring which is
+/// which.
+abstract class CredentialBackend {
+  /// Returns the stored value, or null when nothing is stored for [key].
+  /// Throws when the store itself could not be read — the caller relies on that
+  /// distinction to avoid treating an unreadable store as a signed-out user.
+  Future<String?> read(String key);
+
+  Future<void> write(String key, String value);
+
+  Future<void> delete(String key);
+}

--- a/lib/services/credential_file_store.dart
+++ b/lib/services/credential_file_store.dart
@@ -1,0 +1,231 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:path/path.dart' as path;
+import 'package:pointycastle/export.dart';
+
+import 'credential_backend.dart';
+import 'logger_service.dart';
+
+/// Encrypted, machine-bound credential file used when the platform's own
+/// secure storage is unavailable.
+///
+/// SteamOS ships without a Secret Service: `org.freedesktop.secrets` is not
+/// even D-Bus activatable, so libsecret cannot store anything and both the
+/// NeoSync token and the RetroAchievements API key are lost on every restart
+/// (issue #302). Installing gnome-keyring by hand is not a durable answer on an
+/// immutable OS, so the app carries its own store for that case.
+///
+/// The security model, stated plainly: the key is derived from material that
+/// lives on the same machine, so this protects a credential from being read out
+/// of a backup, a synced folder, or a user-data directory copied to another
+/// machine — not from someone who already has the user's account. That is still
+/// strictly better than the plaintext SharedPreferences fallback the macOS
+/// build has always used, and it is only ever reached once the real keychain
+/// has failed.
+class CredentialFileStore implements CredentialBackend {
+  CredentialFileStore(this.directory);
+
+  /// Directory holding the credential file. This is the user-data directory, so
+  /// credentials share the lifetime of the database that stores the matching
+  /// usernames: wiping user data signs the user out instead of leaving a key
+  /// behind for an account the database no longer knows about.
+  final String directory;
+
+  static final _log = LoggerService.instance;
+
+  static const String _fileName = 'credentials.enc';
+  static const String _deviceKeyFileName = 'credentials.key';
+  static const int _formatVersion = 1;
+  static const int _saltLength = 16;
+  static const int _nonceLength = 12;
+  static const int _macBits = 128;
+  static const int _keyLength = 32;
+  static const int _deviceKeyLength = 32;
+
+  static final Uint8List _hkdfInfo = Uint8List.fromList(
+    utf8.encode('neostation-credential-store-v1'),
+  );
+
+  final Random _random = Random.secure();
+
+  File get _file => File(path.join(directory, _fileName));
+  File get _deviceKeyFile => File(path.join(directory, _deviceKeyFileName));
+
+  /// Returns the stored value for [key], or null when nothing is stored.
+  ///
+  /// Throws on an unreadable file so the caller can tell "no credential" from
+  /// "could not look", which is what stops a transient failure being treated as
+  /// a sign-out.
+  @override
+  Future<String?> read(String key) async {
+    final entries = await _readAll();
+    final value = entries[key];
+    return (value is String && value.isNotEmpty) ? value : null;
+  }
+
+  @override
+  Future<void> write(String key, String value) async {
+    final entries = await _readAll();
+    entries[key] = value;
+    await _writeAll(entries);
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    final entries = await _readAll();
+    if (!entries.containsKey(key)) return;
+    entries.remove(key);
+    await _writeAll(entries);
+  }
+
+  Future<Map<String, dynamic>> _readAll() async {
+    final file = _file;
+    if (!await file.exists()) return <String, dynamic>{};
+
+    final envelope = jsonDecode(await file.readAsString());
+    if (envelope is! Map || envelope['v'] != _formatVersion) {
+      _log.w('CredentialFileStore: unrecognised credential file, ignoring it');
+      return <String, dynamic>{};
+    }
+
+    final salt = base64Decode(envelope['salt'] as String);
+    final nonce = base64Decode(envelope['nonce'] as String);
+    final payload = base64Decode(envelope['data'] as String);
+
+    try {
+      final plaintext = _cipher(
+        forEncryption: false,
+        key: await _deriveKey(salt),
+        nonce: nonce,
+      ).process(payload);
+      final decoded = jsonDecode(utf8.decode(plaintext));
+      return decoded is Map
+          ? Map<String, dynamic>.from(decoded)
+          : <String, dynamic>{};
+    } catch (e) {
+      // Undecryptable is indistinguishable from tampered, and both mean the
+      // key material this file was written with is gone (a reinstalled OS
+      // changes /etc/machine-id). Report "nothing stored" rather than an
+      // unreadable store: the user signs in again and the next write replaces
+      // the file, whereas a throw here would retry forever with no way out.
+      _log.w('CredentialFileStore: credential file could not be decrypted: $e');
+      return <String, dynamic>{};
+    }
+  }
+
+  Future<void> _writeAll(Map<String, dynamic> entries) async {
+    await Directory(directory).create(recursive: true);
+
+    final salt = _randomBytes(_saltLength);
+    final nonce = _randomBytes(_nonceLength);
+    final payload = _cipher(
+      forEncryption: true,
+      key: await _deriveKey(salt),
+      nonce: nonce,
+    ).process(Uint8List.fromList(utf8.encode(jsonEncode(entries))));
+
+    final envelope = jsonEncode({
+      'v': _formatVersion,
+      'salt': base64Encode(salt),
+      'nonce': base64Encode(nonce),
+      'data': base64Encode(payload),
+    });
+
+    // Write-then-rename so a crash mid-write cannot leave a half-written file
+    // that reads as "no credentials" and silently signs the user out.
+    final temp = File('${_file.path}.tmp');
+    await temp.writeAsString(envelope, flush: true);
+    await _restrictToOwner(temp);
+    await temp.rename(_file.path);
+  }
+
+  GCMBlockCipher _cipher({
+    required bool forEncryption,
+    required Uint8List key,
+    required Uint8List nonce,
+  }) {
+    return GCMBlockCipher(AESEngine())..init(
+      forEncryption,
+      AEADParameters(KeyParameter(key), _macBits, nonce, Uint8List(0)),
+    );
+  }
+
+  /// Derives the file key from a per-install random secret plus, on Linux, the
+  /// machine's own id. The machine id is what makes a copied user-data folder
+  /// useless on another machine; the random secret is what stops the key being
+  /// guessable from the machine id alone.
+  Future<Uint8List> _deriveKey(Uint8List salt) async {
+    final material = <int>[...await _deviceSecret()];
+    final machineId = _machineId();
+    if (machineId != null) {
+      material.addAll(utf8.encode(machineId));
+    }
+
+    final derivator = HKDFKeyDerivator(SHA256Digest())
+      ..init(
+        HkdfParameters(
+          Uint8List.fromList(material),
+          _keyLength,
+          salt,
+          _hkdfInfo,
+        ),
+      );
+
+    final key = Uint8List(_keyLength);
+    derivator.deriveKey(Uint8List(0), 0, key, 0);
+    return key;
+  }
+
+  Future<Uint8List> _deviceSecret() async {
+    final file = _deviceKeyFile;
+    if (await file.exists()) {
+      final existing = await file.readAsBytes();
+      if (existing.length == _deviceKeyLength) return existing;
+      _log.w('CredentialFileStore: device key is malformed, regenerating it');
+    }
+
+    final secret = _randomBytes(_deviceKeyLength);
+    await Directory(directory).create(recursive: true);
+    await file.writeAsBytes(secret, flush: true);
+    await _restrictToOwner(file);
+    return secret;
+  }
+
+  /// The host's stable machine id, or null where the platform has none.
+  String? _machineId() {
+    if (!Platform.isLinux) return null;
+    for (final candidate in const [
+      '/etc/machine-id',
+      '/var/lib/dbus/machine-id',
+    ]) {
+      try {
+        final file = File(candidate);
+        if (!file.existsSync()) continue;
+        final id = file.readAsStringSync().trim();
+        if (id.isNotEmpty) return id;
+      } catch (_) {
+        // An unreadable machine id only costs the machine binding, so fall
+        // through to the next candidate rather than failing the whole read.
+      }
+    }
+    return null;
+  }
+
+  Future<void> _restrictToOwner(File file) async {
+    if (Platform.isWindows) return;
+    try {
+      await Process.run('chmod', ['600', file.path]);
+    } catch (e) {
+      _log.w('CredentialFileStore: could not restrict ${file.path}: $e');
+    }
+  }
+
+  Uint8List _randomBytes(int length) {
+    return Uint8List.fromList(
+      List<int>.generate(length, (_) => _random.nextInt(256)),
+    );
+  }
+}

--- a/lib/services/credential_store.dart
+++ b/lib/services/credential_store.dart
@@ -1,0 +1,277 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'config_service.dart';
+import 'credential_backend.dart';
+import 'credential_file_store.dart';
+import 'logger_service.dart';
+
+/// Where a credential actually ended up.
+enum CredentialWriteOutcome {
+  /// The platform keychain/keyring took it, as intended.
+  secureStorage,
+
+  /// The platform store refused it and the app's encrypted file took it.
+  /// The credential still survives a restart; only the OS protection is lost.
+  encryptedFile,
+
+  /// Nothing could be persisted. The credential lives in this process only, so
+  /// the current session works and the next launch starts signed out.
+  sessionOnly,
+}
+
+/// Thrown when every backend failed to answer a read.
+///
+/// This is deliberately distinct from "nothing is stored": callers must not
+/// treat an unreadable store as a signed-out user, or a transient failure
+/// deletes a perfectly good account.
+class CredentialStoreException implements Exception {
+  CredentialStoreException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'CredentialStoreException: $message';
+}
+
+/// The single place the app keeps user credentials.
+///
+/// Every platform prefers its own secure storage. What differs is what happens
+/// when that fails, which on Linux is routine rather than exceptional: SteamOS
+/// has no Secret Service at all, so libsecret cannot store anything and both
+/// the NeoSync token and the RetroAchievements key vanished on every restart
+/// (issue #302). Desktop platforms therefore fall through to an encrypted file
+/// in the user-data directory, and anything still unwritable after that is kept
+/// in memory so at least the current session works.
+///
+/// Reads walk the same chain, which also retires the plaintext
+/// SharedPreferences token that macOS builds have used since the Keychain was
+/// unreliable for ad-hoc-signed builds: it is read once, rewritten to a real
+/// store, and removed.
+class CredentialStore {
+  static final _log = LoggerService.instance;
+
+  /// Do not let a transient Android Keystore error erase credentials. This can
+  /// happen during cold boot on some launchers, and the default `resetOnError`
+  /// behaviour turns a temporary read failure into a permanent logout.
+  ///
+  /// NeoStation's macOS builds are also distributed outside the App Store. The
+  /// classic Keychain remains encrypted by macOS without requiring the
+  /// restricted Keychain Sharing entitlement used by the data-protection
+  /// Keychain, so ad-hoc-signed builds can persist credentials securely.
+  static const FlutterSecureStorage _secureStorage = FlutterSecureStorage(
+    aOptions: AndroidOptions(resetOnError: false, migrateWithBackup: true),
+    mOptions: MacOsOptions(usesDataProtectionKeychain: false),
+  );
+
+  /// Credentials that could not be persisted at all, kept for this process so
+  /// the session the user just signed into still works.
+  static final Map<String, String> _session = <String, String>{};
+
+  static CredentialBackend? _secureOverride;
+  static CredentialBackend? _fileOverride;
+  static bool _fileOverrideSet = false;
+  static Future<CredentialBackend?>? _fileStore;
+
+  static CredentialBackend get _secure =>
+      _secureOverride ?? const _SecureStorageBackend(_secureStorage);
+
+  /// Replaces the backends for tests. Passing null for [file] models a platform
+  /// with no fallback store.
+  @visibleForTesting
+  static void debugUseBackends({
+    CredentialBackend? secure,
+    CredentialBackend? file,
+  }) {
+    _secureOverride = secure;
+    _fileOverride = file;
+    _fileOverrideSet = true;
+    _fileStore = null;
+    _session.clear();
+  }
+
+  @visibleForTesting
+  static void debugReset() {
+    _secureOverride = null;
+    _fileOverride = null;
+    _fileOverrideSet = false;
+    _fileStore = null;
+    _session.clear();
+  }
+
+  /// Returns the stored credential, or null when nothing is stored.
+  ///
+  /// Throws [CredentialStoreException] when a store existed but could not be
+  /// read, so callers can preserve state instead of signing the user out.
+  static Future<String?> read(String key) async {
+    // The session copy only exists when persisting failed, which makes it the
+    // freshest value by definition.
+    final session = _session[key];
+    if (session != null) return session;
+
+    var secureFailed = false;
+    var fallbackFailed = false;
+
+    try {
+      final value = await _secure.read(key);
+      if (value != null && value.isNotEmpty) return value;
+    } catch (e) {
+      secureFailed = true;
+      _log.w('CredentialStore: secure storage unreadable for "$key": $e');
+    }
+
+    final file = await _fileBackend();
+    if (file != null) {
+      try {
+        final value = await file.read(key);
+        if (value != null && value.isNotEmpty) return value;
+      } catch (e) {
+        fallbackFailed = true;
+        _log.w('CredentialStore: credential file unreadable for "$key": $e');
+      }
+    }
+
+    try {
+      final legacy = await _readLegacyPreference(key);
+      if (legacy != null) {
+        _log.i('CredentialStore: migrating "$key" out of shared preferences');
+        await write(key, legacy);
+        return legacy;
+      }
+    } catch (e) {
+      fallbackFailed = true;
+      _log.w('CredentialStore: legacy preferences unreadable for "$key": $e');
+    }
+
+    // A broken keyring is the normal state on SteamOS, not a transient fault,
+    // so a healthy fallback store that simply holds nothing is the answer:
+    // reporting "unreadable" there would have every launch retry an auto-login
+    // that can never succeed. Where there is no fallback (mobile), a failed
+    // secure read still means "could not look", which is what stops a cold-boot
+    // keystore hiccup being mistaken for a signed-out user.
+    if (fallbackFailed || (secureFailed && file == null)) {
+      throw CredentialStoreException('No credential store could be read');
+    }
+    return null;
+  }
+
+  /// Persists [value], reporting where it landed so the caller can warn the
+  /// user when the credential will not survive a restart.
+  static Future<CredentialWriteOutcome> write(String key, String value) async {
+    _session.remove(key);
+
+    try {
+      await _secure.write(key, value);
+      await _clearFile(key);
+      await _clearLegacyPreference(key);
+      return CredentialWriteOutcome.secureStorage;
+    } catch (e) {
+      _log.w('CredentialStore: secure storage rejected "$key": $e');
+    }
+
+    final file = await _fileBackend();
+    if (file != null) {
+      try {
+        await file.write(key, value);
+        await _clearLegacyPreference(key);
+        _log.i('CredentialStore: stored "$key" in the encrypted fallback file');
+        return CredentialWriteOutcome.encryptedFile;
+      } catch (e) {
+        _log.e('CredentialStore: credential file rejected "$key": $e');
+      }
+    }
+
+    _session[key] = value;
+    _log.e('CredentialStore: "$key" could not be persisted; session only');
+    return CredentialWriteOutcome.sessionOnly;
+  }
+
+  /// Removes the credential from every store. Best effort by design: a store
+  /// that cannot be reached now must not block clearing the others.
+  static Future<void> delete(String key) async {
+    _session.remove(key);
+
+    try {
+      await _secure.delete(key);
+    } catch (e) {
+      _log.w('CredentialStore: could not clear "$key" from secure storage: $e');
+    }
+
+    await _clearFile(key);
+    await _clearLegacyPreference(key);
+  }
+
+  static Future<void> _clearFile(String key) async {
+    final file = await _fileBackend();
+    if (file == null) return;
+    try {
+      await file.delete(key);
+    } catch (e) {
+      _log.w('CredentialStore: could not clear "$key" from the file store: $e');
+    }
+  }
+
+  /// The encrypted file store, or null on platforms that do not use one.
+  ///
+  /// Mobile is excluded on purpose: its keystore is reliable, and on Android the
+  /// user-data directory can live on shared external storage, which is no place
+  /// for a token file.
+  static Future<CredentialBackend?> _fileBackend() {
+    if (_fileOverrideSet) {
+      return Future<CredentialBackend?>.value(_fileOverride);
+    }
+    if (!Platform.isLinux && !Platform.isMacOS && !Platform.isWindows) {
+      return Future<CredentialBackend?>.value();
+    }
+    return _fileStore ??= _createFileStore();
+  }
+
+  static Future<CredentialBackend?> _createFileStore() async {
+    try {
+      return CredentialFileStore(await ConfigService.getUserDataPath());
+    } catch (e) {
+      _log.e('CredentialStore: no user-data path for the file store: $e');
+      // Do not cache the failure: the Android-style storage wait can resolve
+      // later, and a null here would otherwise stick for the whole session.
+      _fileStore = null;
+      return null;
+    }
+  }
+
+  /// Reads the plaintext SharedPreferences copy older builds wrote on macOS.
+  static Future<String?> _readLegacyPreference(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getString(key);
+    return (value != null && value.isNotEmpty) ? value : null;
+  }
+
+  static Future<void> _clearLegacyPreference(String key) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (prefs.containsKey(key)) {
+        await prefs.remove(key);
+      }
+    } catch (e) {
+      _log.w('CredentialStore: could not clear legacy preference "$key": $e');
+    }
+  }
+}
+
+class _SecureStorageBackend implements CredentialBackend {
+  const _SecureStorageBackend(this._storage);
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<String?> read(String key) => _storage.read(key: key);
+
+  @override
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value);
+
+  @override
+  Future<void> delete(String key) => _storage.delete(key: key);
+}

--- a/lib/services/neosync/auth_service.dart
+++ b/lib/services/neosync/auth_service.dart
@@ -1,23 +1,19 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:neostation/models/user.dart';
+import 'package:neostation/services/credential_store.dart';
 import 'package:neostation/services/logger_service.dart';
-import 'dart:io';
 import 'package:neostation/utils/app_config.dart';
 
 /// Service responsible for managing user authentication and profile synchronization.
 ///
-/// Handles registration, login, email verification, password recovery, and session
-/// persistence using secure storage (or shared preferences on macOS).
+/// Handles registration, login, email verification, password recovery, and
+/// session persistence. Where the token is kept is [CredentialStore]'s problem,
+/// including the platforms whose secure storage cannot hold it.
 class AuthService extends ChangeNotifier {
   /// Storage key for the authentication JWT token.
   static const String _tokenKey = 'auth_token';
-
-  /// Primary storage for sensitive credentials on supported platforms.
-  final FlutterSecureStorage _storage = const FlutterSecureStorage();
 
   static final _log = LoggerService.instance;
 
@@ -37,13 +33,7 @@ class AuthService extends ChangeNotifier {
   /// while purging them on explicit authentication errors (401/403).
   Future<void> initialize() async {
     try {
-      String? token;
-      if (Platform.isMacOS) {
-        final prefs = await SharedPreferences.getInstance();
-        token = prefs.getString(_tokenKey);
-      } else {
-        token = await _storage.read(key: _tokenKey);
-      }
+      final token = await CredentialStore.read(_tokenKey);
       if (token != null) {
         final profileResult = await getProfile();
         if (profileResult['success'] == true) {
@@ -59,12 +49,7 @@ class AuthService extends ChangeNotifier {
             _log.w(
               'AuthService: Token invalid or expired ($statusCode). Clearing storage.',
             );
-            if (Platform.isMacOS) {
-              final prefs = await SharedPreferences.getInstance();
-              await prefs.remove(_tokenKey);
-            } else {
-              await _storage.delete(key: _tokenKey);
-            }
+            await CredentialStore.delete(_tokenKey);
           } else {
             _log.i(
               'AuthService: Unexpected server error ($statusCode). Token preserved.',
@@ -147,11 +132,13 @@ class AuthService extends ChangeNotifier {
         final token = data['token'];
         final userData = data['user'];
 
-        if (Platform.isMacOS) {
-          final prefs = await SharedPreferences.getInstance();
-          await prefs.setString(_tokenKey, token);
-        } else {
-          await _storage.write(key: _tokenKey, value: token);
+        final storage = await CredentialStore.write(_tokenKey, token);
+        final tokenPersisted = storage != CredentialWriteOutcome.sessionOnly;
+        if (!tokenPersisted) {
+          _log.w(
+            'Login succeeded but the token could not be persisted; the '
+            'session ends when the app closes',
+          );
         }
 
         _currentUser = User.fromJson(userData);
@@ -165,6 +152,7 @@ class AuthService extends ChangeNotifier {
             'message': 'Login successful, but email not verified',
             'emailVerified': false,
             'user': user,
+            'tokenPersisted': tokenPersisted,
           };
         }
 
@@ -173,6 +161,7 @@ class AuthService extends ChangeNotifier {
           'message': 'Login successful',
           'emailVerified': true,
           'user': user,
+          'tokenPersisted': tokenPersisted,
         };
       } else {
         String errorMessage = data['error'] ?? 'Login failed';
@@ -276,13 +265,7 @@ class AuthService extends ChangeNotifier {
   /// Automatically updates the internal [_currentUser] state on success.
   Future<Map<String, dynamic>> getProfile() async {
     try {
-      String? token;
-      if (Platform.isMacOS) {
-        final prefs = await SharedPreferences.getInstance();
-        token = prefs.getString(_tokenKey);
-      } else {
-        token = await _storage.read(key: _tokenKey);
-      }
+      final token = await CredentialStore.read(_tokenKey);
       if (token == null) {
         return {'success': false, 'message': 'Not authenticated'};
       }
@@ -380,12 +363,7 @@ class AuthService extends ChangeNotifier {
 
   /// Terminates the current user session and purges the stored authentication token.
   Future<void> logout() async {
-    if (Platform.isMacOS) {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_tokenKey);
-    } else {
-      await _storage.delete(key: _tokenKey);
-    }
+    await CredentialStore.delete(_tokenKey);
     _isLoggedIn = false;
     _currentUser = null;
     notifyListeners();

--- a/lib/services/neosync/billing_service.dart
+++ b/lib/services/neosync/billing_service.dart
@@ -1,10 +1,8 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:neostation/models/billing_models.dart';
+import 'package:neostation/services/credential_store.dart';
 import 'package:neostation/services/logger_service.dart';
-import 'dart:io';
 import 'package:neostation/utils/app_config.dart';
 import 'package:flutter/material.dart';
 
@@ -17,7 +15,6 @@ class BillingService extends ChangeNotifier {
   static const String _tokenKey = 'auth_token';
 
   /// Primary storage for sensitive credentials.
-  final FlutterSecureStorage _storage = const FlutterSecureStorage();
 
   final _log = LoggerService.instance;
 
@@ -39,11 +36,14 @@ class BillingService extends ChangeNotifier {
 
   /// Retrieves the current authentication token from secure storage.
   Future<String?> _getToken() async {
-    if (Platform.isMacOS) {
-      final prefs = await SharedPreferences.getInstance();
-      return prefs.getString(_tokenKey);
+    try {
+      return await CredentialStore.read(_tokenKey);
+    } catch (e) {
+      // An unreadable store is not a signed-out user: report "no token" for
+      // this call and leave the stored credential alone.
+      _log.w('Could not read the NeoSync token: $e');
+      return null;
     }
-    return await _storage.read(key: _tokenKey);
   }
 
   /// Constructs the standard HTTP headers for authenticated billing API requests.

--- a/lib/services/neosync/neo_sync_service.dart
+++ b/lib/services/neosync/neo_sync_service.dart
@@ -1,12 +1,11 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart' as http;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:neostation/models/neo_sync_models.dart';
 import 'package:neostation/utils/app_config.dart';
 import 'package:flutter/material.dart';
 import 'package:crypto/crypto.dart';
+import 'package:neostation/services/credential_store.dart';
 import 'package:neostation/services/logger_service.dart';
 import '../../repositories/sync_repository.dart';
 
@@ -16,7 +15,6 @@ import '../../repositories/sync_repository.dart';
 /// conflict resolution for game save states and configurations.
 class NeoSyncService extends ChangeNotifier {
   static const String _tokenKey = 'auth_token';
-  final FlutterSecureStorage _storage = const FlutterSecureStorage();
   final _log = LoggerService.instance;
 
   bool _isLoading = false;
@@ -236,11 +234,14 @@ class NeoSyncService extends ChangeNotifier {
 
   /// Retrieves the JWT authentication token from secure storage.
   Future<String?> _getToken() async {
-    if (Platform.isMacOS) {
-      final prefs = await SharedPreferences.getInstance();
-      return prefs.getString(_tokenKey);
+    try {
+      return await CredentialStore.read(_tokenKey);
+    } catch (e) {
+      // An unreadable store is not a signed-out user: report "no token" for
+      // this call and leave the stored credential alone.
+      _log.w('Could not read the NeoSync token: $e');
+      return null;
     }
-    return await _storage.read(key: _tokenKey);
   }
 
   /// Generates the standard HTTP headers required for authenticated API requests.

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -2,10 +2,7 @@ import 'dart:convert';
 import 'dart:async';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:web_socket_channel/status.dart' as status;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:neostation/models/notification_models.dart';
-import 'dart:io';
 import 'package:neostation/utils/app_config.dart';
 import 'package:flutter/material.dart';
 import 'package:neostation/widgets/plan_welcome_modal.dart';
@@ -15,6 +12,7 @@ import 'package:neostation/providers/neo_sync_provider.dart';
 import 'package:neostation/sync/sync_manager.dart';
 import 'package:neostation/sync/providers/neo_sync_adapter.dart';
 import 'package:provider/provider.dart';
+import 'package:neostation/services/credential_store.dart';
 import 'package:neostation/services/logger_service.dart';
 
 /// Service responsible for real-time notifications via WebSockets.
@@ -24,7 +22,6 @@ import 'package:neostation/services/logger_service.dart';
 /// and UI integration for displaying system modals.
 class NotificationService extends ChangeNotifier {
   static const String _tokenKey = 'auth_token';
-  final FlutterSecureStorage _storage = const FlutterSecureStorage();
   final _log = LoggerService.instance;
 
   WebSocketChannel? _channel;
@@ -145,11 +142,14 @@ class NotificationService extends ChangeNotifier {
   }
 
   Future<String?> _getToken() async {
-    if (Platform.isMacOS) {
-      final prefs = await SharedPreferences.getInstance();
-      return prefs.getString(_tokenKey);
+    try {
+      return await CredentialStore.read(_tokenKey);
+    } catch (e) {
+      // An unreadable store is not a signed-out user: report "no token" for
+      // this call and leave the stored credential alone.
+      _log.w('Could not read the NeoSync token: $e');
+      return null;
     }
-    return await _storage.read(key: _tokenKey);
   }
 
   /// Establishes the WebSocket connection with the notification server.

--- a/lib/widgets/auth_form.dart
+++ b/lib/widgets/auth_form.dart
@@ -262,7 +262,12 @@ class AuthFormState extends State<AuthForm> with LoginFormSelection<AuthForm> {
       }
 
       setState(() {
-        _message = result['message'];
+        // A login the device could not store still works until the app closes.
+        // Say that instead of the backend's plain "Login successful", which the
+        // next launch would contradict.
+        _message = result['tokenPersisted'] == false
+            ? AppLocale.credentialStorageUnavailable.getString(context)
+            : result['message'];
       });
 
       // Handle email not verified case (can come as error from backend)

--- a/test/credential_file_store_test.dart
+++ b/test/credential_file_store_test.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/credential_file_store.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  late Directory directory;
+  late CredentialFileStore store;
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('neostation-creds');
+    store = CredentialFileStore(directory.path);
+  });
+
+  tearDown(() async {
+    if (await directory.exists()) {
+      await directory.delete(recursive: true);
+    }
+  });
+
+  File credentialFile() => File(path.join(directory.path, 'credentials.enc'));
+
+  test('round-trips a credential', () async {
+    await store.write('ra_api_key', 'super-secret');
+
+    expect(await store.read('ra_api_key'), 'super-secret');
+    // A fresh instance proves the value came off disk, not out of memory.
+    expect(
+      await CredentialFileStore(directory.path).read('ra_api_key'),
+      'super-secret',
+    );
+  });
+
+  test('returns null for a key that was never stored', () async {
+    expect(await store.read('auth_token'), isNull);
+
+    await store.write('ra_api_key', 'super-secret');
+    expect(await store.read('auth_token'), isNull);
+  });
+
+  test('keeps other credentials when one is deleted', () async {
+    await store.write('ra_api_key', 'key');
+    await store.write('auth_token', 'jwt');
+
+    await store.delete('ra_api_key');
+
+    expect(await store.read('ra_api_key'), isNull);
+    expect(await store.read('auth_token'), 'jwt');
+  });
+
+  test('never writes the credential in the clear', () async {
+    await store.write('ra_api_key', 'super-secret');
+
+    final onDisk = await credentialFile().readAsString();
+    expect(onDisk.contains('super-secret'), isFalse);
+    expect(onDisk.contains('ra_api_key'), isFalse);
+  });
+
+  test('reads as empty when the key material no longer matches', () async {
+    await store.write('ra_api_key', 'super-secret');
+
+    // Losing the device key is what a reinstalled OS looks like. The user has
+    // to sign in again, but the app must not get stuck on an undecryptable
+    // file: reporting "nothing stored" lets the next write replace it.
+    await File(path.join(directory.path, 'credentials.key')).delete();
+
+    expect(
+      await CredentialFileStore(directory.path).read('ra_api_key'),
+      isNull,
+    );
+
+    await store.write('ra_api_key', 'new-secret');
+    expect(
+      await CredentialFileStore(directory.path).read('ra_api_key'),
+      'new-secret',
+    );
+  });
+
+  test('rejects a tampered payload rather than trusting it', () async {
+    await store.write('ra_api_key', 'super-secret');
+
+    final envelope =
+        jsonDecode(await credentialFile().readAsString())
+            as Map<String, dynamic>;
+    final payload = base64Decode(envelope['data'] as String);
+    payload[0] ^= 0xFF;
+    envelope['data'] = base64Encode(payload);
+    await credentialFile().writeAsString(jsonEncode(envelope));
+
+    // AES-GCM authentication fails, so the entry is gone rather than forged.
+    expect(
+      await CredentialFileStore(directory.path).read('ra_api_key'),
+      isNull,
+    );
+  });
+
+  test('ignores a credential file from a future format version', () async {
+    await store.write('ra_api_key', 'super-secret');
+
+    final envelope =
+        jsonDecode(await credentialFile().readAsString())
+            as Map<String, dynamic>;
+    envelope['v'] = 99;
+    await credentialFile().writeAsString(jsonEncode(envelope));
+
+    expect(
+      await CredentialFileStore(directory.path).read('ra_api_key'),
+      isNull,
+    );
+  });
+
+  test('restricts the credential files to the owner', () async {
+    await store.write('ra_api_key', 'super-secret');
+
+    if (Platform.isWindows) return;
+    for (final name in const ['credentials.enc', 'credentials.key']) {
+      final mode = await Process.run('stat', [
+        '-c',
+        '%a',
+        path.join(directory.path, name),
+      ]);
+      expect((mode.stdout as String).trim(), '600', reason: name);
+    }
+  });
+}

--- a/test/credential_store_test.dart
+++ b/test/credential_store_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/credential_backend.dart';
+import 'package:neostation/services/credential_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// A backend that works, so the happy path can be asserted.
+class _MemoryBackend implements CredentialBackend {
+  final Map<String, String> values = {};
+
+  @override
+  Future<String?> read(String key) async => values[key];
+
+  @override
+  Future<void> write(String key, String value) async => values[key] = value;
+
+  @override
+  Future<void> delete(String key) async => values.remove(key);
+}
+
+/// A backend that fails the way a missing Secret Service does: every call
+/// throws, including the read.
+class _BrokenBackend implements CredentialBackend {
+  @override
+  Future<String?> read(String key) async {
+    throw Exception('secret_service_get_sync: the name is not activatable');
+  }
+
+  @override
+  Future<void> write(String key, String value) async {
+    throw Exception('secret_password_storev_sync: Object does not exist');
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    throw Exception('secret_service_get_sync: the name is not activatable');
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+  tearDown(CredentialStore.debugReset);
+
+  test('prefers secure storage and keeps the fallback file clear', () async {
+    final secure = _MemoryBackend();
+    final file = _MemoryBackend()..values['token'] = 'stale';
+    CredentialStore.debugUseBackends(secure: secure, file: file);
+
+    final outcome = await CredentialStore.write('token', 'fresh');
+
+    expect(outcome, CredentialWriteOutcome.secureStorage);
+    expect(secure.values['token'], 'fresh');
+    // A stale copy left behind would resurface the moment the keyring failed.
+    expect(file.values, isEmpty);
+    expect(await CredentialStore.read('token'), 'fresh');
+  });
+
+  test('falls back to the encrypted file when the keyring refuses', () async {
+    final secure = _BrokenBackend();
+    final file = _MemoryBackend();
+    CredentialStore.debugUseBackends(secure: secure, file: file);
+
+    final outcome = await CredentialStore.write('token', 'abc123');
+
+    expect(outcome, CredentialWriteOutcome.encryptedFile);
+    expect(file.values['token'], 'abc123');
+    expect(await CredentialStore.read('token'), 'abc123');
+  });
+
+  test(
+    'keeps the credential for the session when nothing can store it',
+    () async {
+      CredentialStore.debugUseBackends(secure: _BrokenBackend(), file: null);
+
+      final outcome = await CredentialStore.write('token', 'abc123');
+
+      // The session still works; only the next launch is signed out.
+      expect(outcome, CredentialWriteOutcome.sessionOnly);
+      expect(await CredentialStore.read('token'), 'abc123');
+    },
+  );
+
+  test('reports an unreadable store instead of "not signed in"', () async {
+    // No fallback store, as on mobile: a failed keystore read means "could not
+    // look", and treating it as a signed-out user would delete a valid account.
+    CredentialStore.debugUseBackends(secure: _BrokenBackend(), file: null);
+
+    expect(
+      () => CredentialStore.read('token'),
+      throwsA(isA<CredentialStoreException>()),
+    );
+  });
+
+  test('a healthy fallback answers for a broken keyring', () async {
+    // The SteamOS case: libsecret always throws, so every launch would retry an
+    // auto-login forever if an empty-but-working fallback did not settle it.
+    CredentialStore.debugUseBackends(
+      secure: _BrokenBackend(),
+      file: _MemoryBackend(),
+    );
+
+    expect(await CredentialStore.read('token'), isNull);
+  });
+
+  test('returns null when the stores are readable and empty', () async {
+    CredentialStore.debugUseBackends(
+      secure: _MemoryBackend(),
+      file: _MemoryBackend(),
+    );
+
+    expect(await CredentialStore.read('token'), isNull);
+  });
+
+  test(
+    'migrates the legacy plaintext preference out of shared prefs',
+    () async {
+      SharedPreferences.setMockInitialValues({'auth_token': 'legacy-jwt'});
+      final secure = _MemoryBackend();
+      CredentialStore.debugUseBackends(secure: secure, file: _MemoryBackend());
+
+      expect(await CredentialStore.read('auth_token'), 'legacy-jwt');
+      expect(secure.values['auth_token'], 'legacy-jwt');
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.containsKey('auth_token'), isFalse);
+    },
+  );
+
+  test('delete clears every store, including a failing one', () async {
+    final file = _MemoryBackend()..values['token'] = 'abc123';
+    CredentialStore.debugUseBackends(secure: _BrokenBackend(), file: file);
+    await CredentialStore.write('token', 'abc123');
+
+    await CredentialStore.delete('token');
+
+    // The keyring throwing must not stop the other stores being cleared.
+    expect(file.values, isEmpty);
+  });
+}


### PR DESCRIPTION
# Description

SteamOS ships without a Secret Service: `org.freedesktop.secrets` is not even D-Bus activatable, so `libsecret` cannot store anything. Both the NeoSync token and the RetroAchievements API key were lost on every restart, and the failure reached the user as a raw `PlatformException` labelled "Network error". Installing gnome-keyring by hand is not a durable answer on an immutable OS, and the Flatpak secret portal does not help either, because its only backend implementation is gnome-keyring.

This adds `CredentialStore`, a single place the app keeps user credentials, with a defined fallback chain:

1. the platform keychain/keyring, still preferred everywhere,
2. on desktop, an encrypted file in the user-data directory (`CredentialFileStore`),
3. memory, so at least the session the user just signed into works.

A write reports where the value actually landed, so a login that will not survive a restart can say so instead of claiming success.

`CredentialFileStore` is AES-256-GCM with an HKDF key derived from a per-install random secret plus, on Linux, `/etc/machine-id`. It is written atomically and restricted to the owner. The machine binding is what makes a copied user-data folder useless elsewhere. The security model is documented in the class, including what it deliberately does not protect against.

Three things fall out of the consolidation:

* **NeoSync**: four services each carried the same `Platform.isMacOS` branch around the JWT, eight in total, parking the token in plaintext `SharedPreferences` because the macOS Keychain was unreliable for ad-hoc-signed builds. `CredentialStore` owns that decision now, and reads retire the plaintext copy: it is read once, rewritten to a real store, and removed.
* **RetroAchievements**: the repository configured its own `FlutterSecureStorage`, so the Android and macOS hardening it had worked out lived in one file while the NeoSync token went unprotected in another. Both share one store now, and the RA key gains the Linux fallback.
* **Android**: gains `resetOnError: false`, which the RA key already used, so a transient Keystore error during cold boot can no longer turn a temporary read failure into a permanent logout. The storage location is unchanged, so existing tokens still read back.

A read distinguishes "nothing stored" from "could not look", because treating an unreadable store as a signed-out user deletes a valid account. On desktop a healthy but empty fallback settles the question, so a broken keyring no longer has every launch retry an auto-login that can never succeed. Where there is no fallback, the old fail-closed behaviour is unchanged.

RomM and ScreenScraper still keep their secrets base64-encoded in SQLite. Moving those onto this store is deliberately left to a follow-up, to keep this change focused.

Closes #302
Closes #356 

## Steps to Reproduce

**Preconditions:** SteamOS, or any Linux without a usable Secret Service. Confirm the machine is in that state first:

```bash
secret-tool store --label="test" application neostation
# secret-tool: Object does not exist at path "/org/freedesktop/secrets/collection/login"
```

1. Launch NeoStation on that machine.
2. Go to Settings, NeoSync, and sign in.
3. The login fails with `Network error: PlatformException(Libsecret error, secret_service_get_sync: the name is not activatable, null, null)`.
4. Go to RetroAchievements and save a web API key. It appears to work.
5. Quit and relaunch. The RA key is gone and the account is signed out again.

## Steps to Verify

**Preconditions:** the same machine, with the keyring still unavailable.

1. Launch NeoStation and sign in to NeoSync. The sign-in succeeds.
2. Confirm the credential was persisted, owner-only:
   ```bash
   ls -l ~/.neostation/user-data/credentials.enc
   ```
3. Quit and relaunch. The account is still signed in, with no re-entry of the password.
4. Save a RetroAchievements web API key, relaunch, and confirm it is still there.
5. On a machine with a working keyring (any normal Linux desktop, Windows, macOS), sign in and confirm no `credentials.enc` is created: the keychain path is unchanged and the fallback is not reached.
6. To see the third tier, make the user-data directory unwritable and sign in. The session works and the UI says the login could not be saved, rather than reporting a network error.

## Tested on

- [ ] Android — device:
- [x] Linux — device: Steam Deck (SteamOS), the #302 repro machine
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

The Android and macOS paths are covered by unit tests and by the fact that the storage location is unchanged on both, but neither has been run on a device for this branch. The Android change worth a second look is `resetOnError: false` on the NeoSync token; the RA key has shipped with it for a while.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [ ] New assets have compatible licenses

New tests, 16 in total. `test/credential_store_test.dart` covers the fallback order, the session-only outcome when nothing can store a value, the read that must not be mistaken for signed-out, a healthy fallback answering for a broken keyring, delete reaching every store including a failing one, and the legacy plaintext preference being migrated out of shared prefs. `test/credential_file_store_test.dart` covers the round trip, that the credential is never written in the clear, a tampered payload being rejected, key material that no longer matches reading as empty (the machine binding), an unknown future format version being ignored, and owner-only file permissions. The first file drives fake backends through `CredentialStore.debugUseBackends`.

<details>
<summary><b>Extra checks</b></summary>

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [x] No hardcoded UI strings — everything goes through `AppLocale`

One new key, `credentialStorageUnavailable`, shown when a sign-in worked but nothing could be persisted. Where the encrypted fallback took the credential the user is told nothing, because there is nothing for them to do.

**Not applicable:** no database schema change, no new screen or navigation, no ROM path handling, no `assets/systems/` or emulator launch changes.

</details>
