### PR TITLE
fix(database): stop fresh-install creation racing the second engine

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/SecondaryAppsPresentation.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/SecondaryAppsPresentation.kt
@@ -92,6 +92,9 @@ class SecondaryAppsPresentation(
         return super.dispatchKeyEvent(event)
     }
 
+    // Deprecated since API 33, but Dialog still routes BACK through it and the
+    // override must stay for the platforms that do.
+    @Suppress("DEPRECATION")
     override fun onBackPressed() {
         // Deliberately empty: BACK must never dismiss the bottom screen.
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -1329,6 +1329,24 @@ class SqliteService {
   /// Pragma statements are wrapped individually so a filesystem error on one
   /// (e.g. an SD card that doesn't support WAL) doesn't block the entire DB.
   Future<void> _onConfigure(DatabaseAdapter db) async {
+    // Set before anything else: the pragmas below and first-run creation all
+    // write, and on dual-display devices a second Flutter engine writes to this
+    // same file concurrently. Without a busy timeout the loser of a race fails
+    // instantly with SQLITE_BUSY ("database is locked") instead of waiting for
+    // the other connection to commit.
+    //
+    // 15s rather than a token value because [_onCreate] holds the write lock
+    // for the whole of first-run seeding (122 systems, 2422 emulators). The
+    // worst case is the first cold boot after an install, where ART is still
+    // warming up: 5s was observed to expire there, and the timeout only ever
+    // caps how long a blocked writer waits, so a generous bound costs nothing
+    // on the uncontended path.
+    try {
+      await db.execute('PRAGMA busy_timeout = 15000;');
+    } catch (e) {
+      _log.w('Could not set PRAGMA busy_timeout = 15000: $e');
+    }
+
     try {
       await db.execute('PRAGMA foreign_keys = ON;');
     } catch (e) {
@@ -1701,19 +1719,33 @@ class SqliteService {
   }
 
   /// Creates initial database tables during first run.
+  ///
+  /// The schema, its seed data and the `user_version` stamp are committed as a
+  /// single transaction. Dual-display devices run a second Flutter engine
+  /// against this same database file (see `subDisplay()` in `lib/main.dart`),
+  /// and that engine opens the file while first-run creation is still in
+  /// flight. Committing the tables ahead of the stamp left a window in which it
+  /// observed "tables exist but user_version is 0", which [_initDatabaseCore]
+  /// reads as a legacy install and answers by replaying every migration from
+  /// v1 over an already-current schema. Migration v5 then throws on
+  /// `app_emulators.id`, a column migration v49 removes.
   Future<void> _onCreate(DatabaseAdapter db, int version) async {
     final stopwatch = Stopwatch()..start();
 
     try {
-      // Create schema within an atomic transaction.
+      // Create schema, seed it and stamp its version atomically.
       await db.transaction((txn) async {
         await _createAppTables(txn);
         await _createUserTables(txn);
         await _createRetroArchTables(txn);
-      });
 
-      // Populate initial data.
-      await _insertInitialData(db);
+        // Populate initial data.
+        await _insertInitialData(db);
+
+        // Stamp the version alongside the schema it describes, so no other
+        // connection can read this database as an unversioned legacy install.
+        await txn.execute('PRAGMA user_version = $version;');
+      });
 
       // Initialize optimized indexes.
       await _createIndexes(db);

--- a/test/fresh_database_version_stamp_test.dart
+++ b/test/fresh_database_version_stamp_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+
+/// Regression cover for the fresh-install crash on dual-display devices.
+///
+/// `subDisplay()` runs a second Flutter engine against the same database file,
+/// so first-run creation is observed by another connection while it is still in
+/// flight. When the tables were committed ahead of the `user_version` stamp,
+/// that connection saw "tables exist but user_version is 0", which
+/// `_initDatabaseCore` reads as a legacy install and answers by replaying every
+/// migration from v1 over an already-current schema. Migration v5 then throws
+/// `no such column: id` and takes database initialization down with it.
+///
+/// `_onCreate` now stamps the version inside the same transaction as the
+/// schema, so that intermediate state is never visible. These tests pin the two
+/// facts that fix depends on.
+void main() {
+  late sqlite.Database db;
+
+  setUp(() {
+    db = sqlite.sqlite3.openInMemory();
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  int userVersion() =>
+      db.select('PRAGMA user_version;').first.values.first! as int;
+
+  group('user_version stamping is atomic with schema creation', () {
+    test('a committed transaction publishes tables and stamp together', () async {
+      final adapter = DatabaseAdapter(db);
+
+      await adapter.transaction((txn) async {
+        await txn.execute('CREATE TABLE user_config (id INTEGER PRIMARY KEY);');
+        await txn.execute('PRAGMA user_version = 153;');
+      });
+
+      expect(userVersion(), 153);
+      expect(
+        db.select(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='user_config';",
+        ),
+        isNotEmpty,
+      );
+    });
+
+    test(
+      'a failed transaction leaves neither the tables nor the stamp',
+      () async {
+        final adapter = DatabaseAdapter(db);
+
+        await expectLater(
+          adapter.transaction((txn) async {
+            await txn.execute(
+              'CREATE TABLE user_config (id INTEGER PRIMARY KEY);',
+            );
+            await txn.execute('PRAGMA user_version = 153;');
+            throw StateError('seeding failed');
+          }),
+          throwsStateError,
+        );
+
+        // Rolling back the stamp with the schema is what keeps a half-created
+        // database from being mistaken for an unversioned legacy install.
+        expect(userVersion(), 0);
+        expect(
+          db.select(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='user_config';",
+          ),
+          isEmpty,
+        );
+      },
+    );
+  });
+
+  group('replaying migrations over a current schema', () {
+    setUp(() {
+      // The modern app_emulators, as migration v49 left it: keyed by
+      // (os_id, unique_identifier), with no `id` column.
+      db.execute('''
+        CREATE TABLE app_emulators (
+            unique_identifier TEXT NOT NULL,
+            os_id INTEGER NOT NULL,
+            system_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            is_standalone INTEGER NOT NULL DEFAULT 0,
+            core_filename TEXT,
+            is_default INTEGER NOT NULL DEFAULT 0,
+            is_ra_compatible INTEGER NOT NULL DEFAULT 0,
+            android_package_name TEXT,
+            android_activity_name TEXT,
+            PRIMARY KEY (os_id, unique_identifier)
+        );
+      ''');
+    });
+
+    test(
+      'migration v5 cannot run against the post-v49 app_emulators',
+      () async {
+        // Documents the hazard rather than papering over it: migrations v5-v48
+        // predate v49 and address `app_emulators.id`, so the version-0 replay
+        // path is only ever safe on a genuinely pre-v49 database. Guarding v5
+        // alone would just move the failure to v6.
+        await expectLater(
+          SqliteMigrations.migrateToVersion(db, 5),
+          throwsA(isA<sqlite.SqliteException>()),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
# Description

On dual-display devices `subDisplay()` runs a second Flutter engine against the same SQLite file. `_onCreate` committed the schema in one transaction, but `user_version` was only stamped at the end of `_initDatabaseCore` — after seeding and indexing. An engine that opened the file inside that window saw *tables exist but `user_version` is 0*, which `_initDatabaseCore` reads as a legacy install and answers by replaying every migration from v1 over an already-current schema.

Migration v5 selects `app_emulators.id`. Migration **v49** removes that column when it rekeys the table to `(os_id, unique_identifier)`. So v5 threw `no such column: id` and took database initialization down with an unhandled exception:

```
Legacy install detected (version=0 but tables exist). Running migrations.
Migration v5: Adding PlayStation 2 emulator for Android
[E] Error in migration v5: SqliteException(1): no such column: id
E/flutter: Unhandled Exception: SqliteException(1) ... no such column: id
[W] Could not load saved language, defaulting to en
```

**The fix:** seed the database and stamp `user_version` inside the same transaction as the `CREATE TABLE`s, so that intermediate state is never observable and only genuinely legacy databases reach the replay path.

Guarding migration v5 would not have fixed this — v5 through v48 all address `app_emulators.id`, so the failure would simply have moved to v6. The version-0 replay path is only ever safe on a genuinely pre-v49 database.

`PRAGMA busy_timeout = 15000` is set first in `_onConfigure`. This is **required by** the change above rather than cosmetic: the write lock is now held for all of first-run seeding (122 systems, 2422 emulators), so the engine that loses the race has to wait instead of failing instantly on `SQLITE_BUSY`. At 5000 the first cold boot after an install still lost it. This also clears the pre-existing `database is locked (code 5)` when flagging achievement-compatible emulators.

Also suppresses the deprecation warning on the deliberate `onBackPressed()` override in `SecondaryAppsPresentation` — behaviour unchanged, and it was the only Kotlin build warning originating in our own source rather than a pub package.

## Steps to Verify

**Preconditions:** an Android dual-display device (verified on the AYN Thor), dev channel, and a wiped database — this only reproduces on a *fresh* database, since a populated one never enters the create path.

1. Check out `main`, deploy to the device, and wipe the database: `./deploy-thor.sh --dev --reset-db`.
2. Open `…/files/user-data/app.log` and confirm the failure: `Legacy install detected`, `Error in migration v5`, `no such column: id`, and an `Unhandled Exception`.
3. Check out this branch and repeat step 1.
4. Confirm `app.log` contains **zero** occurrences of `Legacy install detected`, `Error in migration v5`, `no such column: id`, `database is locked`, and `Unhandled Exception`.
5. Pull the database and confirm it is healthy: `user_version` 153, 23 tables, 5 `app_os` rows, 122 systems, 2422 emulators, `PRAGMA integrity_check` = `ok`.
6. Restart the app on the now-populated database and confirm the startup logs no errors at all.

Reproduce on the install-then-first-boot path specifically. The race is timing-dependent: two of three fresh-database runs were clean even before the timeout was raised, so a single clean run does not prove it fixed.

## Tested on

- [x] Android — device: AYN Thor (dual-display, dev channel, DB v153)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Three `--reset-db` runs, the last on a freshly built and installed APK. Zero occurrences of any of the five error markers; database verified healthy each time.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1575)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

**The database**
- [x] No new column and no schema change — `_databaseVersion` is untouched, so no migration slot is claimed and there is nothing to renumber against other branches
- [x] `test/fresh_database_version_stamp_test.dart` covers the invariant the fix relies on: the stamp commits with the schema, a failed transaction rolls back both, and migration v5 throws against the post-v49 schema (pinning why the replay path must not be re-entered)

**Android**
- [x] Verified on a device, not only on desktop
