### PR TITLE
fix(system-art): recover backgrounds that fail to download

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -72,6 +72,8 @@ mixin AppLocale {
   static const String systemArtError = 'system_art_error';
   static const String systemArtApplyTitle = 'system_art_apply_title';
   static const String systemArtApplyBody = 'system_art_apply_body';
+  static const String systemArtRedownloadTitle = 'system_art_redownload_title';
+  static const String systemArtRedownloadBody = 'system_art_redownload_body';
   static const String systemArtDownloading = 'system_art_downloading';
   static const String about = 'about';
   static const String exit = 'exit';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -52,6 +52,9 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.systemArtApplyTitle: 'System Art anwenden?',
   AppLocale.systemArtApplyBody:
       'Das System-Art-Paket wird für alle Systeme heruntergeladen. Dies kann einen Moment dauern.',
+  AppLocale.systemArtRedownloadTitle: 'System Art erneut herunterladen?',
+  AppLocale.systemArtRedownloadBody:
+      'Das zwischengespeicherte Paket wird gelöscht und erneut heruntergeladen. Verwende dies, wenn einige System-Hintergründe fehlen.',
   AppLocale.systemArtDownloading: 'System-Art-Paket wird heruntergeladen...',
   AppLocale.about: 'Über',
   AppLocale.exit: 'Beenden',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -52,6 +52,9 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.systemArtApplyTitle: 'Apply System Art?',
   AppLocale.systemArtApplyBody:
       'The System Art pack will be downloaded for all systems. This may take a moment.',
+  AppLocale.systemArtRedownloadTitle: 'Re-download System Art?',
+  AppLocale.systemArtRedownloadBody:
+      'The cached pack will be deleted and downloaded again. Use this if some system backgrounds are missing.',
   AppLocale.systemArtDownloading: 'Downloading System Art pack...',
   AppLocale.about: 'About',
   AppLocale.exit: 'Exit',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -52,6 +52,9 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.systemArtApplyTitle: '¿Aplicar System Art?',
   AppLocale.systemArtApplyBody:
       'Se descargará el paquete de System Art para todos los sistemas. Esto puede tardar algunos momentos.',
+  AppLocale.systemArtRedownloadTitle: '¿Volver a descargar System Art?',
+  AppLocale.systemArtRedownloadBody:
+      'El paquete en caché se eliminará y se descargará de nuevo. Usa esta opción si faltan algunos fondos de sistemas.',
   AppLocale.systemArtDownloading: 'Descargando el paquete de System Art...',
   AppLocale.about: 'Acerca de',
   AppLocale.exit: 'Salir',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -52,6 +52,9 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.systemArtApplyTitle: 'Appliquer System Art ?',
   AppLocale.systemArtApplyBody:
       'Le pack System Art sera téléchargé pour tous les systèmes. Cela peut prendre quelques instants.',
+  AppLocale.systemArtRedownloadTitle: 'Retélécharger System Art ?',
+  AppLocale.systemArtRedownloadBody:
+      'Le pack en cache sera supprimé puis téléchargé à nouveau. Utilisez cette option si certains arrière-plans de systèmes sont manquants.',
   AppLocale.systemArtDownloading: 'Téléchargement du pack System Art...',
   AppLocale.about: 'À propos',
   AppLocale.exit: 'Quitter',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -52,6 +52,9 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.systemArtApplyTitle: 'Terapkan System Art?',
   AppLocale.systemArtApplyBody:
       'Paket System Art akan diunduh untuk semua sistem. Ini mungkin memerlukan beberapa saat.',
+  AppLocale.systemArtRedownloadTitle: 'Unduh ulang System Art?',
+  AppLocale.systemArtRedownloadBody:
+      'Paket yang tersimpan akan dihapus dan diunduh ulang. Gunakan ini jika beberapa latar belakang sistem tidak muncul.',
   AppLocale.systemArtDownloading: 'Mengunduh paket System Art...',
   AppLocale.about: 'Tentang',
   AppLocale.exit: 'Keluar',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -52,6 +52,9 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.systemArtApplyTitle: 'Applicare System Art?',
   AppLocale.systemArtApplyBody:
       'Il pacchetto System Art verrà scaricato per tutti i sistemi. Potrebbe richiedere alcuni istanti.',
+  AppLocale.systemArtRedownloadTitle: 'Scaricare di nuovo System Art?',
+  AppLocale.systemArtRedownloadBody:
+      'Il pacchetto nella cache verrà eliminato e scaricato di nuovo. Usa questa opzione se mancano alcuni sfondi dei sistemi.',
   AppLocale.systemArtDownloading: 'Download del pacchetto System Art...',
   AppLocale.about: 'Informazioni',
   AppLocale.exit: 'Esci',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -50,6 +50,9 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.systemArtApplyTitle: 'System Art を適用しますか？',
   AppLocale.systemArtApplyBody:
       'すべてのシステムの System Art パックがダウンロードされます。少し時間がかかる場合があります。',
+  AppLocale.systemArtRedownloadTitle: 'System Art を再ダウンロードしますか？',
+  AppLocale.systemArtRedownloadBody:
+      'キャッシュされたパックを削除して再度ダウンロードします。一部のシステム背景が表示されない場合に使用してください。',
   AppLocale.systemArtDownloading: 'System Art パックをダウンロード中...',
   AppLocale.about: 'NeoStationについて',
   AppLocale.exit: '終了',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -49,6 +49,9 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.systemArtError: '시스템 아트를 불러올 수 없습니다',
   AppLocale.systemArtApplyTitle: '시스템 아트를 적용할까요?',
   AppLocale.systemArtApplyBody: '모든 시스템용 시스템 아트 팩을 다운로드합니다. 다소 시간이 걸릴 수 있습니다.',
+  AppLocale.systemArtRedownloadTitle: '시스템 아트를 다시 다운로드할까요?',
+  AppLocale.systemArtRedownloadBody:
+      '캐시된 팩을 삭제하고 다시 다운로드합니다. 일부 시스템 배경이 표시되지 않을 때 사용하세요.',
   AppLocale.systemArtDownloading: '시스템 아트 팩 다운로드 중...',
   AppLocale.about: '소개',
   AppLocale.exit: '종료',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -52,6 +52,9 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.systemArtApplyTitle: 'Aplicar System Art?',
   AppLocale.systemArtApplyBody:
       'O pacote de System Art será baixado para todos os sistemas. Isso pode levar alguns instantes.',
+  AppLocale.systemArtRedownloadTitle: 'Baixar System Art novamente?',
+  AppLocale.systemArtRedownloadBody:
+      'O pacote em cache será excluído e baixado novamente. Use esta opção se faltarem alguns fundos de sistemas.',
   AppLocale.systemArtDownloading: 'Baixando o pacote de System Art...',
   AppLocale.about: 'Sobre',
   AppLocale.exit: 'Sair',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -52,6 +52,9 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.systemArtApplyTitle: 'Применить System Art?',
   AppLocale.systemArtApplyBody:
       'Пакет System Art будет загружен для всех систем. Это может занять некоторое время.',
+  AppLocale.systemArtRedownloadTitle: 'Загрузить System Art заново?',
+  AppLocale.systemArtRedownloadBody:
+      'Кэшированный пакет будет удалён и загружен заново. Используйте это, если отсутствуют некоторые фоны систем.',
   AppLocale.systemArtDownloading: 'Загрузка пакета System Art...',
   AppLocale.about: 'О программе',
   AppLocale.exit: 'Выход',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -49,6 +49,8 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.systemArtError: '无法加载 System Art',
   AppLocale.systemArtApplyTitle: '应用 System Art？',
   AppLocale.systemArtApplyBody: '将为所有系统下载 System Art 包，这可能需要一些时间。',
+  AppLocale.systemArtRedownloadTitle: '重新下载 System Art？',
+  AppLocale.systemArtRedownloadBody: '将删除已缓存的包并重新下载。如果部分系统背景缺失，请使用此选项。',
   AppLocale.systemArtDownloading: '正在下载 System Art 包...',
   AppLocale.about: '关于',
   AppLocale.exit: '退出',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -49,6 +49,8 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.systemArtError: '無法載入 System Art',
   AppLocale.systemArtApplyTitle: '套用 System Art？',
   AppLocale.systemArtApplyBody: '將為所有系統下載 System Art 包，這可能需要一些時間。',
+  AppLocale.systemArtRedownloadTitle: '重新下載 System Art？',
+  AppLocale.systemArtRedownloadBody: '將刪除已快取的包並重新下載。如果部分系統背景缺失，請使用此選項。',
   AppLocale.systemArtDownloading: '正在下載 System Art 包...',
   AppLocale.about: '關於',
   AppLocale.exit: '離開',

--- a/lib/providers/neo_assets_provider.dart
+++ b/lib/providers/neo_assets_provider.dart
@@ -85,20 +85,39 @@ class NeoAssetsProvider extends ChangeNotifier {
   /// performs a batch download with real-time progress updates.
   Future<void> downloadAndApplyTheme(
     String themeFolder,
-    List<String> systemFolderNames,
-  ) async {
+    List<String> systemFolderNames, {
+    bool forceRedownload = false,
+  }) async {
     try {
       final plan = await NeoAssetsService.buildThemeDownloadPlan(
         themeFolder,
         systemFolderNames,
       );
 
-      if (plan.totalAssetsToDownload > 0) {
+      // A forced redownload wipes the cache before refetching, so only honour
+      // it once the theme metadata has actually come back: deleting art we
+      // then cannot re-fetch (offline, CDN down) would leave the user with
+      // none at all, which is worse than the missing background they asked us
+      // to repair.
+      final forced = forceRedownload && plan.remoteMetadata != null;
+      if (forceRedownload && !forced) {
+        _log.w(
+          'Skipping forced redownload of "$themeFolder": '
+          'theme metadata unreachable, keeping the cached art',
+        );
+      }
+
+      final clearFirst = forced || plan.forceRedownload;
+      final totalAssets = clearFirst
+          ? plan.systemsToDownload.length
+          : plan.totalAssetsToDownload;
+
+      if (totalAssets > 0) {
         _downloading = true;
         _downloadProgress = 0.0;
         notifyListeners();
 
-        if (plan.forceRedownload) {
+        if (clearFirst) {
           await NeoAssetsService.downloadAllThemeAssets(
             themeFolder,
             plan.systemsToDownload,
@@ -112,7 +131,7 @@ class NeoAssetsProvider extends ChangeNotifier {
           await NeoAssetsService.downloadMissingThemeAssets(
             themeFolder,
             plan.systemsToDownload,
-            missingTotal: plan.totalAssetsToDownload,
+            missingTotal: totalAssets,
             onProgress: (done, t) {
               _downloadProgress = t == 0 ? 1.0 : done / t;
               notifyListeners();

--- a/lib/screens/settings_screen/new_settings_options/system_art_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/system_art_settings_content.dart
@@ -136,11 +136,17 @@ class SystemArtSettingsContentState extends State<SystemArtSettingsContent> {
       targetName = themes[themeIndex].name;
     }
 
-    if (neoAssets.activeThemeFolder == targetFolder) return;
+    // Re-picking the pack that is already applied is the repair path: it wipes
+    // the cache and refetches, which is the only way to recover a background
+    // that failed to download when the pack was first applied. "None" has
+    // nothing to redownload, so it stays a no-op.
+    final isRedownload = neoAssets.activeThemeFolder == targetFolder;
+    if (isRedownload && targetFolder.isEmpty) return;
 
     final confirmed = await _showConfirmDialog(
       targetName,
       targetFolder.isEmpty,
+      isRedownload: isRedownload,
     );
     if (!confirmed) return;
     if (!mounted) return;
@@ -151,16 +157,27 @@ class SystemArtSettingsContentState extends State<SystemArtSettingsContent> {
       await neoAssets.clearTheme();
     } else {
       final systemFolders = _getSystemFolderNames();
-      await neoAssets.downloadAndApplyTheme(targetFolder, systemFolders);
+      await neoAssets.downloadAndApplyTheme(
+        targetFolder,
+        systemFolders,
+        forceRedownload: isRedownload,
+      );
     }
   }
 
-  Future<bool> _showConfirmDialog(String themeName, bool isNone) async {
+  Future<bool> _showConfirmDialog(
+    String themeName,
+    bool isNone, {
+    bool isRedownload = false,
+  }) async {
     final result = await showDialog<bool>(
       context: context,
       barrierDismissible: false,
-      builder: (ctx) =>
-          _ThemeConfirmDialog(themeName: themeName, isNone: isNone),
+      builder: (ctx) => _ThemeConfirmDialog(
+        themeName: themeName,
+        isNone: isNone,
+        isRedownload: isRedownload,
+      ),
     );
     return result ?? false;
   }
@@ -530,7 +547,15 @@ class _ThemeConfirmDialog extends StatefulWidget {
   final String themeName;
   final bool isNone;
 
-  const _ThemeConfirmDialog({required this.themeName, required this.isNone});
+  /// The pack is already applied and the user is re-picking it to wipe the
+  /// cache and fetch it again — worded as a repair, not as applying a theme.
+  final bool isRedownload;
+
+  const _ThemeConfirmDialog({
+    required this.themeName,
+    required this.isNone,
+    this.isRedownload = false,
+  });
 
   @override
   State<_ThemeConfirmDialog> createState() => _ThemeConfirmDialogState();
@@ -585,7 +610,10 @@ class _ThemeConfirmDialogState extends State<_ThemeConfirmDialog> {
           Icon(Symbols.image_rounded, color: primary, size: 20.r),
           SizedBox(width: 8.r),
           Text(
-            AppLocale.systemArtApplyTitle.getString(context),
+            (widget.isRedownload
+                    ? AppLocale.systemArtRedownloadTitle
+                    : AppLocale.systemArtApplyTitle)
+                .getString(context),
             style: theme.textTheme.titleMedium?.copyWith(
               fontSize: 14.r,
               color: primary,
@@ -608,7 +636,10 @@ class _ThemeConfirmDialogState extends State<_ThemeConfirmDialog> {
           if (!widget.isNone) ...[
             SizedBox(height: 8.r),
             Text(
-              AppLocale.systemArtApplyBody.getString(context),
+              (widget.isRedownload
+                      ? AppLocale.systemArtRedownloadBody
+                      : AppLocale.systemArtApplyBody)
+                  .getString(context),
               style: theme.textTheme.bodyMedium?.copyWith(
                 fontSize: 11.r,
                 color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
@@ -667,7 +698,8 @@ class _ThemeConfirmDialogState extends State<_ThemeConfirmDialog> {
               ),
               SizedBox(width: 4.r),
               Text(
-                AppLocale.apply.getString(context),
+                (widget.isRedownload ? AppLocale.download : AppLocale.apply)
+                    .getString(context),
                 style: TextStyle(fontSize: 12.r),
               ),
             ],

--- a/lib/services/neo_assets_service.dart
+++ b/lib/services/neo_assets_service.dart
@@ -1,16 +1,51 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 import 'config_service.dart';
 import 'logger_service.dart';
 import '../utils/bounded_concurrency.dart';
 
+/// Assets are served from the repository's `dist/` tree, not the source tree:
+/// CI re-encodes every image there against an SSIMULACRA2 floor of 80, which
+/// is the same pack at ~40% of the bytes. It is a complete mirror (same folder
+/// layout, same filenames), rebuilt and committed by the single-writer
+/// `optimize-assets` workflow on every push that touches the source art — the
+/// same workflow that already generates the `systems` list in each
+/// `theme.json`, so this adds no new dependency on CI having run.
 const _baseRaw =
-    'https://raw.githubusercontent.com/misobadev/neostation-assets/main';
+    'https://raw.githubusercontent.com/misobadev/neostation-assets/main/dist';
 const _manifestUrl = '$_baseRaw/manifest.json';
 
 final _log = LoggerService.instance;
+
+/// Outcome of a single remote asset fetch.
+enum AssetFetchStatus {
+  /// The file is on disk (freshly downloaded or already cached).
+  cached,
+
+  /// The server answered 404: the asset genuinely is not published.
+  notFound,
+
+  /// The asset could not be reached (timeout, socket error, 429, 5xx). Says
+  /// nothing about whether it exists, so it must never be cached as absent.
+  failed,
+}
+
+/// The status of an asset fetch plus the local path when it succeeded.
+class AssetFetchResult {
+  final AssetFetchStatus status;
+  final String? path;
+
+  const AssetFetchResult(this.status, [this.path]);
+
+  /// Whether the asset is now available on disk.
+  bool get isCached => status == AssetFetchStatus.cached;
+
+  /// Whether the server positively reported the asset as absent.
+  bool get isNotFound => status == AssetFetchStatus.notFound;
+}
 
 /// Represents a plan for downloading or updating theme assets.
 class ThemeDownloadPlan {
@@ -198,6 +233,26 @@ class NeoAssetsService {
   static List<NeoAssetsTheme>? _cachedThemes;
   static String? _cachedThemeDir;
 
+  /// HTTP client for every remote fetch. Swappable so tests can drive the
+  /// 404-versus-transient-failure split without a network.
+  static http.Client _client = http.Client();
+
+  /// Points the service at a stub client and a scratch cache directory.
+  @visibleForTesting
+  static void debugConfigure({http.Client? client, String? cacheDir}) {
+    _client = client ?? http.Client();
+    _cachedThemeDir = cacheDir;
+    _cachedThemes = null;
+  }
+
+  /// Restores the real client and drops any test cache directory.
+  @visibleForTesting
+  static void debugReset() {
+    _client = http.Client();
+    _cachedThemeDir = null;
+    _cachedThemes = null;
+  }
+
   /// Fetches the global manifest of available themes.
   ///
   /// Tries the remote manifest first (caching it to disk on success), then
@@ -233,7 +288,7 @@ class NeoAssetsService {
   /// back to the on-disk copy.
   static Future<List<NeoAssetsTheme>?> _fetchRemoteThemes() async {
     try {
-      final response = await http.get(Uri.parse(_manifestUrl));
+      final response = await _client.get(Uri.parse(_manifestUrl));
       if (response.statusCode != 200) {
         _log.w(
           'Failed to fetch neostation-assets manifest: ${response.statusCode}',
@@ -376,25 +431,75 @@ class NeoAssetsService {
     return '$_baseRaw/themes/$themeFolder/theme.json';
   }
 
-  /// Downloads a remote asset to the local filesystem and returns the absolute path.
-  static Future<String?> downloadAndCacheAsset(
+  /// How long a single asset request may take before it is retried.
+  static const Duration _requestTimeout = Duration(seconds: 20);
+
+  /// Attempts per asset before giving up. Theme packs are ~100 small files
+  /// pulled from a shared CDN, so the odd 429/timeout is routine.
+  static const int _maxFetchAttempts = 3;
+
+  /// Base backoff between attempts, multiplied by the attempt number.
+  static const Duration _retryBackoff = Duration(milliseconds: 500);
+
+  /// Downloads a remote asset to the local filesystem.
+  ///
+  /// Distinguishes a definitive HTTP 404 ([AssetFetchStatus.notFound]) from an
+  /// asset that could not be reached right now ([AssetFetchStatus.failed]:
+  /// timeout, socket error, 429, 5xx). Only a 404 proves the theme does not
+  /// ship the file, and only a 404 may be cached as a permanent negative
+  /// result — a flaky request must stay retryable, or one dropped connection
+  /// blanks a system's art for the life of the install.
+  ///
+  /// Bytes land in a sibling `.part` file that is renamed into place only once
+  /// the body is fully written, so an interrupted write can never leave a
+  /// truncated image that later reads as "already cached".
+  static Future<AssetFetchResult> fetchAndCacheAsset(
     String url,
     String localPath,
   ) async {
+    final file = File(localPath);
     try {
-      final file = File(localPath);
-      if (await file.exists()) return localPath;
-
-      await file.parent.create(recursive: true);
-      final response = await http.get(Uri.parse(url));
-      if (response.statusCode != 200) return null;
-
-      await file.writeAsBytes(response.bodyBytes);
-      return localPath;
+      if (await file.exists()) {
+        return AssetFetchResult(AssetFetchStatus.cached, localPath);
+      }
     } catch (e) {
-      _log.e('Error caching asset $url: $e');
-      return null;
+      _log.w('Error checking cached asset $localPath: $e');
     }
+
+    for (var attempt = 1; attempt <= _maxFetchAttempts; attempt++) {
+      try {
+        final response = await _client
+            .get(Uri.parse(url))
+            .timeout(_requestTimeout);
+
+        if (response.statusCode == 200) {
+          await file.parent.create(recursive: true);
+          final part = File('$localPath.part');
+          await part.writeAsBytes(response.bodyBytes, flush: true);
+          await part.rename(localPath);
+          return AssetFetchResult(AssetFetchStatus.cached, localPath);
+        }
+
+        if (response.statusCode == 404) {
+          return const AssetFetchResult(AssetFetchStatus.notFound);
+        }
+
+        _log.w(
+          'Asset fetch failed ($url): HTTP ${response.statusCode} '
+          '(attempt $attempt/$_maxFetchAttempts)',
+        );
+      } catch (e) {
+        _log.w(
+          'Asset fetch errored ($url): $e (attempt $attempt/$_maxFetchAttempts)',
+        );
+      }
+
+      if (attempt < _maxFetchAttempts) {
+        await Future.delayed(_retryBackoff * attempt);
+      }
+    }
+
+    return const AssetFetchResult(AssetFetchStatus.failed);
   }
 
   /// Returns the local directory used for theme asset caching.
@@ -492,7 +597,7 @@ class NeoAssetsService {
     String themeFolder,
   ) async {
     try {
-      final response = await http.get(
+      final response = await _client.get(
         Uri.parse(getThemeMetadataUrl(themeFolder)),
       );
       if (response.statusCode != 200) {
@@ -512,13 +617,23 @@ class NeoAssetsService {
 
   /// Reads the version string from the locally cached theme metadata.
   static Future<String?> readLocalThemeVersion(String themeFolder) async {
+    final json = await readLocalThemeMetadata(themeFolder);
+    return json?['version']?.toString();
+  }
+
+  /// Reads the cached `theme.json` for a theme, or null when it is absent or
+  /// unreadable. Lets a plan fall back to the last known coverage list when
+  /// the remote metadata cannot be reached.
+  static Future<Map<String, dynamic>?> readLocalThemeMetadata(
+    String themeFolder,
+  ) async {
     try {
       final metadataPath = await themeMetadataCachePath(themeFolder);
       final file = File(metadataPath);
       if (!await file.exists()) return null;
       final json = jsonDecode(await file.readAsString());
       if (json is! Map<String, dynamic>) return null;
-      return json['version']?.toString();
+      return json;
     } catch (e) {
       _log.w('Error reading local theme metadata for "$themeFolder": $e');
       return null;
@@ -548,33 +663,18 @@ class NeoAssetsService {
   ) async {
     int missing = 0;
     for (final system in systemFolderNames) {
-      if (!await _backgroundResolvedOrKnownMissing(themeFolder, system)) {
+      if (!await _backgroundCached(themeFolder, system)) {
         missing++;
       }
     }
     return missing;
   }
 
-  /// Local path of the negative-cache marker for a system whose background is
-  /// not provided by the theme. Lives inside the theme's `backgrounds/` dir so
-  /// it is wiped by [clearThemeCache] on a version bump, re-enabling probing.
-  static Future<String> _backgroundMissingMarkerPath(
-    String themeFolder,
-    String systemFolderName,
-  ) async {
-    final dir = await _cacheDir();
-    return path.join(
-      dir,
-      themeFolder,
-      'backgrounds',
-      '$systemFolderName.missing',
-    );
-  }
-
-  /// True when a system's background is cached (.webp/.gif) OR is known to be
-  /// absent from the theme (a `.missing` marker exists). Prevents re-probing
-  /// systems the pack simply does not cover on every re-selection.
-  static Future<bool> _backgroundResolvedOrKnownMissing(
+  /// True when a system's background is already cached (`.webp` or `.gif`).
+  ///
+  /// Coverage itself is decided by the theme's declared `systems` list, so an
+  /// uncovered system is never probed and needs no negative-cache marker.
+  static Future<bool> _backgroundCached(
     String themeFolder,
     String systemFolderName,
   ) async {
@@ -584,46 +684,35 @@ class NeoAssetsService {
       systemFolderName,
       ext: 'gif',
     );
-    final marker = await _backgroundMissingMarkerPath(
-      themeFolder,
-      systemFolderName,
-    );
-    return await File(bgWebp).exists() ||
-        await File(bgGif).exists() ||
-        await File(marker).exists();
-  }
-
-  /// Records that a system's background is absent from the theme so it is not
-  /// re-downloaded on subsequent selections (cleared on version bump).
-  static Future<void> _writeMissingMarker(
-    String themeFolder,
-    String systemFolderName,
-  ) async {
-    try {
-      final marker = File(
-        await _backgroundMissingMarkerPath(themeFolder, systemFolderName),
-      );
-      await marker.parent.create(recursive: true);
-      await marker.writeAsString('');
-    } catch (e) {
-      _log.w(
-        'Error writing missing marker for "$themeFolder/$systemFolderName": $e',
-      );
-    }
+    return await File(bgWebp).exists() || await File(bgGif).exists();
   }
 
   /// Resolves which of the user's systems this theme actually covers.
   ///
-  /// When `theme.json` declares a `systems` list, returns the intersection with
-  /// the user's systems so uncovered systems are never probed (no 404s). When
-  /// the list is absent (older themes / offline metadata), returns all of the
-  /// user's systems and relies on the `.missing` negative-cache fallback.
+  /// The theme's declared `systems` list is authoritative: it is generated by
+  /// the same `optimize-assets` workflow that builds the `dist/` tree, so a
+  /// published pack always carries one. Returning the intersection means an
+  /// uncovered system is never probed, which is what makes the old `.missing`
+  /// negative cache unnecessary.
+  ///
+  /// [localMetadata] is the on-disk `theme.json`, used when the remote copy is
+  /// unreachable. If neither declares a list, coverage is empty rather than
+  /// "every system": blind-probing ~100 systems is what the negative cache
+  /// existed to prevent, and a visible "nothing to download" beats silently
+  /// re-probing on every selection.
   static List<String> _resolveCoveredSystems(
     Map<String, dynamic>? remoteMetadata,
+    Map<String, dynamic>? localMetadata,
     List<String> systemFolderNames,
   ) {
-    final declared = remoteMetadata?['systems'];
-    if (declared is! List) return systemFolderNames;
+    final declared = remoteMetadata?['systems'] ?? localMetadata?['systems'];
+    if (declared is! List) {
+      _log.w(
+        'Theme metadata declares no "systems" list; treating the pack as '
+        'covering nothing rather than probing every system',
+      );
+      return const [];
+    }
     final covered = declared.map((e) => e.toString()).toSet();
     return systemFolderNames.where(covered.contains).toList();
   }
@@ -633,12 +722,19 @@ class NeoAssetsService {
     String themeFolder,
     List<String> systemFolderNames,
   ) async {
+    // Shed `.missing` markers written by older builds. They could not tell a
+    // 404 from a dropped connection, so an unknown share of them are false
+    // negatives that would keep a system blank forever.
+    await deleteLegacyMissingMarkers();
+
     final remoteMetadata = await _fetchThemeMetadata(themeFolder);
-    final localVersion = await readLocalThemeVersion(themeFolder);
+    final localMetadata = await readLocalThemeMetadata(themeFolder);
+    final localVersion = localMetadata?['version']?.toString();
     final remoteVersion = remoteMetadata?['version']?.toString();
 
     final coveredSystems = _resolveCoveredSystems(
       remoteMetadata,
+      localMetadata,
       systemFolderNames,
     );
 
@@ -679,8 +775,13 @@ class NeoAssetsService {
   ) async {
     final webpPath = await backgroundCachePath(themeFolder, systemFolderName);
     final webpUrl = getBackgroundUrl(themeFolder, systemFolderName);
-    var result = await downloadAndCacheAsset(webpUrl, webpPath);
-    if (result != null) return result;
+    final webp = await fetchAndCacheAsset(webpUrl, webpPath);
+    if (webp.isCached) return webp.path;
+
+    // A transient webp failure says the server is unreachable, not that the
+    // system is uncovered — probing the legacy gif would only repeat the same
+    // failure (and, applied offline across ~100 systems, double the wait).
+    if (!webp.isNotFound) return _unresolved(themeFolder, systemFolderName);
 
     final gifPath = await backgroundCachePath(
       themeFolder,
@@ -688,12 +789,30 @@ class NeoAssetsService {
       ext: 'gif',
     );
     final gifUrl = getBackgroundUrl(themeFolder, systemFolderName, ext: 'gif');
-    result = await downloadAndCacheAsset(gifUrl, gifPath);
-    if (result != null) return result;
+    final gif = await fetchAndCacheAsset(gifUrl, gifPath);
+    if (gif.isCached) return gif.path;
+    if (!gif.isNotFound) return _unresolved(themeFolder, systemFolderName);
 
-    // Neither format exists remotely: record a negative-cache marker so this
-    // system is not re-probed on every re-selection of the theme.
-    await _writeMissingMarker(themeFolder, systemFolderName);
+    // Both formats answered 404 for a system the theme's `systems` list claims
+    // to cover: the metadata has drifted from the published files. Nothing to
+    // cache — the next plan re-reads the list and this corrects itself when
+    // the pack is rebuilt.
+    _log.w(
+      'Theme "$themeFolder" declares "$systemFolderName" but ships no '
+      'background for it (both .webp and .gif returned 404)',
+    );
+    return null;
+  }
+
+  /// Leaves a system unresolved after a transient failure. Deliberately writes
+  /// no marker: the next download plan must retry it, or one flaky request
+  /// during the initial ~100-file download blanks that system's art for good
+  /// (the marker is cleared only by a full theme-version redownload).
+  static String? _unresolved(String themeFolder, String systemFolderName) {
+    _log.w(
+      'Background "$themeFolder/$systemFolderName" unresolved after retries; '
+      'leaving it retryable for the next theme refresh',
+    );
     return null;
   }
 
@@ -704,7 +823,7 @@ class NeoAssetsService {
   ) async {
     final localPath = await logoCachePath(themeFolder, systemFolderName);
     final url = getLogoUrl(themeFolder, systemFolderName);
-    return downloadAndCacheAsset(url, localPath);
+    return (await fetchAndCacheAsset(url, localPath)).path;
   }
 
   /// Max background downloads in flight at once. Theme assets are small,
@@ -746,7 +865,7 @@ class NeoAssetsService {
     // Skip systems already cached or known to be absent from the theme.
     final pending = <String>[];
     for (final system in systemFolderNames) {
-      if (!await _backgroundResolvedOrKnownMissing(themeFolder, system)) {
+      if (!await _backgroundCached(themeFolder, system)) {
         pending.add(system);
       }
     }
@@ -760,6 +879,50 @@ class NeoAssetsService {
       (system) => getCachedBackground(themeFolder, system),
       onEach: () => onProgress?.call(++done, missingTotal),
     );
+  }
+
+  /// Sentinel recording that the one-time cleanup of legacy `.missing` markers
+  /// has already run for this install. Lives in the theme cache root, so
+  /// wiping the cache (which re-downloads everything anyway) resets it.
+  static Future<String> _markerCleanupSentinelPath() async {
+    final dir = await _cacheDir();
+    return path.join(dir, '.missing-markers-cleared');
+  }
+
+  /// Deletes every `.missing` marker left by older builds, once per install.
+  ///
+  /// The markers are no longer written or read: coverage now comes from the
+  /// theme's declared `systems` list, so an uncovered system is never probed
+  /// and needs no negative cache. Installs upgraded from an older build still
+  /// carry the files, and a stale marker used to make a system's background
+  /// read as "resolved" and stay permanently blank, so they are swept once.
+  ///
+  /// Called from [buildThemeDownloadPlan] rather than at startup: an install
+  /// that never opens System Art pays nothing.
+  static Future<void> deleteLegacyMissingMarkers() async {
+    try {
+      final sentinel = File(await _markerCleanupSentinelPath());
+      if (await sentinel.exists()) return;
+
+      final dir = Directory(await _cacheDir());
+      int cleared = 0;
+      if (await dir.exists()) {
+        await for (final entity in dir.list(recursive: true)) {
+          if (entity is File && entity.path.endsWith('.missing')) {
+            await entity.delete();
+            cleared++;
+          }
+        }
+      }
+
+      await sentinel.parent.create(recursive: true);
+      await sentinel.writeAsString('');
+      if (cleared > 0) {
+        _log.i('Cleared $cleared legacy .missing marker(s) (no longer used)');
+      }
+    } catch (e) {
+      _log.w('Error clearing legacy .missing markers: $e');
+    }
   }
 
   /// Deletes all cached assets for a specific theme folder.

--- a/test/neo_assets_service_test.dart
+++ b/test/neo_assets_service_test.dart
@@ -1,0 +1,219 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:neostation/services/neo_assets_service.dart';
+import 'package:path/path.dart' as path;
+
+/// Coverage comes from the theme's declared `systems` list, so a system the
+/// pack does not cover is never requested at all. What still has to hold is
+/// the split between "the server says this is absent" (404) and "the server
+/// could not be reached" (timeout, 429, 5xx): only the former is a fact about
+/// the pack, and treating the latter as absence is how systems used to lose
+/// their backgrounds for the life of an install.
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('neo_assets_test');
+  });
+
+  tearDown(() {
+    NeoAssetsService.debugReset();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  /// Wires the service to [handler] and a scratch cache directory.
+  void useClient(Future<http.Response> Function(http.Request) handler) {
+    NeoAssetsService.debugConfigure(
+      client: MockClient(handler),
+      cacheDir: tempDir.path,
+    );
+  }
+
+  File backgroundFile(String theme, String system, {String ext = 'webp'}) =>
+      File(path.join(tempDir.path, theme, 'backgrounds', '$system.$ext'));
+
+  group('getCachedBackground', () {
+    test('caches the webp when the asset exists', () async {
+      useClient((request) async {
+        if (request.url.path.endsWith('/backgrounds/wii.webp')) {
+          return http.Response.bytes([1, 2, 3], 200);
+        }
+        return http.Response('not found', 404);
+      });
+
+      final result = await NeoAssetsService.getCachedBackground(
+        'NeoStation',
+        'wii',
+      );
+
+      expect(result, isNotNull);
+      expect(File(result!).readAsBytesSync(), [1, 2, 3]);
+    });
+
+    test('leaves no .part file behind on success', () async {
+      useClient((request) async => http.Response.bytes([1], 200));
+
+      await NeoAssetsService.getCachedBackground('NeoStation', 'wii');
+
+      final parts = Directory(
+        path.join(tempDir.path, 'NeoStation'),
+      ).listSync(recursive: true).where((e) => e.path.endsWith('.part'));
+      expect(parts, isEmpty);
+    });
+
+    test('falls back to the legacy gif when the webp is a 404', () async {
+      useClient((request) async {
+        if (request.url.path.endsWith('.gif')) {
+          return http.Response.bytes([7], 200);
+        }
+        return http.Response('not found', 404);
+      });
+
+      final result = await NeoAssetsService.getCachedBackground(
+        'NeoStation',
+        'wii',
+      );
+
+      expect(result, isNotNull);
+      expect(
+        backgroundFile('NeoStation', 'wii', ext: 'gif').existsSync(),
+        true,
+      );
+    });
+
+    test('a rate-limited webp does not go on to probe the gif', () async {
+      // A server refusing requests has nothing to say about the legacy gif
+      // either, and probing it would double the wait across ~100 systems.
+      final requested = <String>[];
+      useClient((request) async {
+        requested.add(request.url.path);
+        return http.Response('rate limited', 429);
+      });
+
+      final result = await NeoAssetsService.getCachedBackground(
+        'NeoStation',
+        'pce',
+      );
+
+      expect(result, isNull);
+      expect(requested.length, 3);
+      expect(requested.every((p) => p.endsWith('.webp')), isTrue);
+    });
+
+    test('a network error leaves nothing cached', () async {
+      useClient((request) async => throw const SocketException('reset'));
+
+      final result = await NeoAssetsService.getCachedBackground(
+        'NeoStation',
+        'pccd',
+      );
+
+      expect(result, isNull);
+      expect(backgroundFile('NeoStation', 'pccd').existsSync(), isFalse);
+    });
+
+    test('a transient failure resolves on a later attempt', () async {
+      var attempts = 0;
+      useClient((request) async {
+        attempts++;
+        if (attempts == 1) return http.Response('rate limited', 429);
+        return http.Response.bytes([9], 200);
+      });
+
+      final result = await NeoAssetsService.getCachedBackground(
+        'NeoStation',
+        'wii',
+      );
+
+      expect(result, isNotNull);
+    });
+  });
+
+  group('buildThemeDownloadPlan coverage', () {
+    /// Serves a theme.json declaring [systems], and 404s every asset.
+    void serveMetadata(List<String>? systems) {
+      useClient((request) async {
+        if (request.url.path.endsWith('theme.json')) {
+          return http.Response(
+            jsonEncode({'version': '1.0.0', 'systems': ?systems}),
+            200,
+          );
+        }
+        return http.Response('not found', 404);
+      });
+    }
+
+    test('plans only the systems the theme declares', () async {
+      serveMetadata(['wii', 'snes']);
+
+      final plan = await NeoAssetsService.buildThemeDownloadPlan('NeoStation', [
+        'wii',
+        'snes',
+        'uncovered',
+      ]);
+
+      expect(plan.systemsToDownload, ['wii', 'snes']);
+    });
+
+    test('covers nothing when no systems list is declared', () async {
+      // Blind-probing every system is what the old negative cache existed to
+      // prevent, so an undeclared list must not fall back to "all systems".
+      serveMetadata(null);
+
+      final plan = await NeoAssetsService.buildThemeDownloadPlan('NeoStation', [
+        'wii',
+        'snes',
+      ]);
+
+      expect(plan.systemsToDownload, isEmpty);
+      expect(plan.totalAssetsToDownload, 0);
+    });
+
+    test('falls back to the cached theme.json when offline', () async {
+      final metadata = File(
+        path.join(tempDir.path, 'NeoStation', 'theme.json'),
+      );
+      metadata.parent.createSync(recursive: true);
+      metadata.writeAsStringSync(
+        jsonEncode({
+          'version': '1.0.0',
+          'systems': ['wii'],
+        }),
+      );
+
+      useClient((request) async => throw const SocketException('offline'));
+
+      final plan = await NeoAssetsService.buildThemeDownloadPlan('NeoStation', [
+        'wii',
+        'snes',
+      ]);
+
+      expect(plan.systemsToDownload, ['wii']);
+    });
+  });
+
+  group('deleteLegacyMissingMarkers', () {
+    test('clears markers once, then does not walk the cache again', () async {
+      NeoAssetsService.debugConfigure(cacheDir: tempDir.path);
+
+      final marker = File(
+        path.join(tempDir.path, 'NeoStation', 'backgrounds', 'wii.missing'),
+      );
+      marker.parent.createSync(recursive: true);
+      marker.writeAsStringSync('');
+
+      await NeoAssetsService.deleteLegacyMissingMarkers();
+      expect(marker.existsSync(), isFalse);
+
+      // The sentinel makes this a one-shot sweep, so a file recreated
+      // afterwards is left alone rather than costing a walk on every plan.
+      marker.writeAsStringSync('');
+      await NeoAssetsService.deleteLegacyMissingMarkers();
+      expect(marker.existsSync(), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
# Description

A system whose background download hit a timeout, a 429 or a 5xx was recorded as "not provided by this theme" and never retried. One flaky request during the initial ~100-file download left that system permanently blank: the negative-cache marker was only cleared by a full theme-version redownload, and re-selecting the same pack was a no-op, so there was no way back.

**Telling absence apart from failure.** Only an HTTP 404 proves the pack does not ship a file. Unreachable assets now retry (3 attempts, backing off) and stay retryable afterwards instead of being cached as absent. Bytes land in a sibling `.part` file that is renamed into place only once the body is fully written, so an interrupted write can no longer leave a truncated image that later reads as "already cached".

**The negative cache is gone.** Coverage now comes from the theme's declared `systems` list, which the same `optimize-assets` workflow generates alongside the art. Uncovered systems are never requested, so there is nothing for a marker to remember. Markers left by older builds are swept once per install, since a stale one would keep a system blank forever. When no `systems` list is declared the pack covers nothing rather than blind-probing every system, falling back to the cached `theme.json` when the remote copy is unreachable.

**A repair path.** Re-picking the pack that is already applied now wipes the cache and refetches, worded as a re-download rather than as applying a theme. It is refused while the theme metadata is unreachable: deleting art that cannot then be refetched is worse than the missing background it set out to repair.

**Smaller downloads.** Assets are served from the repository's `dist/` tree, the CI-optimised mirror of the same pack. Measured on `NeoStation/backgrounds/xbox.webp`: 172,308 bytes versus 452,462, a 62% reduction.

## Steps to Verify

**Preconditions:** an Android device with a System Art pack already applied and at least one system whose background is blank (or an install carrying `.missing` markers from a previous build, in `<user-data>/themes/<Theme>/backgrounds/*.missing`).

1. Open Settings, System Art, and select the pack that is **already applied**. The dialog reads "Re-download System Art?" with a **Download** button rather than "Apply".
2. Confirm. The cached pack is wiped and refetched, and the previously blank backgrounds appear.
3. Check the log: any legacy markers are cleared once, and a `.missing-markers-cleared` sentinel appears in the themes directory. Re-entering does not sweep again.
4. Turn off Wi-Fi and re-pick the applied pack. It is refused with `Skipping forced redownload ... theme metadata unreachable`, and the cached art is still there.
5. With Wi-Fi still off, apply a pack from scratch. No `.missing` markers are written. Restore the network, re-apply, and the art downloads.
6. With `None` active, select `None` again. Nothing happens, no dialog.

## Tested on

- [x] Android — device: AYN Thor (dev channel, release build)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Verified on device against a real install carrying 110 `.missing` markers across 4 themes. After the fix those were cleared and none were rewritten, all 95 covered backgrounds refetched from `dist/`, no `.part` files left behind, and the download plan reported `covered=95/122 missing=0` both before and after the coverage rewrite, confirming it changed no behaviour.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1540)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files (`systemArtRedownloadTitle`, `systemArtRedownloadBody`)
- [x] No hardcoded UI strings — everything goes through `AppLocale`

</details>
