### PR TITLE
feat(systems): add xemu and Ryubing, fix the RPCS3 Windows arguments

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.18"
+  "latest_version": "0.3.19"
 }

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -70,7 +70,7 @@
       "platforms": {
         "windows": {
           "executable": "rpcs3.exe",
-          "args": "--no-gui bootPath{file.path}\""
+          "args": "--no-gui \"{file.path}\""
         },
         "linux": {
           "executable": "rpcs3",

--- a/assets/systems/switch.json
+++ b/assets/systems/switch.json
@@ -209,6 +209,18 @@
           "launch_arguments": "-n org.benjisc.android/org.kenjinx.android.MainActivity -a org.kenjinx.android.LAUNCH_GAME -e bootPath \"{file.path}\"\n"
         }
       }
+    },
+    {
+      "name": "Standalone Ryubing",
+      "unique_id": "switch.io.ryubing.ryujinx",
+      "description": "Supported extensions: nro, nso, nca, xci, nsp.",
+      "is_retroachievements_compatible": false,
+      "platforms": {
+        "windows": {
+          "executable": "Ryujinx.exe",
+          "args": "\"{file.path}\""
+        }
+      }
     }
   ],
   "neosync": {

--- a/assets/systems/xbox.json
+++ b/assets/systems/xbox.json
@@ -3,10 +3,6 @@
     "id": "xbox",
     "multidisc": true,
     "name": "Xbox",
-    "neosync": {
-      "sync": false,
-      "sync_folder": null
-    },
     "short_name": "Xbox",
     "details": {
       "manufacturer": "Microsoft",
@@ -53,6 +49,23 @@
       "platforms": {
         "android": {
           "launch_arguments": "-n com.rfandango.haku_x/.LauncherActivity -d \"{file.uri}\""
+        }
+      }
+    },
+    {
+      "name": "Standalone xemu",
+      "unique_id": "xbox.app.xemu-project.xemu",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: xiso, iso.",
+      "platforms": {
+        "windows": {
+          "executable": "xemu.exe",
+          "args": "-full-screen -dvd_path \"{file.path}\""
+        },
+        "linux": {
+          "executable": "xemu",
+          "emudeck_launcher": "xemu-emu.sh",
+          "args": "-full-screen -dvd_path \"{file.path}\""
         }
       }
     }


### PR DESCRIPTION
# Description

Three `assets/systems/` changes reported on Discord, plus the manifest bump so they reach existing installs over the air.

- **PS3 / RPCS3 (Windows)**: the `args` string was mangled (`--no-gui bootPath{file.path}"`), so RPCS3 was handed a junk argument instead of the ROM path. Now `--no-gui "{file.path}"`.
- **Xbox**: adds `Standalone xemu` for Windows and Linux (`-full-screen -dvd_path "{file.path}"`, with the `xemu-emu.sh` EmuDeck launcher on Linux). Also drops a stray duplicate `neosync` block nested under `system` — the real one at the file root is unchanged.
- **Switch**: adds `Standalone Ryubing` for Windows (`Ryujinx.exe "{file.path}"`).
- **Manifest**: `latest_version` 0.3.18 to 0.3.19 so the three definitions ship OTA.

JSON only, no Dart or Kotlin changes, in line with the "fix launch behaviour in JSON, keep `EmulatorLauncher.kt` emulator-agnostic" rule.

## Steps to Verify

**Preconditions:** a Windows install with RPCS3, xemu, and Ryubing set up, and at least one PS3, Xbox, and Switch ROM scanned.

1. Launch the app and accept the systems update prompt (0.3.19).
2. Open a PS3 game, pick RPCS3, launch. It boots the selected game instead of erroring on an unknown argument.
3. Open an Xbox game, pick **Standalone xemu**, launch. xemu opens the disc image full screen.
4. Open a Switch game, pick **Standalone Ryubing**, launch. Ryujinx boots the selected title.
5. On the Steam Deck, repeat step 3 with the EmuDeck xemu install.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — the definitions come from Discord reports by users running these emulators; the three JSON files parse and the systems test suite passes, but I do not have RPCS3, xemu, or Ryubing installed here.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated — no code paths changed, existing systems tests cover the JSON
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**`assets/systems/` or emulator launching**
- [x] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible
- [x] `assets/manifest.json` version bumped if this should reach existing installs OTA

</details>
