### PR TITLE
ci(pages): build the wiki from a workflow with a docs path filter

### DIFF
--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -1,0 +1,88 @@
+name: Deploy Wiki
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # The whole point of building from a workflow. The legacy branch-based
+      # Pages build watched the *branch*, not `source.path`, so every push to
+      # main republished the wiki: on 2026-08-27 four Dart-only commits each
+      # triggered a full rebuild, and the fourth (run 33100404469) hung in
+      # `updating_pages` for ten minutes before GitHub aborted it. A legacy
+      # build cannot be path-filtered, because the workflow is synthesized by
+      # GitHub rather than checked in.
+      - 'docs/**'
+      - '.github/workflows/deploy-wiki.yml'
+  # Build (never deploy) the same commit a PR would merge, so a broken
+  # _config.yml or an unresolvable remote_theme fails review instead of main.
+  # There is no local escape hatch for this: building the wiki needs Ruby and
+  # the `github-pages` gem, which nothing in this repo otherwise requires.
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-wiki.yml'
+  # Republish without a docs change: needed for the first run after Pages is
+  # switched to `build_type: workflow`, and to retry a GitHub-side timeout.
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+# Only the deploy job gets `pages: write` / `id-token: write`; the build job
+# reads Pages settings and nothing more. Fork PRs get a read-only token
+# whatever this says, but the split keeps the publishing credential out of the
+# job that executes the site's own content.
+permissions:
+  contents: read
+
+# Real deploys share one queue and are never cancelled: killing a publish
+# mid-flight leaves the live site on the previous build with nothing queued to
+# correct it. PR validation builds get a throwaway per-ref queue instead, so
+# they neither block nor cancel a deploy, and a new push supersedes the old.
+concurrency:
+  group: pages-${{ github.event_name == 'pull_request' && github.ref || 'production' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Build Jekyll site
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      # GitHub's own image for the legacy build environment: it bundles the
+      # `github-pages` gem, so `remote_theme: just-the-docs/just-the-docs` in
+      # docs/_config.yml keeps resolving exactly as it did before, without this
+      # repo having to carry a Gemfile and lockfile just to pin the theme.
+      # It is a Docker action, so the Node 20 runner deprecation does not apply.
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,6 +10,11 @@ permalink: pretty
 heading_anchors: true
 search_enabled: true
 
-just_the_docs:
-  aux_links:
-    "NeoStation on GitHub": https://github.com/misobadev/neostation-frontend
+# Matches the app itself, which is dark-only.
+color_scheme: dark
+
+# Top level, not under a `just_the_docs:` key. That namespace is only read for
+# per-collection settings, so the nested version silently rendered no aux nav
+# at all rather than erroring.
+aux_links:
+  "NeoStation on GitHub": https://github.com/misobadev/neostation-frontend


### PR DESCRIPTION
# Description

Pages uses the legacy branch build (`main:/docs`), which watches the branch, not `source.path` — so every push to main republishes the wiki. On 2026-08-27 four Dart-only commits each triggered a rebuild, and [run 33100404469](https://github.com/misobadev/neostation-frontend/actions/runs/33100404469) hung in `updating_pages` for ten minutes before GitHub aborted it. None of the four touched `docs/`.

Legacy builds can't be path-filtered, so build from Actions instead:

- Deploys only on `docs/**` or this workflow, plus `workflow_dispatch`.
- PRs to those paths build but don't deploy — the only way to validate the wiki, which needs Ruby and the `github-pages` gem.
- `actions/jekyll-build-pages` is GitHub's image for the legacy build env, so `remote_theme` keeps resolving with no Gemfile.
- `pages: write` / `id-token: write` scoped to the deploy job only.

`docs/_config.yml`: `color_scheme: dark`, and `aux_links` moved to the top level — nested under `just_the_docs:` it was silently ignored, so the header renders no aux nav today.

**Needs a maintainer (admin-only, I have push):** switch Settings → Pages → Source to **GitHub Actions**, then enable **Enforce HTTPS** (`https_enforced` is currently false). Until the source is switched the `deploy` job here will fail; the live site keeps serving the previous build either way.

## Steps to Verify

**Preconditions:** merged, Pages source switched to GitHub Actions.

1. Push a Dart-only commit — no Deploy Wiki run appears.
2. Push a `docs/**` commit — one run, and it deploys.
3. https://wiki.neostation.dev/ renders dark, with a "NeoStation on GitHub" link in the header.
4. `curl -sI http://wiki.neostation.dev/` returns 301 to https.

## Tested on

- [x] Not runtime-tested — why: no app code. The green `Build Jekyll site` check is the verification; artifact inspection is in the comment below.

## Checklist

- [x] `dart format .` / `flutter analyze` / `flutter test` — no Dart touched
- [x] No secrets, credentials, or personal data in the diff
