### PR TITLE
fix(neosync): custom save folder sync + docs and diagnostics

### DIFF
--- a/docs/features/neosync.md
+++ b/docs/features/neosync.md
@@ -7,37 +7,92 @@ nav_order: 3
 
 # NeoSync
 
-NeoSync synchronises game saves and states through your NeoSync account. It includes account registration, email verification, password recovery, cloud-save browsing, quota information, and custom save folders for standalone emulators.
+NeoSync is your cloud companion for NeoStation. It keeps your game saves, save states and memory cards in sync across all of your devices, so your progress is safe even if a device is lost or replaced.
+
+## Before You Start
+
+The NeoSync tab is hidden by default. To show it:
+
+1. Open **Settings → General**.
+2. Turn on **Show NeoSync tab**.
 
 ## Sign In or Create an Account
 
-Open the **NeoSync** tab. You can register a new account or sign in with an existing account. New registrations require email verification; NeoStation can also resend the verification email and start password recovery.
+Open the **NeoSync** tab and choose to create an account or sign in.
 
-If the NeoSync tab is not visible, enable **Show NeoSync tab** in the General settings.
+- New accounts need email verification. NeoStation can resend the verification email.
+- If you forget your password, use the password recovery option.
 
-## Save Synchronisation
+## How Automatic Syncing Works
 
-Once signed in, NeoSync tracks local and cloud save files and can show synchronisation progress and errors. The **Save List** lets you browse and refresh your online saves.
+NeoStation syncs automatically, the same way a storefront syncs your library before and after a session:
 
-> **Note:** Only one save-sync provider is active at a time. If another connected provider owns save synchronisation, NeoSync remains available for its account and cloud-save views but does not run active save sync.
+- **When NeoStation starts**, it checks the cloud and downloads any newer saves.
+- **Before a game launches**, it pulls down the latest saves, states and memory cards for that game.
+- **After you finish a game**, it pushes your local changes up to the cloud.
+
+Because of this, you only need to play and let NeoStation handle the rest. You can turn this automatic behaviour **on or off** in the NeoSync settings, but leaving it on is the recommended way to keep everything current.
+
+### What Is Synced
+
+NeoStation saves each file with the system and the emulator (or RetroArch core) that created it. This means:
+
+- Game saves and save states are linked to the game they belong to.
+- Memory cards and other shared files are shared across the whole system.
+- RetroArch saves are tracked per core, so switching between devices keeps using the right emulator.
+
+## Per-Game Status
+
+Each game in your library shows a small cloud status so you know where its save stands:
+
+| Status | Meaning |
+|---|---|
+| **No save found** | There is no save for this game yet, on this device or in the cloud. |
+| **Local only** | The save exists on this device but has not been uploaded yet. |
+| **Cloud only** | The save is in the cloud but not on this device yet. |
+| **Up to date** | The local and cloud saves match. |
+| **Disabled** | Cloud sync is turned off for this game. |
+| **Quota exceeded** | Your storage plan is full. Free up space or upgrade. |
+
+You can turn cloud sync on or off for an individual game.
+
+## Save List
+
+The **Save List** shows every file you have in the cloud. You can:
+
+- Browse your online saves, states and memory cards.
+- **Search** by name to find a specific save.
+- **Filter** by scope (per-game saves or memory cards), system, or emulator.
+- **Sort** by newest/oldest or by name.
+- **Refresh** the list to show the latest files.
+- **Delete** a cloud save.
 
 ## Custom Save Folders
 
-Use **Custom Save Folders** when a standalone emulator stores saves in a location NeoStation cannot discover automatically.
+Some standalone emulators store their saves in a folder that NeoStation cannot find automatically. You can point NeoStation at it:
 
 1. Open **Custom Save Folders** in the NeoSync area.
-2. Choose a system and emulator.
-3. Select the save folder.
-4. Select **Configure**, then use **Sync now** when needed.
+2. Choose the system and emulator.
+3. Select the save folder on your device.
+4. Choose **Configure**, then **Sync now** when you want to back up or pull down that folder.
 
-Removing a custom save folder unlinks it from synchronisation; it does not delete the local files.
+Removing a custom save folder only disconnects it from syncing; it does not delete the local files.
 
-## Delete a Cloud Save
+## Downloading a Save Manually
 
-NeoSync asks for confirmation before deleting a cloud save.
+Cloud downloads on the device are automatic. If you want to copy a save or memory card down by hand, NeoStation also provides a web view where you can browse, download and delete your cloud files:
 
-> **Warning:** Deleting a cloud save is permanent. If you need a local copy first, use the available download option before deleting it.
+[https://neosync.cloud/](https://neosync.cloud/)
+
+## Storage and Plans
+
+Your NeoSync account has a storage limit. When you are close to the limit, NeoStation shows how much space you are using and how much remains. If you run out of space, syncing pauses so you can free up room or upgrade your plan.
+
+When you delete a cloud save, NeoStation asks for confirmation.
+
+> **Warning:** Deleting a cloud save is permanent. If you might need a local copy, download it from the web view first.
 
 ## Related Pages
 
 - [Troubleshooting](/troubleshooting/)
+- [Configuring Emulators](/configuration/configuring-emulators/)

--- a/docs/features/neosync.md
+++ b/docs/features/neosync.md
@@ -16,9 +16,13 @@ The NeoSync tab is hidden by default. To show it:
 1. Open **Settings → General**.
 2. Turn on **Show NeoSync tab**.
 
+## The Official Site
+
+The official NeoSync website is [https://neosync.cloud/](https://neosync.cloud/). You can sign in or create an account there exactly as you can in the NeoStation app.
+
 ## Sign In or Create an Account
 
-Open the **NeoSync** tab and choose to create an account or sign in.
+Open the **NeoSync** tab and choose to create an account or sign in. You can also do this on the [official site](https://neosync.cloud/).
 
 - New accounts need email verification. NeoStation can resend the verification email.
 - If you forget your password, use the password recovery option.
@@ -80,9 +84,13 @@ Removing a custom save folder only disconnects it from syncing; it does not dele
 
 ## Downloading a Save Manually
 
-Cloud downloads on the device are automatic. If you want to copy a save or memory card down by hand, NeoStation also provides a web view where you can browse, download and delete your cloud files:
+Cloud downloads on the device are automatic. If you want to copy a save or memory card down by hand, use the [official site](https://neosync.cloud/) to browse, download and delete your cloud files.
 
-[https://neosync.cloud/](https://neosync.cloud/)
+## Legacy (v1) Saves
+
+Saves from the previous NeoSync version are kept as **backup only**. Legacy saves are not synced by NeoStation and can only be downloaded as a backup from the [official site](https://neosync.cloud/).
+
+From now on, NeoStation only uses the new **NeoSync v2** cloud storage for normal synchronisation.
 
 ## Storage and Plans
 
@@ -90,7 +98,7 @@ Your NeoSync account has a storage limit. When you are close to the limit, NeoSt
 
 When you delete a cloud save, NeoStation asks for confirmation.
 
-> **Warning:** Deleting a cloud save is permanent. If you might need a local copy, download it from the web view first.
+> **Warning:** Deleting a cloud save is permanent. If you might need a local copy, download it from the [official site](https://neosync.cloud/) first.
 
 ## Related Pages
 

--- a/docs/features/neosync.md
+++ b/docs/features/neosync.md
@@ -83,6 +83,8 @@ Some standalone emulators store their saves in a folder that NeoStation cannot f
 3. Select the save folder on your device.
 4. Choose **Configure**, then **Sync now** when you want to back up or pull down that folder.
 
+> **Important:** For a custom folder to sync, it must be configured on **every device** you want to synchronise with. NeoStation cannot place a save into a custom folder that the target device has not been pointed at, so configure the same system + emulator + folder on each device.
+
 Removing a custom save folder only disconnects it from syncing; it does not delete the local files.
 
 ## Deleting a Cloud Save

--- a/docs/features/neosync.md
+++ b/docs/features/neosync.md
@@ -29,12 +29,14 @@ Open the **NeoSync** tab and choose to create an account or sign in. You can als
 
 ## How Automatic Syncing Works
 
-NeoStation syncs automatically, the same way a storefront syncs your library before and after a session:
+NeoStation syncs automatically, but it does **not** sync all of your saves at once — syncing everything in a single pass would saturate NeoSync's servers. Instead, each game is synchronised as you reach it:
 
-- **Whenever NeoStation walks through your games**, each one is checked and synchronised with the cloud as it is browsed.
+- **Whenever NeoStation walks through your games**, the game you land on is checked and synchronised with the cloud as you browse.
 - **When NeoStation starts**, it checks the cloud and downloads any newer saves.
 - **Before a game launches**, it pulls down the latest saves, states and memory cards for that game.
 - **After you finish a game**, it pushes your local changes up to the cloud.
+
+Because each game is synced one at a time, give it a moment: look for the **sync/checkmark** indicator on the left side of the screen and wait until the synchronisation finishes before moving on or launching the game.
 
 Because of this, you only need to play and let NeoStation handle the rest. You can turn this automatic behaviour **on or off** in the NeoSync settings, but leaving it on is the recommended way to keep everything current.
 

--- a/docs/features/neosync.md
+++ b/docs/features/neosync.md
@@ -31,6 +31,7 @@ Open the **NeoSync** tab and choose to create an account or sign in. You can als
 
 NeoStation syncs automatically, the same way a storefront syncs your library before and after a session:
 
+- **Whenever NeoStation walks through your games**, each one is checked and synchronised with the cloud as it is browsed.
 - **When NeoStation starts**, it checks the cloud and downloads any newer saves.
 - **Before a game launches**, it pulls down the latest saves, states and memory cards for that game.
 - **After you finish a game**, it pushes your local changes up to the cloud.
@@ -82,9 +83,17 @@ Some standalone emulators store their saves in a folder that NeoStation cannot f
 
 Removing a custom save folder only disconnects it from syncing; it does not delete the local files.
 
-## Downloading a Save Manually
+## Deleting a Cloud Save
 
-Cloud downloads on the device are automatic. If you want to copy a save or memory card down by hand, use the [official site](https://neosync.cloud/) to browse, download and delete your cloud files.
+You can delete a cloud save from **NeoStation** (in the **Save List**) or from the [official site](https://neosync.cloud/). NeoStation asks for confirmation before deleting a cloud save.
+
+> **Warning:** Deleting a cloud save is permanent. If you might need a local copy, download it from the [official site](https://neosync.cloud/) first.
+
+## Downloading a Save
+
+Downloads in NeoStation are **automatic**, triggered by synchronisation: they happen while NeoStation walks through your games and before and after each game session.
+
+There is **no manual download button** in NeoStation. If you want to download a save or memory card by hand, use the [official site](https://neosync.cloud/).
 
 ## Legacy (v1) Saves
 
@@ -95,10 +104,6 @@ From now on, NeoStation only uses the new **NeoSync v2** cloud storage for norma
 ## Storage and Plans
 
 Your NeoSync account has a storage limit. When you are close to the limit, NeoStation shows how much space you are using and how much remains. If you run out of space, syncing pauses so you can free up room or upgrade your plan.
-
-When you delete a cloud save, NeoStation asks for confirmation.
-
-> **Warning:** Deleting a cloud save is permanent. If you might need a local copy, download it from the [official site](https://neosync.cloud/) first.
 
 ## Related Pages
 

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -34,3 +34,4 @@ Open a system, then use its emulator settings to choose from the emulators avail
 - [Adding Your Games](/library/adding-your-games/)
 - [Scraping & Metadata](/features/scraping-and-metadata/)
 - [RetroAchievements](/features/retroachievements/)
+- [NeoSync Cloud Saves](/features/neosync/)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,6 +25,17 @@ Confirm that you are signed in to ScreenScraper and that the game system is mapp
 
 Run **Settings → Tools → Match RetroAchievements Games**. Matching a large library can take time and may be paused and resumed. Sign in to the RetroAchievements tab to view results.
 
+## A NeoSync save is not appearing on another device
+
+1. Sign in to NeoSync on the same account on every device, and confirm sync is turned on.
+2. Let each device sync once (start the app, or launch a game) before looking for the save.
+3. Open the **NeoSync → Save List** to confirm the file exists in the cloud at all.
+4. Check the save status on the game itself. **Local only** means the file has not been uploaded yet; **Cloud only** means it is waiting to be downloaded.
+5. If it is a standalone emulator save, confirm the emulator has a **Custom Save Folder** configured on the device where you expect the file.
+6. If the file is on the other device but shows the wrong emulator, delete the duplicate in the [NeoSync web view](https://neosync.cloud/) and let the device re-upload.
+
+If the save still does not appear, gather the device `app.log` and its platform, NeoStation version, system, emulator and the exact filename, then open an issue. The log reports where each save was written and why a download failed, including permission errors.
+
 ## Steam Deck controls feel wrong
 
 Launch NeoStation from Steam. See [Steam Deck & SteamOS](/platforms/steam-deck-and-steamos/) for the lizard-mode symptoms and setup.

--- a/lib/providers/neosync/neosync_download.dart
+++ b/lib/providers/neosync/neosync_download.dart
@@ -116,18 +116,23 @@ extension NeoSyncDownload on NeoSyncProvider {
             _processedItems.add('Custom save: ${cloudFile.fileName}');
           } else {
             NeoSyncProvider._log.i(
-              'Download: skipped (already current) ${cloudFile.fileName} '
-              '-> ${localFile.path}',
+              'Download: shared already current ${cloudFile.fileName}',
             );
             _skippedFiles++;
           }
           return;
         }
+        // A shared memory card has no game to associate; without a configured
+        // custom folder there is nowhere to place it. Record a clear reason.
         NeoSyncProvider._log.w(
-          'Download: shared file ${cloudFile.fileName} has no configured '
-          'custom folder for system "${v2Path.system}" emulator '
-          '"${v2Path.emulatorSlug}"; falling through to game lookup',
+          'Download: shared ${cloudFile.fileName} skipped: no custom save '
+          'folder for system=${v2Path.system} emulator=${v2Path.emulatorSlug}',
         );
+        _skippedFiles++;
+        _processedItems.add(
+          'Skipped shared cloud file (no custom folder): ${cloudFile.fileName}',
+        );
+        return;
       }
 
       // 1. Resolve the game associated with the file
@@ -135,7 +140,7 @@ extension NeoSyncDownload on NeoSyncProvider {
 
       if (game == null) {
         NeoSyncProvider._log.w(
-          'Download: could not identify game for ${cloudFile.fileName} '
+          'Download: no game matched ${cloudFile.fileName} '
           '(system "${v2Path?.system ?? '?'}" / "${cloudFile.gameName}")',
         );
         _processedItems.add(
@@ -168,9 +173,7 @@ extension NeoSyncDownload on NeoSyncProvider {
             _processedItems.add('Auto-updated: ${cloudFile.fileName}');
           } else {
             NeoSyncProvider._log.i(
-              'Download: local ${localFile.path} is newer ('
-              '${localStat.modified}) than cloud '
-              '${cloudFile.fileName} (${cloudFile.uploadedAt}); skipping',
+              'Download: skipping ${cloudFile.fileName} (local is newer)',
             );
             _skippedFiles++;
           }
@@ -332,6 +335,39 @@ extension NeoSyncDownload on NeoSyncProvider {
     NeoSyncFile cloudFile,
     String savesPath,
   ) async {
+    final v2Path = CloudPathBuilder.parse(cloudFile.fileName);
+    if (v2Path != null && v2Path.isShared) {
+      final customFolder = await NeoSyncSaveFolderRepository.getFolder(
+        v2Path.system,
+        v2Path.emulatorSlug,
+      );
+      if (customFolder != null && customFolder.isNotEmpty) {
+        final localFile = File(path.join(customFolder, v2Path.filePath));
+        await localFile.parent.create(recursive: true);
+        if (!localFile.existsSync() ||
+            cloudFile.uploadedAt.isAfter(await localFile.lastModified())) {
+          await _downloadCloudFileImpl(cloudFile, localFile);
+          _downloadedFiles++;
+          _processedItems.add('Updated: ${cloudFile.fileName}');
+        } else {
+          NeoSyncProvider._log.i(
+            'Download: shared already current ${cloudFile.fileName}',
+          );
+          _skippedFiles++;
+        }
+        return;
+      }
+      NeoSyncProvider._log.w(
+        'Download: shared ${cloudFile.fileName} skipped: no custom save '
+        'folder for system=${v2Path.system} emulator=${v2Path.emulatorSlug}',
+      );
+      _skippedFiles++;
+      _processedItems.add(
+        'Skipped shared cloud file (no custom folder): ${cloudFile.fileName}',
+      );
+      return;
+    }
+
     GameModel? game = await _findGameForCloudFile(cloudFile);
     if (game == null) {
       NeoSyncProvider._log.w(
@@ -360,8 +396,7 @@ extension NeoSyncDownload on NeoSyncProvider {
           _processedItems.add('Updated: ${cloudFile.fileName}');
         } else {
           NeoSyncProvider._log.i(
-            'Download: conflict phase, local ${localFile.path} newer; '
-            'skipping ${cloudFile.fileName}',
+            'Download: skipping ${cloudFile.fileName} (local is newer)',
           );
           _skippedFiles++;
         }

--- a/lib/providers/neosync/neosync_path_resolver.dart
+++ b/lib/providers/neosync/neosync_path_resolver.dart
@@ -694,16 +694,23 @@ extension NeoSyncPathResolver on NeoSyncProvider {
     // Buscar la carpeta más apropiada.
     String targetFolder = resolvedFolders.first;
 
-    // NeoSync v2 paths carry system/emulator/scope. For per-game saves, prefer
-    // the configured custom folder when the emulator has one, otherwise fall
-    // back to the standard resolution below.
-    if (v2Path != null && !v2Path.isShared) {
+    // NeoSync v2 paths carry system/emulator/scope. Always prefer the
+    // configured custom folder when the emulator has one — for per-game saves
+    // AND shared memory cards (ARMSX2 .ps2, DuckStation memcards). Custom
+    // folders are only offered for standalone emulators, so RetroArch saves
+    // (no matching custom folder) still fall through to the standard
+    // resolution below.
+    if (v2Path != null) {
       final customFolder = await NeoSyncSaveFolderRepository.getFolder(
         v2Path.system,
         v2Path.emulatorSlug,
       );
       if (customFolder != null && customFolder.isNotEmpty) {
-        return [path.join(customFolder, v2Path.filePath)];
+        final target = path.join(customFolder, v2Path.filePath);
+        NeoSyncProvider._log.i(
+          'Download: ${cloudFile.fileName} -> custom folder $target',
+        );
+        return [target];
       }
     }
 


### PR DESCRIPTION
# Description

Fixes NeoSync custom save folders for standalone emulators (ARMSX2, DuckStation, ...) not being pulled down to the mapped folder, and brings the NeoSync user documentation in line with how it actually works.

A shared memory card (e.g. an ARMSX2 `.ps2`) was uploaded to NeoSync but when loading the game on another device it was downloaded to the generic RetroArch saves directory instead of the configured custom folder, so it never appeared where the emulator reads it.

**Root cause:** `resolveCloudFileToLocalPath` (used by the per-game download path `detectGameSaveFiles` / `_autoDownloadCloudSave`, which runs when a standalone emulator launches a game) only mapped **per-game** v2 files to the configured custom folder and explicitly **excluded shared memory cards** (`!v2Path.isShared`). Shared cards fell through to the generic saves path.

## Changes

- Always prefer the configured custom folder for a v2 path, for per-game saves and shared memory cards alike. RetroArch saves (no matching custom folder) still fall through unchanged.
- Apply the same shared-memory-card handling to the unified/conflict sync path, so shared memcards download to their custom folder there too.
- Shared memory cards without a configured custom folder stop with a single clear warning and are counted as skipped, instead of falling through to a game lookup that always fails for them.
- Targeted, non-invasive download logging for standalone/shared files (destination, write outcome, failure reason/errno).
- Reworked the NeoSync documentation: official site (neosync.cloud), account creation there, legacy v1 backup-only, v2-only syncing, deleting from NeoStation, automatic download (no manual), per-game incremental syncing, and that custom save folders must be configured on every device.

## Steps to Verify

**Preconditions:**

1. Two devices (or one device + the NeoSync web view) signed in to the same NeoSync account.
2. RetroArch and a standalone emulator (e.g. ARMSX2/DuckStation) with a custom save folder configured on **both** devices.

1. On device A, create/play a RetroArch game and a standalone-emulator game, then quit to let it sync.
2. Confirm both saves appear in the cloud.
3. On device B, launch the same games (or let auto-sync run) and confirm the saves land in their correct folders.
4. If a shared memory card does not download, check the log for the reason (no custom folder configured on that device, or a write/permission error).
5. Confirm the doc reflects NeoSync behaviour at the user level.

## Tested on

- [ ] Android — device: not runtime-tested on a device for this PR (routing + logging change)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [X] Not runtime-tested — why: verification done via `flutter analyze`, targeted unit/integration tests, and reasoning over the two download paths; the previous RetroArch fix was validated on-device by the reporter.

## Checklist

- [X] `dart format .` — no diff
- [X] `flutter analyze` — clean (no errors *or* warnings)
- [X] `flutter test` — all passing
- [ ] Tests added or updated
- [X] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [ ] New assets have compatible licenses

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [ ] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [X] No hardcoded UI strings — everything goes through `AppLocale`

**The database**
- [ ] Column added to the versioned migration in `sqlite_migrations.dart` **and** the `CREATE TABLE` in `sqlite_service.dart`
- [ ] Migration number is above every slot in use on any open branch, not just `main` + 1
- [ ] Migration is idempotent (`PRAGMA table_info` guard) and has a test
- [ ] `_databaseVersion` bumped; new column selected in *every* system-loading query

**Navigation or a new screen**
- [ ] Every interactive element is reachable by D-pad, not just touch/mouse
- [ ] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()`
- [ ] B cancels / goes back, including out of a focused text field

**Android**
- [X] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths
- [ ] Verified on a device, not only on desktop

**`assets/systems/` or emulator launching**
- [ ] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible
- [ ] `assets/manifest.json` version bumped if this should reach existing installs OTA

</details>