### PR TITLE
fix(audio): stop SFX reopening the audio engine while the screen is off

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:neostation/sync/providers/neo_sync_adapter.dart';
 import 'package:neostation/sync/providers/romm_provider.dart';
 import 'package:neostation/services/notification_service.dart';
 import 'package:neostation/services/game_service.dart';
+import 'package:neostation/services/secondary_apps_service.dart';
 import 'package:neostation/services/game_legend_visibility.dart';
 import 'package:neostation/repositories/config_repository.dart';
 import 'package:neostation/repositories/scraper_repository.dart';
@@ -459,6 +460,11 @@ void main() async {
 
   // Background music initialization removed
 
+  // SFX must never reopen the SoLoud engine while the screen is off: an open
+  // AAudio stream holds AudioFlinger's 'AudioMix' wakelock and blocks SoC
+  // suspend. This engine's screen-power truth is GameService.deviceScreenOn.
+  SfxService.isScreenOn = () => GameService.deviceScreenOn.value;
+
   // Initialize SFX service for navigation sounds (fire-and-forget).
   SfxService().init().then((_) {
     // Apply persisted SFX preferences immediately.
@@ -806,6 +812,14 @@ Future<void> subDisplay() async {
   // without this the display would open on the brightness fallback (black)
   // even for a user on a light theme. Read it from the same config row.
   String? initThemeName;
+
+  // Same screen-power guard as the main engine, keyed off this engine's own
+  // notifier: the two engines share no memory, so GameService's is not live
+  // here. Set before the config read below, which can throw — falling back to
+  // the always-on default would leave this engine free to reopen the audio
+  // device behind a dark screen, which is the whole bug being fixed.
+  SfxService.isScreenOn = () => SecondaryAppsService.deviceScreenOn.value;
+
   try {
     final rawConfig = await ConfigRepository.getUserConfig();
     if (rawConfig != null && rawConfig['app_language'] != null) {

--- a/lib/services/sfx_service.dart
+++ b/lib/services/sfx_service.dart
@@ -66,12 +66,32 @@ class SfxService {
 
   Completer<void>? _initCompleter;
 
+  /// Whether the display this engine drives is currently powered on.
+  ///
+  /// NeoStation runs as a HOME launcher, so the activity is never paused when
+  /// the device locks; the native screen receiver is the only reliable "device
+  /// is asleep" signal. Each engine wires its own notifier here — the main
+  /// engine [GameService.deviceScreenOn], the sub-display engine
+  /// [SecondaryAppsService.deviceScreenOn] — because the two engines share no
+  /// memory. Defaults to always-on, so this is a no-op on desktop.
+  static bool Function() isScreenOn = () => true;
+
   /// Initializes the SoLoud engine and pre-loads all UI sound assets into memory.
   ///
   /// Subsequent calls will wait for the ongoing initialization or return
   /// immediately if already initialized.
   Future<void> init() async {
     if (_isInitialized) return;
+
+    // Never reopen the audio device behind a dark screen. An initialized SoLoud
+    // engine holds an AAudio output stream, and AudioFlinger keeps an
+    // 'AudioMix' partial wakelock for as long as one is open, which stops the
+    // SoC suspending at all. [MusicPlayerService.appPaused] tears the engine
+    // down on screen-off for exactly that reason; without this guard the next
+    // nav/enter/back sound reopened it milliseconds later through
+    // [_ensureInitialized] and silently undid the teardown, leaving the device
+    // awake for the whole locked session. The sound would be inaudible anyway.
+    if (!isScreenOn()) return;
 
     if (_isInitializing) {
       return _initCompleter?.future;


### PR DESCRIPTION
# Description

`MusicPlayerService.appPaused()` releases the shared SoLoud engine on screen-off so the SoC can deep-sleep. That fix works, and then gets silently undone: `SfxService.handleEngineTornDown()` only marks the service uninitialised, so the next nav/enter/back sound runs `_ensureInitialized()` -> `init()` -> `SoLoud.instance.init()` and reopens the audio device milliseconds later.

An open AAudio output makes AudioFlinger hold a `PARTIAL_WAKE_LOCK` (`'AudioMix'`), and that stops the SoC suspending at all for as long as it is held. A game session is the worst case: the panel keeps updating, a controller nudged in a bag is enough to fire a nav sound, and nothing ever closes the stream again.

In `app.log` the two lines land on consecutive line numbers, repeatedly:

```
[SfxService] Engine released; SFX will reload on resume.
[SfxService] Initializing...
[SfxService] Ready. 5/5 sounds loaded.
```

The fix gates `init()` on a per-engine screen-power predicate. The two Flutter engines share no memory, so each wires its own notifier: `GameService.deviceScreenOn` for the main engine, `SecondaryAppsService.deviceScreenOn` inside `subDisplay()`. It is set before the config read that can throw, so a failed read cannot leave the sub-display engine unguarded. The predicate defaults to always-on, making this a no-op on desktop.

## Steps to Reproduce

**Preconditions:** Android handheld, unplugged (a USB connection holds the SoC awake and hides this entirely), any game that launches an external emulator.

1. Note the suspend counter: `adb shell cat /sys/power/suspend_stats/success`
2. Launch a game from NeoStation so an emulator takes the foreground.
3. Lock the device and leave it for 15 minutes, on battery.
4. Read the suspend counter again. It has not moved.
5. `adb shell dumpsys power` shows `PARTIAL_WAKE_LOCK 'AudioMix' ... ws=WorkSource{<neostation uid>}`.
6. `adb shell dumpsys audio` shows an `AAudio` player for the NeoStation uid in `state:started`, while the emulator's own player is correctly `state:stopped`.

## Steps to Verify

**Preconditions:** as above.

1. Repeat steps 1 to 4 with this build.
2. The suspend counter now increments normally (roughly 50 per minute on an AYN Thor).
3. `dumpsys power` reports `Wake Locks: size=0`.
4. `dumpsys audio` lists no NeoStation player at all.
5. Unlock and confirm UI sounds still play: navigate the carousel, enter a system, press B to go back.

### Measured on an AYN Thor

Unplugged over wireless adb, two identical 15 minute locked windows with a game session live, same PID throughout:

| Metric | Before | After |
| --- | --- | --- |
| SoC suspends | **0** | **808** |
| Screen-off uptime on battery | **99.9%** | 41.5% |
| NeoStation CPU | 12.8 s | 1.1 s |
| Open audio players | 1 (`state:started`) | none |

41.5% matches the idle control measured on the same rig in the same session, so the residual is the measurement setup (wireless adb keeps the device partly awake), not NeoStation.

Battery mAh figures are deliberately not quoted: on this rig the charge counter could not resolve them (an idle control leg drew *more* than the loaded one), so the suspend count and CPU are the trustworthy signals.

## Tested on

- [x] Android — device: AYN Thor (dual-screen, unplugged, dev channel)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Desktop is unaffected by construction: the predicate defaults to always-on and only the Android screen receiver ever writes the notifiers.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1530)
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

No unit test added: the behaviour is a native audio/wakelock interaction across two Flutter engines, which the widget-test harness cannot observe. It was verified on-device instead, with the before and after numbers above.
