### PR TITLE
fix(retroachievements): stop the in-game poll running while the screen is off

### DIFF
--- a/lib/services/secondary_achievements_controller.dart
+++ b/lib/services/secondary_achievements_controller.dart
@@ -5,6 +5,7 @@ import '../models/game_model.dart';
 import '../models/secondary_display_state.dart';
 import '../providers/file_provider.dart';
 import '../providers/retro_achievements_provider.dart';
+import 'game_service.dart';
 import 'retro_achievements_resolver.dart';
 import 'screenshot_service.dart';
 
@@ -166,13 +167,41 @@ class SecondaryAchievementsController {
       clearNewlyEarnedIds: true,
     );
 
+    GameService.deviceScreenOn.removeListener(_onScreenPowerChanged);
+    GameService.deviceScreenOn.addListener(_onScreenPowerChanged);
     _startPoll();
   }
 
   void _startPoll() {
     if (!Platform.isAndroid) return;
+    // Never poll behind a dark screen; see [_onScreenPowerChanged].
+    if (!GameService.deviceScreenOn.value) return;
     _pollTimer?.cancel();
     _pollTimer = Timer.periodic(pollInterval, (_) => _onTick());
+  }
+
+  /// Suspends the live poll while the device screen is off, and rearms it on
+  /// wake if the session is still open.
+  ///
+  /// NeoStation runs as a HOME launcher, so the activity is never paused when
+  /// the device locks and nothing else stands this timer down: the poll would
+  /// otherwise keep waking the radio for a RetroAchievements fetch every 30s
+  /// for as long as a game session stays open. Measured on an AYN Thor over a
+  /// 15-minute locked session: 30 fetches, ~222 KB of traffic, and ~90% of all
+  /// the CPU the app burned in that state, for data no one can see. The
+  /// emulator is suspended behind the lock, so no unlocks can arrive meanwhile
+  /// and nothing is missed by pausing.
+  ///
+  /// This controller is created from the main-engine screens, so the main
+  /// engine's notifier is the live one here. It defaults to true and is only
+  /// ever written by the Android channel handler, making this a desktop no-op.
+  void _onScreenPowerChanged() {
+    if (!GameService.deviceScreenOn.value) {
+      _stopPoll();
+      return;
+    }
+    // stop() clears _gameId when the game exits; only rearm a live session.
+    if (_gameId != null) _startPoll();
   }
 
   Future<void> _onTick() async {
@@ -228,6 +257,7 @@ class SecondaryAchievementsController {
   /// (it fades back to whatever art is underneath); leave it false when the host
   /// re-pushes full display state itself.
   void stop({bool hidePanel = false}) {
+    GameService.deviceScreenOn.removeListener(_onScreenPowerChanged);
     _stopPoll();
     _gameId = null;
     // ignore: unawaited_futures


### PR DESCRIPTION
# Description

`SecondaryAchievementsController` polls RetroAchievements every 30s to keep the secondary display's achievement panel current while a game is running. The poll starts in `pushForLaunch` and is only stopped by `stop()` when the game exits, so it kept running with the device locked. NeoStation runs as a HOME launcher, so the activity is never paused on lock and nothing else stood the timer down.

The result: for as long as a game session stays open, the app wakes the radio twice a minute to refresh a panel nobody can see. Roughly 120 API calls and 888 KB per hour, indefinitely.

This gates the poll on `GameService.deviceScreenOn`: cancel on screen-off, rearm on wake when the session is still live. Despite the class name and its job of driving the bottom screen, the controller is created from the main-engine screens (`my_games_list`, `my_systems_carousel`, `my_systems_grid`, `search_screen`), so the main engine's notifier is the live one here. It defaults to true and is only ever written by the Android screen receiver, so this is a no-op on desktop.

Nothing is missed while paused: the emulator is suspended behind the lock, so no unlocks can arrive.

## Steps to Reproduce

**Preconditions:** Android, RetroAchievements connected, secondary display active, and a game whose ROM hash actually resolves to an RA achievement set (roughly half a library does, so verify the achievements panel appears on the bottom screen rather than assuming).

1. Launch that game from the game list so the emulator takes the foreground.
2. Confirm the bottom screen shows the achievements panel, not just Now Playing. Now Playing is pushed unconditionally and is not evidence the poll started.
3. Lock the device and leave it.
4. The poll keeps firing every 30s. On an AYN Thor, unplugged, over a 15 minute locked window: 30 fetches, +184 KB rx / +38 KB tx on the app's uid, and 1.0s of app CPU.

## Steps to Verify

1. Repeat the above with this build.
2. The poll stops at lock and resumes on wake.
3. Unlock and confirm the achievements panel still updates during play.

### Measured on an AYN Thor

Verified with temporary instrumentation rather than by inference, after network byte counting turned out to be an unreliable proxy (see below):

```
screen power -> false gameId=1469      <- lock: poll cancelled
     ... 150s (5 tick intervals) of silence, zero ticks ...
screen power -> true  gameId=1469      <- wake
_startPoll: android=true screenOn=true gameId=1469
_onTick: active=true screenOn=true gameId=1469
_onTick: active=true screenOn=true gameId=1469
```

Cost of the bug, from an earlier controlled A/B on the same device, same build and same PID, with RetroAchievements signed out as the control:

| | RA connected | RA signed out |
| --- | --- | --- |
| rx | +184,205 B / +380 pkt | +0 B / +0 pkt |
| tx | +37,641 B / +391 pkt | +0 B / +0 pkt |
| app CPU | 1.0 s | 0.1 s |
| SoC suspends | +807 | +806 |

Every byte transferred in a locked game session was this poll, and it was about 90% of all CPU the app used in that state. 0.1s matches an idle home screen.

**This is not a suspend blocker.** Suspend counts were unchanged either way, so this is a data and API-load fix, not a deep-sleep fix. Battery mAh is deliberately not claimed: the measurement rig could not resolve it.

**Caveat on measuring this area:** `_onTick` can complete without touching the network even with `forceRefresh: true`, so a zero-traffic reading does not mean the poll is stopped. `fetchSnapshot` also logs only on error, so a running poll is invisible in the log. Anyone re-testing this should instrument the tick rather than count packets.

## Tested on

- [x] Android — device: AYN Thor (unplugged, dev channel, Dr. Mario / NES, gameId 1469)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Desktop is unaffected by construction: the notifier defaults to true and is only written by the Android channel handler.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1530)
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

No unit test added: the behaviour depends on the native screen receiver driving a static notifier while an external emulator holds the foreground, which the widget-test harness cannot reproduce. Verified on-device instead, with the trace above.
