### PR TITLE
fix(android): stop the fast SAF walk reporting unreadable folders as empty

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
@@ -1327,7 +1327,9 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
      *
      * Returns null — meaning "caller should use the SAF walk" — whenever the fast
      * path is not provably equivalent: non-primary volume (SD, USB OTG), permission
-     * not held, or the path not resolving to a readable directory.
+     * not held, the path not resolving to a readable directory, or any directory
+     * failing to list mid-walk. It never reports a directory it could not read as
+     * an empty one.
      */
     private fun fastWalkSafTree(
         uriString: String,
@@ -1395,7 +1397,23 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
                 while (stack.isNotEmpty()) {
                     val (dir, dirDocId) = stack.removeLast()
                     if (!visited.add(dir.canonicalPath)) continue
-                    val children = dir.listFiles() ?: continue
+                    // listFiles() returns null on an I/O or permission failure,
+                    // which at this level is indistinguishable from an empty
+                    // directory. Skipping it would report every file it holds as
+                    // deleted, so decline the whole walk instead and let the SAF
+                    // walk -- which reaches the tree through the
+                    // DocumentsProvider rather than direct I/O -- answer. This is
+                    // the contract the Dart side documents: null means "cannot
+                    // serve this", never "no files".
+                    val children = dir.listFiles()
+                    if (children == null) {
+                        android.util.Log.w(
+                            "MainActivity",
+                            "fastWalkSafTree: listFiles() failed for ${dir.path}, falling back"
+                        )
+                        runOnUiThread { result.success(null) }
+                        return@Thread
+                    }
                     // Sorted so the result order does not depend on filesystem order.
                     children.sortBy { it.name }
 

--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -11,6 +11,7 @@ import 'package:neostation/services/logger_service.dart';
 import 'dart:io';
 import 'dart:convert';
 import 'package:path/path.dart' as path;
+import 'package:flutter/foundation.dart';
 
 /// Summary report of a ROM scanning operation for a specific system.
 class ScanSummary {
@@ -1156,14 +1157,15 @@ class SqliteDatabaseService {
     // Fast path: walk the tree with direct filesystem I/O in one native call
     // instead of a DocumentsProvider query per directory. Returns null when it
     // cannot prove equivalence (non-primary volume, permission not held), in
-    // which case the SAF walk below runs unchanged.
+    // which case the SAF walk below runs unchanged — as it also does when the
+    // fast walk claims a directory is empty and the DocumentsProvider disagrees.
     final fastEntries = await SafDirectoryService.fastWalkTree(
       uri,
       recursive: recursive,
       extensions: validExtensions,
       ignoreHiddenFiles: ignoreHiddenFiles,
     );
-    if (fastEntries != null) {
+    if (fastEntries != null && fastEntries.isNotEmpty) {
       for (final item in fastEntries) {
         entries.add(
           RomEntry(
@@ -1173,12 +1175,48 @@ class SqliteDatabaseService {
           ),
         );
       }
-      final fastWalkNote = fastEntries.isEmpty ? ' (empty, non-null)' : '';
       _log.i(
         'SafScan[${path.basename(uri)}]: fast walk found ${entries.length} '
-        'entries$fastWalkNote',
+        'entries',
       );
       return entries;
+    }
+
+    // An empty result is the one answer the fast walk must not be taken at its
+    // word on. `File.listFiles()` returns null on an I/O or permission failure,
+    // and a storage mount that has not caught up with MANAGE_EXTERNAL_STORAGE
+    // makes that failure indistinguishable from an empty directory: the path
+    // still reports as a readable directory, it just lists nothing. The scan
+    // then reads "no files" as "every ROM for this system was deleted" and
+    // prunes the rows, taking favourites, play time and per-game settings with
+    // them. Ask the DocumentsProvider, which reads the tree by a wholly
+    // different route, before believing it.
+    //
+    // The extra query lands only where the fast path saved nothing: a directory
+    // that really is empty answers immediately, and one that turns out to hold
+    // files needed the query anyway.
+    if (fastEntries != null) {
+      final visibleChildren = visibleSafChildren(
+        await SafDirectoryService.listFiles(uri),
+        ignoreHiddenFiles: ignoreHiddenFiles,
+      );
+      if (visibleChildren.isEmpty) {
+        _log.i(
+          'SafScan[${path.basename(uri)}]: fast walk found 0 entries '
+          '(confirmed empty by the DocumentsProvider)',
+        );
+        return entries;
+      }
+      final directoryCount = visibleChildren
+          .where((child) => child['isDirectory'] == true)
+          .length;
+      _log.w(
+        'SafScan[${path.basename(uri)}]: fast walk found 0 entries but the '
+        'DocumentsProvider lists ${visibleChildren.length} child(ren) '
+        '($directoryCount directories) - distrusting the fast walk and '
+        're-walking with SAF',
+      );
+      // Falls through to the SAF walk below.
     }
 
     try {
@@ -1308,6 +1346,27 @@ class SqliteDatabaseService {
   static bool _isDotEntryName(String name) {
     final trimmed = name.trim();
     return trimmed.isNotEmpty && trimmed.startsWith('.');
+  }
+
+  /// The DocumentsProvider's view of a directory the fast walk called empty,
+  /// with the entries the scan ignores removed.
+  ///
+  /// Hidden entries are dropped so a folder holding nothing but a `.nomedia`
+  /// still reads as empty: it holds no ROMs either way, and treating it as a
+  /// contradiction would send every such folder down the slow walk for nothing.
+  /// Anything left is a file or directory the fast walk should have seen and
+  /// did not, which makes its answer unusable.
+  @visibleForTesting
+  static List<Map<String, dynamic>> visibleSafChildren(
+    List<Map<String, dynamic>> children, {
+    bool ignoreHiddenFiles = true,
+  }) {
+    return children
+        .where(
+          (child) =>
+              !_shouldSkipSafEntry(child, ignoreHiddenFiles: ignoreHiddenFiles),
+        )
+        .toList();
   }
 
   static bool _shouldSkipSafEntry(

--- a/lib/services/saf_directory_service.dart
+++ b/lib/services/saf_directory_service.dart
@@ -168,8 +168,13 @@ class SafDirectoryService {
   /// happens natively so only matching files cross the channel.
   ///
   /// Returns null when the fast path does not apply — a non-primary volume (SD
-  /// card, USB OTG), MANAGE_EXTERNAL_STORAGE not held, or an unreadable path.
+  /// card, USB OTG), MANAGE_EXTERNAL_STORAGE not held, an unreadable path, or a
+  /// directory that fails to list part-way through the walk.
   /// Callers must fall back to [listFiles]; null never means "no files".
+  ///
+  /// An empty (non-null) result is not proof of an empty directory either: it is
+  /// only as trustworthy as the storage mount the walk read through. Callers that
+  /// treat absence as deletion must confirm it against [listFiles].
   static Future<List<Map<String, dynamic>>?> fastWalkTree(
     String uri, {
     required bool recursive,

--- a/test/rom_scan_fast_walk_empty_test.dart
+++ b/test/rom_scan_fast_walk_empty_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_database_service.dart';
+
+/// The native fast SAF walk answers a directory it could not read the same way
+/// it answers one that is genuinely empty, and the scan reads "no files" as
+/// "every ROM for this system was deleted". Before an empty fast walk is
+/// believed, the DocumentsProvider is asked for a second opinion; these cover
+/// what counts as a contradiction.
+///
+/// Reported by a user whose whole library vanished behind this: 120 populated
+/// ROM directories all reported `fast walk found 0 entries (empty, non-null)`
+/// while the same tree listed 178 subfolders through the DocumentsProvider.
+void main() {
+  Map<String, dynamic> file(String name, {bool hidden = false}) => {
+    'name': name,
+    'uri': 'content://tree/primary%3AROMs/document/primary%3AROMs%2F$name',
+    'isDirectory': false,
+    'isHidden': hidden,
+  };
+
+  Map<String, dynamic> dir(String name) => {
+    'name': name,
+    'uri': 'content://tree/primary%3AROMs/document/primary%3AROMs%2F$name',
+    'isDirectory': true,
+    'isHidden': false,
+  };
+
+  group('visibleSafChildren', () {
+    test('a directory the provider also sees as empty stays empty', () {
+      expect(SqliteDatabaseService.visibleSafChildren(const []), isEmpty);
+    });
+
+    test('a file the fast walk missed contradicts it', () {
+      expect(
+        SqliteDatabaseService.visibleSafChildren([file('Sonic.md')]),
+        hasLength(1),
+      );
+    });
+
+    test('a subdirectory contradicts it too', () {
+      // A non-recursive scan finds no files in a directory of directories, but
+      // the fast walk claiming *nothing* is there is still unusable: recursion
+      // is exactly where a failed listing hides the most.
+      expect(
+        SqliteDatabaseService.visibleSafChildren([dir('Disc 1')]),
+        hasLength(1),
+      );
+    });
+
+    test('a folder holding only hidden entries reads as empty', () {
+      // Otherwise every .nomedia-only folder pays for the slow walk on every
+      // scan and gains nothing: it holds no ROMs either way.
+      expect(
+        SqliteDatabaseService.visibleSafChildren([
+          file('.nomedia'),
+          file('cover.png', hidden: true),
+        ]),
+        isEmpty,
+      );
+    });
+
+    test('hidden entries count once the user asks to see them', () {
+      expect(
+        SqliteDatabaseService.visibleSafChildren([
+          file('.hidden.nes'),
+        ], ignoreHiddenFiles: false),
+        hasLength(1),
+      );
+    });
+
+    test('a hidden entry does not mask a real one beside it', () {
+      expect(
+        SqliteDatabaseService.visibleSafChildren([
+          file('.nomedia'),
+          file('Sonic.md'),
+        ]),
+        hasLength(1),
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

The native fast SAF walk answers a directory it could not read exactly as it answers one that is genuinely empty. The scan then reads "no files" as "every ROM for this system was deleted", so the user's library silently disappears and the rows are pruned along with their favourites, play time and per-game settings.

A user's `app.log` shows the whole failure in one shot:

- One ROM root, `content://com.android.externalstorage.documents/tree/primary%3AROMs`, with a valid grant (zero `SAF permission missing` warnings).
- `AndroidPreFilter: 178 existing subfolder(s); 99 system(s) matched` — the DocumentsProvider sees the tree fine, and every matched system resolves to a scan target.
- **1817 of 1817** directory walks served by the fast path. The SAF walk, which reads the same tree through a different mechanism and would have found the files, never ran once:

  ```
  grep -oE "SafScan\[[^]]*\]: [a-z ]*" app.log | sed -E 's/SafScan\[[^]]*\]//' | sort | uniq -c
     1817 : fast walk found
  ```

- Every folder but `n3ds` (6) and `steam` (15) came back `fast walk found 0 entries (empty, non-null)`, across 7 app restarts and 14 scans. All of them had passed the native `!root.isDirectory || !root.canRead()` gate, so `java.io.File` agreed each was a readable directory and then listed nothing in it.

That combination — readable directory, zero children, while the DocumentsProvider lists the tree — is what `dir.listFiles() ?: continue` turns into `result.success(emptyList())`. Most likely underneath is a storage mount that had not caught up with `MANAGE_EXTERNAL_STORAGE` (`isExternalStorageManager()` returns true, `opendir` still fails), which also explains why `steam` survived: those are `.steam` metadata files NeoStation itself wrote under a previous install. The exact kernel-level cause is not provable from a log and does not change the fix.

The user cleared it by removing the ROM folder and picking the same one again. That touches neither the filesystem nor the permission, so it is a coin flip, not a repair.

Three changes, all of them about not trusting an absence:

- **`_scanSafUri` asks the DocumentsProvider before accepting an empty fast walk.** The extra query lands only where the fast path saved nothing: a directory that really is empty answers immediately, and one that turns out to hold files needed the query anyway. Folders holding only hidden entries still count as empty, so a `.nomedia`-only folder does not send every scan down the slow path for nothing.
- **`fastWalkSafTree` declines the whole walk when `listFiles()` returns null**, rather than skipping the directory and returning a partial list. This is the contract the Dart side already documents: null means "cannot serve this", never "no files".
- **The log line separates the three cases it used to collapse into one** — confirmed empty, contradicted by the provider (with the child and directory counts), or present but filtered out by extension. Diagnosing this took two passes over an 8.7k-line log precisely because `(empty, non-null)` meant all three.

Left alone deliberately: the fast path is *not* demoted for the rest of a scan when one directory contradicts it. A folder of non-matching files is a legitimate contradiction, and a heuristic there would trade a rare correctness win for a broad performance cliff. The per-directory fallback is already correct.

The scan machinery itself is exonerated by the same log — alias resolution, extension seeding, `recursive_scan` and the SAF grant all check out, so none of them are touched here.

## Steps to Verify

**Preconditions:** an Android device with All-Files-Access granted, a ROM root on internal storage holding several populated system folders, and at least one folder that is genuinely empty (say `roms/gx4000`).

1. Scan normally and confirm the library is complete — the fast path still serves every populated folder in one native call, and `app.log` shows `fast walk found N entries` with no fallback.
2. Confirm the empty folder logs `fast walk found 0 entries (confirmed empty by the DocumentsProvider)` and adds nothing. No extra SAF walk runs for it.
3. Simulate the fault: make a populated system folder unreadable to the fast path (`chmod 000` on the directory via root, or revoke All-Files-Access and re-grant it without restarting so the mount goes stale).
4. Rescan. Before this change the system reports 0 games and its existing rows are pruned. After it, `app.log` warns `fast walk found 0 entries but the DocumentsProvider lists N child(ren) ... re-walking with SAF` and the games are still there.
5. Confirm a `.nomedia`-only folder is still treated as empty and does not trigger the fallback on every scan.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: unit tests, `flutter analyze` and a `flutter build apk --flavor dev` compile pass all run clean, but the fallback itself is Android-only and needs a device to exercise. Steps 3–4 above are the ones that matter and are not yet run on hardware.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1530)
- [x] Tests added or updated — `test/rom_scan_fast_walk_empty_test.dart` covers what counts as a contradiction
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses — no new assets

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths — the URIs are still built by `DocumentsContract.buildDocumentUriUsingTree` on both walks, so `rom_path` spellings are unchanged and no rows are orphaned by falling back
- [ ] Verified on a device, not only on desktop — see above

</details>
