### PR TITLE
fix(secondary): register fvp in the secondary display engine

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -790,6 +790,14 @@ Future<void> subDisplay() async {
   WidgetsFlutterBinding.ensureInitialized();
   debugPrint('--- [SECONDARY ENGINE] subDisplay signal received ---');
 
+  // This engine has its own VideoPlayerPlatform: main()'s registerWith() ran in
+  // the other isolate and never reached here, so without this the preview video
+  // falls back to the platform default (ExoPlayer on Android) while the main
+  // display plays through libmdk. ES-DE fallback videos can be .mkv/.avi/.wmv,
+  // none of which ExoPlayer decodes, so the same game would play up top and
+  // fail on the bottom screen.
+  registerWith();
+
   // The secondary display runs in its own engine/isolate, so it must set up
   // localization independently — otherwise AppLocale.getString() falls back to
   // raw keys here. Mirror the persisted-language init done in main().

--- a/test/file_provider_test.dart
+++ b/test/file_provider_test.dart
@@ -145,4 +145,76 @@ void main() {
       ]);
     });
   });
+  group('FileProvider.getEsdeVideoCandidates', () {
+    final dbHelper = DatabaseTestHelper();
+    late dynamic db;
+    late FileProvider provider;
+
+    setUp(() async {
+      db = await dbHelper.setUp();
+      await db.execute(
+        "INSERT INTO app_systems (id, real_name, folder_name, screenscraper_id) VALUES ('snes', 'SNES', 'snes', 4)",
+      );
+      await db.execute(
+        "INSERT INTO user_config (esde_folder_path) VALUES ('/esde')",
+      );
+      await db.execute(
+        "INSERT INTO user_system_settings (app_system_id, esde_media_dir) VALUES ('snes', 'snes')",
+      );
+      provider = FileProvider();
+      await provider.refreshEsde();
+    });
+
+    tearDown(() async {
+      await dbHelper.tearDown();
+    });
+
+    test('covers every video extension ES-DE writes, mp4 first', () {
+      expect(provider.getEsdeVideoCandidates('snes', 'sonic.smc'), [
+        '/esde/downloaded_media/snes/videos/sonic.mp4',
+        '/esde/downloaded_media/snes/videos/sonic.webm',
+        '/esde/downloaded_media/snes/videos/sonic.mkv',
+        '/esde/downloaded_media/snes/videos/sonic.avi',
+        '/esde/downloaded_media/snes/videos/sonic.wmv',
+        '/esde/downloaded_media/snes/videos/sonic.mov',
+        '/esde/downloaded_media/snes/videos/sonic.m4v',
+      ]);
+    });
+
+    test(
+      'falls back to the category root after the recorded subfolder',
+      () async {
+        // The subfolder recorded at import time is only ever one of the folders
+        // ES-DE listed this ROM in, so a video sitting at the category root has
+        // to stay reachable — images already behave this way.
+        await db.execute(
+          "INSERT INTO user_screenscraper_metadata (app_system_id, filename, esde_media_subdir) VALUES ('snes', 'sonic.smc', 'Hacks')",
+        );
+        await provider.refreshEsde();
+
+        expect(provider.getEsdeVideoCandidates('snes', 'sonic.smc'), [
+          '/esde/downloaded_media/snes/videos/Hacks/sonic.mp4',
+          '/esde/downloaded_media/snes/videos/Hacks/sonic.webm',
+          '/esde/downloaded_media/snes/videos/Hacks/sonic.mkv',
+          '/esde/downloaded_media/snes/videos/Hacks/sonic.avi',
+          '/esde/downloaded_media/snes/videos/Hacks/sonic.wmv',
+          '/esde/downloaded_media/snes/videos/Hacks/sonic.mov',
+          '/esde/downloaded_media/snes/videos/Hacks/sonic.m4v',
+          '/esde/downloaded_media/snes/videos/sonic.mp4',
+          '/esde/downloaded_media/snes/videos/sonic.webm',
+          '/esde/downloaded_media/snes/videos/sonic.mkv',
+          '/esde/downloaded_media/snes/videos/sonic.avi',
+          '/esde/downloaded_media/snes/videos/sonic.wmv',
+          '/esde/downloaded_media/snes/videos/sonic.mov',
+          '/esde/downloaded_media/snes/videos/sonic.m4v',
+        ]);
+      },
+    );
+
+    test('returns nothing for a system with no recorded ES-DE media dir', () {
+      // getVideoPath keys on this to skip the existence checks entirely, so an
+      // empty list is the contract, not just an absence of candidates.
+      expect(provider.getEsdeVideoCandidates('nes', 'mario.nes'), isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
# Description

Two follow-ups from the review of #434, which widened the ES-DE read-time fallback from `.mp4` to every video format ES-DE writes.

**1. `subDisplay()` never registered fvp.** `main()` calls `registerWith()` (`lib/main.dart:257`), which sets `VideoPlayerPlatform.instance` to fvp's libmdk/FFmpeg backend. That instance is a Dart static, and the secondary display runs in its own engine and isolate, so the registration never reached it. fvp declares a `dartPluginClass` only for Linux, Windows, elinux and ohos, never for Android, so nothing re-registered it there either and the second engine kept the default `AndroidVideoPlayer`, i.e. ExoPlayer.

That was harmless while an ES-DE fallback video could only ever be `.mp4`. Now that `.mkv`, `.avi` and `.wmv` are reachable and ExoPlayer decodes none of them, the same game would play a trailer on the top screen and show nothing on the bottom one. One line in `subDisplay()` puts both engines on the same backend.

**2. `getEsdeVideoCandidates` had no direct test.** It is the part of #434 with genuinely new semantics, and both halves were uncovered: the seven-extension list, and the category-root fallback that the old `getEsdeVideoPath` never had (it only looked inside the recorded subfolder, so a video sitting at the category root resolved to nothing regardless of format). This adds the exact-list cases the image resolver already has, plus the empty-list case for an unmapped system, since `getVideoPath` keys on that to skip its existence checks entirely.

Rebased onto `main` now that #434 has merged, so the diff is just these two changes.

## Steps to Reproduce

**Preconditions:** a dual-screen Android handheld (AYN Thor), and any system with a preview video.

1. Open a system and move the selection onto a game that has a preview video.
2. Let the selection settle so the video starts.
3. The bottom screen's player is ExoPlayer, not libmdk. With a `.mp4` this still plays, so it is invisible; with the `.mkv`/`.avi`/`.wmv` fallbacks #434 makes reachable, the bottom screen renders nothing while the top screen plays.

## Steps to Verify

Measured on the Thor (fvp 0.37.3, before #440's bump; re-confirmed on 0.38.1 after the rebase) by temporarily printing `VideoPlayerPlatform.instance.runtimeType` from both entrypoints, and counting `ExoPlayerImpl: Init` in logcat while a preview video played (Atari 7800, `Ace of Aces (USA).mp4`). Identical builds, the single line in `subDisplay()` the only difference:

| build | main engine | secondary engine | `ExoPlayerImpl: Init` |
| --- | --- | --- | --- |
| without this fix | `MdkVideoPlayerPlatform` | `AndroidVideoPlayer` | 1 |
| with this fix | `MdkVideoPlayerPlatform` | `MdkVideoPlayerPlatform` | 0 |

Exactly one player is created either way, which also confirms the games-list preview video is driven by the secondary engine. On the fixed build the decode goes through libmdk's `AMediaCodec` path (`c2.qti.avc.decoder`), and three `screencap` captures of the bottom display taken a second apart hash differently, so it is still rendering the preview rather than a frozen frame.

To reproduce that check:

1. Deploy to a dual-screen device and select a game with a preview video.
2. `adb logcat | grep ExoPlayerImpl` — no ExoPlayer is constructed.
3. `flutter test test/file_provider_test.dart` — the three new `FileProvider.getEsdeVideoCandidates` cases pass.

## Tested on

- [x] Android — device: AYN Thor (dual-screen, dev channel)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1524)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [ ] New assets have compatible licenses
