### PR TITLE
fix(neosync): never upload with an empty game_name

### DIFF
--- a/lib/providers/neosync/neosync_upload.dart
+++ b/lib/providers/neosync/neosync_upload.dart
@@ -403,7 +403,17 @@ extension NeoSyncUpload on NeoSyncProvider {
       } else {
         relativePath = _calculateRelativePath(file, basePath, isState: isState);
       }
-      final gameName = _extractGameNameFromPath(file.path);
+      final rawGameName = _extractGameNameFromPath(file.path);
+      // The NeoSync backend hard-rejects an upload whose game_name is empty.
+      // Guard against a basename that resolves to '' (e.g. a path ending in a
+      // separator) so a custom-folder save is never silently dropped.
+      final gameName = rawGameName.isEmpty ? 'Shared Save' : rawGameName;
+      if (rawGameName.isEmpty) {
+        NeoSyncProvider._log.w(
+          'Upload: empty game_name for ${file.path}; using fallback '
+          '"$gameName"',
+        );
+      }
 
       // Resolve the game hash (ra_hash) so the v2 upload carries the ROM hash.
       // The save base name usually matches the ROM name, so find the game by
@@ -544,7 +554,14 @@ extension NeoSyncUpload on NeoSyncProvider {
         basePath,
         isState: isState,
       );
-      final gameName = _extractGameNameFromPath(file.path);
+      final rawGameName = _extractGameNameFromPath(file.path);
+      final gameName = rawGameName.isEmpty ? 'Shared Save' : rawGameName;
+      if (rawGameName.isEmpty) {
+        NeoSyncProvider._log.w(
+          'Upload: empty game_name for ${file.path}; using fallback '
+          '"$gameName"',
+        );
+      }
 
       String? gameHash;
       try {


### PR DESCRIPTION
# Description

A custom-folder save that resolved to an **empty** game name was rejected by the
NeoSync backend (`game_name is required`), so the file never reached the cloud
and could never be downloaded on another device. This is what a user hit when
configuring an ARMSX2 (PS2) memcard folder: the immediate backup upload failed
with `Upload failed: game_name is required`, leaving nothing for the other
device to pull down.

## Changes

- Fall back to a placeholder name (`Shared Save`) when the derived game name is
  empty in both upload paths (`_processAutoUploadFile` and
  `_processUploadFileWithConflictDetection`).
- Log a warning with the offending path so an empty `game_name` is never silent.

## Steps to Verify

**Preconditions:**

1. Two devices signed in to the same NeoSync account.
2. A standalone emulator (e.g. ARMSX2/DuckStation) with a custom save folder
   configured on both devices.

1. Select a custom save folder that contains a memory card.
2. Confirm the immediate upload no longer fails with `game_name is required`.
3. On the other device, verify the memory card is pulled down.

## Tested on

- [ ] Android — device: not runtime-tested
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [X] Not runtime-tested — why: verified via `flutter analyze` and the NeoSync
      upload path; the reported failure path is guarded and now logs the path.

## Checklist

- [X] `dart format .` — no diff
- [X] `flutter analyze` — clean
- [X] `flutter test` — all passing
- [ ] Tests added or updated
- [X] No secrets, credentials, or personal data in the diff
- [ ] New assets have compatible licenses