### PR TITLE
fix(esde): search for all media formats supported by ES-DE

### DIFF
--- a/lib/models/game_model.dart
+++ b/lib/models/game_model.dart
@@ -489,14 +489,17 @@ class GameModel {
     if (fileProvider != null && fileProvider.isInitialized) {
       final master = fileProvider.getVideoPath(systemFolderName, romname);
       // ES-DE read-time fallback video (cheap in-memory lookup, no I/O).
-      final esde = fileProvider.getEsdeVideoPath(systemFolderName, romname);
+      final esdeCandidates = fileProvider.getEsdeVideoCandidates(systemFolderName, romname);
       // No ES-DE fallback for this system: return the master path without any
       // filesystem stat — getVideoPath is called on the scroll hot path and
       // there is nothing to fall back to anyway.
-      if (esde == null) return master;
+      if (esdeCandidates.isEmpty) return master;
       // Prefer the master video; only fall back to ES-DE when it's missing.
       if (File(master).existsSync()) return master;
-      if (File(esde).existsSync()) return esde;
+      // Check each ES-DE candidate in order and return the first that exists
+      for (final esdeCandidate in esdeCandidates) {
+        if (File(esdeCandidate).existsSync()) return esdeCandidate;
+      }
       return master;
     }
     final baseName = _stripRomExtension(romname);

--- a/lib/models/game_model.dart
+++ b/lib/models/game_model.dart
@@ -488,8 +488,11 @@ class GameModel {
   String getVideoPath(String systemFolderName, [FileProvider? fileProvider]) {
     if (fileProvider != null && fileProvider.isInitialized) {
       final master = fileProvider.getVideoPath(systemFolderName, romname);
-      // ES-DE read-time fallback video (cheap in-memory lookup, no I/O).
-      final esdeCandidates = fileProvider.getEsdeVideoCandidates(systemFolderName, romname);
+      // ES-DE read-time fallback video. Checks existence of each candidate.
+      final esdeCandidates = fileProvider.getEsdeVideoCandidates(
+        systemFolderName,
+        romname,
+      );
       // No ES-DE fallback for this system: return the master path without any
       // filesystem stat — getVideoPath is called on the scroll hot path and
       // there is nothing to fall back to anyway.

--- a/lib/providers/file_provider.dart
+++ b/lib/providers/file_provider.dart
@@ -82,9 +82,18 @@ class FileProvider extends ChangeNotifier {
   };
 
   /// Image extensions ES-DE writes into `downloaded_media`.
-  static const List<String> _esdeMediaExtensions = ['png', 'webp', 'jpg'];
-  /// video extensions ES-DE writes into `downloaded_media`.
-  static const List<String> _esdeVideoExtensions = ['mp4', 'webm',  'mkv', 'avi', 'wmv', 'mov'];
+  static const List<String> _esdeMediaExtensions = ['png', 'jpg', 'webp'];
+
+  /// Video extensions ES-DE writes into `downloaded_media`.
+  static const List<String> _esdeVideoExtensions = [
+    'mp4',
+    'webm',
+    'mkv',
+    'avi',
+    'wmv',
+    'mov',
+    'm4v',
+  ];
 
   // Getters
   String? get userDataPath => _userDataPath;
@@ -499,11 +508,15 @@ class FileProvider extends ChangeNotifier {
   /// this ROM the subfolder is tried first, then the category root: ES-DE can
   /// list one ROM filename in several subfolders and only one of them is
   /// recorded, so the root is where the art often actually sits.
+  ///
+  /// If [extensions] is provided, it overrides the default image extensions
+  /// with the provided list (e.g., video extensions for video lookups).
   List<String> getEsdeMediaCandidates(
     String systemFolderName,
     String imageType,
-    String romName,
-  ) {
+    String romName, [
+    List<String>? extensions,
+  ]) {
     if (_esdeRoot == null) return const [];
     final esdeDir = _esdeSystemDirs[systemFolderName];
     if (esdeDir == null) return const [];
@@ -517,10 +530,12 @@ class FileProvider extends ChangeNotifier {
       '',
     ];
 
+    final extList = extensions ?? _esdeMediaExtensions;
+
     final candidates = <String>[];
     for (final category in categories) {
       for (final sub in subdirs) {
-        for (final extension in _esdeMediaExtensions) {
+        for (final extension in extList) {
           candidates.add(
             path.joinAll([
               _esdeRoot!,
@@ -546,56 +561,13 @@ class FileProvider extends ChangeNotifier {
   /// a media subfolder for this ROM the subfolder is tried first, then the
   /// category root: ES-DE can list one ROM filename in several subfolders and
   /// only one of them is recorded, so the root is where the video often actually sits.
-  List<String> getEsdeVideoCandidates(
-    String systemFolderName,
-    String romName,
-  ) {
-    if (_esdeRoot == null) return const [];
-    final esdeDir = _esdeSystemDirs[systemFolderName];
-    if (esdeDir == null) return const [];
-    final baseName = _stripRomExtension(romName, systemFolderName);
-    final subdir =
-        _esdeMediaSubdirs[_esdeSubdirKey(systemFolderName, baseName)];
-    final subdirs = <String>[
-      if (subdir != null && subdir.isNotEmpty) subdir,
-      '',
-    ];
-
-    final candidates = <String>[];
-    for (final sub in subdirs) {
-      for (final extension in _esdeVideoExtensions) {
-        candidates.add(
-          path.joinAll([
-            _esdeRoot!,
-            'downloaded_media',
-            esdeDir,
-            'videos',
-            if (sub.isNotEmpty) sub,
-            '$baseName.$extension',
-          ]),
-        );
-      }
-    }
-    return candidates;
-  }
-
-  /// Resolves the read-time fallback path for a preview video inside the user's
-  /// ES-DE `downloaded_media` tree, or null if ES-DE is not configured for this
-  /// system. Does NOT check existence.
-  ///
-  /// This is a convenience method that returns the first candidate path (with mp4
-  /// extension) or null. For full extension support, use [getEsdeVideoCandidates].
-  String? getEsdeVideoPath(String systemFolderName, String romName) {
-    final candidates = getEsdeVideoCandidates(systemFolderName, romName);
-    if (candidates.isEmpty) return null;
-    // Return the first candidate (mp4 extension without subdir) for backward compatibility
-    // The full list with all extensions is available via getEsdeVideoCandidates
-    for (final candidate in candidates) {
-      if (candidate.endsWith('.mp4')) {
-        return candidate;
-      }
-    }
-    return candidates.first;
+  List<String> getEsdeVideoCandidates(String systemFolderName, String romName) {
+    return getEsdeMediaCandidates(
+      systemFolderName,
+      'videos',
+      romName,
+      _esdeVideoExtensions,
+    );
   }
 
   /// Resets the internal state of the provider.

--- a/lib/providers/file_provider.dart
+++ b/lib/providers/file_provider.dart
@@ -82,7 +82,9 @@ class FileProvider extends ChangeNotifier {
   };
 
   /// Image extensions ES-DE writes into `downloaded_media`.
-  static const List<String> _esdeMediaExtensions = ['png', 'jpg'];
+  static const List<String> _esdeMediaExtensions = ['png', 'webp', 'jpg'];
+  /// video extensions ES-DE writes into `downloaded_media`.
+  static const List<String> _esdeVideoExtensions = ['mp4', 'webm',  'mkv', 'avi', 'wmv', 'mov'];
 
   // Getters
   String? get userDataPath => _userDataPath;
@@ -535,24 +537,65 @@ class FileProvider extends ChangeNotifier {
     return candidates;
   }
 
-  /// Resolves the read-time fallback path for a preview video inside the user's
-  /// ES-DE `downloaded_media` tree, or null if ES-DE is not configured for this
-  /// system. Does NOT check existence.
-  String? getEsdeVideoPath(String systemFolderName, String romName) {
-    if (_esdeRoot == null) return null;
+  /// Candidate read-time fallback paths for a video asset inside the user's
+  /// ES-DE `downloaded_media` tree, most-preferred first, or empty if ES-DE is
+  /// not configured for this system. Does NOT check existence —
+  /// the caller stats them in order.
+  ///
+  /// Candidates cover every video extension ES-DE writes. When the import recorded
+  /// a media subfolder for this ROM the subfolder is tried first, then the
+  /// category root: ES-DE can list one ROM filename in several subfolders and
+  /// only one of them is recorded, so the root is where the video often actually sits.
+  List<String> getEsdeVideoCandidates(
+    String systemFolderName,
+    String romName,
+  ) {
+    if (_esdeRoot == null) return const [];
     final esdeDir = _esdeSystemDirs[systemFolderName];
-    if (esdeDir == null) return null;
+    if (esdeDir == null) return const [];
     final baseName = _stripRomExtension(romName, systemFolderName);
     final subdir =
         _esdeMediaSubdirs[_esdeSubdirKey(systemFolderName, baseName)];
-    return path.joinAll([
-      _esdeRoot!,
-      'downloaded_media',
-      esdeDir,
-      'videos',
+    final subdirs = <String>[
       if (subdir != null && subdir.isNotEmpty) subdir,
-      '$baseName.mp4',
-    ]);
+      '',
+    ];
+
+    final candidates = <String>[];
+    for (final sub in subdirs) {
+      for (final extension in _esdeVideoExtensions) {
+        candidates.add(
+          path.joinAll([
+            _esdeRoot!,
+            'downloaded_media',
+            esdeDir,
+            'videos',
+            if (sub.isNotEmpty) sub,
+            '$baseName.$extension',
+          ]),
+        );
+      }
+    }
+    return candidates;
+  }
+
+  /// Resolves the read-time fallback path for a preview video inside the user's
+  /// ES-DE `downloaded_media` tree, or null if ES-DE is not configured for this
+  /// system. Does NOT check existence.
+  ///
+  /// This is a convenience method that returns the first candidate path (with mp4
+  /// extension) or null. For full extension support, use [getEsdeVideoCandidates].
+  String? getEsdeVideoPath(String systemFolderName, String romName) {
+    final candidates = getEsdeVideoCandidates(systemFolderName, romName);
+    if (candidates.isEmpty) return null;
+    // Return the first candidate (mp4 extension without subdir) for backward compatibility
+    // The full list with all extensions is available via getEsdeVideoCandidates
+    for (final candidate in candidates) {
+      if (candidate.endsWith('.mp4')) {
+        return candidate;
+      }
+    }
+    return candidates.first;
   }
 
   /// Resets the internal state of the provider.

--- a/test/esde_media_write_protection_test.dart
+++ b/test/esde_media_write_protection_test.dart
@@ -183,7 +183,7 @@ void main() {
       'lib/models/game_model.dart',
     };
 
-    const esdeApis = ['getEsdeMediaCandidates(', 'getEsdeVideoPath('];
+    const esdeApis = ['getEsdeMediaCandidates(', 'getEsdeVideoCandidates(', 'getEsdeVideoPath('];
 
     test('only the read resolvers consume ES-DE path helpers', () {
       final offenders = <String>[];

--- a/test/esde_media_write_protection_test.dart
+++ b/test/esde_media_write_protection_test.dart
@@ -183,7 +183,7 @@ void main() {
       'lib/models/game_model.dart',
     };
 
-    const esdeApis = ['getEsdeMediaCandidates(', 'getEsdeVideoCandidates(', 'getEsdeVideoPath('];
+    const esdeApis = ['getEsdeMediaCandidates(', 'getEsdeVideoCandidates('];
 
     test('only the read resolvers consume ES-DE path helpers', () {
       final offenders = <String>[];

--- a/test/file_provider_test.dart
+++ b/test/file_provider_test.dart
@@ -66,8 +66,10 @@ void main() {
       expect(candidates, [
         '/esde/downloaded_media/snes/covers/sonic.png',
         '/esde/downloaded_media/snes/covers/sonic.jpg',
+        '/esde/downloaded_media/snes/covers/sonic.webp',
         '/esde/downloaded_media/snes/3dboxes/sonic.png',
         '/esde/downloaded_media/snes/3dboxes/sonic.jpg',
+        '/esde/downloaded_media/snes/3dboxes/sonic.webp',
       ]);
     });
 
@@ -87,8 +89,10 @@ void main() {
         expect(candidates, [
           '/esde/downloaded_media/snes/marquees/Hacks/sonic.png',
           '/esde/downloaded_media/snes/marquees/Hacks/sonic.jpg',
+          '/esde/downloaded_media/snes/marquees/Hacks/sonic.webp',
           '/esde/downloaded_media/snes/marquees/sonic.png',
           '/esde/downloaded_media/snes/marquees/sonic.jpg',
+          '/esde/downloaded_media/snes/marquees/sonic.webp',
         ]);
       },
     );
@@ -125,8 +129,10 @@ void main() {
         [
           '/esde/downloaded_media/snes/screenshots/sonic.png',
           '/esde/downloaded_media/snes/screenshots/sonic.jpg',
+          '/esde/downloaded_media/snes/screenshots/sonic.webp',
           '/esde/downloaded_media/snes/titlescreens/sonic.png',
           '/esde/downloaded_media/snes/titlescreens/sonic.jpg',
+          '/esde/downloaded_media/snes/titlescreens/sonic.webp',
         ],
       );
     });
@@ -135,6 +141,7 @@ void main() {
       expect(provider.getEsdeMediaCandidates('snes', 'fanarts', 'sonic.smc'), [
         '/esde/downloaded_media/snes/fanart/sonic.png',
         '/esde/downloaded_media/snes/fanart/sonic.jpg',
+        '/esde/downloaded_media/snes/fanart/sonic.webp',
       ]);
     });
   });


### PR DESCRIPTION
# Description

- Add support for all image formats supported by ES-DE:
  - `.jpg`
  - `.png`
  - `.webp`
- Add support for all video formats supported by ES-DE:
  - `.mp4`
  - `.mkv`
  - `.avi`
  - `.wmv`
  - `.mov`
  - `.webm`
  - `.m4v`

Closes #433

## Steps to Verify

<!-- Required for bug fixes. Preconditions first (which system, how many games,
     which device), then numbered steps someone else can follow. -->

**Preconditions:**

1. ES-DE media folders containing additional ES-DE-supported media flies with extensions like `webp` or `webm`
2. imported ES-DE metadata and media in neostation

## Tested on

<!-- Name the device. Desktop-only testing does not catch Android SAF path bugs. -->

- [ ] Android — device:
- [x] Linux — device: bazzite-deck-gnome-44.20260825
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [ ] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [ ] New assets have compatible licenses
