### PR TITLE
fix(secondary): show the bottom-screen keyboard over the panel

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/SecondaryAppsPresentation.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/SecondaryAppsPresentation.kt
@@ -61,12 +61,26 @@ class SecondaryAppsPresentation(
      * key handling of its own, so it never needs key focus: FLAG_NOT_FOCUSABLE
      * keeps touch working while leaving every key event, and the focused
      * display, with the main activity on top.
+     *
+     * FLAG_ALT_FOCUSABLE_IM rides along because FLAG_NOT_FOCUSABLE on its own
+     * also declares "this window does not interact with the input method", and
+     * such a window is layered *above* the IME window on its display. Dual-screen
+     * handhelds can pin the keyboard to the bottom screen (on the AYN Thor,
+     * Settings.System `ime_show_on_second`), and there the IME window is created
+     * on this display while the edit field stays on the main one — so our
+     * full-screen panel simply covered it and typing anywhere in NeoStation
+     * showed no keyboard at all. Adding the flag inverts only that IME
+     * relationship ("behind/away from the IME") and leaves key focus where it
+     * is: still not focusable, so this window can never become the IME target.
      */
     private fun hardenAgainstDismissal() {
         setCancelable(false)
         setCanceledOnTouchOutside(false)
         try {
-            window?.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+            window?.addFlags(
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                    WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM
+            )
         } catch (e: Exception) {
             Log.w(TAG, "Could not make secondary window non-focusable: ${e.message}")
         }


### PR DESCRIPTION
# Description

Dual-screen handhelds can pin the system keyboard to the bottom screen. On the AYN Thor that is `Settings.System.ime_show_on_second`: the edit field stays on the main display while the IME window is created on the secondary one. NeoStation did not honour it, and typing anywhere in the app (search, RetroAchievements / RomM / NeoSync logins) showed no keyboard at all, on either screen.

The keyboard was there, drawn, and hidden underneath our own bottom-screen panel. `SecondaryAppsPresentation` sets `FLAG_NOT_FOCUSABLE` so BACK cannot tear the panel down and so the bottom display never becomes the focused one (PR #146). That flag also declares "this window does not interact with the input method", and such a window is layered *above* the IME window on its display, so the full-screen panel simply covered Gboard.

`FLAG_ALT_FOCUSABLE_IM` inverts only that IME relationship ("behave as if it needs the input method, and be placed behind / away from it"). Key focus is untouched: the window is still not focusable, so it can never become the IME target, and every reason the original flag exists still holds (BACK is still swallowed, the focused window on the bottom display is unchanged, gamepad keys still reach `MainActivity`).

Evidence on device, before the fix: `dumpsys window windows` listed the NeoStation `PRESENTATION` window above `InputMethod` on display 4 with both `isVisible=true` and `HAS_DRAWN`, and a `screencap` of display 4 showed only NeoStation. After the fix the two are the other way round and the keyboard is visible.

Behaviour on devices without a pinned keyboard is unchanged: with the keyboard on the main screen there is no IME window on the secondary display, so the flag does nothing.

Related: #276 (a request for a built-in on-screen keyboard, which this PR does not implement).

## Steps to Reproduce

**Preconditions:** an AYN Thor (or another dual-screen Android handheld that can pin the keyboard to the bottom screen), NeoStation running with the secondary screen enabled, and the system setting on (`adb shell settings get system ime_show_on_second` returns `1`).

1. Open the Search tab.
2. Focus the search field (tap it, or press A on it).
3. Before: no keyboard appears on either screen, and there is no way to type. `adb shell dumpsys input_method` shows `mInputShown=true` and `mCurTokenDisplayId=4`, so the keyboard is up, just covered.

## Steps to Verify

**Preconditions:** as above.

1. Open the Search tab and focus the search field.
2. The keyboard appears on the bottom screen, over the NeoStation panel.
3. Tap a letter on it. The letter reaches the field and the result count on the main screen updates (in testing, 9140 results down to 3121 for "g").
4. Press B. The keyboard is dismissed and the bottom panel redraws normally.
5. Confirm nothing else moved: `adb shell dumpsys window displays` still shows the launcher, not NeoStation, as `mCurrentFocus` on the secondary display, and BACK on the bottom screen still does not dismiss the panel.

## Tested on

- [x] Android - device: AYN Thor (Android 13, dual screen), dev flavour, release build
- [ ] Linux - device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested - why:

## Checklist

- [x] `dart format .` - no diff
- [x] `flutter analyze` - clean (no errors *or* warnings)
- [x] `flutter test` - all passing (1524 tests)
- [ ] Tests added or updated (window-flag behaviour on a second physical display is not unit-testable; verified on device)
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses (no new assets)

<details>
<summary><b>Extra checks</b></summary>

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths (no path logic touched)
- [x] Verified on a device, not only on desktop

</details>

## Notes

While a field is focused, the bottom screen belongs to the keyboard, so the Now Playing panel and the app dock are covered until it is dismissed. Gboard also shows its landscape extract editor (a dark area with a DONE button) above the keys, because the edit field lives on the other display. That is the IME's own behaviour, not something this window controls.
