### PR TITLE
fix(neosync): canonical RetroArch emulator slug and download diagnostics

### DIFF
--- a/lib/providers/neo_sync_provider.dart
+++ b/lib/providers/neo_sync_provider.dart
@@ -266,6 +266,7 @@ class NeoSyncProvider extends ChangeNotifier {
   /// Upon successful download, it synchronizes the local database sync state
   /// to match the cloud version.
   Future<void> _downloadCloudFile(NeoSyncFile cloudFile, File localFile) async {
+    _log.i('Download: starting ${cloudFile.fileName} -> ${localFile.path}');
     final result = await _neoSyncService.downloadFile(cloudFile.id);
     if (result['success'] == true && result['data'] != null) {
       // Pre-launch deadline guard: the network fetch is done, but if the
@@ -280,7 +281,20 @@ class NeoSyncProvider extends ChangeNotifier {
       }
 
       final bytes = result['data'] as List<int>;
-      await localFile.writeAsBytes(bytes);
+      try {
+        await localFile.parent.create(recursive: true);
+        await localFile.writeAsBytes(bytes, flush: true);
+        _log.i('Download: OK ${bytes.length} bytes -> ${localFile.path}');
+      } on FileSystemException catch (e) {
+        _log.e(
+          'Download: WRITE FAILED for ${localFile.path}: '
+          '${e.osError?.message ?? e.message} (errno ${e.osError?.errorCode})',
+        );
+        rethrow;
+      } catch (e) {
+        _log.e('Download: write to ${localFile.path} errored: $e');
+        rethrow;
+      }
 
       try {
         final stat = await localFile.stat();
@@ -296,7 +310,13 @@ class NeoSyncProvider extends ChangeNotifier {
         _log.w('Could not save sync state for ${localFile.path}: $e');
       }
     } else {
-      throw Exception(result['message'] ?? 'Failed to download file');
+      final reason = result['message'] ?? 'Unknown download failure';
+      final statusCode = result['status_code'];
+      _log.e(
+        'Download: FAILED for ${cloudFile.fileName} -> ${localFile.path}: '
+        '$reason (status ${statusCode ?? 'n/a'})',
+      );
+      throw Exception(reason);
     }
   }
 

--- a/lib/providers/neosync/neosync_core.dart
+++ b/lib/providers/neosync/neosync_core.dart
@@ -157,7 +157,7 @@ extension NeoSyncCore on NeoSyncProvider {
       if (e is QuotaExceededException) {
         _error = 'Storage quota exceeded after ${e.attemptCount} attempts';
         _syncStatus = 'Quota exceeded - sync stopped';
-        _processedItems.add('🚫 Storage quota exceeded - sync stopped');
+        _processedItems.add('Storage quota exceeded - sync stopped');
         NeoSyncProvider._log.e(
           'Sync stopped due to quota exceeded: ${e.message}',
         );
@@ -219,7 +219,7 @@ extension NeoSyncCore on NeoSyncProvider {
     }
     if (!_autoSyncEnabled) return;
 
-    _processedItems.add('🎮 Syncing saves before game start...');
+    _processedItems.add('Syncing saves before game start...');
     await autoSync();
   }
 
@@ -230,7 +230,7 @@ extension NeoSyncCore on NeoSyncProvider {
     }
     if (!_autoSyncEnabled) return;
 
-    _processedItems.add('🎮 Syncing saves after game end...');
+    _processedItems.add('Syncing saves after game end...');
     await autoSyncUploads(); // Only upload local changes after the game
   }
 
@@ -241,7 +241,7 @@ extension NeoSyncCore on NeoSyncProvider {
     }
     if (!_autoSyncEnabled) return;
 
-    _processedItems.add('🚀 Checking for cloud updates on app start...');
+    _processedItems.add('Checking for cloud updates on app start...');
     await autoSyncDownloads(); // Only download on initialization
   }
 
@@ -710,6 +710,12 @@ extension NeoSyncCore on NeoSyncProvider {
         isState: isState,
         explicitSystemFolder: game.systemFolderName,
       );
+      if (relativePath == null) {
+        NeoSyncProvider._log.w(
+          'Auto-upload skipped for ${game.name}: no resolvable sync path',
+        );
+        return false;
+      }
 
       final parsed = CloudPathBuilder.parse(relativePath);
       final result = await _neoSyncService.syncFile(
@@ -750,14 +756,27 @@ extension NeoSyncCore on NeoSyncProvider {
     try {
       // 1. Resolver la ruta local de manera universal
       final localPaths = await resolveCloudFileToLocalPath(game, cloudSave);
-      if (localPaths.isEmpty) return false;
+      if (localPaths.isEmpty) {
+        NeoSyncProvider._log.w(
+          'Auto-download: no path for ${cloudSave.fileName} '
+          '(${game.name}); skipping',
+        );
+        return false;
+      }
 
       // Verificar si el sistema tiene sync deshabilitado
       final system = await _getSystemForGame(game);
       if (system != null && !system.neosync.sync) {
+        NeoSyncProvider._log.w(
+          'Auto-download: sync disabled for ${system.realName}; '
+          'skipping ${cloudSave.fileName}',
+        );
         return false;
       }
 
+      NeoSyncProvider._log.i(
+        'Auto-download: ${cloudSave.fileName} -> ${localPaths.join(', ')}',
+      );
       bool anySuccess = false;
       for (final localPath in localPaths) {
         final localFile = File(localPath);
@@ -1250,6 +1269,12 @@ extension NeoSyncCore on NeoSyncProvider {
               savesPath,
               explicitSystemFolder: game.systemFolderName,
             );
+            if (relativePath == null) {
+              NeoSyncProvider._log.w(
+                'Pre-launch upload skipped for ${game.name}: no sync path',
+              );
+              return;
+            }
 
             final parsed = CloudPathBuilder.parse(relativePath);
             final result = await _neoSyncService.syncFile(
@@ -1320,6 +1345,12 @@ extension NeoSyncCore on NeoSyncProvider {
             savesPath,
             explicitSystemFolder: game.systemFolderName,
           );
+          if (relativePath == null) {
+            NeoSyncProvider._log.w(
+              'Post-game upload skipped for ${game.name}: no sync path',
+            );
+            return;
+          }
 
           final parsed = CloudPathBuilder.parse(relativePath);
           final result = await _neoSyncService.syncFile(
@@ -1384,13 +1415,14 @@ extension NeoSyncCore on NeoSyncProvider {
       }
 
       final file = File(targetPath);
+      NeoSyncProvider._log.i('Restore: ${cloudFile.fileName} -> ${file.path}');
       // Asegurar directorio existe
       await file.parent.create(recursive: true);
 
       // Usar el método común de descarga
       await _downloadCloudFile(cloudFile, file);
     } catch (e) {
-      NeoSyncProvider._log.e('Error restoring cloud backup: $e');
+      NeoSyncProvider._log.e('Restore: FAILED for ${cloudFile.fileName}: $e');
       rethrow;
     }
   }

--- a/lib/providers/neosync/neosync_download.dart
+++ b/lib/providers/neosync/neosync_download.dart
@@ -66,7 +66,7 @@ extension NeoSyncDownload on NeoSyncProvider {
   /// Fase 2: Descargar archivos de la nube
   Future<void> _performDownloadPhase(String savesPath) async {
     _syncStatus = 'Phase 2: Downloading cloud files...';
-    _processedItems.add('⬇️ Phase 2: Downloading files from cloud...');
+    _processedItems.add('Phase 2: Downloading files from cloud...');
     notify();
 
     final result = await _neoSyncService.getAllFiles();
@@ -80,7 +80,7 @@ extension NeoSyncDownload on NeoSyncProvider {
       return;
     }
 
-    _processedItems.add('⬇️ Found ${cloudFiles.length} cloud files to process');
+    _processedItems.add('Found ${cloudFiles.length} cloud files to process');
 
     for (final cloudFile in cloudFiles) {
       await _processDownloadFileWithConflictDetection(cloudFile, savesPath);
@@ -113,12 +113,21 @@ extension NeoSyncDownload on NeoSyncProvider {
               cloudFile.uploadedAt.isAfter(await localFile.lastModified())) {
             await _downloadCloudFileImpl(cloudFile, localFile);
             _downloadedFiles++;
-            _processedItems.add('⬇️ Custom save: ${cloudFile.fileName}');
+            _processedItems.add('Custom save: ${cloudFile.fileName}');
           } else {
+            NeoSyncProvider._log.i(
+              'Download: skipped (already current) ${cloudFile.fileName} '
+              '-> ${localFile.path}',
+            );
             _skippedFiles++;
           }
           return;
         }
+        NeoSyncProvider._log.w(
+          'Download: shared file ${cloudFile.fileName} has no configured '
+          'custom folder for system "${v2Path.system}" emulator '
+          '"${v2Path.emulatorSlug}"; falling through to game lookup',
+        );
       }
 
       // 1. Resolve the game associated with the file
@@ -126,7 +135,11 @@ extension NeoSyncDownload on NeoSyncProvider {
 
       if (game == null) {
         NeoSyncProvider._log.w(
-          'Could not identify game for cloud file: ${cloudFile.fileName}',
+          'Download: could not identify game for ${cloudFile.fileName} '
+          '(system "${v2Path?.system ?? '?'}" / "${cloudFile.gameName}")',
+        );
+        _processedItems.add(
+          'No game matched cloud file: ${cloudFile.fileName}',
         );
         return;
       }
@@ -134,7 +147,16 @@ extension NeoSyncDownload on NeoSyncProvider {
       // 2. Resolve local path using the universal system
       final localPaths = await resolveCloudFileToLocalPath(game, cloudFile);
 
-      if (localPaths.isEmpty) return;
+      if (localPaths.isEmpty) {
+        NeoSyncProvider._log.w(
+          'Download: no local path resolved for ${cloudFile.fileName} '
+          '(game "${game.name}")',
+        );
+        _processedItems.add(
+          'No destination for ${cloudFile.fileName} (${game.name})',
+        );
+        return;
+      }
 
       for (final localPath in localPaths) {
         final localFile = File(localPath);
@@ -143,18 +165,26 @@ extension NeoSyncDownload on NeoSyncProvider {
           if (cloudFile.uploadedAt.isAfter(localStat.modified)) {
             await _downloadCloudFileImpl(cloudFile, localFile);
             _downloadedFiles++;
-            _processedItems.add('⬇️ Auto-updated: ${cloudFile.fileName}');
+            _processedItems.add('Auto-updated: ${cloudFile.fileName}');
           } else {
+            NeoSyncProvider._log.i(
+              'Download: local ${localFile.path} is newer ('
+              '${localStat.modified}) than cloud '
+              '${cloudFile.fileName} (${cloudFile.uploadedAt}); skipping',
+            );
             _skippedFiles++;
           }
         } else {
           await localFile.parent.create(recursive: true);
           await _downloadCloudFileImpl(cloudFile, localFile);
           _downloadedFiles++;
-          _processedItems.add('✨ Auto-downloaded new: ${cloudFile.fileName}');
+          _processedItems.add('Auto-downloaded new: ${cloudFile.fileName}');
         }
       }
     } catch (e) {
+      NeoSyncProvider._log.e(
+        'Download: error processing ${cloudFile.fileName}: $e',
+      );
       _processedItems.add('Error downloading ${cloudFile.fileName}: $e');
     }
   }
@@ -238,10 +268,34 @@ extension NeoSyncDownload on NeoSyncProvider {
     NeoSyncFile cloudFile,
     File localFile,
   ) async {
+    NeoSyncProvider._log.i(
+      'Download: starting ${cloudFile.fileName} -> ${localFile.path}',
+    );
     final result = await _neoSyncService.downloadFile(cloudFile.id);
     if (result['success'] == true && result['data'] != null) {
       final bytes = result['data'] as List<int>;
-      await localFile.writeAsBytes(bytes);
+      try {
+        await localFile.parent.create(recursive: true);
+        await localFile.writeAsBytes(bytes, flush: true);
+        NeoSyncProvider._log.i(
+          'Download: OK ${bytes.length} bytes -> ${localFile.path}',
+        );
+      } on FileSystemException catch (e) {
+        NeoSyncProvider._log.e(
+          'Download: WRITE FAILED for ${localFile.path}: '
+          '${e.osError?.message ?? e.message} (errno ${e.osError?.errorCode})',
+        );
+        _processedItems.add(
+          'Write failed on ${localFile.path}: '
+          '${e.osError?.message ?? e.message}',
+        );
+        rethrow;
+      } catch (e) {
+        NeoSyncProvider._log.e(
+          'Download: write to ${localFile.path} errored: $e',
+        );
+        rethrow;
+      }
 
       // Save the actual local sync state in the database.
       // This avoids the "Operation not permitted" error on Android 11+ when trying
@@ -258,11 +312,18 @@ extension NeoSyncDownload on NeoSyncProvider {
         );
       } catch (e) {
         NeoSyncProvider._log.w(
-          'Could not save sync state for ${localFile.path}: $e',
+          'Download: could not save sync state for ${localFile.path}: $e',
         );
       }
     } else {
-      throw Exception(result['message'] ?? 'Failed to download file');
+      final reason = result['message'] ?? 'Unknown download failure';
+      final statusCode = result['status_code'];
+      NeoSyncProvider._log.e(
+        'Download: FAILED for ${cloudFile.fileName} -> ${localFile.path}: '
+        '$reason (status ${statusCode ?? 'n/a'})',
+      );
+      _processedItems.add('Download failed: ${cloudFile.fileName} - $reason');
+      throw Exception(reason);
     }
   }
 
@@ -272,11 +333,22 @@ extension NeoSyncDownload on NeoSyncProvider {
     String savesPath,
   ) async {
     GameModel? game = await _findGameForCloudFile(cloudFile);
-    if (game == null) return;
+    if (game == null) {
+      NeoSyncProvider._log.w(
+        'Download: conflict phase, no game for ${cloudFile.fileName}; skipping',
+      );
+      return;
+    }
 
     final localPaths = await resolveCloudFileToLocalPath(game, cloudFile);
 
-    if (localPaths.isEmpty) return;
+    if (localPaths.isEmpty) {
+      NeoSyncProvider._log.w(
+        'Download: conflict phase, no path for ${cloudFile.fileName} '
+        '(${game.name}); skipping',
+      );
+      return;
+    }
 
     for (final localPath in localPaths) {
       final localFile = File(localPath);
@@ -285,15 +357,19 @@ extension NeoSyncDownload on NeoSyncProvider {
         if (cloudFile.uploadedAt.isAfter(localStat.modified)) {
           await _downloadCloudFileImpl(cloudFile, localFile);
           _downloadedFiles++;
-          _processedItems.add('⬇️ Updated: ${cloudFile.fileName}');
+          _processedItems.add('Updated: ${cloudFile.fileName}');
         } else {
+          NeoSyncProvider._log.i(
+            'Download: conflict phase, local ${localFile.path} newer; '
+            'skipping ${cloudFile.fileName}',
+          );
           _skippedFiles++;
         }
       } else {
         await localFile.parent.create(recursive: true);
         await _downloadCloudFileImpl(cloudFile, localFile);
         _downloadedFiles++;
-        _processedItems.add('✨ Downloaded: ${cloudFile.fileName}');
+        _processedItems.add('Downloaded: ${cloudFile.fileName}');
       }
     }
   }

--- a/lib/providers/neosync/neosync_path_resolver.dart
+++ b/lib/providers/neosync/neosync_path_resolver.dart
@@ -192,7 +192,7 @@ extension NeoSyncPathResolver on NeoSyncProvider {
   }
 
   /// Helper to calculate relative path for sync, with special handling for various systems
-  Future<String> _calculateSyncRelativePath(
+  Future<String?> _calculateSyncRelativePath(
     GameModel game,
     File file,
     String basePath, {
@@ -216,6 +216,14 @@ extension NeoSyncPathResolver on NeoSyncProvider {
       isState: isState,
       explicitSystemFolder: explicitSystemFolder,
     );
+    if (v2Path == null) {
+      // Only RetroArch files whose core is unresolvable return null; skip the
+      // upload rather than invent a legacy `saves/...` path or `retroarch.unknown`.
+      NeoSyncProvider._log.i(
+        'RA sync path: skipped ${file.path} (no resolvable core)',
+      );
+      return null;
+    }
     if (v2Path.startsWith('v2/saves/') || v2Path.startsWith('v2/states/')) {
       return v2Path;
     }
@@ -288,9 +296,11 @@ extension NeoSyncPathResolver on NeoSyncProvider {
   ///
   /// Uses the standard `saves|states/<system>/<emulator-slug>/<scope>/...`
   /// layout so the emulator that produced the save is always identifiable.
-  /// When the emulator slug cannot be determined it falls back to the legacy
-  /// relative path so existing flows keep working.
-  Future<String> _buildV2CloudPath(
+  /// When the emulator slug cannot be determined for a non-RetroArch file it
+  /// falls back to the legacy relative path so existing flows keep working;
+  /// for a RetroArch file it returns null so the caller skips the upload
+  /// instead of inventing `retroarch.unknown`.
+  Future<String?> _buildV2CloudPath(
     GameModel game,
     File file,
     String basePath, {
@@ -314,26 +324,30 @@ extension NeoSyncPathResolver on NeoSyncProvider {
       retroBase = statesPath;
     }
     if (retroBase != null) {
-      final relativeToBase = path.relative(file.path, from: retroBase);
-      final segments = relativeToBase.split(RegExp(r'[/\\]'));
-      // Only a per-core subfolder layout (<base>/<core>/<game>.srm) encodes
-      // the core in the path. Flat saves (<base>/<game>.srm, the default)
-      // have a single segment that is the file itself, so the core must come
-      // from the game's emulator metadata below.
-      if (segments.length > 1) {
-        final coreName = segments.first;
-        if (coreName.isNotEmpty) {
-          emulatorSlug = CloudPathBuilder.retroArchCoreSlug(coreName);
-          // A core like mgba serves several systems, so it is only a fallback.
-          // The game's own system is authoritative.
-          systemFolderFromCore = await _systemFolderForRetroArchFile(
-            file,
-            retroBase,
+      final coreName = _retroArchCoreFolderForFile(file, retroBase);
+      if (coreName != null) {
+        emulatorSlug = CloudPathBuilder.retroArchCoreSlug(coreName);
+        // A core like mgba serves several systems, so it is only a fallback.
+        // The game's own system is authoritative.
+        systemFolderFromCore = await _systemFolderForRetroArchFile(
+          file,
+          retroBase,
+        );
+      } else {
+        // Flat RetroArch save (<base>/<game>.srm, the default). Only trust a
+        // RetroArch-core emulator; never a standalone (GBA Free) and never
+        // invent `retroarch.unknown`.
+        emulatorSlug = _retroArchCoreSlugFromGame(game);
+        if (emulatorSlug == null) {
+          NeoSyncProvider._log.w(
+            'RA v2 path: skipping ${file.path} (no resolvable core)',
           );
+          return null;
         }
       }
+    } else {
+      emulatorSlug ??= await _resolveEmulatorSlugForGame(game, system);
     }
-    emulatorSlug ??= await _resolveEmulatorSlugForGame(game, system);
     // Priority: the caller's explicit system (from the games list context),
     // then the game's own system, then the core-derived fallback. Finally the
     // emulator is cross-checked so the save never lands under a system the
@@ -346,7 +360,19 @@ extension NeoSyncPathResolver on NeoSyncProvider {
     systemFolder = await _reconcileEmulatorSystem(systemFolder, emulatorSlug);
 
     if (systemFolder == null || emulatorSlug == null) {
+      if (retroBase != null) {
+        NeoSyncProvider._log.w(
+          'RA v2 path: skipping ${file.path} (no system/emulator)',
+        );
+        return null;
+      }
       return _calculateRelativePath(file, basePath, isState: isState);
+    }
+    if (retroBase != null) {
+      NeoSyncProvider._log.i(
+        'RA v2 path: ${file.path} -> '
+        'system=$systemFolder emulator=$emulatorSlug',
+      );
     }
 
     final fileName = path.basename(file.path);
@@ -433,33 +459,78 @@ extension NeoSyncPathResolver on NeoSyncProvider {
   ///
   /// Only a per-core subfolder layout (`<base>/<core>/<game>.srm`) encodes the
   /// core in the path; flat saves (`<base>/<game>.srm`) have a single segment
-  /// that is the file itself. For flat saves the emulator is resolved from the
-  /// game's own emulator metadata (e.g. a SNES save -> `retroarch.snes9x`)
-  /// instead of misreading the game file name as a core.
+  /// that is the file itself. For flat saves the slug is only derived from the
+  /// game's own emulator *iff* that emulator is itself a RetroArch core (e.g.
+  /// `gba.ra.mgba` -> `retroarch.mgba`); a standalone emulator such as GBA Free
+  /// must never be reported as the producer of a RetroArch save. Returns null
+  /// when no core can be determined so callers skip the upload instead of
+  /// inventing `retroarch.unknown`.
   Future<String?> _resolveRetroArchEmulatorSlug(
     File file,
     String retroArchBase,
   ) async {
-    final relativeToBase = path.relative(file.path, from: retroArchBase);
-    final segments = relativeToBase.split(RegExp(r'[/\\]'));
-    if (segments.length > 1) {
-      final coreName = segments.first;
-      if (coreName.isNotEmpty) {
-        return CloudPathBuilder.retroArchCoreSlug(coreName);
-      }
+    final coreName = _retroArchCoreFolderForFile(file, retroArchBase);
+    if (coreName != null) {
+      NeoSyncProvider._log.i('RA slug: core "$coreName" for ${file.path}');
+      return CloudPathBuilder.retroArchCoreSlug(coreName);
     }
 
     final fileName = path.basenameWithoutExtension(file.path);
     try {
       final row = await GameRepository.findRomByFilenamePrefix('$fileName%');
-      if (row == null) return null;
+      if (row == null) {
+        NeoSyncProvider._log.w(
+          'RA slug: no game matched flat save "$fileName"; skipping',
+        );
+        return null;
+      }
       final game = _gameModelFromRomRow(row, fileName);
-      final system = await _getSystemForGame(game);
-      return await _resolveEmulatorSlugForGame(game, system);
+      final slug = _retroArchCoreSlugFromGame(game);
+      NeoSyncProvider._log.i(
+        slug == null
+            ? 'RA slug: flat save "$fileName" has no RetroArch core '
+                  '(emulator "${game.emulatorName ?? 'unknown'}"); skipping'
+            : 'RA slug: flat save "$fileName" -> $slug',
+      );
+      return slug;
     } catch (e) {
       NeoSyncProvider._log.w('Error resolving emulator slug for $fileName: $e');
       return null;
     }
+  }
+
+  /// Returns the RetroArch core folder name when [file] lives in a per-core
+  /// subfolder under [basePath] (`<base>/<core>/<game>.srm`), else null.
+  String? _retroArchCoreFolderForFile(File file, String basePath) {
+    final relativeToBase = path.relative(file.path, from: basePath);
+    final segments = relativeToBase.split(RegExp(r'[/\\]'));
+    if (segments.length > 1) {
+      final coreName = segments.first;
+      if (coreName.isNotEmpty) return coreName;
+    }
+    return null;
+  }
+
+  /// Derives a `retroarch.<core>` slug from [game]'s emulator, but ONLY when
+  /// that emulator is itself a RetroArch core (`gba.ra.mgba`,
+  /// `gba.ra64.mgba`, `gba.ra32.mgba` or a core name). A standalone emulator
+  /// (GBA Free, DuckStation, AetherSX2...) may be selected for a game whose
+  /// save was actually written by a RetroArch core, so it is never trusted for
+  /// a RetroArch save. Returns null when no RetroArch core can be determined.
+  String? _retroArchCoreSlugFromGame(GameModel game) {
+    final uniqueId = game.emulatorName?.trim() ?? '';
+    if (uniqueId.isNotEmpty) {
+      final lower = uniqueId.toLowerCase();
+      if (lower.contains('.ra.') ||
+          lower.contains('.ra64.') ||
+          lower.contains('.ra32.')) {
+        return CloudPathBuilder.slugFromEmulatorUniqueId(uniqueId);
+      }
+    }
+    if (game.coreName != null && game.coreName!.isNotEmpty) {
+      return CloudPathBuilder.retroArchCoreSlug(game.coreName!);
+    }
+    return null;
   }
 
   /// Builds a lightweight [GameModel] from a `findRomByFilenamePrefix` row so

--- a/lib/providers/neosync/neosync_upload.dart
+++ b/lib/providers/neosync/neosync_upload.dart
@@ -249,7 +249,7 @@ extension NeoSyncUpload on NeoSyncProvider {
   /// Fase 1: Subir archivos locales
   Future<void> _performUploadPhase(String basePath) async {
     _syncStatus = 'Phase 1: Uploading local files...';
-    _processedItems.add('📤 Phase 1: Scanning and uploading local files...');
+    _processedItems.add('Phase 1: Scanning and uploading local files...');
     notify();
 
     // Determine if it is a states folder for RetroArch
@@ -263,7 +263,7 @@ extension NeoSyncUpload on NeoSyncProvider {
     }
 
     _totalFiles = saveFiles.length * 2;
-    _processedItems.add('📤 Found ${saveFiles.length} local files to process');
+    _processedItems.add('Found ${saveFiles.length} local files to process');
 
     for (final file in saveFiles) {
       await _processUploadFileWithConflictDetection(
@@ -334,7 +334,7 @@ extension NeoSyncUpload on NeoSyncProvider {
         if (gameRow == null && !isSharedCard) {
           _skippedFiles++;
           _processedItems.add(
-            '⏭️ Skipped save for a game not in your library: '
+            'Skipped save for a game not in your library: '
             '${path.basename(file.path)}',
           );
           return;
@@ -342,15 +342,25 @@ extension NeoSyncUpload on NeoSyncProvider {
 
         // RetroArch stores saves as <savesPath>/<core>/<game>.srm when per-core
         // subfolders are enabled, or flat as <savesPath>/<game>.srm otherwise.
-        // Derive the emulator slug from the core folder when present so a save
-        // lands under retroarch.<core> regardless of which standalone the game
-        // metadata points at; flat saves fall back to the game's own emulator
-        // metadata. The system is resolved from the game (a core like mgba
-        // serves several systems) and falls back to the core mapping.
+        // Derive the emulator slug from the RetroArch core folder when present;
+        // for flat saves only the game's own RetroArch core is trusted (never a
+        // standalone emulator). When no core can be resolved the save is
+        // skipped instead of being uploaded under `retroarch.unknown`.
         final emulatorSlug = await _resolveRetroArchEmulatorSlug(
           file,
           retroArchBasePath,
         );
+        if (emulatorSlug == null) {
+          NeoSyncProvider._log.w(
+            'RA upload skipped for ${file.path}: no resolvable core',
+          );
+          _skippedFiles++;
+          _processedItems.add(
+            'Skipped RetroArch save (no core resolved): '
+            '${path.basename(file.path)}',
+          );
+          return;
+        }
         var system = await _systemFolderForRetroArchFile(
           file,
           retroArchBasePath,
@@ -359,13 +369,28 @@ extension NeoSyncUpload on NeoSyncProvider {
         // otherwise trust the emulator's own system (a save from a NES core can
         // never belong to cps1, no matter what the game metadata says).
         system = await _reconcileEmulatorSystem(system, emulatorSlug);
+        if (system == null) {
+          NeoSyncProvider._log.w(
+            'RA upload skipped for ${file.path}: no system resolved '
+            '(emulator $emulatorSlug)',
+          );
+          _skippedFiles++;
+          _processedItems.add(
+            'Skipped RetroArch save (no system resolved): '
+            '${path.basename(file.path)}',
+          );
+          return;
+        }
+        NeoSyncProvider._log.i(
+          'RA upload: ${file.path} -> system=$system emulator=$emulatorSlug',
+        );
         // Memory-card style files are shared between games, matching the
         // `_buildV2CloudPath` behaviour: they go under the `shared` scope with
         // no game segment so the download routes them to the configured custom
         // folder.
         relativePath = CloudPathBuilder.build(
-          system: system ?? 'unknown',
-          emulatorSlug: emulatorSlug ?? 'unknown',
+          system: system,
+          emulatorSlug: emulatorSlug,
           scope: isSharedCard ? 'shared' : 'game',
           filePath: path.basename(file.path),
           gameName: isSharedCard
@@ -411,10 +436,10 @@ extension NeoSyncUpload on NeoSyncProvider {
       if (result['success']) {
         if (result['skipped'] == true) {
           _skippedFiles++;
-          _processedItems.add('⏭️ Already synced: $relativePath');
+          _processedItems.add('Already synced: $relativePath');
         } else {
           _uploadedFiles++;
-          _processedItems.add('📤 Auto-uploaded: $relativePath');
+          _processedItems.add('Auto-uploaded: $relativePath');
           _resetQuotaAttempts();
         }
       } else {
@@ -449,7 +474,7 @@ extension NeoSyncUpload on NeoSyncProvider {
             'Switch upload skipped: titleId "$titleId" not found in DB (${file.path})',
           );
           _processedItems.add(
-            '⚠️ No game matched titleId $titleId — skipping upload',
+            'No game matched titleId $titleId - skipping upload',
           );
           return;
         }
@@ -481,10 +506,10 @@ extension NeoSyncUpload on NeoSyncProvider {
           if (result['success']) {
             if (result['skipped'] == true) {
               _skippedFiles++;
-              _processedItems.add('⏭️ Already synced: $relativePath');
+              _processedItems.add('Already synced: $relativePath');
             } else {
               _uploadedFiles++;
-              _processedItems.add('📤 Auto-uploaded: $relativePath');
+              _processedItems.add('Auto-uploaded: $relativePath');
               _resetQuotaAttempts();
             }
           } else {
@@ -545,10 +570,10 @@ extension NeoSyncUpload on NeoSyncProvider {
       if (result['success']) {
         if (result['skipped'] == true) {
           _skippedFiles++;
-          _processedItems.add('⏭️ Already synced: $relativePath');
+          _processedItems.add('Already synced: $relativePath');
         } else {
           _uploadedFiles++;
-          _processedItems.add('📤 Uploaded: $relativePath');
+          _processedItems.add('Uploaded: $relativePath');
           _resetQuotaAttempts();
         }
       } else {


### PR DESCRIPTION
## Summary

Fixes the duplicate NeoSync uploads and adds download diagnostics.

### Problem
RetroArch saves could be uploaded under three different emulator slugs for the
same game/system:
- `retroarch.<core>` (correct, per-core subfolder)
- the game's standalone emulator slug (`gbfree`) when the save is in the flat
  layout
- `retroarch.unknown` when no core could be resolved

The backend stores each distinct v2 path as a separate file row (no slug
canonicalization, no unique index), so this produced the triple duplicates
reported on the account.

### Changes
- Derive the RetroArch emulator slug exclusively from the core folder
  (`retroarch.<core>`). For flat saves only trust a RetroArch-core emulator
  (`.ra.`/`.ra64.`/`.ra32.` or a core name); never fall back to a standalone
  emulator (GBA Free).
- Skip the upload when no core can be resolved, instead of inventing
  `retroarch.unknown` or a legacy `saves/` path.
- Centralize the logic in `_resolveRetroArchEmulatorSlug` and share it across
  `_processAutoUploadFile`, `_buildV2CloudPath` and `_calculateSyncRelativePath`.
- Add download diagnostics logging the target path, bytes written, and the
  failure reason (server status code + message, or write errors surfaced
  through `FileSystemException` with the OS error / errno), so a permissions or
  matching failure shows up in the device log.
- Remove emoji markers from sync messages.

### Verification
- `flutter analyze`: no issues
- Targeted NeoSync/RomM tests: all pass

Backend (neosync-sync-service) was not modified in this PR.