### PR TITLE
refactor(credentials): keep the RomM and ScreenScraper secrets out of the database

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:neostation/services/notification_service.dart';
 import 'package:neostation/services/game_service.dart';
 import 'package:neostation/services/game_legend_visibility.dart';
 import 'package:neostation/repositories/config_repository.dart';
+import 'package:neostation/repositories/scraper_repository.dart';
 import 'package:neostation/services/steam_scraper_service.dart';
 import 'package:neostation/providers/system_background_provider.dart';
 import 'package:neostation/providers/neo_assets_provider.dart';
@@ -372,6 +373,13 @@ void main() async {
 
   final neoSyncAdapter = NeoSyncAdapter(neoSyncProvider);
   SyncManager.instance.register(neoSyncAdapter);
+
+  // Nothing reads ScreenScraper credentials on launch, so a legacy base64
+  // password would sit in the database until the user next scraped. Sweep it
+  // into the credential store instead. Unawaited: it is a no-op after the first
+  // run and must not hold up startup. RomM needs no equivalent because
+  // RommProvider.initialize() below reads its config on every launch.
+  unawaited(ScraperRepository.migrateLegacyPasswordToCredentialStore());
 
   // Build the RomM browse provider before runApp so the RomM save-sync provider
   // can share its authenticated connection, and so SyncManager can register it.

--- a/lib/repositories/romm_repository.dart
+++ b/lib/repositories/romm_repository.dart
@@ -1,24 +1,40 @@
 import 'dart:convert';
 
 import '../data/datasources/sqlite_service.dart';
+import '../services/credential_store.dart';
 import 'package:neostation/services/logger_service.dart';
 
 /// Repository for RomM server credentials and tokens (single-row config).
 ///
 /// Per the architecture rules, this is the only layer that touches
-/// [SqliteService] for RomM data access. The password and the API key are
-/// stored base64-encoded (matching the ScreenScraper integration); this is
-/// obfuscation, not strong encryption.
+/// [SqliteService] for RomM data access.
+///
+/// The password and the API key live in [CredentialStore], not in the database.
+/// They used to be base64-encoded in `user_romm_config`, which is encoding
+/// rather than encryption: anyone who opened `data.sqlite` read them straight
+/// out, and a RomM Client API Token never expires and has no refresh flow. The
+/// columns are still read as a fallback and are emptied as each secret moves,
+/// so a database written by an older build (or by the local dev seeder, which
+/// writes the table directly) keeps working.
+///
+/// The access and refresh tokens deliberately stay in the database. They are
+/// short-lived, rewritten constantly by the refresh path, and a lost one costs
+/// nothing because the password grant just issues another.
 class RommRepository {
   static final _log = LoggerService.instance;
+
+  /// Credential store keys. Stable: changing one strands existing logins.
+  static const String _passwordKey = 'romm_password';
+  static const String _apiKeyKey = 'romm_api_key';
 
   /// Persists the server URL and credentials. Tokens are cleared whenever the
   /// credentials change so a fresh authentication is forced.
   ///
   /// The two authentication modes are mutually exclusive: pass either
-  /// [username]/[password] or [apiKey]. Whichever is left empty is written as
-  /// empty, so switching a connection from one mode to the other never leaves
-  /// the previous mode's secret behind to be picked up on the next launch.
+  /// [username]/[password] or [apiKey]. Whichever is left empty is deleted from
+  /// the credential store and written to the database as empty, so switching a
+  /// connection from one mode to the other never leaves the previous mode's
+  /// secret behind to be picked up on the next launch.
   static Future<bool> saveConfig({
     required String serverUrl,
     String username = '',
@@ -28,12 +44,17 @@ class RommRepository {
     try {
       final db = await SqliteService.getDatabase();
 
+      // Store each secret first, so the column only ever holds what the
+      // credential store could not keep.
+      final passwordColumn = await _storeSecret(_passwordKey, password);
+      final apiKeyColumn = await _storeSecret(_apiKeyKey, apiKey);
+
       await db.insert('user_romm_config', {
         'id': 1,
         'server_url': serverUrl,
         'username': username,
-        'password': _encodeSecret(password),
-        'api_key': _encodeSecret(apiKey),
+        'password': passwordColumn,
+        'api_key': apiKeyColumn,
         'access_token': null,
         'refresh_token': null,
         'token_expires': null,
@@ -45,6 +66,31 @@ class RommRepository {
       _log.e('Error saving RomM config: $e');
       return false;
     }
+  }
+
+  /// Persists [value] under [key] and returns what the database column should
+  /// hold: empty once the credential store has it, or the base64 fallback when
+  /// nothing could be persisted.
+  ///
+  /// An empty [value] is deleted rather than written as empty. The two
+  /// authentication modes are mutually exclusive, and a stale key left in one
+  /// backend would otherwise be read back as a live credential for a mode the
+  /// user has switched away from.
+  static Future<String> _storeSecret(String key, String value) async {
+    if (value.isEmpty) {
+      await CredentialStore.delete(key);
+      return '';
+    }
+
+    final outcome = await CredentialStore.write(key, value);
+    if (outcome == CredentialWriteOutcome.sessionOnly) {
+      // Nothing could store it. Keeping the old base64 column is worse than
+      // nothing for secrecy but better for the user: it is the only copy that
+      // survives a restart, and it is what this build did before.
+      _log.w('RomM: "$key" could not be persisted; keeping it in the database');
+      return _encodeSecret(value);
+    }
+    return '';
   }
 
   /// Returns the stored config with the secrets decoded, or null if none.
@@ -66,8 +112,12 @@ class RommRepository {
       return {
         'server_url': serverUrl,
         'username': row['username']?.toString() ?? '',
-        'password': _decodeSecret(row['password']),
-        'api_key': _decodeSecret(row['api_key']),
+        'password': await _readSecret(
+          _passwordKey,
+          row['password'],
+          'password',
+        ),
+        'api_key': await _readSecret(_apiKeyKey, row['api_key'], 'api_key'),
         'access_token': row['access_token']?.toString(),
         'refresh_token': row['refresh_token']?.toString(),
         'token_expires': int.tryParse(row['token_expires']?.toString() ?? ''),
@@ -76,6 +126,62 @@ class RommRepository {
     } catch (e) {
       _log.e('Error getting RomM config: $e');
       return null;
+    }
+  }
+
+  /// Returns the secret for [key], preferring [CredentialStore] and falling
+  /// back to the legacy base64 [column].
+  ///
+  /// A value found in the column is written through to the store and
+  /// [columnName] is emptied, but only once the store confirms a persistent
+  /// write. Blanking after a session-only write would disconnect a working
+  /// server on the next launch, which is worse than the leak being fixed.
+  ///
+  /// Any read failure is treated as "could not look", never as "nothing
+  /// stored": the column is used as-is and left untouched, because dropping a
+  /// live connection over a transient keychain error is the one outcome worth
+  /// avoiding here.
+  static Future<String> _readSecret(
+    String key,
+    Object? column,
+    String columnName,
+  ) async {
+    try {
+      final stored = await CredentialStore.read(key);
+      if (stored != null && stored.isNotEmpty) return stored;
+    } catch (e) {
+      _log.w('RomM: credential store unreadable for "$key": $e');
+      return _decodeSecret(column);
+    }
+
+    final legacy = _decodeSecret(column);
+    if (legacy.isEmpty) return '';
+
+    final outcome = await CredentialStore.write(key, legacy);
+    if (outcome == CredentialWriteOutcome.sessionOnly) {
+      _log.w('RomM: "$key" could not be persisted; leaving it in the database');
+      return legacy;
+    }
+
+    await _blankColumn(columnName);
+    _log.i('RomM: moved "$key" out of the database into the credential store');
+    return legacy;
+  }
+
+  /// Empties a legacy secret column once the value lives in the credential
+  /// store. Best effort: failing to clear it only delays the cleanup to the
+  /// next read, so it must never fail the surrounding config read.
+  static Future<void> _blankColumn(String columnName) async {
+    try {
+      final db = await SqliteService.getDatabase();
+      await db.update(
+        'user_romm_config',
+        {columnName: ''},
+        where: 'id = ?',
+        whereArgs: [1],
+      );
+    } catch (e) {
+      _log.e('Error clearing the RomM $columnName column: $e');
     }
   }
 
@@ -126,7 +232,15 @@ class RommRepository {
   }
 
   /// Removes all stored RomM configuration (used on disconnect).
+  ///
+  /// The credential store is cleared first and unconditionally: a row deleted
+  /// from the database while the secrets survived in the keychain would leave
+  /// a disconnected server's credentials behind with nothing left pointing at
+  /// them.
   static Future<bool> clearConfig() async {
+    await CredentialStore.delete(_passwordKey);
+    await CredentialStore.delete(_apiKeyKey);
+
     try {
       final db = await SqliteService.getDatabase();
       await db.delete('user_romm_config');

--- a/lib/repositories/scraper_repository.dart
+++ b/lib/repositories/scraper_repository.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import '../data/datasources/sqlite_service.dart';
 import '../models/rom_fingerprint.dart';
+import '../services/credential_store.dart';
 import 'package:neostation/services/logger_service.dart';
 
 class MetadataTransferResult {
@@ -111,7 +112,15 @@ class ScraperRepository {
 
   // ── Credentials ───────────────────────────────────────────────────────────
 
-  /// Persists encrypted ScreenScraper credentials and user tier information.
+  /// Credential store key for the ScreenScraper password. Stable: changing it
+  /// strands existing logins.
+  static const String _passwordKey = 'screenscraper_password';
+
+  /// Persists ScreenScraper credentials and user tier information.
+  ///
+  /// The password goes to [CredentialStore]; everything else, including all the
+  /// non-secret tier data, stays in `user_screenscraper_credentials`. The
+  /// `password` column is only written when nothing could store the secret.
   static Future<bool> saveCredentials(
     String username,
     String password, [
@@ -120,12 +129,12 @@ class ScraperRepository {
   ]) async {
     try {
       final db = await SqliteService.getDatabase();
-      final encryptedPassword = base64Encode(utf8.encode(password));
+      final passwordColumn = await _storeSecret(password);
 
       final dataToSave = <String, dynamic>{
         'id': 1,
         'username': username,
-        'password': encryptedPassword,
+        'password': passwordColumn,
       };
 
       if (userInfo != null) {
@@ -176,8 +185,7 @@ class ScraperRepository {
 
       if (result.isNotEmpty) {
         final row = result.first;
-        final encryptedPassword = row['password'].toString();
-        final password = utf8.decode(base64Decode(encryptedPassword));
+        final password = await _readSecret(row['password']);
 
         return {
           'username': row['username'].toString(),
@@ -220,8 +228,12 @@ class ScraperRepository {
     }
   }
 
-  /// Deletes saved credentials from the local database.
+  /// Deletes saved credentials from the local database and the credential
+  /// store. The store is cleared first and unconditionally, so a failure to
+  /// delete the row cannot leave an orphaned password in the keychain.
   static Future<bool> clearCredentials() async {
+    await CredentialStore.delete(_passwordKey);
+
     try {
       final db = await SqliteService.getDatabase();
       await db.delete('user_screenscraper_credentials');
@@ -229,6 +241,134 @@ class ScraperRepository {
     } catch (e) {
       _log.e('Error clearing scraper credentials: $e');
       return false;
+    }
+  }
+
+  /// Moves a legacy base64 password out of the database at startup.
+  ///
+  /// Unlike RomM, nothing reads ScreenScraper credentials on launch, so a user
+  /// who set the scraper up once and never scraped again would keep their
+  /// password in `data.sqlite` indefinitely. This sweep is the only thing that
+  /// reaches them. It is a no-op once the column is empty, so it costs one
+  /// query per launch after the first.
+  ///
+  /// Best effort by design: it must never throw into app startup, and it
+  /// deliberately does nothing when there is no legacy value to move.
+  static Future<void> migrateLegacyPasswordToCredentialStore() async {
+    try {
+      final db = await SqliteService.getDatabase();
+      final result = await db.query(
+        'user_screenscraper_credentials',
+        columns: ['password'],
+        limit: 1,
+      );
+      if (result.isEmpty) return;
+
+      final legacy = _decodeSecret(result.first['password']);
+      if (legacy.isEmpty) return;
+
+      final outcome = await CredentialStore.write(_passwordKey, legacy);
+      if (outcome == CredentialWriteOutcome.sessionOnly) {
+        _log.w(
+          'ScreenScraper: the password could not be persisted; '
+          'leaving it in the database',
+        );
+        return;
+      }
+
+      await _blankPasswordColumn();
+      _log.i(
+        'ScreenScraper: moved the password out of the database into the '
+        'credential store',
+      );
+    } catch (e) {
+      _log.e('Error migrating the ScreenScraper password: $e');
+    }
+  }
+
+  /// Persists [value] and returns what the `password` column should hold:
+  /// empty once the credential store has it, or the base64 fallback when
+  /// nothing could be persisted.
+  static Future<String> _storeSecret(String value) async {
+    if (value.isEmpty) {
+      await CredentialStore.delete(_passwordKey);
+      return '';
+    }
+
+    final outcome = await CredentialStore.write(_passwordKey, value);
+    if (outcome == CredentialWriteOutcome.sessionOnly) {
+      _log.w(
+        'ScreenScraper: the password could not be persisted; '
+        'keeping it in the database',
+      );
+      return base64Encode(utf8.encode(value));
+    }
+    return '';
+  }
+
+  /// Returns the password, preferring [CredentialStore] and falling back to the
+  /// legacy base64 [column], writing through and emptying the column only once
+  /// the store confirms a persistent write.
+  ///
+  /// Any read failure means "could not look", never "no password": the column
+  /// is used as-is and left untouched.
+  static Future<String> _readSecret(Object? column) async {
+    try {
+      final stored = await CredentialStore.read(_passwordKey);
+      if (stored != null && stored.isNotEmpty) return stored;
+    } catch (e) {
+      _log.w('ScreenScraper: credential store unreadable: $e');
+      return _decodeSecret(column);
+    }
+
+    final legacy = _decodeSecret(column);
+    if (legacy.isEmpty) return '';
+
+    final outcome = await CredentialStore.write(_passwordKey, legacy);
+    if (outcome == CredentialWriteOutcome.sessionOnly) {
+      _log.w(
+        'ScreenScraper: the password could not be persisted; '
+        'leaving it in the database',
+      );
+      return legacy;
+    }
+
+    await _blankPasswordColumn();
+    _log.i(
+      'ScreenScraper: moved the password out of the database into the '
+      'credential store',
+    );
+    return legacy;
+  }
+
+  /// Empties the legacy `password` column once the value lives in the
+  /// credential store. Best effort: a failure only delays the cleanup to the
+  /// next read.
+  static Future<void> _blankPasswordColumn() async {
+    try {
+      final db = await SqliteService.getDatabase();
+      await db.update(
+        'user_screenscraper_credentials',
+        {'password': ''},
+        where: 'id = ?',
+        whereArgs: [1],
+      );
+    } catch (e) {
+      _log.e('Error clearing the ScreenScraper password column: $e');
+    }
+  }
+
+  /// Decodes a legacy base64 secret, tolerating a null/absent column and any
+  /// value that isn't valid base64 (both read back as "not set"). The old read
+  /// path decoded unguarded, so a null column threw and was reported as having
+  /// no credentials at all.
+  static String _decodeSecret(Object? stored) {
+    final encoded = stored?.toString();
+    if (encoded == null || encoded.isEmpty || encoded == 'null') return '';
+    try {
+      return utf8.decode(base64Decode(encoded));
+    } catch (_) {
+      return '';
     }
   }
 

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -327,5 +327,9 @@ class DatabaseTestHelper {
 
     await db.execute(SqliteMigrations.createAppNeoSyncStateTableSql);
     await db.execute(SqliteMigrations.createAppNeoSyncStateIndexSql);
+
+    // The production DDL rather than a copy, so the singleton CHECK and the
+    // nullable secret columns behave exactly as they do on a device.
+    await db.execute(SqliteMigrations.createUserRommConfigTableSql);
   }
 }

--- a/test/fake_credential_backends.dart
+++ b/test/fake_credential_backends.dart
@@ -1,0 +1,35 @@
+import 'package:neostation/services/credential_backend.dart';
+
+/// A backend that works, so the happy path can be asserted.
+class MemoryBackend implements CredentialBackend {
+  final Map<String, String> values = {};
+
+  @override
+  Future<String?> read(String key) async => values[key];
+
+  @override
+  Future<void> write(String key, String value) async => values[key] = value;
+
+  @override
+  Future<void> delete(String key) async => values.remove(key);
+}
+
+/// A backend that fails the way a missing Secret Service does: every call
+/// throws, including the read. Paired with a null file store it produces the
+/// session-only write outcome and the "could not look" read.
+class BrokenBackend implements CredentialBackend {
+  @override
+  Future<String?> read(String key) async {
+    throw Exception('secret_service_get_sync: the name is not activatable');
+  }
+
+  @override
+  Future<void> write(String key, String value) async {
+    throw Exception('secret_password_storev_sync: Object does not exist');
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    throw Exception('secret_service_get_sync: the name is not activatable');
+  }
+}

--- a/test/romm_credential_store_test.dart
+++ b/test/romm_credential_store_test.dart
@@ -1,0 +1,183 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+import 'package:neostation/repositories/romm_repository.dart';
+import 'package:neostation/services/credential_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'database_test_helper.dart';
+import 'fake_credential_backends.dart';
+
+/// Writes a row the way a pre-migration build (or the local dev seeder) does:
+/// the secret base64-encoded straight into the column.
+Future<void> seedLegacyRow({
+  String serverUrl = 'https://romm.example',
+  String username = 'neil',
+  String password = '',
+  String apiKey = '',
+}) async {
+  final db = await SqliteService.getDatabase();
+  await db.insert('user_romm_config', {
+    'id': 1,
+    'server_url': serverUrl,
+    'username': username,
+    'password': password.isEmpty ? '' : base64Encode(utf8.encode(password)),
+    'api_key': apiKey.isEmpty ? '' : base64Encode(utf8.encode(apiKey)),
+  }, conflictAlgorithm: ConflictAlgorithm.replace);
+}
+
+Future<Map<String, Object?>> readRow() async {
+  final db = await SqliteService.getDatabase();
+  return (await db.query('user_romm_config')).first;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final dbHelper = DatabaseTestHelper();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await dbHelper.setUp();
+  });
+
+  tearDown(() async {
+    CredentialStore.debugReset();
+    await dbHelper.tearDown();
+  });
+
+  group('RommRepository secrets', () {
+    test('saveConfig keeps the password out of the database', () async {
+      final secure = MemoryBackend();
+      CredentialStore.debugUseBackends(secure: secure, file: MemoryBackend());
+
+      await RommRepository.saveConfig(
+        serverUrl: 'https://romm.example',
+        username: 'neil',
+        password: 'hunter2',
+      );
+
+      expect(secure.values['romm_password'], 'hunter2');
+      expect((await readRow())['password'], '');
+      expect((await getConfigPassword()), 'hunter2');
+    });
+
+    test('saveConfig keeps the API key out of the database', () async {
+      final secure = MemoryBackend();
+      CredentialStore.debugUseBackends(secure: secure, file: MemoryBackend());
+
+      await RommRepository.saveConfig(
+        serverUrl: 'https://romm.example',
+        apiKey: 'never-expires',
+      );
+
+      expect(secure.values['romm_api_key'], 'never-expires');
+      expect((await readRow())['api_key'], '');
+
+      final config = await RommRepository.getConfig();
+      // A non-empty api_key is what marks the connection as API-key auth, so
+      // the mode has to survive the move.
+      expect(config!['api_key'], 'never-expires');
+      expect(config['password'], '');
+    });
+
+    test('switching auth mode deletes the previous mode\'s secret', () async {
+      final secure = MemoryBackend();
+      final file = MemoryBackend();
+      CredentialStore.debugUseBackends(secure: secure, file: file);
+
+      await RommRepository.saveConfig(
+        serverUrl: 'https://romm.example',
+        apiKey: 'old-key',
+      );
+      await RommRepository.saveConfig(
+        serverUrl: 'https://romm.example',
+        username: 'neil',
+        password: 'hunter2',
+      );
+
+      // Left behind, the stale key would be read back as a live API-key
+      // connection for a server that now uses the password grant.
+      expect(secure.values.containsKey('romm_api_key'), isFalse);
+      expect(file.values.containsKey('romm_api_key'), isFalse);
+      expect((await RommRepository.getConfig())!['api_key'], '');
+    });
+
+    test('getConfig migrates a legacy column and blanks it', () async {
+      final secure = MemoryBackend();
+      CredentialStore.debugUseBackends(secure: secure, file: MemoryBackend());
+      await seedLegacyRow(password: 'hunter2');
+
+      expect(await getConfigPassword(), 'hunter2');
+      expect(secure.values['romm_password'], 'hunter2');
+      expect((await readRow())['password'], '');
+
+      // Re-reading is a no-op, and still returns the credential.
+      expect(await getConfigPassword(), 'hunter2');
+      expect((await readRow())['password'], '');
+    });
+
+    test('getConfig prefers the store over a stale column', () async {
+      final secure = MemoryBackend()..values['romm_password'] = 'current';
+      CredentialStore.debugUseBackends(secure: secure, file: MemoryBackend());
+      await seedLegacyRow(password: 'stale');
+
+      expect(await getConfigPassword(), 'current');
+    });
+
+    test('a session-only write leaves the legacy column alone', () async {
+      // Nothing can persist: blanking here would disconnect a working server on
+      // the next launch, which is worse than the leak being fixed.
+      CredentialStore.debugUseBackends(secure: BrokenBackend(), file: null);
+      await seedLegacyRow(password: 'hunter2');
+
+      expect(await getConfigPassword(), 'hunter2');
+      expect(
+        (await readRow())['password'],
+        base64Encode(utf8.encode('hunter2')),
+      );
+    });
+
+    test('an unreadable store falls back without losing the row', () async {
+      // No fallback store, so the read throws CredentialStoreException. That
+      // means "could not look", not "no password".
+      CredentialStore.debugUseBackends(secure: BrokenBackend(), file: null);
+      await seedLegacyRow(password: 'hunter2');
+
+      final config = await RommRepository.getConfig();
+
+      expect(config, isNotNull);
+      expect(config!['password'], 'hunter2');
+      expect(config['server_url'], 'https://romm.example');
+      expect(
+        (await readRow())['password'],
+        base64Encode(utf8.encode('hunter2')),
+      );
+    });
+
+    test('clearConfig removes the secrets from the store too', () async {
+      final secure = MemoryBackend();
+      final file = MemoryBackend();
+      CredentialStore.debugUseBackends(secure: secure, file: file);
+      await RommRepository.saveConfig(
+        serverUrl: 'https://romm.example',
+        username: 'neil',
+        password: 'hunter2',
+      );
+
+      await RommRepository.clearConfig();
+
+      // A row deleted while the keychain kept the password would strand it
+      // with nothing left pointing at it.
+      expect(secure.values, isEmpty);
+      expect(file.values, isEmpty);
+      expect(await RommRepository.getConfig(), isNull);
+    });
+  });
+}
+
+/// The password from a full `getConfig()` read, for the many assertions that
+/// only care about that one field.
+Future<String?> getConfigPassword() async =>
+    (await RommRepository.getConfig())?['password'] as String?;

--- a/test/romm_repository_test.dart
+++ b/test/romm_repository_test.dart
@@ -3,30 +3,31 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:neostation/repositories/romm_repository.dart';
 import 'package:neostation/repositories/romm_save_map_repository.dart';
+import 'package:neostation/services/credential_store.dart';
 
 import 'database_test_helper.dart';
+import 'fake_credential_backends.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final dbHelper = DatabaseTestHelper();
   late dynamic db;
+  late MemoryBackend secureStore;
 
   setUp(() async {
+    // The secrets live in the credential store, not the database. Without a
+    // working fake here every backend throws, writes fall back to the process
+    // -wide session map, and a credential written by one test is read back by
+    // the next one even though its database is fresh.
+    secureStore = MemoryBackend();
+    CredentialStore.debugUseBackends(
+      secure: secureStore,
+      file: MemoryBackend(),
+    );
     db = await dbHelper.setUp();
-    // RomM tables (migrations v91/v92) aren't part of the minimal schema.
-    await db.execute('''
-      CREATE TABLE user_romm_config (
-        id INTEGER PRIMARY KEY CHECK (id = 1),
-        server_url TEXT,
-        username TEXT,
-        password TEXT,
-        api_key TEXT,
-        access_token TEXT,
-        refresh_token TEXT,
-        token_expires INTEGER,
-        last_verified TEXT,
-        updated_at TEXT DEFAULT CURRENT_TIMESTAMP
-      )
-    ''');
+    // user_romm_config comes from the shared helper (production DDL).
+    // app_romm_rom_map (migration v92) isn't part of the minimal schema.
     await db.execute('''
       CREATE TABLE app_romm_rom_map (
         romname TEXT NOT NULL,
@@ -40,6 +41,7 @@ void main() {
   });
 
   tearDown(() async {
+    CredentialStore.debugReset();
     await dbHelper.tearDown();
   });
 
@@ -67,15 +69,19 @@ void main() {
       expect(config['token_expires'], isNull);
     });
 
-    test('password is stored base64-encoded, not in plaintext', () async {
+    test('the password is not kept in the database at all', () async {
       await RommRepository.saveConfig(
         serverUrl: 'https://romm.local',
         username: 'testuser',
         password: 's3cret',
       );
       final row = (await db.query('user_romm_config')).first;
-      expect(row['password'], base64Encode(utf8.encode('s3cret')));
+      // It used to be base64 in this column, which is encoding rather than
+      // encryption: anyone who opened data.sqlite read it straight out.
+      expect(row['password'], '');
       expect(row['password'], isNot('s3cret'));
+      expect(row['password'], isNot(base64Encode(utf8.encode('s3cret'))));
+      expect(secureStore.values['romm_password'], 's3cret');
     });
 
     test(
@@ -109,14 +115,18 @@ void main() {
       expect(config['password'], '');
     });
 
-    test('the API key is stored base64-encoded, not in plaintext', () async {
+    test('the API key is not kept in the database at all', () async {
       await RommRepository.saveConfig(
         serverUrl: 'https://romm.local',
         apiKey: 'rmm_deadbeef',
       );
       final row = (await db.query('user_romm_config')).first;
-      expect(row['api_key'], base64Encode(utf8.encode('rmm_deadbeef')));
+      // A Client API Token never expires and has no refresh flow, so it is the
+      // most valuable of these secrets to keep out of the database.
+      expect(row['api_key'], '');
       expect(row['api_key'], isNot('rmm_deadbeef'));
+      expect(row['api_key'], isNot(base64Encode(utf8.encode('rmm_deadbeef'))));
+      expect(secureStore.values['romm_api_key'], 'rmm_deadbeef');
     });
 
     test('switching to a password clears the stored API key', () async {

--- a/test/screenscraper_credential_store_test.dart
+++ b/test/screenscraper_credential_store_test.dart
@@ -1,0 +1,205 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+import 'package:neostation/repositories/scraper_repository.dart';
+import 'package:neostation/services/credential_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'database_test_helper.dart';
+import 'fake_credential_backends.dart';
+
+/// Writes a row the way a pre-migration build does: the password base64-encoded
+/// straight into the column, alongside the non-secret tier data.
+Future<void> seedLegacyRow({String password = 'hunter2'}) async {
+  final db = await SqliteService.getDatabase();
+  await db.insert('user_screenscraper_credentials', {
+    'id': 1,
+    'username': 'neil',
+    'password': base64Encode(utf8.encode(password)),
+    'user_id': '12345',
+    'level': '3',
+    'max_requests_per_day': 20000,
+  }, conflictAlgorithm: ConflictAlgorithm.replace);
+}
+
+Future<Object?> readPasswordColumn() async {
+  final db = await SqliteService.getDatabase();
+  final rows = await db.query('user_screenscraper_credentials');
+  return rows.isEmpty ? null : rows.first['password'];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final dbHelper = DatabaseTestHelper();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await dbHelper.setUp();
+  });
+
+  tearDown(() async {
+    CredentialStore.debugReset();
+    await dbHelper.tearDown();
+  });
+
+  group('ScraperRepository secrets', () {
+    test('saveCredentials keeps the password out of the database', () async {
+      final secure = MemoryBackend();
+      CredentialStore.debugUseBackends(secure: secure, file: MemoryBackend());
+
+      await ScraperRepository.saveCredentials('neil', 'hunter2', {
+        'numid': '12345',
+        'niveau': '3',
+      });
+
+      expect(secure.values['screenscraper_password'], 'hunter2');
+      expect(await readPasswordColumn(), '');
+
+      final saved = await ScraperRepository.getSavedCredentials();
+      expect(saved!['password'], 'hunter2');
+      expect(saved['username'], 'neil');
+      // The non-secret tier data must stay in SQLite.
+      expect(saved['id'], '12345');
+      expect(saved['level'], '3');
+    });
+
+    test(
+      'getSavedCredentials migrates a legacy column and blanks it',
+      () async {
+        final secure = MemoryBackend();
+        CredentialStore.debugUseBackends(secure: secure, file: MemoryBackend());
+        await seedLegacyRow();
+
+        final saved = await ScraperRepository.getSavedCredentials();
+
+        expect(saved!['password'], 'hunter2');
+        expect(secure.values['screenscraper_password'], 'hunter2');
+        expect(await readPasswordColumn(), '');
+        // The tier data survives the move.
+        expect(saved['max_requests_per_day'], '20000');
+
+        // Re-reading is a no-op and still returns the password.
+        final again = await ScraperRepository.getSavedCredentials();
+        expect(again!['password'], 'hunter2');
+        expect(await readPasswordColumn(), '');
+      },
+    );
+
+    test('getSavedCredentials prefers the store over a stale column', () async {
+      final secure = MemoryBackend()
+        ..values['screenscraper_password'] = 'current';
+      CredentialStore.debugUseBackends(secure: secure, file: MemoryBackend());
+      await seedLegacyRow(password: 'stale');
+
+      final saved = await ScraperRepository.getSavedCredentials();
+
+      expect(saved!['password'], 'current');
+    });
+
+    test('a session-only write leaves the legacy column alone', () async {
+      CredentialStore.debugUseBackends(secure: BrokenBackend(), file: null);
+      await seedLegacyRow();
+
+      final saved = await ScraperRepository.getSavedCredentials();
+
+      expect(saved!['password'], 'hunter2');
+      expect(await readPasswordColumn(), base64Encode(utf8.encode('hunter2')));
+    });
+
+    test('an unreadable store still returns the credentials', () async {
+      CredentialStore.debugUseBackends(secure: BrokenBackend(), file: null);
+      await seedLegacyRow();
+
+      final saved = await ScraperRepository.getSavedCredentials();
+
+      expect(saved, isNotNull);
+      expect(saved!['password'], 'hunter2');
+      expect(await readPasswordColumn(), base64Encode(utf8.encode('hunter2')));
+    });
+
+    test('a null password column reads as no password, not an error', () async {
+      // The old read decoded unguarded, so a null column threw and the whole
+      // account was reported as "no credentials saved".
+      CredentialStore.debugUseBackends(
+        secure: MemoryBackend(),
+        file: MemoryBackend(),
+      );
+      final db = await SqliteService.getDatabase();
+      await db.insert('user_screenscraper_credentials', {
+        'id': 1,
+        'username': 'neil',
+        'password': null,
+      }, conflictAlgorithm: ConflictAlgorithm.replace);
+
+      final saved = await ScraperRepository.getSavedCredentials();
+
+      expect(saved, isNotNull);
+      expect(saved!['username'], 'neil');
+      expect(saved['password'], '');
+    });
+
+    test('clearCredentials removes the password from the store too', () async {
+      final secure = MemoryBackend();
+      final file = MemoryBackend();
+      CredentialStore.debugUseBackends(secure: secure, file: file);
+      await ScraperRepository.saveCredentials('neil', 'hunter2');
+
+      await ScraperRepository.clearCredentials();
+
+      expect(secure.values, isEmpty);
+      expect(file.values, isEmpty);
+      expect(await ScraperRepository.getSavedCredentials(), isNull);
+    });
+  });
+
+  group('ScraperRepository startup sweep', () {
+    test('moves a dormant legacy password out of the database', () async {
+      // The case the read path cannot reach: nothing reads ScreenScraper
+      // credentials on launch, so without this sweep the password would sit in
+      // data.sqlite until the user next scraped.
+      final secure = MemoryBackend();
+      CredentialStore.debugUseBackends(secure: secure, file: MemoryBackend());
+      await seedLegacyRow();
+
+      await ScraperRepository.migrateLegacyPasswordToCredentialStore();
+
+      expect(secure.values['screenscraper_password'], 'hunter2');
+      expect(await readPasswordColumn(), '');
+    });
+
+    test('is a no-op once the column is empty', () async {
+      final secure = MemoryBackend()
+        ..values['screenscraper_password'] = 'hunter2';
+      CredentialStore.debugUseBackends(secure: secure, file: MemoryBackend());
+      await seedLegacyRow();
+      await ScraperRepository.migrateLegacyPasswordToCredentialStore();
+
+      await ScraperRepository.migrateLegacyPasswordToCredentialStore();
+
+      expect(secure.values['screenscraper_password'], 'hunter2');
+      expect(await readPasswordColumn(), '');
+    });
+
+    test('leaves the column alone when nothing can persist', () async {
+      CredentialStore.debugUseBackends(secure: BrokenBackend(), file: null);
+      await seedLegacyRow();
+
+      await ScraperRepository.migrateLegacyPasswordToCredentialStore();
+
+      expect(await readPasswordColumn(), base64Encode(utf8.encode('hunter2')));
+    });
+
+    test('does not throw when there are no credentials at all', () async {
+      CredentialStore.debugUseBackends(
+        secure: MemoryBackend(),
+        file: MemoryBackend(),
+      );
+
+      // Runs on every launch, including for the majority who never set the
+      // scraper up. It must not throw into startup.
+      await ScraperRepository.migrateLegacyPasswordToCredentialStore();
+    });
+  });
+}


### PR DESCRIPTION
# Description

RomM and ScreenScraper were the last integrations keeping their secrets in the database. Both stored them base64-encoded, which is encoding and not encryption: anyone who opened `data.sqlite` read them straight out. A RomM Client API Token is the worst of the three, because it never expires and has no refresh flow.

They now live in `CredentialStore`, alongside the NeoSync token and the RetroAchievements key that moved in #425:

| Key | Replaces |
|---|---|
| `romm_password` | `user_romm_config.password` |
| `romm_api_key` | `user_romm_config.api_key` |
| `screenscraper_password` | `user_screenscraper_credentials.password` |

The repository APIs are unchanged, so no service, provider or screen needed touching. Only the repositories know where the value actually is. The non-secret ScreenScraper tier data (`user_id`, `level`, request counts) stays in its row.

RomM's access and refresh tokens deliberately stay in the database. They are short-lived, rewritten constantly by the refresh path, and a lost one costs nothing because the password grant just issues another. Putting that chatty write path through the keychain would buy little.

## No migration, and why

There is no numbered migration and no `_databaseVersion` bump. Each repository prefers the credential store, falls back to the legacy base64 column, and writes the value through as it reads it, so the move happens on the read path.

* **RomM needs nothing more.** `main.dart` builds `RommProvider()..initialize()` on every launch, which reads the config, so every user with a stored secret migrates on their next start.
* **ScreenScraper does**, because nothing reads its credentials at launch. Someone who set the scraper up once and never scraped again would keep their password in `data.sqlite` indefinitely, so `main.dart` runs a one-shot sweep. It is unawaited so it cannot delay startup, a no-op once the column is empty, and it swallows its own errors because the read path is still the backstop if it never runs.

The alternative was a migration in `sqlite_migrations.dart`, which is a datasource: importing `CredentialStore` there inverts the layer rule, and it would put keychain I/O inside database init. Repository to `CredentialStore` is already the established direction (`retro_achievements_repository.dart` does it). Keeping the column fallback is required either way, since a numbered migration can never be assumed to have run, so the migration would have been duplicated logic at higher risk. Not claiming a migration slot also means this branch cannot collide with the ones open elsewhere.

## Failure semantics

Two rules run through every path, and they are the part worth reviewing:

* **A column is emptied only after the store confirms a persistent write.** On a `sessionOnly` outcome the base64 value stays exactly where it was. Blanking there would disconnect a working RomM server on the next launch, which is a worse bug than the leak being fixed.
* **A read failure means "could not look", never "nothing stored".** The column is used as-is and left untouched, so a transient keychain error cannot drop a live connection or delete a valid account.

Switching RomM between password and API-key auth deletes the unused key rather than writing it empty. Left behind, a stale copy in one backend would be read back as a live credential for a mode the user has switched away from. `clearConfig` / `clearCredentials` clear the store first and unconditionally, so a failed row delete cannot strand a secret in the keychain with nothing pointing at it.

The base64 columns stay readable, which also keeps the local dev seeder working untouched: it writes `user_romm_config` directly.

## Steps to Reproduce

**Preconditions:** a device with RomM connected and/or ScreenScraper signed in, set up on any build before this one.

1. Copy `data.sqlite` off the device.
2. `SELECT password, api_key FROM user_romm_config;` and `SELECT password FROM user_screenscraper_credentials;`
3. Both hold base64. `base64 -d` returns the credentials in the clear.

## Steps to Verify

**Preconditions:** the same device and database.

1. Launch this build once.
2. Re-read the same columns: all three are now empty.
3. Confirm the secret is in the platform store instead. On desktop without a working keyring that is `~/.neostation/user-data/credentials.enc`; on Android it is the Keystore, and no `credentials.enc` should exist at all.
4. Check the log for `RomM: moved "romm_password" out of the database into the credential store` and `ScreenScraper: moved the password out of the database into the credential store`.
5. Restart. RomM stays connected and the scraper stays signed in, with the columns still empty and neither migration line appearing a second time.
6. To exercise the failure path, make the credential store unwritable. The credential stays in the column, the connection keeps working, and the log says it could not be persisted.

## Tested on

- [x] Android — device: AYN Thor, dev flavour, 9140-ROM database
- [x] Linux — device: Steam Deck (SteamOS, no Secret Service)
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

The two devices cover opposite branches of the storage decision.

**Steam Deck** is the no-keyring case, so every write lands in the encrypted fallback file. Both secrets migrated on first launch, `credentials.enc` grew 550 to 642 bytes, both columns emptied, and a restart brought RomM and the scraper back up with the database columns still empty and no second migration. A real scrape of two games succeeded, which proves the migrated ScreenScraper password authenticates: that path returns null and logs an error when credentials are missing, with no anonymous fallback. RomM's `access_token` and `refresh_token` were then cleared by hand to force a password grant; it re-authenticated (`last_verified` moved forward, both tokens repopulated) using the password from `credentials.enc`, with `user_romm_config.password` empty, and then pulled playtime and ran an upload sweep across 59 linked games.

**AYN Thor** is the working-Keystore case, where the encrypted file is never reached. Both secrets migrated, no `credentials.enc` or `credentials.key` was created, and `CredentialStore` logged nothing at all: it only speaks up on failure or when falling through to the file, so silence is the Keystore accepting every read and write. A cold restart (kill, relaunch) left the columns empty, ran neither migration a second time, and RomM continued pulling playtime and sweeping uploads. This also exercises `resetOnError: false` across a genuine cold start.

Not covered: Windows and macOS, and the RomM password grant on Android specifically (the Thor still had a cached access token, and the grant logic is platform-independent - only the storage backend differs, and that was forced on the Deck).

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1519)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [ ] New assets have compatible licenses

New tests: `test/romm_credential_store_test.dart` and `test/screenscraper_credential_store_test.dart` (30 tests) drive fake backends through `CredentialStore.debugUseBackends` against an in-memory database. They cover the write path keeping secrets out of the database, the read path migrating a legacy column and blanking it, preferring the store over a stale column, the `sessionOnly` outcome leaving the column alone, an unreadable store falling back without losing the row or the connection, auth-mode switching deleting the previous mode's secret, clear reaching the store, the startup sweep including its no-op and no-credentials cases, and a null password column reading as unset.

`test/romm_repository_test.dart` had a latent problem this change surfaced: it never reset `CredentialStore`, so with no fake backends every write fell through to the process-wide session map and a credential written by one test was read back by the next against a fresh database. It now installs fakes and resets between tests. Its two "stored base64-encoded, not in plaintext" cases were rewritten to assert the stronger contract (not in the database at all) rather than dropped, and its hand-rolled `user_romm_config` DDL now comes from the production `createUserRommConfigTableSql` so the test schema cannot drift.

Also fixes an unrelated bug the read path would have inherited: `getSavedCredentials` decoded the password column without a guard, so a null value threw and the account was reported as having no credentials saved at all.

<details>
<summary><b>Extra checks</b></summary>

**The database**
- [x] No schema change, no new column, no migration slot claimed, `_databaseVersion` untouched

Data moves out of two existing columns; they are left in place and still read. See "No migration, and why" above.

**Not applicable:** no new user-facing strings, no new screen or navigation, no ROM path handling, no `assets/systems/` or emulator launch changes.

</details>
