### PR TITLE
docs: build the wiki with the Just the Docs theme

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,15 @@
+remote_theme: just-the-docs/just-the-docs
+
+title: NeoStation Wiki
+description: NeoStation is a landscape, gamepad-driven emulation frontend for Windows, Linux, macOS, Android, and Android TV.
+
+url: "https://wiki.neostation.dev"
+baseurl: ""
+
+permalink: pretty
+heading_anchors: true
+search_enabled: true
+
+just_the_docs:
+  aux_links:
+    "NeoStation on GitHub": https://github.com/misobadev/neostation-frontend

--- a/docs/configuration/configuring-emulators.md
+++ b/docs/configuration/configuring-emulators.md
@@ -1,3 +1,9 @@
+---
+title: Configuring Emulators
+layout: default
+nav_order: 3
+---
+
 # Configuring Emulators
 
 NeoStation uses the bundled system definitions to decide which emulators are available for each system. Available choices depend on your platform and installed software.
@@ -26,5 +32,5 @@ Android launches supported standalone emulators using their configured applicati
 
 ## Related Pages
 
-- [Getting Started](../getting-started/getting-started.md)
-- [Troubleshooting](../troubleshooting.md)
+- [Getting Started](/getting-started/getting-started/)
+- [Troubleshooting](/troubleshooting/)

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,3 +1,8 @@
+---
+title: FAQs
+layout: default
+nav_order: 7
+---
 
 # FAQs
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -1,0 +1,14 @@
+---
+title: Features
+layout: default
+has_children: true
+nav_order: 6
+---
+
+# Features
+
+NeoStation's features for enriching your library and playing games. This section covers metadata scraping, achievements, and cloud save synchronisation.
+
+- [RetroAchievements](/features/retroachievements/)
+- [Scraping & Metadata](/features/scraping-and-metadata/)
+- [NeoSync](/features/neosync/)

--- a/docs/features/neosync.md
+++ b/docs/features/neosync.md
@@ -1,3 +1,10 @@
+---
+title: NeoSync
+layout: default
+parent: Features
+nav_order: 3
+---
+
 # NeoSync
 
 NeoSync synchronises game saves and states through your NeoSync account. It includes account registration, email verification, password recovery, cloud-save browsing, quota information, and custom save folders for standalone emulators.
@@ -33,4 +40,4 @@ NeoSync asks for confirmation before deleting a cloud save.
 
 ## Related Pages
 
-- [Troubleshooting](../troubleshooting.md)
+- [Troubleshooting](/troubleshooting/)

--- a/docs/features/retroachievements.md
+++ b/docs/features/retroachievements.md
@@ -1,3 +1,10 @@
+---
+title: RetroAchievements
+layout: default
+parent: Features
+nav_order: 1
+---
+
 # RetroAchievements
 
 Connect your RetroAchievements account to view supported-game information, achievement progress, recent unlocks, completions, masteries, and leaderboards in NeoStation.
@@ -32,5 +39,5 @@ Disconnecting signs you out and removes the saved RetroAchievements credentials 
 
 ## Related Pages
 
-- [Adding Your Games](../library/adding-your-games.md)
-- [Troubleshooting](../troubleshooting.md)
+- [Adding Your Games](/library/adding-your-games/)
+- [Troubleshooting](/troubleshooting/)

--- a/docs/features/scraping-and-metadata.md
+++ b/docs/features/scraping-and-metadata.md
@@ -1,3 +1,10 @@
+---
+title: Scraping & Metadata
+layout: default
+parent: Features
+nav_order: 2
+---
+
 # Scraping & Metadata
 
 NeoStation can use ScreenScraper to obtain game metadata and media for your local library.
@@ -31,5 +38,5 @@ NeoStation may report that you are not signed in, the system is not mapped to Sc
 
 ## Related Pages
 
-- [Adding Your Games](../library/adding-your-games.md)
-- [Troubleshooting](../troubleshooting.md)
+- [Adding Your Games](/library/adding-your-games/)
+- [Troubleshooting](/troubleshooting/)

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -1,3 +1,9 @@
+---
+title: Getting Started
+layout: default
+nav_order: 2
+---
+
 # Getting Started
 
 Set up a local game library by adding one or more ROM folders, scanning them, and selecting an emulator for each system you want to play.
@@ -21,10 +27,10 @@ You can configure up to five ROM folders. Use **Rescan All ROM Folders** in the 
 
 ## Choose an Emulator
 
-Open a system, then use its emulator settings to choose from the emulators available for that system. If a standalone emulator needs its executable selected, see [Configuring Emulators](../configuration/configuring-emulators.md).
+Open a system, then use its emulator settings to choose from the emulators available for that system. If a standalone emulator needs its executable selected, see [Configuring Emulators](/configuration/configuring-emulators/).
 
 ## Next Steps
 
-- [Adding Your Games](../library/adding-your-games.md)
-- [Scraping & Metadata](../features/scraping-and-metadata.md)
-- [RetroAchievements](../features/retroachievements.md)
+- [Adding Your Games](/library/adding-your-games/)
+- [Scraping & Metadata](/features/scraping-and-metadata/)
+- [RetroAchievements](/features/retroachievements/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,26 +1,32 @@
+---
+title: Home
+layout: default
+nav_order: 1
+---
+
 # NeoStation Wiki
 
 NeoStation is a landscape, gamepad-driven emulation frontend for Windows, Linux, macOS, Android, and Android TV.
 
 ## Get started
 
-- [Getting Started](getting-started/getting-started.md) — add a ROM folder, scan it, and choose an emulator.
-- [Adding Your Games](library/adding-your-games.md) — ROM folders, scans, subfolders, and Android storage access.
-- [Configuring Emulators](configuration/configuring-emulators.md) — configure RetroArch or a standalone emulator.
+- [Getting Started](/getting-started/getting-started/) — add a ROM folder, scan it, and choose an emulator.
+- [Adding Your Games](/library/adding-your-games/) — ROM folders, scans, subfolders, and Android storage access.
+- [Configuring Emulators](/configuration/configuring-emulators/) — configure RetroArch or a standalone emulator.
 
 ## Library features
 
-- [Multi-Disc Games](library/multi-disc-games.md) — organise recognised disc sets into folders and `.m3u` playlists.
-- [Scraping & Metadata](features/scraping-and-metadata.md) — connect ScreenScraper and choose what to download.
-- [RetroAchievements](features/retroachievements.md) — sign in, match your library, and view progress.
-- [NeoSync](features/neosync.md) — sign in and manage cloud save synchronisation.
+- [Multi-Disc Games](/library/multi-disc-games/) — organise recognised disc sets into folders and `.m3u` playlists.
+- [Scraping & Metadata](/features/scraping-and-metadata/) — connect ScreenScraper and choose what to download.
+- [RetroAchievements](/features/retroachievements/) — sign in, match your library, and view progress.
+- [NeoSync](/features/neosync/) — sign in and manage cloud save synchronisation.
 
 ## Platform guides
 
-- [Steam Deck & SteamOS](platforms/steam-deck-and-steamos.md) — run the AppImage through Steam for proper controller input.
+- [Steam Deck & SteamOS](/platforms/steam-deck-and-steamos/) — run the AppImage through Steam for proper controller input.
 
 ## Help and contributions
-- [FAQS](faqs.md)
-- [Troubleshooting](troubleshooting.md)
+- [FAQS](/faqs/)
+- [Troubleshooting](/troubleshooting/)
 - [Contributing](https://github.com/misobadev/neostation-frontend/blob/main/CONTRIBUTING.md)
 - [Report an issue](https://github.com/misobadev/neostation-frontend/issues)

--- a/docs/library/adding-your-games.md
+++ b/docs/library/adding-your-games.md
@@ -1,3 +1,10 @@
+---
+title: Adding Your Games
+layout: default
+parent: Library
+nav_order: 1
+---
+
 # Adding Your Games
 
 NeoStation builds your local library from the folders listed in **Settings → Directories**.
@@ -28,6 +35,6 @@ Open **Settings → Directories**, select a configured ROM folder, and confirm *
 
 ## Related Pages
 
-- [Getting Started](../getting-started/getting-started.md)
-- [Multi-Disc Games](multi-disc-games.md)
-- [Troubleshooting](../troubleshooting.md)
+- [Getting Started](/getting-started/getting-started/)
+- [Multi-Disc Games](/library/multi-disc-games/)
+- [Troubleshooting](/troubleshooting/)

--- a/docs/library/index.md
+++ b/docs/library/index.md
@@ -1,0 +1,13 @@
+---
+title: Library
+layout: default
+has_children: true
+nav_order: 5
+---
+
+# Library
+
+NeoStation builds your local library from ROM folders you add. This section covers adding your games and organising recognised disc sets.
+
+- [Adding Your Games](/library/adding-your-games/)
+- [Multi-Disc Games](/library/multi-disc-games/)

--- a/docs/library/multi-disc-games.md
+++ b/docs/library/multi-disc-games.md
@@ -1,3 +1,10 @@
+---
+title: Multi-Disc Games
+layout: default
+parent: Library
+nav_order: 2
+---
+
 # Multi-Disc Games
 
 **Organize Multi-Disc Games** finds recognised disc sets, puts each set in a game folder, and creates an `.m3u` playlist for emulators that use one.
@@ -36,5 +43,5 @@ Existing `.m3u` files are moved into the game folder when appropriate. A directo
 
 ## Related Pages
 
-- [Adding Your Games](adding-your-games.md)
-- [Troubleshooting](../troubleshooting.md)
+- [Adding Your Games](/library/adding-your-games/)
+- [Troubleshooting](/troubleshooting/)

--- a/docs/platforms/steam-deck-and-steamos.md
+++ b/docs/platforms/steam-deck-and-steamos.md
@@ -1,3 +1,9 @@
+---
+title: Steam Deck & SteamOS
+layout: default
+nav_order: 4
+---
+
 # Steam Deck & SteamOS
 
 NeoStation's Linux build supports Steam Deck. Run its AppImage through Steam so Steam Input presents the Deck controls as a gamepad.
@@ -18,6 +24,6 @@ Outside Steam, the Deck may use lizard mode: it presents controls as keyboard an
 
 ## Related Pages
 
-- [Getting Started](../getting-started/getting-started.md)
-- [Configuring Emulators](../configuration/configuring-emulators.md)
-- [Troubleshooting](../troubleshooting.md)
+- [Getting Started](/getting-started/getting-started/)
+- [Configuring Emulators](/configuration/configuring-emulators/)
+- [Troubleshooting](/troubleshooting/)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,3 +1,9 @@
+---
+title: Troubleshooting
+layout: default
+nav_order: 7
+---
+
 # Troubleshooting
 
 ## My games do not appear
@@ -21,7 +27,7 @@ Run **Settings → Tools → Match RetroAchievements Games**. Matching a large l
 
 ## Steam Deck controls feel wrong
 
-Launch NeoStation from Steam. See [Steam Deck & SteamOS](platforms/steam-deck-and-steamos.md) for the lizard-mode symptoms and setup.
+Launch NeoStation from Steam. See [Steam Deck & SteamOS](/platforms/steam-deck-and-steamos/) for the lizard-mode symptoms and setup.
 
 ## Collecting Useful Information
 
@@ -29,6 +35,6 @@ When opening an issue, include your platform, NeoStation version, the system and
 
 ## Related Pages
 
-- [Getting Started](getting-started/getting-started.md)
-- [Configuring Emulators](configuration/configuring-emulators.md)
-- [Scraping & Metadata](features/scraping-and-metadata.md)
+- [Getting Started](/getting-started/getting-started/)
+- [Configuring Emulators](/configuration/configuring-emulators/)
+- [Scraping & Metadata](/features/scraping-and-metadata/)


### PR DESCRIPTION
## Description

The wiki at wiki.neostation.dev (GitHub Pages serving `docs/`) printed raw Markdown with no navigation. This adds a Jekyll config using the **Just the Docs** remote theme so GitHub Pages renders an actual, navigable documentation index.

Changes:
- Add `docs/_config.yml` (Just the Docs remote theme, site title, custom domain URL, pretty permalinks, search).
- Give every page front matter (`title`, `layout`, `nav_order`, `parent`) to drive the sidebar.
- Add `docs/library/index.md` and `docs/features/index.md` as section landing parents with `has_children: true`.
- Rewrite internal links to pretty URLs (`/getting-started/getting-started/` instead of `...md`) so navigation no longer 404s.

Resulting sidebar order: Home, Getting Started, Configuring Emulators, Steam Deck & SteamOS, Library, Features, FAQs, Troubleshooting.

## Steps to Verify

1. Push a docs change (or merge) to main.
2. Open https://wiki.neostation.dev and confirm the sidebar and index render, and that every page and cross-link resolves.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: static documentation site only. Validated with a local Jekyll build (`bundle exec jekyll build`) using the remote theme, which is the same route GitHub Pages takes at build time.

## Checklist

- [x] `dart format .` — no diff (docs-only change)
- [x] `flutter analyze` — not applicable (docs-only change)
- [x] `flutter test` — not applicable (docs-only change)
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [ ] New assets have compatible licenses