### PR TITLE
fix(settings): stop offering Show Subfolders and Recursive Scan on virtual systems

### DIFF
--- a/lib/constants/system_folder_names.dart
+++ b/lib/constants/system_folder_names.dart
@@ -4,15 +4,33 @@ class SystemFolderNames {
   static const String music = 'music';
   static const String android = 'android';
 
-  /// Systems the subfolder view cannot apply to: virtual aggregates that own no
-  /// ROM folder of their own ([all], [favorites]), the music library, and the
-  /// installed-apps grid. The game list skips the setting for these, so the
-  /// global "Show Subfolders" toggle leaves them alone rather than writing a
-  /// flag nothing will ever read.
+  /// Systems the "Recursive Scan" setting cannot apply to: they own no ROM
+  /// folder to walk. [all] and [favorites] aggregate games that belong to other
+  /// systems, and [android] lists installed apps.
+  ///
+  /// Offering the switch on one of these is not merely inert: flipping it
+  /// triggers a real scan for a folder of that name, which would file whatever
+  /// it found under a system that is supposed to hold nothing of its own.
+  ///
+  /// [music] is deliberately absent — it owns a real folder that can nest.
+  ///
+  /// A new virtual system belongs here the moment it is added to
+  /// `assets/systems/`, together with a migration that clears both flags on
+  /// databases that already carry a row for it.
+  static const Set<String> recursiveScanExcluded = {all, favorites, android};
+
+  /// Systems the subfolder view cannot apply to: everything in
+  /// [recursiveScanExcluded], plus the music library, which owns a folder but
+  /// is browsed as a playlist rather than a folder tree. The game list skips
+  /// the setting for these, so the global "Show Subfolders" toggle leaves them
+  /// alone rather than writing a flag nothing will ever read.
+  ///
+  /// This must stay a superset of [recursiveScanExcluded]: the per-system
+  /// settings dialog stacks "Show Subfolders" directly under "Recursive Scan"
+  /// and addresses both by position, so a system may never drop the recursive
+  /// row while keeping the subfolder one.
   static const Set<String> subfolderViewExcluded = {
-    all,
-    favorites,
+    ...recursiveScanExcluded,
     music,
-    android,
   };
 }

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -525,6 +525,10 @@ class SqliteMigrations {
       case 147:
         await _migrateToVersion147(db);
         break;
+      // 148 is claimed by another branch that is not merged yet.
+      case 149:
+        await _migrateToVersion149(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -6526,6 +6530,80 @@ class SqliteMigrations {
       _log.i('Migration v147 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v147: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v149: clears the per-system flags that the systems owning no ROM
+  /// folder of their own can no longer set.
+  ///
+  /// 'all' and 'favorites' aggregate games belonging to other systems and
+  /// 'android' lists installed apps, so none of them offers "Recursive Scan"
+  /// any more; 'music' owns a folder but is browsed as a playlist, so it never
+  /// offered the subfolder view either. Earlier builds did show those switches,
+  /// and a flipped switch left a row behind that nothing reads — except the
+  /// scan's `hasFolderWhenNonRecursive` branch, which only runs when
+  /// `recursive_scan = 0` and would keep a system alive off a same-named folder
+  /// on disk.
+  ///
+  /// Both columns are reset to their schema defaults (`subfolder_view` 0,
+  /// `recursive_scan` 1) rather than deleting the row, which also carries the
+  /// naming settings the user did choose.
+  ///
+  /// Guarded on `PRAGMA table_info` (the columns arrived in different versions)
+  /// and written as plain UPDATEs over the current value, so re-running it is a
+  /// no-op. The lists are the literal contents of
+  /// `SystemFolderNames.recursiveScanExcluded` / `subfolderViewExcluded`: a
+  /// migration records the schema as it was at this version and must not follow
+  /// a constant that later versions may extend.
+  static Future<void> _migrateToVersion149(Database db) async {
+    _log.i('Migration v149: clearing dead per-system flags on virtual systems');
+    try {
+      final tables = db
+          .select("SELECT name FROM sqlite_master WHERE type = 'table'")
+          .map((r) => r['name'].toString())
+          .toSet();
+      if (!tables.contains('user_system_settings') ||
+          !tables.contains('app_systems')) {
+        _log.i('v149: tables absent, nothing to do');
+        return;
+      }
+
+      final columns = db
+          .select('PRAGMA table_info(user_system_settings)')
+          .map((c) => c['name'].toString())
+          .toSet();
+
+      if (columns.contains('subfolder_view')) {
+        db.execute(
+          'UPDATE user_system_settings SET subfolder_view = 0 '
+          'WHERE subfolder_view != 0 AND app_system_id IN ('
+          '  SELECT id FROM app_systems '
+          "  WHERE folder_name IN ('all', 'favorites', 'android', 'music')"
+          ')',
+        );
+        _log.i('v149: subfolder_view cleared on ${db.updatedRows} row(s)');
+      } else {
+        _log.i('v149: no subfolder_view column, nothing to clear');
+      }
+
+      if (columns.contains('recursive_scan')) {
+        db.execute(
+          'UPDATE user_system_settings SET recursive_scan = 1 '
+          'WHERE recursive_scan != 1 AND app_system_id IN ('
+          '  SELECT id FROM app_systems '
+          "  WHERE folder_name IN ('all', 'favorites', 'android')"
+          ')',
+        );
+        _log.i('v149: recursive_scan reset on ${db.updatedRows} row(s)');
+      } else {
+        _log.i('v149: no recursive_scan column, nothing to reset');
+      }
+
+      _log.i('Migration v149 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v149: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -459,7 +459,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 147;
+  static const int _databaseVersion = 149;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -928,103 +928,109 @@ class _SystemGamesListState extends State<SystemGamesList> {
             ),
             SizedBox(height: 16.r),
 
-            // Configuration Component: Recursive Library Scanning.
+            // Configuration Component: Recursive Library Scanning. Hidden for
+            // the systems that own no ROM folder to walk — there the switch
+            // would kick off a scan for a folder of that name and file
+            // whatever it found under a system meant to hold nothing.
             StatefulBuilder(
               builder: (context, setStateBuilder) {
                 return Column(
                   children: [
-                    Container(
-                      margin: EdgeInsets.only(bottom: 12.r),
-                      padding: EdgeInsets.symmetric(
-                        horizontal: 12.r,
-                        vertical: 8.r,
-                      ),
-                      decoration: BoxDecoration(
-                        color: Colors.black.withValues(alpha: 0.2),
-                        borderRadius: BorderRadius.circular(12.r),
-                        border: Border.all(
-                          color: Colors.white.withValues(alpha: 0.05),
+                    if (!SystemFolderNames.recursiveScanExcluded.contains(
+                      widget.system.folderName,
+                    ))
+                      Container(
+                        margin: EdgeInsets.only(bottom: 12.r),
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 12.r,
+                          vertical: 8.r,
                         ),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            Symbols.folder_shared_rounded,
-                            color: Colors.white.withValues(alpha: 0.7),
-                            size: 16.r,
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.2),
+                          borderRadius: BorderRadius.circular(12.r),
+                          border: Border.all(
+                            color: Colors.white.withValues(alpha: 0.05),
                           ),
-                          SizedBox(width: 8.r),
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                AppLocale.recursiveScan.getString(context),
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 12.r,
-                                  fontWeight: FontWeight.w500,
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Symbols.folder_shared_rounded,
+                              color: Colors.white.withValues(alpha: 0.7),
+                              size: 16.r,
+                            ),
+                            SizedBox(width: 8.r),
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  AppLocale.recursiveScan.getString(context),
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 12.r,
+                                    fontWeight: FontWeight.w500,
+                                  ),
                                 ),
-                              ),
-                              Text(
-                                AppLocale.recursiveScanSubtitle.getString(
-                                  context,
-                                ),
-                                style: TextStyle(
-                                  color: Colors.white.withValues(alpha: 0.5),
-                                  fontSize: 10.r,
-                                ),
-                              ),
-                            ],
-                          ),
-                          SizedBox(width: 16.r),
-                          Switch(
-                            value: currentScanValue,
-                            activeThumbColor: Theme.of(
-                              context,
-                            ).colorScheme.primary,
-                            onChanged: (value) async {
-                              final oldSystem = widget.system;
-                              setStateBuilder(() {
-                                currentScanValue = value;
-                              });
-
-                              try {
-                                await SystemRepository.setRecursiveScan(
-                                  oldSystem.id!,
-                                  value,
-                                );
-
-                                if (!context.mounted) return;
-                                final configProvider = context
-                                    .read<SqliteConfigProvider>();
-
-                                await configProvider.scanSystems();
-                                if (!context.mounted) return;
-
-                                await Provider.of<SqliteDatabaseProvider>(
-                                  context,
-                                  listen: false,
-                                ).loadDatabase();
-                                if (!context.mounted) return;
-
-                                await _loadGames();
-                              } catch (e) {
-                                _log.e('Error toggling recursive scan: $e');
-                                if (!context.mounted) return;
-                                AppNotification.showNotification(
-                                  context,
-                                  AppLocale.failedToSaveSetting.getString(
+                                Text(
+                                  AppLocale.recursiveScanSubtitle.getString(
                                     context,
                                   ),
-                                  type: NotificationType.error,
-                                );
-                              }
-                            },
-                          ),
-                        ],
+                                  style: TextStyle(
+                                    color: Colors.white.withValues(alpha: 0.5),
+                                    fontSize: 10.r,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            SizedBox(width: 16.r),
+                            Switch(
+                              value: currentScanValue,
+                              activeThumbColor: Theme.of(
+                                context,
+                              ).colorScheme.primary,
+                              onChanged: (value) async {
+                                final oldSystem = widget.system;
+                                setStateBuilder(() {
+                                  currentScanValue = value;
+                                });
+
+                                try {
+                                  await SystemRepository.setRecursiveScan(
+                                    oldSystem.id!,
+                                    value,
+                                  );
+
+                                  if (!context.mounted) return;
+                                  final configProvider = context
+                                      .read<SqliteConfigProvider>();
+
+                                  await configProvider.scanSystems();
+                                  if (!context.mounted) return;
+
+                                  await Provider.of<SqliteDatabaseProvider>(
+                                    context,
+                                    listen: false,
+                                  ).loadDatabase();
+                                  if (!context.mounted) return;
+
+                                  await _loadGames();
+                                } catch (e) {
+                                  _log.e('Error toggling recursive scan: $e');
+                                  if (!context.mounted) return;
+                                  AppNotification.showNotification(
+                                    context,
+                                    AppLocale.failedToSaveSetting.getString(
+                                      context,
+                                    ),
+                                    type: NotificationType.error,
+                                  );
+                                }
+                              },
+                            ),
+                          ],
+                        ),
                       ),
-                    ),
 
                     // Real-time Scan Progress Feedback.
                     Consumer<SqliteConfigProvider>(

--- a/lib/widgets/system_emulator_settings_dialog.dart
+++ b/lib/widgets/system_emulator_settings_dialog.dart
@@ -77,8 +77,9 @@ class _SystemEmulatorSettingsDialogState
   late ScrollController _hiddenScrollController;
   // Emulators tab: 0 = default/core action, 1 = executable picker.
   int _emulatorActionIndex = 0;
-  // 0: Prefer filename, 1: Hide ext, 2: (), 3: [], 4: Recursive?,
-  // 5: Show subfolders
+  // 0: Prefer filename, 1: Hide ext, 2: (), 3: [], 4: Recursive (only when
+  // [_offersRecursiveScan]), 5: Show subfolders (only when
+  // [_offersSubfolderView]).
   late int _totalGeneralItems;
   late List<GlobalKey> _generalItemKeys;
   late List<GlobalKey> _appearanceItemKeys;
@@ -114,9 +115,7 @@ class _SystemEmulatorSettingsDialogState
     // Initialize local system state
     _system = widget.system;
     _totalGeneralItems =
-        (_system.folderName == 'all' || _system.folderName == 'android')
-        ? 4
-        : 6;
+        4 + (_offersRecursiveScan ? 1 : 0) + (_offersSubfolderView ? 1 : 0);
 
     _generalScrollController = ScrollController();
     _hiddenScrollController = ScrollController();
@@ -327,6 +326,22 @@ class _SystemEmulatorSettingsDialogState
       );
     }
   }
+
+  // ── General tab rows ──────────────────────────────────────────────────────
+
+  /// Whether this system offers the "Recursive Scan" row — see
+  /// [SystemFolderNames.recursiveScanExcluded] for the systems that don't.
+  bool get _offersRecursiveScan =>
+      !SystemFolderNames.recursiveScanExcluded.contains(_system.folderName);
+
+  /// Whether this system offers the "Show Subfolders" row.
+  ///
+  /// The games list resolves the flag through the same
+  /// [SystemFolderNames.subfolderViewExcluded] set, so offering the switch on
+  /// an excluded system (the virtual aggregates, the music library, the
+  /// installed-apps grid) would only ever write a value nothing reads.
+  bool get _offersSubfolderView =>
+      !SystemFolderNames.subfolderViewExcluded.contains(_system.folderName);
 
   // ── Hidden games ──────────────────────────────────────────────────────────
 

--- a/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
+++ b/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
@@ -200,13 +200,9 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
         _toggleHideParentheses(!_system.hideParentheses);
       } else if (_generalIndex == 3) {
         _toggleHideBrackets(!_system.hideBrackets);
-      } else if (_generalIndex == 4 &&
-          widget.system.folderName != 'all' &&
-          widget.system.folderName != 'android') {
+      } else if (_generalIndex == 4 && _offersRecursiveScan) {
         _toggleRecursiveScan(!_system.recursiveScan);
-      } else if (_generalIndex == 5 &&
-          widget.system.folderName != 'all' &&
-          widget.system.folderName != 'android') {
+      } else if (_generalIndex == 5 && _offersSubfolderView) {
         // Inert unless recursive scanning is on (no subfolders to show).
         if (_system.recursiveScan) {
           _toggleSubfolderView(!_system.subfolderView);

--- a/lib/widgets/system_emulator_settings_dialog/tabs.dart
+++ b/lib/widgets/system_emulator_settings_dialog/tabs.dart
@@ -508,8 +508,7 @@ extension _Tabs on _SystemEmulatorSettingsDialogState {
           value: _system.hideBrackets,
           onChanged: _toggleHideBrackets,
         ),
-        if (widget.system.folderName != 'all' &&
-            widget.system.folderName != 'android') ...[
+        if (_offersRecursiveScan) ...[
           SizedBox(height: 4.r),
           _buildSwitchItem(
             index: 4,
@@ -519,6 +518,8 @@ extension _Tabs on _SystemEmulatorSettingsDialogState {
             value: _system.recursiveScan,
             onChanged: _toggleRecursiveScan,
           ),
+        ],
+        if (_offersSubfolderView) ...[
           SizedBox(height: 4.r),
           _buildSwitchItem(
             index: 5,

--- a/test/subfolder_view_test.dart
+++ b/test/subfolder_view_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/constants/system_folder_names.dart';
 import 'package:neostation/models/system_model.dart';
 import 'package:neostation/utils/rom_tree.dart';
 
@@ -110,6 +111,50 @@ void main() {
           '/mnt/sd/roms/nes',
         ]),
         'Translations',
+      );
+    });
+  });
+
+  group('SystemFolderNames.subfolderViewExcluded', () {
+    test('covers every system with no browsable ROM tree of its own', () {
+      expect(
+        SystemFolderNames.subfolderViewExcluded,
+        containsAll([
+          SystemFolderNames.all,
+          SystemFolderNames.favorites,
+          SystemFolderNames.music,
+          SystemFolderNames.android,
+        ]),
+      );
+    });
+
+    test('is a superset of the systems that offer no recursive scan', () {
+      // The settings dialog stacks "Show Subfolders" directly under "Recursive
+      // Scan" and indexes both by position, so a system may never drop the
+      // recursive row while keeping the subfolder one.
+      expect(
+        SystemFolderNames.subfolderViewExcluded,
+        containsAll(SystemFolderNames.recursiveScanExcluded),
+      );
+    });
+  });
+
+  group('SystemFolderNames.recursiveScanExcluded', () {
+    test('covers the systems that own no ROM folder to walk', () {
+      expect(
+        SystemFolderNames.recursiveScanExcluded,
+        containsAll([
+          SystemFolderNames.all,
+          SystemFolderNames.favorites,
+          SystemFolderNames.android,
+        ]),
+      );
+    });
+
+    test('keeps music, whose folder can nest', () {
+      expect(
+        SystemFolderNames.recursiveScanExcluded,
+        isNot(contains(SystemFolderNames.music)),
       );
     });
   });

--- a/test/virtual_system_flags_migration_test.dart
+++ b/test/virtual_system_flags_migration_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+
+/// Tests for migration v149, which clears the per-system flags that the systems
+/// owning no ROM folder of their own can no longer set: "Show Subfolders" on
+/// 'all' / 'favorites' / 'music' / 'android', and "Recursive Scan" on the first
+/// three. Earlier builds offered those switches, so a user who flipped one left
+/// a row behind that nothing reads.
+void main() {
+  late Database db;
+
+  setUp(() {
+    db = sqlite3.openInMemory();
+    db.execute('''
+      CREATE TABLE app_systems (
+        id TEXT PRIMARY KEY,
+        real_name TEXT,
+        folder_name TEXT
+      )
+    ''');
+    db.execute('''
+      CREATE TABLE user_system_settings (
+        app_system_id TEXT PRIMARY KEY,
+        recursive_scan INTEGER DEFAULT 1,
+        subfolder_view INTEGER DEFAULT 0,
+        hide_extension INTEGER DEFAULT 0,
+        updated_at TEXT
+      )
+    ''');
+    for (final id in ['nes', 'psx', 'all', 'favorites', 'music', 'android']) {
+      db.execute(
+        'INSERT INTO app_systems (id, real_name, folder_name) '
+        'VALUES (?, ?, ?)',
+        [id, id.toUpperCase(), id],
+      );
+    }
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  Future<void> runV149() => SqliteMigrations.migrateToVersion(db, 149);
+
+  /// Writes the state an older build could leave behind: both switches flipped.
+  void seedFlags(String systemId, {int recursive = 0, int subfolder = 1}) {
+    db.execute(
+      'INSERT INTO user_system_settings '
+      '(app_system_id, recursive_scan, subfolder_view, hide_extension) '
+      'VALUES (?, ?, ?, 1)',
+      [systemId, recursive, subfolder],
+    );
+  }
+
+  Map<String, Object?> flagsFor(String systemId) => db.select(
+    'SELECT * FROM user_system_settings WHERE app_system_id = ?',
+    [systemId],
+  ).first;
+
+  group('migration v149', () {
+    test(
+      'clears subfolder_view on every system that cannot browse a tree',
+      () async {
+        for (final id in ['all', 'favorites', 'music', 'android']) {
+          seedFlags(id);
+        }
+
+        await runV149();
+
+        for (final id in ['all', 'favorites', 'music', 'android']) {
+          expect(flagsFor(id)['subfolder_view'], 0, reason: id);
+        }
+      },
+    );
+
+    test(
+      'resets recursive_scan on the systems that own no ROM folder',
+      () async {
+        for (final id in ['all', 'favorites', 'android']) {
+          seedFlags(id);
+        }
+
+        await runV149();
+
+        for (final id in ['all', 'favorites', 'android']) {
+          expect(flagsFor(id)['recursive_scan'], 1, reason: id);
+        }
+      },
+    );
+
+    test('leaves recursive_scan on music, which owns a real folder', () async {
+      seedFlags('music');
+
+      await runV149();
+
+      expect(flagsFor('music')['recursive_scan'], 0);
+    });
+
+    test('leaves real systems alone', () async {
+      seedFlags('nes');
+      seedFlags('psx', recursive: 1, subfolder: 1);
+
+      await runV149();
+
+      expect(flagsFor('nes')['recursive_scan'], 0);
+      expect(flagsFor('nes')['subfolder_view'], 1);
+      expect(flagsFor('psx')['subfolder_view'], 1);
+    });
+
+    test('keeps the naming settings the user did choose', () async {
+      seedFlags('favorites');
+
+      await runV149();
+
+      expect(flagsFor('favorites')['hide_extension'], 1);
+    });
+
+    test('re-running is a no-op', () async {
+      seedFlags('favorites');
+
+      await runV149();
+      await runV149();
+
+      expect(flagsFor('favorites')['subfolder_view'], 0);
+      expect(flagsFor('favorites')['recursive_scan'], 1);
+    });
+
+    test('survives a database that has neither table', () async {
+      db.execute('DROP TABLE user_system_settings');
+
+      await expectLater(runV149(), completes);
+    });
+  });
+}


### PR DESCRIPTION
# Description

Follow-up to #418. That PR added `SystemFolderNames.subfolderViewExcluded` and wired it into the global stamp, the override count, the seeding and the game list's guard, but not into the per-system settings dialog, which kept its older and narrower test (`!= 'all' && != 'android'`). So **Favorites and Music still offered "Show Subfolders"**, and **Favorites still offered "Recursive ROMs Scan"**.

"Show Subfolders" was merely dead on those systems: flipping it wrote the flag, showed the confirmation toast, and the game list ignored it. "Recursive ROMs Scan" was not merely dead. Toggling it calls `rescanSystemSilent`, which walks the ROM roots looking for a folder of that name and files whatever it finds under a system that is meant to hold nothing of its own. The scan's `hasFolderWhenNonRecursive` branch also runs only when `recursive_scan` is `0`, so a Favorites row with the flag off could keep the tile alive off a same-named folder on disk regardless of whether anything is actually favorited.

**The exclusions are now two sets, the second derived from the first:**

```dart
static const Set<String> recursiveScanExcluded = {all, favorites, android};
static const Set<String> subfolderViewExcluded = {...recursiveScanExcluded, music};
```

Music keeps Recursive Scan, since it owns a real folder that can nest. It is excluded from the folder *view* only. The spread makes the superset relation structural rather than a convention two lists have to remember, which matters because the dialog stacks the two rows and addresses them by position.

The dialog now derives its row count (`4 +` one per offered row) instead of hardcoding 4-or-6, and the same two getters drive the row list, the count and the A-button handler. A future change cannot move one and leave another behind, which is exactly the drift that caused this bug. `_buildEmptyState()` in `my_games_list.dart` carries a second copy of the recursive switch and is gated on the same set.

**Migration v149** clears the rows earlier builds left behind: `subfolder_view = 0` on all/favorites/android/music and `recursive_scan = 1` on all/favorites/android, joined through `app_systems.folder_name`. The row is reset rather than deleted, since it also holds the naming settings the user did choose. Guarded on `PRAGMA table_info` (the two columns arrived in different versions) and written as UPDATEs over the current value, so re-running is a no-op. The `folder_name` lists are literal rather than reading the constants on purpose: a migration records the schema as it was at its own version and must not follow a set that later versions extend.

Slot **149**, not 148: 148 is claimed by an unmerged branch, so the switch carries the usual reservation comment.

## Steps to Verify

**Preconditions:** Android device, at least one favorited game (so the Favorites tile is rendered) and at least one track in the `music` ROM folder (a Music tile with zero tracks is not rendered at all, so there is nothing to select).

1. Open **Settings** on a normal system (NES): press START on its card. The General tab shows **6** rows, ending in "Recursive ROMs Scan" and "Show Subfolders". The dialog does not fit 6 rows, so scroll to see the last one.
2. Press B, select the **Favorites** tile, press START. The General tab shows **4** rows, ending in "Hide brackets in file name []". Neither "Recursive ROMs Scan" nor "Show Subfolders" is present.
3. Press B, select the **Music** tile, press START. The General tab shows **5** rows: "Recursive ROMs Scan" is present and is the last row, "Show Subfolders" is not.
4. On Favorites and on Music, hold D-pad DOWN past the last row. The highlight wraps back to the first row with no dead stop and no vanishing highlight (the row count and the navigation are derived from the same value).
5. On a build from before this change, turn "Show Subfolders" on for Favorites or Music, then install this build. The flag is cleared on first launch and the game list is unchanged.

## Tested on

- [x] Android - device: AYN Thor (dev channel, DB migrated 147 to 149 in place)
- [ ] Linux - device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested - why:

Verified on device by reading the dialog's `uiautomator` dump rather than by eye: NES 6 rows, Favorites 4, Music 5, matching the table above. D-pad wrap-around checked on both Favorites (0-1-2-3-0) and Music (0-1-2-3-4-0). The Music fixture deliberately had one track inside a `Chiptunes/` subfolder, so the system had a real nested tree behind it and the assertion is not vacuous.

Not covered: the `All` and `Android` dialogs were not opened (unchanged by this PR, still 4 rows through the same code path), and reverse UP-wrap was not tested separately.

## Checklist

- [x] `dart format .` - no diff
- [x] `flutter analyze` - clean (no errors *or* warnings)
- [x] `flutter test` - all passing (1500)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses (no new assets)

<details>
<summary><b>Extra checks - expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files (no new keys: this PR only removes rows, it adds no string)
- [x] No hardcoded UI strings - everything goes through `AppLocale`

**The database**
- [x] Column added to the versioned migration in `sqlite_migrations.dart` **and** the `CREATE TABLE` in `sqlite_service.dart` (no new column: this is a data cleanup of existing ones)
- [x] Migration number is above every slot in use on any open branch, not just `main` + 1 (148 is claimed by an unmerged branch and is left empty)
- [x] Migration is idempotent (`PRAGMA table_info` guard) and has a test (7 cases in `test/virtual_system_flags_migration_test.dart`)
- [x] `_databaseVersion` bumped; new column selected in *every* system-loading query (no new column)

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse (row count and A-button handler are derived from the same getters as the rendered rows; wrap-around verified on device)
- [x] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()` (no new route)
- [x] B cancels / goes back, including out of a focused text field (unchanged)

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths (no path parsing changed)
- [x] Verified on a device, not only on desktop

**`assets/systems/` or emulator launching**
- [x] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible (not applicable)
- [x] `assets/manifest.json` version bumped if this should reach existing installs OTA (not applicable)

</details>
