### PR TITLE
feat(3ds): add RetroArch Azahar core

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/EmulatorLauncher.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/EmulatorLauncher.kt
@@ -143,13 +143,20 @@ object EmulatorLauncher {
                     val finalValue = value.toString()
 
                     // RetroArch-specific: LIBRETRO core path construction uses the package name
-                    // to locate the correct cores directory. CONFIGFILE default is set below.
+                    // to locate the correct cores directory. A bare core name uses RetroArch's
+                    // current Android suffix; an explicitly named core file is preserved for
+                    // cores that retain the legacy `_libretro.so` filename (e.g. Azahar).
                     if (packageName.startsWith("com.retroarch") && key == "LIBRETRO" && !finalValue.startsWith("/")) {
                         val libretroDir = getDefaultLibretroDirectory(context, packageName)
-                        val base = finalValue
-                            .removeSuffix("_libretro_android.so")
-                            .removeSuffix("_libretro.so")
-                        intent.putExtra(key, "$libretroDir${base}_libretro_android.so")
+                        val coreFilename = if (
+                            finalValue.endsWith("_libretro_android.so") ||
+                                finalValue.endsWith("_libretro.so")
+                        ) {
+                            finalValue
+                        } else {
+                            "${finalValue}_libretro_android.so"
+                        }
+                        intent.putExtra(key, "$libretroDir$coreFilename")
                         continue
                     }
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.16"
+  "latest_version": "0.3.18"
 }

--- a/assets/systems/3ds.json
+++ b/assets/systems/3ds.json
@@ -113,6 +113,28 @@
       }
     },
     {
+      "name": "RetroArch Azahar",
+      "unique_id": "3ds.ra.azahar",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf, z3dsx, zcci, zcxi.",
+      "platforms": {
+        "windows": {
+          "executable": "retroarch.exe",
+          "args": "-L azahar_libretro.dll \"{file.path}\""
+        },
+        "linux": {
+          "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
+          "args": "-L azahar_libretro.so \"{file.path}\""
+        },
+        "macos": {
+          "executable": "RetroArch.App",
+          "args": "-L azahar_libretro.dylib \"{file.path}\""
+        }
+      }
+    },
+    {
       "name": "RetroArch64 Citra",
       "default_core": true,
       "unique_id": "3ds.ra64.citra",
@@ -143,6 +165,17 @@
       "platforms": {
         "android": {
           "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"citra_canary\""
+        }
+      }
+    },
+    {
+      "name": "RetroArch64 Azahar",
+      "unique_id": "3ds.ra64.azahar",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf, z3dsx, zcci, zcxi.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"azahar_libretro.so\""
         }
       }
     },

--- a/lib/screens/retro_achievements_screen/ra_content.dart
+++ b/lib/screens/retro_achievements_screen/ra_content.dart
@@ -3,6 +3,8 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:neostation/utils/gamepad_nav.dart';
 import 'package:provider/provider.dart';
 import '../../providers/retro_achievements_provider.dart';
+import '../../providers/file_provider.dart';
+import '../../providers/sqlite_config_provider.dart';
 import '../../repositories/retro_achievements_repository.dart';
 import '../../widgets/confirm_action_dialog.dart';
 import '../../widgets/custom_notification.dart';
@@ -15,6 +17,9 @@ import '../app_screen.dart' show AppNavigation;
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import '../../utils/login_form_selection.dart';
+import '../../models/retro_achievements_dashboard_models.dart';
+import '../../models/system_model.dart';
+import '../game_screen/my_games_list.dart';
 import 'ra_dashboard.dart';
 
 class RAContent extends StatefulWidget {
@@ -36,6 +41,10 @@ class _RAContentState extends State<RAContent>
   /// button. Nothing is selected at rest — Right parks on it, Left releases it,
   /// and Up/Down stay dedicated to scrolling the dashboard.
   bool _logoutSelected = false;
+
+  /// The dashboard's one actionable content card. It is only selectable when
+  /// the weekly game has a matching ROM in the user's library.
+  bool _weekCardSelected = false;
 
   /// Set while Right is scrolling the header back into view, so the scroll
   /// listener doesn't read that movement as the user leaving the button.
@@ -100,7 +109,14 @@ class _RAContentState extends State<RAContent>
   void _selectCurrent() {
     final raProvider = context.read<RetroAchievementsProvider>();
     if (raProvider.isConnected) {
-      if (_logoutSelected) _requestDisconnect();
+      if (_logoutSelected) {
+        _requestDisconnect();
+        return;
+      }
+      if (_weekCardSelected) {
+        final owned = raProvider.ownedWeekGame;
+        if (owned != null) _openOwnedWeekGame(owned);
+      }
       return;
     }
     if (focusSelectedField()) return;
@@ -114,6 +130,12 @@ class _RAContentState extends State<RAContent>
   bool _setLogoutSelected(bool selected) {
     if (!mounted || _logoutSelected == selected) return false;
     setState(() => _logoutSelected = selected);
+    return true;
+  }
+
+  bool _setWeekCardSelected(bool selected) {
+    if (!mounted || _weekCardSelected == selected) return false;
+    setState(() => _weekCardSelected = selected);
     return true;
   }
 
@@ -141,6 +163,7 @@ class _RAContentState extends State<RAContent>
     if (!mounted) return;
     resetSelection();
     _setLogoutSelected(false);
+    _setWeekCardSelected(false);
     AppNotification.showNotification(
       context,
       AppLocale.disconnectedRA.getString(context),
@@ -218,6 +241,7 @@ class _RAContentState extends State<RAContent>
     if (!context.read<RetroAchievementsProvider>().isConnected) {
       return moveSelection(-1);
     }
+    _setWeekCardSelected(false);
     return _scrollDashboard(-160.r);
   }
 
@@ -225,6 +249,7 @@ class _RAContentState extends State<RAContent>
     if (!context.read<RetroAchievementsProvider>().isConnected) {
       return moveSelection(1);
     }
+    _setWeekCardSelected(false);
     return _scrollDashboard(160.r);
   }
 
@@ -236,13 +261,58 @@ class _RAContentState extends State<RAContent>
   bool _handleNavigateRight() {
     if (!context.read<RetroAchievementsProvider>().isConnected) return false;
     if (_logoutSelected) return false;
+    _setWeekCardSelected(false);
     _scrollHeaderIntoView();
     return _setLogoutSelected(true);
   }
 
   bool _handleNavigateLeft() {
     if (!context.read<RetroAchievementsProvider>().isConnected) return false;
-    return _setLogoutSelected(false);
+    if (_logoutSelected) return _setLogoutSelected(false);
+    if (context.read<RetroAchievementsProvider>().ownedWeekGame == null) {
+      return false;
+    }
+    _scrollHeaderIntoView();
+    return _setWeekCardSelected(true);
+  }
+
+  Future<void> _openOwnedWeekGame(OwnedWeekGameResolution owned) async {
+    final configProvider = context.read<SqliteConfigProvider>();
+    final fileProvider = context.read<FileProvider>();
+    final system = _resolveSystem(configProvider.detectedSystems, owned);
+    if (system == null) {
+      AppNotification.showNotification(
+        context,
+        AppLocale.raCouldNotResolveLocalSystem.getString(context),
+        type: NotificationType.error,
+      );
+      return;
+    }
+
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => SystemGamesList(
+          system: system,
+          fileProvider: fileProvider,
+          initialRomPath: owned.game.romPath,
+        ),
+      ),
+    );
+  }
+
+  SystemModel? _resolveSystem(
+    List<SystemModel> systems,
+    OwnedWeekGameResolution owned,
+  ) {
+    final folder = owned.game.systemFolderName;
+    if (folder == null || folder.isEmpty) return null;
+    for (final system in systems) {
+      if (system.folderName == folder || system.primaryFolderName == folder) {
+        return system;
+      }
+    }
+    return null;
   }
 
   void _scrollHeaderIntoView() {
@@ -333,7 +403,10 @@ class _RAContentState extends State<RAContent>
                 child: RADashboardHub(
                   scrollController: _dashboardScrollController,
                   logoutSelected: _logoutSelected,
+                  weekCardSelected:
+                      _weekCardSelected && raProvider.ownedWeekGame != null,
                   onDisconnectRequested: _requestDisconnect,
+                  onOwnedWeekGameSelected: _openOwnedWeekGame,
                 ),
               ),
             ),

--- a/lib/screens/retro_achievements_screen/ra_dashboard.dart
+++ b/lib/screens/retro_achievements_screen/ra_dashboard.dart
@@ -9,23 +9,22 @@ import 'package:provider/provider.dart';
 import '../../l10n/app_locale.dart';
 import '../../models/retro_achievements_dashboard_models.dart';
 import '../../models/retro_achievements_user_awards.dart';
-import '../../providers/file_provider.dart';
 import '../../providers/retro_achievements_provider.dart';
-import '../../providers/sqlite_config_provider.dart';
-import '../../screens/game_screen/my_games_list.dart';
-import '../../widgets/custom_notification.dart';
-import '../../models/system_model.dart';
 
 class RADashboardHub extends StatefulWidget {
   final ScrollController? scrollController;
   final bool logoutSelected;
+  final bool weekCardSelected;
   final VoidCallback onDisconnectRequested;
+  final ValueChanged<OwnedWeekGameResolution> onOwnedWeekGameSelected;
 
   const RADashboardHub({
     super.key,
     this.scrollController,
     required this.logoutSelected,
+    required this.weekCardSelected,
     required this.onDisconnectRequested,
+    required this.onOwnedWeekGameSelected,
   });
 
   @override
@@ -342,200 +341,213 @@ class _RADashboardHubState extends State<RADashboardHub> {
         ? theme.colorScheme.secondary
         : theme.colorScheme.primary;
 
-    return InkWell(
-      borderRadius: BorderRadius.circular(12.r),
-      onTap: owned == null ? null : () => _openOwnedWeekGame(context, owned),
-      child: Container(
-        padding: EdgeInsets.all(14.r),
-        decoration: _cardDecoration(
-          theme,
-          borderColor: accent.withValues(
-            alpha: earned
-                ? 0.55
-                : owned != null
-                ? 0.35
-                : 0.15,
-          ),
-          background: theme.cardColor.withValues(
-            alpha: earned
-                ? 0.40
-                : owned != null
-                ? 0.34
-                : 0.25,
-          ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Icon(Symbols.emoji_events_rounded, size: 18.r, color: accent),
-                SizedBox(width: 8.r),
-                Expanded(
-                  child: Text(
-                    AppLocale.aotw.getString(context),
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      fontSize: 11.r,
-                      fontWeight: FontWeight.bold,
-                      color: accent,
-                    ),
+    final selectable = owned != null;
+    final selected = selectable && widget.weekCardSelected;
+
+    return Semantics(
+      button: selectable,
+      selected: selected,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12.r),
+        onTap: owned == null
+            ? null
+            : () => widget.onOwnedWeekGameSelected(owned),
+        child: Container(
+          padding: EdgeInsets.all(14.r),
+          decoration: _cardDecoration(
+            theme,
+            borderColor: selected
+                ? theme.colorScheme.primary
+                : accent.withValues(
+                    alpha: earned
+                        ? 0.55
+                        : owned != null
+                        ? 0.35
+                        : 0.15,
                   ),
-                ),
-                if (earned)
-                  _buildPill(
-                    context,
-                    icon: Symbols.verified_rounded,
-                    label: AppLocale.raEarned.getString(context),
-                    color: accent,
-                  )
-                else if (owned != null)
-                  _buildPill(
-                    context,
-                    icon: Symbols.check_circle_rounded,
-                    label: AppLocale.raOwned.getString(context),
-                    color: accent,
-                  ),
-              ],
+            borderWidth: selected ? 2.r : 1.r,
+            background: theme.cardColor.withValues(
+              alpha: earned
+                  ? 0.40
+                  : owned != null
+                  ? 0.34
+                  : 0.25,
             ),
-            SizedBox(height: 12.r),
-            if (raProvider.gotwLoading && gotw == null)
-              _buildLoadingState(context, minHeight: 138.r)
-            else if (gotw == null)
-              _buildSectionMessage(
-                context,
-                raProvider.gotwError ??
-                    AppLocale.couldNotLoadAOTW.getString(context),
-                isError: true,
-                onRetry: raProvider.fetchGOTW,
-                minHeight: 138.r,
-              )
-            else
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
               Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(10.r),
-                    child: SizedBox(
-                      width: 72.r,
-                      height: 72.r,
-                      child: Image.network(
-                        _raMediaUrl(gotw.achievement.badgeUrl),
-                        fit: BoxFit.cover,
-                        errorBuilder: (context, error, stackTrace) => Container(
-                          color: theme.colorScheme.surface,
-                          child: Icon(
-                            Symbols.emoji_events_rounded,
-                            color: accent,
-                            size: 30.r,
-                          ),
-                        ),
+                  Icon(Symbols.emoji_events_rounded, size: 18.r, color: accent),
+                  SizedBox(width: 8.r),
+                  Expanded(
+                    child: Text(
+                      AppLocale.aotw.getString(context),
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontSize: 11.r,
+                        fontWeight: FontWeight.bold,
+                        color: accent,
                       ),
                     ),
                   ),
-                  SizedBox(width: 12.r),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          gotw.game.title,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
-                            fontSize: 13.r,
-                          ),
+                  if (earned)
+                    _buildPill(
+                      context,
+                      icon: Symbols.verified_rounded,
+                      label: AppLocale.raEarned.getString(context),
+                      color: accent,
+                    )
+                  else if (owned != null)
+                    _buildPill(
+                      context,
+                      icon: Symbols.check_circle_rounded,
+                      label: AppLocale.raOwned.getString(context),
+                      color: accent,
+                    ),
+                ],
+              ),
+              SizedBox(height: 12.r),
+              if (raProvider.gotwLoading && gotw == null)
+                _buildLoadingState(context, minHeight: 138.r)
+              else if (gotw == null)
+                _buildSectionMessage(
+                  context,
+                  raProvider.gotwError ??
+                      AppLocale.couldNotLoadAOTW.getString(context),
+                  isError: true,
+                  onRetry: raProvider.fetchGOTW,
+                  minHeight: 138.r,
+                )
+              else
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(10.r),
+                      child: SizedBox(
+                        width: 72.r,
+                        height: 72.r,
+                        child: Image.network(
+                          _raMediaUrl(gotw.achievement.badgeUrl),
+                          fit: BoxFit.cover,
+                          errorBuilder: (context, error, stackTrace) =>
+                              Container(
+                                color: theme.colorScheme.surface,
+                                child: Icon(
+                                  Symbols.emoji_events_rounded,
+                                  color: accent,
+                                  size: 30.r,
+                                ),
+                              ),
                         ),
-                        SizedBox(height: 4.r),
-                        Text(
-                          gotw.console.title,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurface.withValues(
-                              alpha: 0.7,
+                      ),
+                    ),
+                    SizedBox(width: 12.r),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            gotw.game.title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 13.r,
                             ),
-                            fontSize: 9.r,
                           ),
-                        ),
-                        SizedBox(height: 8.r),
-                        Text(
-                          gotw.achievement.title,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            color: accent,
-                            fontWeight: FontWeight.w700,
-                            fontSize: 11.r,
-                          ),
-                        ),
-                        SizedBox(height: 4.r),
-                        Text(
-                          gotw.achievement.description,
-                          maxLines: 3,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            fontSize: 9.r,
-                            color: theme.colorScheme.onSurface.withValues(
-                              alpha: 0.78,
+                          SizedBox(height: 4.r),
+                          Text(
+                            gotw.console.title,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurface.withValues(
+                                alpha: 0.7,
+                              ),
+                              fontSize: 9.r,
                             ),
                           ),
-                        ),
-                      ],
+                          SizedBox(height: 8.r),
+                          Text(
+                            gotw.achievement.title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: accent,
+                              fontWeight: FontWeight.w700,
+                              fontSize: 11.r,
+                            ),
+                          ),
+                          SizedBox(height: 4.r),
+                          Text(
+                            gotw.achievement.description,
+                            maxLines: 3,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              fontSize: 9.r,
+                              color: theme.colorScheme.onSurface.withValues(
+                                alpha: 0.78,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              if (gotw != null) ...[
+                SizedBox(height: 12.r),
+                Wrap(
+                  spacing: 8.r,
+                  runSpacing: 8.r,
+                  children: [
+                    _buildPill(
+                      context,
+                      icon: Symbols.stars_rounded,
+                      label:
+                          '${gotw.achievement.points} ${AppLocale.raPointsAbbrev.getString(context)}',
+                      color: accent,
+                    ),
+                    _buildPill(
+                      context,
+                      icon: Symbols.groups_rounded,
+                      label:
+                          '${gotw.totalPlayers} ${AppLocale.players.getString(context)}',
+                      color: accent,
+                    ),
+                    _buildPill(
+                      context,
+                      icon: Symbols.trophy_rounded,
+                      label:
+                          '${gotw.unlocksCount} ${AppLocale.unlocks.getString(context)}',
+                      color: accent,
+                    ),
+                  ],
+                ),
+                if (earned) ...[
+                  SizedBox(height: 10.r),
+                  Text(
+                    AppLocale.raAlreadyEarned.getString(context),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontSize: 8.r,
+                      color: accent.withValues(alpha: 0.92),
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ] else if (owned != null) ...[
+                  SizedBox(height: 10.r),
+                  Text(
+                    AppLocale.raTapToOpenLocalGame.getString(context),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontSize: 8.r,
+                      color: accent.withValues(alpha: 0.92),
+                      fontWeight: FontWeight.w600,
                     ),
                   ),
                 ],
-              ),
-            if (gotw != null) ...[
-              SizedBox(height: 12.r),
-              Wrap(
-                spacing: 8.r,
-                runSpacing: 8.r,
-                children: [
-                  _buildPill(
-                    context,
-                    icon: Symbols.stars_rounded,
-                    label:
-                        '${gotw.achievement.points} ${AppLocale.raPointsAbbrev.getString(context)}',
-                    color: accent,
-                  ),
-                  _buildPill(
-                    context,
-                    icon: Symbols.groups_rounded,
-                    label:
-                        '${gotw.totalPlayers} ${AppLocale.players.getString(context)}',
-                    color: accent,
-                  ),
-                  _buildPill(
-                    context,
-                    icon: Symbols.trophy_rounded,
-                    label:
-                        '${gotw.unlocksCount} ${AppLocale.unlocks.getString(context)}',
-                    color: accent,
-                  ),
-                ],
-              ),
-              if (earned) ...[
-                SizedBox(height: 10.r),
-                Text(
-                  AppLocale.raAlreadyEarned.getString(context),
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    fontSize: 8.r,
-                    color: accent.withValues(alpha: 0.92),
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ] else if (owned != null) ...[
-                SizedBox(height: 10.r),
-                Text(
-                  AppLocale.raTapToOpenLocalGame.getString(context),
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    fontSize: 8.r,
-                    color: accent.withValues(alpha: 0.92),
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
               ],
             ],
-          ],
+          ),
         ),
       ),
     );
@@ -1036,13 +1048,14 @@ class _RADashboardHubState extends State<RADashboardHub> {
     ThemeData theme, {
     Color? background,
     Color? borderColor,
+    double borderWidth = 1,
   }) {
     return BoxDecoration(
       color: background ?? theme.cardColor.withValues(alpha: 0.25),
       borderRadius: BorderRadius.circular(12.r),
       border: Border.all(
         color: borderColor ?? theme.colorScheme.primary.withValues(alpha: 0.15),
-        width: 1.r,
+        width: borderWidth,
       ),
     );
   }
@@ -1059,48 +1072,5 @@ class _RADashboardHubState extends State<RADashboardHub> {
     final local = parsed.toLocal();
     String two(int v) => v.toString().padLeft(2, '0');
     return '${local.year}-${two(local.month)}-${two(local.day)}';
-  }
-
-  Future<void> _openOwnedWeekGame(
-    BuildContext context,
-    OwnedWeekGameResolution owned,
-  ) async {
-    final configProvider = context.read<SqliteConfigProvider>();
-    final fileProvider = context.read<FileProvider>();
-    final system = _resolveSystem(configProvider.detectedSystems, owned);
-    if (system == null) {
-      AppNotification.showNotification(
-        context,
-        AppLocale.raCouldNotResolveLocalSystem.getString(context),
-        type: NotificationType.error,
-      );
-      return;
-    }
-
-    if (!context.mounted) return;
-    await Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => SystemGamesList(
-          system: system,
-          fileProvider: fileProvider,
-          initialRomPath: owned.game.romPath,
-        ),
-      ),
-    );
-  }
-
-  SystemModel? _resolveSystem(
-    List<SystemModel> systems,
-    OwnedWeekGameResolution owned,
-  ) {
-    final folder = owned.game.systemFolderName;
-    if (folder == null || folder.isEmpty) return null;
-    for (final system in systems) {
-      if (system.folderName == folder || system.primaryFolderName == folder) {
-        return system;
-      }
-    }
-    return null;
   }
 }

--- a/test/ra_dashboard_week_card_test.dart
+++ b/test/ra_dashboard_week_card_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/models/database_game_model.dart';
+import 'package:neostation/models/retro_achievements_dashboard_models.dart';
+import 'package:neostation/models/retro_achievements_gotw.dart';
+import 'package:neostation/models/retro_achievements_user.dart';
+import 'package:neostation/providers/retro_achievements_provider.dart';
+import 'package:neostation/screens/retro_achievements_screen/ra_dashboard.dart';
+
+class _DashboardProvider extends RetroAchievementsProvider {
+  _DashboardProvider(this._owned);
+
+  final OwnedWeekGameResolution _owned;
+
+  @override
+  RetroAchievementsUser? get user => RetroAchievementsUser(
+    user: 'Player',
+    ulid: '',
+    userPic: '',
+    memberSince: '',
+    richPresenceMsg: '',
+    lastGameId: 0,
+    contribCount: 0,
+    contribYield: 0,
+    totalPoints: 0,
+    totalCasualPoints: 0,
+    totalTruePoints: 0,
+    permissions: 0,
+    untracked: 0,
+    id: 1,
+    userWallActive: false,
+    motto: '',
+  );
+
+  @override
+  RetroAchievementsGOTW? get gotw => RetroAchievementsGOTW(
+    achievement: Achievement(
+      id: 1,
+      title: 'Finish the level',
+      description: 'Reach the goal.',
+      points: 5,
+      trueRatio: 0,
+      type: '',
+      author: '',
+      badgeName: '',
+      badgeUrl: '',
+      dateCreated: '',
+      dateModified: '',
+    ),
+    console: Console(id: 1, title: 'NES'),
+    game: Game(id: 42, title: 'Local game'),
+    startAt: '',
+    totalPlayers: 0,
+    unlocks: const [],
+    unlocksCount: 0,
+    unlocksHardcoreCount: 0,
+  );
+
+  @override
+  OwnedWeekGameResolution? get ownedWeekGame => _owned;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await FlutterLocalization.instance.ensureInitialized();
+    FlutterLocalization.instance.init(
+      mapLocales: [MapLocale('en', AppLocale.en)],
+      initLanguageCode: 'en',
+    );
+  });
+
+  testWidgets('selected owned weekly card opens its local game', (
+    tester,
+  ) async {
+    final owned = OwnedWeekGameResolution(
+      raGameId: 42,
+      game: DatabaseGameModel(
+        filename: 'local.nes',
+        romPath: '/roms/local.nes',
+      ),
+    );
+    OwnedWeekGameResolution? opened;
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<RetroAchievementsProvider>.value(
+        value: _DashboardProvider(owned),
+        child: ScreenUtilInit(
+          designSize: const Size(1280, 720),
+          builder: (context, _) => MaterialApp(
+            localizationsDelegates:
+                FlutterLocalization.instance.localizationsDelegates,
+            supportedLocales: FlutterLocalization.instance.supportedLocales,
+            home: Scaffold(
+              body: RADashboardHub(
+                logoutSelected: false,
+                weekCardSelected: true,
+                onDisconnectRequested: () {},
+                onOwnedWeekGameSelected: (game) => opened = game,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final selectedCard = find.byWidgetPredicate(
+      (widget) => widget is Semantics && widget.properties.selected == true,
+    );
+    expect(selectedCard, findsOneWidget);
+
+    await tester.tap(
+      find.descendant(of: selectedCard, matching: find.byType(InkWell)),
+    );
+    expect(opened, same(owned));
+  });
+}


### PR DESCRIPTION
## Description

Adds the Azahar libretro core as a Nintendo 3DS emulator option for RetroArch on Windows, Linux, macOS, and Android arm64. Bumps the systems manifest so installed NeoStation clients receive the definition over the systems update channel.

Android uses the core’s current explicit legacy filename, `azahar_libretro.so`. The generic Android RetroArch resolver previously rewrote every core name to `_libretro_android.so`; for Azahar that produced RetroArch’s black-screen launch. Explicitly named core libraries are now preserved, while bare core names retain the existing Android suffix behavior.

Closes #429

## Steps to Verify

**Preconditions:**

1. Android RetroArch aarch64 with the Azahar core installed.
2. A decrypted 3DS ROM.

1. Select **RetroArch64 Azahar** for Nintendo 3DS in NeoStation.
2. Launch a 3DS game.
3. Confirm RetroArch starts the game instead of opening to a black screen.

## Tested on

- [x] Android — AYN Thor, Android 13; Pokémon X booted through NeoStation.
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS

## Checklist

- [ ] `dart format .` — no Dart files changed
- [x] `flutter analyze` — clean (no errors or warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated — device-level RetroArch private-storage behavior; verified on hardware
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**Android**
- [x] Verified on a device, not only on desktop

**`assets/systems/` or emulator launching**
- [x] JSON is used for the core definition; `EmulatorLauncher.kt` changes only preserve the explicit legacy filename required by Azahar
- [x] `assets/manifest.json` version bumped for OTA delivery
</details>