### PR TITLE
feat(3ds): add RetroArch Azahar core

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/EmulatorLauncher.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/EmulatorLauncher.kt
@@ -143,13 +143,20 @@ object EmulatorLauncher {
                     val finalValue = value.toString()
 
                     // RetroArch-specific: LIBRETRO core path construction uses the package name
-                    // to locate the correct cores directory. CONFIGFILE default is set below.
+                    // to locate the correct cores directory. A bare core name uses RetroArch's
+                    // current Android suffix; an explicitly named core file is preserved for
+                    // cores that retain the legacy `_libretro.so` filename (e.g. Azahar).
                     if (packageName.startsWith("com.retroarch") && key == "LIBRETRO" && !finalValue.startsWith("/")) {
                         val libretroDir = getDefaultLibretroDirectory(context, packageName)
-                        val base = finalValue
-                            .removeSuffix("_libretro_android.so")
-                            .removeSuffix("_libretro.so")
-                        intent.putExtra(key, "$libretroDir${base}_libretro_android.so")
+                        val coreFilename = if (
+                            finalValue.endsWith("_libretro_android.so") ||
+                                finalValue.endsWith("_libretro.so")
+                        ) {
+                            finalValue
+                        } else {
+                            "${finalValue}_libretro_android.so"
+                        }
+                        intent.putExtra(key, "$libretroDir$coreFilename")
                         continue
                     }
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.17"
+  "latest_version": "0.3.18"
 }

--- a/assets/systems/3ds.json
+++ b/assets/systems/3ds.json
@@ -113,6 +113,28 @@
       }
     },
     {
+      "name": "RetroArch Azahar",
+      "unique_id": "3ds.ra.azahar",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf, z3dsx, zcci, zcxi.",
+      "platforms": {
+        "windows": {
+          "executable": "retroarch.exe",
+          "args": "-L azahar_libretro.dll \"{file.path}\""
+        },
+        "linux": {
+          "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
+          "args": "-L azahar_libretro.so \"{file.path}\""
+        },
+        "macos": {
+          "executable": "RetroArch.App",
+          "args": "-L azahar_libretro.dylib \"{file.path}\""
+        }
+      }
+    },
+    {
       "name": "RetroArch64 Citra",
       "default_core": true,
       "unique_id": "3ds.ra64.citra",
@@ -143,6 +165,17 @@
       "platforms": {
         "android": {
           "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"citra_canary\""
+        }
+      }
+    },
+    {
+      "name": "RetroArch64 Azahar",
+      "unique_id": "3ds.ra64.azahar",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf, z3dsx, zcci, zcxi.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"azahar_libretro.so\""
         }
       }
     },


### PR DESCRIPTION
## Description

Adds the Azahar libretro core as a Nintendo 3DS emulator option for RetroArch on Windows, Linux, macOS, and Android arm64. Bumps the systems manifest so installed NeoStation clients receive the definition over the systems update channel.

Android uses the core’s current explicit legacy filename, `azahar_libretro.so`. The generic Android RetroArch resolver previously rewrote every core name to `_libretro_android.so`; for Azahar that produced RetroArch’s black-screen launch. Explicitly named core libraries are now preserved, while bare core names retain the existing Android suffix behavior.

Closes #429

## Steps to Verify

**Preconditions:**

1. Android RetroArch aarch64 with the Azahar core installed.
2. A decrypted 3DS ROM.

1. Select **RetroArch64 Azahar** for Nintendo 3DS in NeoStation.
2. Launch a 3DS game.
3. Confirm RetroArch starts the game instead of opening to a black screen.

## Tested on

- [x] Android — AYN Thor, Android 13; Pokémon X booted through NeoStation.
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS

## Checklist

- [ ] `dart format .` — no Dart files changed
- [x] `flutter analyze` — clean (no errors or warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated — device-level RetroArch private-storage behavior; verified on hardware
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**Android**
- [x] Verified on a device, not only on desktop

**`assets/systems/` or emulator launching**
- [x] JSON is used for the core definition; `EmulatorLauncher.kt` changes only preserve the explicit legacy filename required by Azahar
- [x] `assets/manifest.json` version bumped for OTA delivery
</details>