### PR TITLE
feat(achievements): select the weekly card with Down from the dashboard top

### DIFF
--- a/lib/screens/retro_achievements_screen/ra_content.dart
+++ b/lib/screens/retro_achievements_screen/ra_content.dart
@@ -38,9 +38,8 @@ class _RAContentState extends State<RAContent>
   final ScrollController _dashboardScrollController = ScrollController();
 
   /// Connected dashboard: whether the cursor is parked on the header's logout
-  /// button. Nothing is selected at rest — Right parks on it, Left steps back
-  /// along the axis onto the week card, and Up/Down stay dedicated to scrolling
-  /// the dashboard.
+  /// button. Nothing is selected at rest — Right parks on it, and Left steps
+  /// back along the axis onto the week card.
   bool _logoutSelected = false;
 
   /// The dashboard's one actionable content card. It is only selectable when
@@ -251,12 +250,33 @@ class _RAContentState extends State<RAContent>
     return _scrollDashboard(-160.r) || released;
   }
 
+  /// Down steps onto the dashboard's one actionable card before it starts
+  /// scrolling, so the card is reachable without knowing to press Left.
+  ///
+  /// Only from the top, and only at rest: selecting a card that has already
+  /// scrolled out of view would leave the highlight invisible, which is the
+  /// same trap [_scrollHeaderIntoView] exists to keep the logout button out of.
+  /// Once the card is selected — or the cursor is parked on logout — Down goes
+  /// back to being a plain scroll.
   bool _handleNavigateDown() {
-    if (!context.read<RetroAchievementsProvider>().isConnected) {
-      return moveSelection(1);
+    final raProvider = context.read<RetroAchievementsProvider>();
+    if (!raProvider.isConnected) return moveSelection(1);
+    if (!_logoutSelected &&
+        !_weekCardSelected &&
+        raProvider.ownedWeekGame != null &&
+        _dashboardAtTop) {
+      return _setWeekCardSelected(true);
     }
     final released = _setWeekCardSelected(false);
     return _scrollDashboard(160.r) || released;
+  }
+
+  /// Whether the dashboard is scrolled to the top, within the same one-pixel
+  /// tolerance [_releaseSelectionOnScroll] and [_scrollHeaderIntoView] use.
+  bool get _dashboardAtTop {
+    if (!_dashboardScrollController.hasClients) return true;
+    final position = _dashboardScrollController.position;
+    return position.pixels <= position.minScrollExtent + 1;
   }
 
   /// Right parks the cursor on the header's logout button.


### PR DESCRIPTION
# Description

Left was the only way onto the Achievement of the Week card added in #431, which is not a gesture anyone finds without being told. Down is the natural "step into the content" direction, so it now selects the card first and starts scrolling afterwards.

Gated on the dashboard being at the top and nothing else being selected. Selecting a card that has already scrolled out of view would leave the highlight invisible, which is the trap `_scrollHeaderIntoView` exists to keep the logout button out of, and pressing Down while reading further down the page should keep scrolling rather than yanking the view back up. Left remains the "take me to the card from anywhere" gesture.

Resulting axis:

| From | Down | Up | Left | Right |
|---|---|---|---|---|
| rest, at top | select card | scroll up | select card | logout |
| rest, scrolled | scroll down | scroll up | select card | logout |
| card selected | deselect, scroll down | deselect | left edge | logout |
| logout | scroll down | scroll up | card | right edge |

## Steps to Verify

**Preconditions:**

1. RetroAchievements connected, with the current Achievement of the Week game present in the local library so the card shows its "Owned" pill.
2. A controller. The card is not selectable when the weekly game is not owned, which is the intended fallback.

1. Open the RetroAchievements tab. Nothing is selected.
2. Press Down. The Achievement of the Week card is selected and the view does not move.
3. Press A. The local game opens in its system list.
4. Back out, press Down twice. The first selects the card, the second releases it and scrolls.
5. Scroll down a few presses, then press Down again. It keeps scrolling rather than jumping back to the card.

## Tested on

- [x] Android — device: AYN Thor
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse
- [x] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()`
- [x] B cancels / goes back, including out of a focused text field

</details>
