### PR TITLE
fix(windows): stop NeoStation navigating and launching games behind a running emulator

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:neostation/services/startup_theme_cache.dart';
 import 'package:neostation/widgets/splash_status_layout.dart';
 import 'package:neostation/widgets/permission_check_wrapper.dart';
 import 'package:neostation/utils/custom_scroll_behavior.dart';
+import 'package:neostation/utils/desktop_window_focus.dart';
 import 'package:neostation/utils/display_metrics_log.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
@@ -250,6 +251,10 @@ void main() async {
       }
       FullscreenNotifier().notifyFullscreenChanged(false);
     }
+
+    // Gamepad input follows window focus from here on. Must come after
+    // ensureInitialized() above, which owns the channel it listens on.
+    await DesktopWindowFocus.initialize();
 
     log.i('Window manager initialized');
   }

--- a/lib/screens/game_screen/my_games_list/launch_flow.dart
+++ b/lib/screens/game_screen/my_games_list/launch_flow.dart
@@ -92,7 +92,7 @@ extension _LaunchFlow on _SystemGamesListState {
       if (_selectedGame != null) _updateSecondaryDisplay(_selectedGame!);
     }
 
-    GamepadNavigationManager.reactivate();
+    GamepadNavigationManager.restoreFocusOwner();
 
     // Reload games list (was cleared to free RAM during gameplay).
     try {
@@ -211,7 +211,11 @@ extension _LaunchFlow on _SystemGamesListState {
     _pushAchievementsForLaunch(_selectedGame!);
 
     // CRITICAL: Deactivate local input to avoid conflicts with external processes.
+    // Claim the input back by name on return: the stack is rebuilt underneath
+    // us during the launch, so "the top layer" is no longer a reliable answer
+    // to who was in charge.
     _gamepadNav.deactivate();
+    GamepadNavigationManager.rememberFocusOwner('system_games_list');
 
     // Free maximum RAM before handing off to the emulator.
     _freeMemoryForGameplay();

--- a/lib/screens/search_screen/search_screen.dart
+++ b/lib/screens/search_screen/search_screen.dart
@@ -1246,6 +1246,7 @@ class _SearchScreenState extends State<SearchScreen> {
     final game = GameModel.fromDatabaseModel(dbGame);
 
     _gamepadNav.deactivate();
+    GamepadNavigationManager.rememberFocusOwner('search_screen');
 
     // Drive the secondary display's "Now Playing" page (and the live RA panel)
     // for this session, exactly as the games list and the Recent Games cards do
@@ -1275,7 +1276,7 @@ class _SearchScreenState extends State<SearchScreen> {
         // Stop the poll and hide the panel; search pushes no display state of
         // its own, so the secondary fades back to whatever art is underneath.
         _achievementsController.stop(hidePanel: true);
-        GamepadNavigationManager.reactivate();
+        GamepadNavigationManager.restoreFocusOwner();
       },
       onLaunchFailed: (ctx, result) async {
         _achievementsController.stop(hidePanel: true);
@@ -1288,7 +1289,7 @@ class _SearchScreenState extends State<SearchScreen> {
             type: NotificationType.error,
           );
         }
-        GamepadNavigationManager.reactivate();
+        GamepadNavigationManager.restoreFocusOwner();
       },
     );
   }

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -318,6 +318,8 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
 
         final syncProvider = context.read<SyncManager>().active!;
 
+        GamepadNavigationManager.rememberFocusOwner('my_systems_carousel');
+
         // Push the in-game RetroAchievements panel to the secondary display.
         // Fired without awaiting so it never blocks the emulator handoff; it
         // lands during launchGameWithDialog's foreground window, overlaying the
@@ -346,7 +348,7 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
             // Stop the poll and hide the panel so it fades back to the art.
             _achievementsController.stop(hidePanel: true);
             if (mounted) setState(() => _isGameLaunching = false);
-            _gamepadNav.activate();
+            GamepadNavigationManager.restoreFocusOwner();
             Provider.of<SqliteDatabaseProvider>(
               context,
               listen: false,
@@ -355,7 +357,7 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
           onLaunchFailed: (ctx, r) async {
             _achievementsController.stop(hidePanel: true);
             if (mounted) setState(() => _isGameLaunching = false);
-            _gamepadNav.activate();
+            GamepadNavigationManager.restoreFocusOwner();
           },
         );
       } catch (e) {

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -310,6 +310,7 @@ class MySystems extends StatelessWidget {
 
       try {
         GamepadNavigationManager.deactivateAll();
+        GamepadNavigationManager.rememberFocusOwner('my_systems_list');
         MySystems.gridLaunchNotifier.value = true;
 
         final fileProvider = Provider.of<FileProvider>(context, listen: false);
@@ -352,7 +353,7 @@ class MySystems extends StatelessWidget {
             // Stop the poll and hide the panel so it fades back to the art.
             achievementsController.stop(hidePanel: true);
             MySystems.gridLaunchNotifier.value = false;
-            GamepadNavigationManager.reactivate();
+            GamepadNavigationManager.restoreFocusOwner();
             Provider.of<SqliteDatabaseProvider>(
               context,
               listen: false,
@@ -361,7 +362,7 @@ class MySystems extends StatelessWidget {
           onLaunchFailed: (ctx, r) async {
             achievementsController.stop(hidePanel: true);
             MySystems.gridLaunchNotifier.value = false;
-            GamepadNavigationManager.reactivate();
+            GamepadNavigationManager.restoreFocusOwner();
           },
         );
       } catch (e) {
@@ -375,7 +376,7 @@ class MySystems extends StatelessWidget {
             type: NotificationType.error,
           );
         }
-        GamepadNavigationManager.reactivate();
+        GamepadNavigationManager.restoreFocusOwner();
       } finally {
         MySystems.isNavigating = false;
       }

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -1527,6 +1527,18 @@ class GameLaunchService {
   }
 
   /// Checks for a running process on Windows using the tasklist command.
+  ///
+  /// CSV output is not cosmetic. `tasklist`'s default table format renders the
+  /// image name in a fixed 25-character column and silently truncates anything
+  /// longer, so reading the full name back out of it is impossible. DuckStation
+  /// ships as `duckstation-qt-x64-ReleaseLTCG.exe` (34 characters) and tasklist
+  /// printed it as `duckstation-qt-x64-Releas`: the filter matched and the row
+  /// came back, but the substring test against the full name did not, so a
+  /// running emulator was reported as gone. [GameLaunchManager]'s poll then
+  /// declared the session over ~2s after launch, which closed the launch dialog
+  /// and handed the controller back to the UI while the game was still on
+  /// screen — every D-pad press navigated NeoStation behind the emulator and
+  /// every A press launched another game. `/FO CSV` quotes the name in full.
   static Future<bool> _isProcessRunning(String processName) async {
     if (!Platform.isWindows) return false;
 
@@ -1535,14 +1547,40 @@ class GameLaunchService {
         '/FI',
         'IMAGENAME eq $processName',
         '/NH',
+        '/FO',
+        'CSV',
       ]);
-      return result.stdout.toString().toLowerCase().contains(
-        processName.toLowerCase(),
-      );
+      return csvListsProcess(result.stdout.toString(), processName);
     } catch (e) {
       _log.e('Error checking if $processName is running: $e');
       return false;
     }
+  }
+
+  /// Whether [output] from `tasklist /FO CSV` lists [processName] as running.
+  ///
+  /// Only the first CSV field — the image name — is compared, and it must match
+  /// in full. Searching the whole line would match a name appearing in another
+  /// column, and would also match the `INFO: No tasks are running which match
+  /// the specified criteria.` notice that tasklist prints on stdout whenever
+  /// the filter selects nothing (that notice echoes no name today, but reading
+  /// only the field we mean costs nothing and cannot be surprised).
+  @visibleForTesting
+  static bool csvListsProcess(String output, String processName) {
+    final target = processName.toLowerCase();
+
+    for (final line in output.split(RegExp(r'\r?\n'))) {
+      final row = line.trim();
+      // Every data row is quoted; anything else is a notice, not a process.
+      if (!row.startsWith('"')) continue;
+
+      final closingQuote = row.indexOf('"', 1);
+      if (closingQuote <= 1) continue;
+
+      if (row.substring(1, closingQuote).toLowerCase() == target) return true;
+    }
+
+    return false;
   }
 
   /// Checks for a running process on Unix-like systems using the pgrep command.

--- a/lib/services/game/game_session_manager.dart
+++ b/lib/services/game/game_session_manager.dart
@@ -247,60 +247,83 @@ class GameSessionManager {
     _playtimeTimer = null;
   }
 
+  /// Whether a teardown is already in flight. See [endGameSession].
+  static bool _isEndingSession = false;
+
   /// Gracefully terminates the active game session and finalizes playtime tracking.
+  ///
+  /// Re-entrant by nature, and guarded accordingly: on desktop the exit
+  /// callback below is dispatched from the middle of this method and drives the
+  /// launch dialog's close synchronously, which calls straight back in here.
+  /// The nested call used to find `_isGameLaunched` still set — it is cleared at
+  /// the bottom — so it re-ran the whole teardown, recording the playtime and
+  /// the RomM session twice, and then read `_currentGame!` after its first
+  /// await, by which point the outer call had finished and nulled it. The
+  /// resulting null-check error surfaced nowhere (an unhandled async error does
+  /// not reach `FlutterError.onError`), so the launch dialog never received
+  /// `completeClose()` and sat on "Closing game" until the user dismissed it by
+  /// hand.
+  ///
+  /// The session state is therefore read once, up front, and every later step
+  /// works from those locals rather than from fields another call may clear.
   static Future<void> endGameSession() async {
-    if (!_isGameLaunched) return;
+    if (!_isGameLaunched || _isEndingSession) return;
+    _isEndingSession = true;
 
-    if (_gameLaunchTime != null &&
-        _lastPlaytimeSave != null &&
-        _currentGameSystem != null &&
-        _currentGame != null) {
-      final now = DateTime.now();
-      final elapsedSinceLastSave = now.difference(_lastPlaytimeSave!).inSeconds;
-      if (elapsedSinceLastSave > 0) {
-        await _savePlayTime(
-          _currentGameSystem!,
-          _currentGame!,
-          elapsedSinceLastSave,
-        );
+    try {
+      final system = _currentGameSystem;
+      final game = _currentGame;
+      final launchTime = _gameLaunchTime;
+      final lastPlaytimeSave = _lastPlaytimeSave;
+
+      if (launchTime != null &&
+          lastPlaytimeSave != null &&
+          system != null &&
+          game != null) {
+        final now = DateTime.now();
+        final elapsedSinceLastSave = now.difference(lastPlaytimeSave).inSeconds;
+        if (elapsedSinceLastSave > 0) {
+          await _savePlayTime(system, game, elapsedSinceLastSave);
+        }
+
+        // Report the session as a whole (not just the un-persisted tail) to the
+        // RomM outbox: RomM stores playtime as sessions, and the incremental
+        // 10s writes above are a local persistence detail.
+        if (game.romPath != null) {
+          await _recordRommPlaySession(
+            romname: game.romname,
+            systemFolder: game.systemFolderName ?? system.folderName,
+            romPath: game.romPath!,
+            start: launchTime,
+            end: now,
+          );
+        }
+        _syncSavesAfterClose(game);
       }
 
-      // Report the session as a whole (not just the un-persisted tail) to the
-      // RomM outbox: RomM stores playtime as sessions, and the incremental
-      // 10s writes above are a local persistence detail.
-      final game = _currentGame!;
-      if (game.romPath != null) {
-        await _recordRommPlaySession(
-          romname: game.romname,
-          systemFolder: game.systemFolderName ?? _currentGameSystem!.folderName,
-          romPath: game.romPath!,
-          start: _gameLaunchTime!,
-          end: now,
-        );
+      _stopPlaytimeTimer();
+
+      if (Platform.isAndroid) {
+        const platform = MethodChannel('com.neogamelab.neostation/game');
+        await platform.invokeMethod('setGamepadBlock', {'block': false});
+        GameSessionPersistence.clearGameSession();
+      } else if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+        if (_onProcessExitCallback != null) {
+          _onProcessExitCallback!();
+        }
       }
-      _syncSavesAfterClose(game);
+
+      _isGameLaunched = false;
+      _gameLaunchTime = null;
+      _lastPlaytimeSave = null;
+      _launchedEmulatorExe = null;
+      _currentGameSystem = null;
+      _currentGame = null;
+
+      _notifySessionEnded();
+    } finally {
+      _isEndingSession = false;
     }
-
-    _stopPlaytimeTimer();
-
-    if (Platform.isAndroid) {
-      const platform = MethodChannel('com.neogamelab.neostation/game');
-      await platform.invokeMethod('setGamepadBlock', {'block': false});
-      GameSessionPersistence.clearGameSession();
-    } else if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
-      if (_onProcessExitCallback != null) {
-        _onProcessExitCallback!();
-      }
-    }
-
-    _isGameLaunched = false;
-    _gameLaunchTime = null;
-    _lastPlaytimeSave = null;
-    _launchedEmulatorExe = null;
-    _currentGameSystem = null;
-    _currentGame = null;
-
-    _notifySessionEnded();
   }
 
   static Future<void> _savePlayTime(

--- a/lib/services/gamepad/gamepad_navigation_manager.dart
+++ b/lib/services/gamepad/gamepad_navigation_manager.dart
@@ -147,6 +147,76 @@ class GamepadNavigationManager {
     }
   }
 
+  /// Records which layer owned input when an external launch began.
+  ///
+  /// Cleared by [restoreFocusOwner].
+  static String? _focusOwnerId;
+
+  /// Remembers [id] as the layer to hand input back to when the game ends.
+  ///
+  /// Call it where the launch begins, before the emulator handoff — by the time
+  /// the game exits, the stack may no longer say who was in charge.
+  static void rememberFocusOwner(String id) {
+    _focusOwnerId = id;
+    _log.i('[GamepadNavigationManager] Launch focus owner: $id');
+  }
+
+  /// Returns input to the layer that owned it when the launch began.
+  ///
+  /// [reactivate] alone is not enough here. A launch tears down and rebuilds a
+  /// lot of UI — the games list drops its entries to free memory for the
+  /// emulator, artwork caches are cleared — and a background screen that
+  /// remounts during that window re-pushes its own layer, landing it on top of
+  /// the stack. Waking "the top layer" then wakes whatever drifted up there
+  /// rather than the screen the user is looking at, and the controller appears
+  /// dead: the observed case was the systems carousel re-registering behind the
+  /// launch dialog, so returning from a game left input on the carousel while
+  /// the games list stayed on screen and deactivated.
+  ///
+  /// Restoring the owner moves it back to the top, which is also the right
+  /// order for what follows: a screen that mounted behind it stays behind it.
+  /// Falls back to [reactivate] when nothing was remembered or the owner is
+  /// gone (its screen was disposed while the game ran).
+  static void restoreFocusOwner() {
+    final ownerId = _focusOwnerId;
+    _focusOwnerId = null;
+
+    if (ownerId == null) {
+      reactivate();
+      return;
+    }
+
+    final index = _stack.indexWhere((layer) => layer.id == ownerId);
+    if (index == -1) {
+      _log.w(
+        '[GamepadNavigationManager] Launch focus owner $ownerId is no longer '
+        'registered; falling back to the top of the stack',
+      );
+      reactivate();
+      return;
+    }
+
+    if (index != _stack.length - 1) {
+      final displaced = _stack.last;
+      _log.i(
+        '[GamepadNavigationManager] Restoring $ownerId over ${displaced.id}, '
+        'which took the top of the stack during the launch',
+      );
+
+      // The drifted layer may have been activated by its own push while the
+      // game was running, so take input off it explicitly.
+      try {
+        displaced.onDeactivate();
+      } catch (e) {
+        _log.e('Error deactivating layer ${displaced.id}: $e');
+      }
+
+      _stack.add(_stack.removeAt(index));
+    }
+
+    reactivate();
+  }
+
   /// Reactivates the topmost layer in the stack.
   static void reactivate() {
     if (_stack.isNotEmpty) {

--- a/lib/utils/desktop_window_focus.dart
+++ b/lib/utils/desktop_window_focus.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:window_manager/window_manager.dart';
+
+import 'package:neostation/services/logger_service.dart';
+
+/// Tracks whether the NeoStation window currently holds OS focus on desktop.
+///
+/// Desktop gamepad input does not follow window focus the way keyboard input
+/// does: the backend reads the device directly, so a launched emulator sitting
+/// in front of NeoStation does not stop the pad from reaching us. The only
+/// thing that normally keeps the hidden UI quiet during a game is the launch
+/// flow deactivating its navigation layers — which means any bug that ends a
+/// session early (see the tasklist image-name truncation fixed alongside this)
+/// hands the controller straight back to a window the user cannot see, and
+/// their next few presses navigate and launch games behind the emulator.
+///
+/// This is the backstop for that whole class of bug: while the window is
+/// blurred, gamepad input is not acted on regardless of what the session
+/// bookkeeping believes.
+///
+/// **Fail open.** The flag starts `true` and every uncertain path leaves it
+/// `true`, so a platform that never reports focus at all behaves exactly as it
+/// does today. The dangerous direction is a *missed focus* event stranding the
+/// app as permanently blurred, so [verifySoon] re-asks the window manager
+/// (at most once a second) whenever input arrives while we believe we are
+/// blurred. A missed event then costs one press, not the session.
+///
+/// Android is untouched: it blocks the pad natively while an emulator is in
+/// the foreground, and [initialize] is never called there.
+class DesktopWindowFocus with WindowListener {
+  DesktopWindowFocus._();
+
+  static final DesktopWindowFocus _instance = DesktopWindowFocus._();
+
+  static final _log = LoggerService.instance;
+
+  /// Minimum spacing between the corrective [verifySoon] round-trips, so a held
+  /// direction cannot fire one per event.
+  static const Duration _verifyInterval = Duration(seconds: 1);
+
+  static bool _focused = true;
+  static bool _listening = false;
+  static DateTime? _lastVerification;
+
+  /// Whether gamepad input should be acted on right now.
+  ///
+  /// Always true off desktop and before [initialize] has run.
+  static bool get allowsInput => _focused;
+
+  /// Starts tracking window focus. Desktop only; safe to call more than once.
+  ///
+  /// Call after `windowManager.ensureInitialized()`, which owns the channel
+  /// this listens on.
+  static Future<void> initialize() async {
+    if (!Platform.isWindows && !Platform.isLinux && !Platform.isMacOS) return;
+    if (_listening) return;
+
+    windowManager.addListener(_instance);
+    _listening = true;
+
+    // Seed from the real state rather than assuming: initialization happens
+    // during startup, and the user may already have clicked away.
+    try {
+      _focused = await windowManager.isFocused();
+    } catch (e) {
+      // Leave the fail-open default in place.
+      _log.w('[WindowFocus] Could not read initial focus state: $e');
+    }
+
+    _log.i('[WindowFocus] Tracking window focus (focused: $_focused)');
+  }
+
+  /// Re-checks the real focus state, at most once per [_verifyInterval].
+  ///
+  /// The corrective path for a focus event that never arrived. Deliberately
+  /// fire-and-forget: the event that triggered it is still dropped, and the
+  /// answer lands in time for the next one.
+  static void verifySoon() {
+    if (!_listening || _focused) return;
+
+    final now = DateTime.now();
+    if (_lastVerification != null &&
+        now.difference(_lastVerification!) < _verifyInterval) {
+      return;
+    }
+    _lastVerification = now;
+
+    windowManager
+        .isFocused()
+        .then((focused) {
+          if (focused && !_focused) {
+            _log.w(
+              '[WindowFocus] Input arrived while blurred but the window is '
+              'focused; correcting (a focus event was missed)',
+            );
+            _focused = true;
+          }
+        })
+        .catchError((Object e) {
+          _log.w('[WindowFocus] Focus re-check failed: $e');
+        });
+  }
+
+  @override
+  void onWindowFocus() {
+    if (_focused) return;
+    _focused = true;
+    _log.i('[WindowFocus] Window focused — gamepad input enabled');
+  }
+
+  @override
+  void onWindowBlur() {
+    if (!_focused) return;
+    _focused = false;
+    _log.i('[WindowFocus] Window blurred — gamepad input suppressed');
+  }
+
+  /// Overrides the tracked state. Tests only.
+  @visibleForTesting
+  static void setFocusedForTesting(bool focused) => _focused = focused;
+
+  /// Restores the pristine state. Tests only.
+  @visibleForTesting
+  static void resetForTesting() {
+    _focused = true;
+    _listening = false;
+    _lastVerification = null;
+  }
+
+  /// Drives [onWindowFocus]/[onWindowBlur] without a real window. Tests only.
+  @visibleForTesting
+  static DesktopWindowFocus get listenerForTesting => _instance;
+}

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -7,6 +7,7 @@ import 'package:window_manager/window_manager.dart';
 import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/services/sfx_service.dart';
 import '../responsive.dart';
+import 'desktop_window_focus.dart';
 import 'gamepad_translator.dart';
 import 'select_tap.dart';
 import '../main.dart' show FullscreenNotifier;
@@ -699,6 +700,16 @@ class GamepadNavigation {
       final translatedEvent = _translator.translateEvent(event);
 
       if (translatedEvent == null) return;
+
+      // Desktop: the pad reaches us whether or not our window has focus, so a
+      // launched emulator in front of NeoStation would otherwise drive the UI
+      // behind it. Deliberately placed AFTER translation, for the same reason
+      // the reactivation grace below is: the translator must observe every edge
+      // or its press/release state sticks and swallows the next real press.
+      if (!DesktopWindowFocus.allowsInput) {
+        DesktopWindowFocus.verifySoon();
+        return;
+      }
 
       final isShoulderInput =
           translatedEvent.inputType == GamepadInputType.buttonLB ||

--- a/lib/widgets/game_launch_dialog.dart
+++ b/lib/widgets/game_launch_dialog.dart
@@ -12,6 +12,7 @@ import '../models/game_model.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import '../services/game_service.dart';
 import '../services/game_launch_manager.dart';
+import '../services/logger_service.dart';
 import '../utils/gamepad_nav.dart';
 import '../constants/system_folder_names.dart';
 
@@ -142,9 +143,22 @@ class _GameLaunchDialogState extends State<GameLaunchDialog> {
 
   Future<void> _performPostSync() async {
     // End game session (saves playtime, unblocks Android native gamepad, clears state).
-    await GameService.endGameSession();
-    // Signal manager that everything is done → triggers closed phase → _closeDialog.
-    GameLaunchManager().completeClose();
+    //
+    // The teardown runs in a try/finally because this dialog is the only thing
+    // that can close itself: if [GameService.endGameSession] throws, the
+    // `completeClose()` below never runs, the dialog never reaches its closed
+    // phase, and the user is left staring at "Closing game" with no way out
+    // but dismissing it by hand. Nothing surfaces either — an unhandled async
+    // error here does not reach `FlutterError.onError`. Whatever happens to
+    // the session, the dialog must still be able to go away.
+    try {
+      await GameService.endGameSession();
+    } catch (e, stack) {
+      LoggerService.instance.e('Error ending game session: $e\n$stack');
+    } finally {
+      // Signal manager that everything is done → triggers closed phase → _closeDialog.
+      GameLaunchManager().completeClose();
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/widgets/game_launch_dialog.dart
+++ b/lib/widgets/game_launch_dialog.dart
@@ -64,10 +64,15 @@ class _GameLaunchDialogState extends State<GameLaunchDialog> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _dialogGamepadNav.initialize();
+      // Modal: launching frees memory and clears caches, so background screens
+      // remount while this dialog is up. Without the flag they push their own
+      // layer on top of it and take the controller off the dialog — including
+      // its own dismiss buttons — for the rest of the session.
       GamepadNavigationManager.pushLayer(
         'game_launch_dialog',
         onActivate: () => _dialogGamepadNav.activate(),
         onDeactivate: () => _dialogGamepadNav.deactivate(),
+        modal: true,
       );
     });
   }

--- a/test/desktop_window_focus_test.dart
+++ b/test/desktop_window_focus_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/desktop_window_focus.dart';
+
+/// Pins the backstop that keeps a background NeoStation window from acting on
+/// gamepad input.
+///
+/// Desktop gamepad input does not follow window focus, so an emulator running
+/// in front of NeoStation still lets the pad reach the hidden UI. Any bug that
+/// ends a game session early therefore turns into ghost navigation: presses
+/// land on a window the user cannot see. These tests fix the two properties
+/// that make the gate safe to have at all — it fails open, and it recovers.
+void main() {
+  setUp(DesktopWindowFocus.resetForTesting);
+  tearDown(DesktopWindowFocus.resetForTesting);
+
+  group('DesktopWindowFocus', () {
+    test('allows input before initialization', () {
+      // Fail open: Android and any platform that never reports focus must
+      // behave exactly as they did before the gate existed.
+      expect(DesktopWindowFocus.allowsInput, isTrue);
+    });
+
+    test('suppresses input while the window is blurred', () {
+      DesktopWindowFocus.listenerForTesting.onWindowBlur();
+
+      expect(DesktopWindowFocus.allowsInput, isFalse);
+    });
+
+    test('restores input when the window is focused again', () {
+      DesktopWindowFocus.listenerForTesting
+        ..onWindowBlur()
+        ..onWindowFocus();
+
+      expect(
+        DesktopWindowFocus.allowsInput,
+        isTrue,
+        reason: 'returning from an emulator must hand the controller back',
+      );
+    });
+
+    test('repeated blur and focus events are idempotent', () {
+      final listener = DesktopWindowFocus.listenerForTesting;
+
+      listener
+        ..onWindowBlur()
+        ..onWindowBlur();
+      expect(DesktopWindowFocus.allowsInput, isFalse);
+
+      listener
+        ..onWindowFocus()
+        ..onWindowFocus();
+      expect(DesktopWindowFocus.allowsInput, isTrue);
+    });
+
+    test('verifySoon is inert when focus is not being tracked', () {
+      // Nothing is listening in a unit test, so the corrective re-check must
+      // not reach for a window-manager channel that does not exist.
+      DesktopWindowFocus.setFocusedForTesting(false);
+
+      expect(DesktopWindowFocus.verifySoon, returnsNormally);
+      expect(DesktopWindowFocus.allowsInput, isFalse);
+    });
+
+    test('verifySoon does nothing while the window is already focused', () {
+      expect(DesktopWindowFocus.verifySoon, returnsNormally);
+      expect(DesktopWindowFocus.allowsInput, isTrue);
+    });
+  });
+}

--- a/test/gamepad_navigation_manager_test.dart
+++ b/test/gamepad_navigation_manager_test.dart
@@ -108,4 +108,131 @@ void main() {
       r.pop('app_screen');
     });
   });
+
+  group('GamepadNavigationManager launch focus owner', () {
+    test(
+      'returns input to the launching screen, not to whatever drifted up',
+      () {
+        // The observed failure: launching frees memory and clears artwork
+        // caches, the systems carousel remounts behind the launch dialog and
+        // re-pushes its layer, and the games list the user is looking at ends up
+        // buried. Waking "the top layer" then woke the carousel and the
+        // controller looked dead.
+        final r = _Recorder();
+        r.push('app_screen');
+        r.push('my_systems_list');
+        r.push('system_games_list');
+
+        GamepadNavigationManager.rememberFocusOwner('system_games_list');
+        GamepadNavigationManager.deactivateAll();
+
+        // The background screen remounts mid-launch and lands on top.
+        r.pop('my_systems_list');
+        r.push('my_systems_list');
+        r.events.clear();
+
+        GamepadNavigationManager.restoreFocusOwner();
+
+        expect(r.events, ['-my_systems_list', '+system_games_list']);
+
+        r.pop('system_games_list');
+        r.pop('my_systems_list');
+        r.pop('app_screen');
+      },
+    );
+
+    test('leaves the owner alone when it is already on top', () {
+      final r = _Recorder();
+      r.push('app_screen');
+      r.push('system_games_list');
+
+      GamepadNavigationManager.rememberFocusOwner('system_games_list');
+      GamepadNavigationManager.deactivateAll();
+      r.events.clear();
+
+      GamepadNavigationManager.restoreFocusOwner();
+
+      expect(r.events, [
+        '+system_games_list',
+      ], reason: 'the ordinary path must not churn the stack');
+
+      r.pop('system_games_list');
+      r.pop('app_screen');
+    });
+
+    test('falls back to the top layer when the owner is gone', () {
+      // Its screen was disposed while the game ran.
+      final r = _Recorder();
+      r.push('app_screen');
+      r.push('system_games_list');
+
+      GamepadNavigationManager.rememberFocusOwner('system_games_list');
+      GamepadNavigationManager.deactivateAll();
+      r.pop('system_games_list');
+      r.events.clear();
+
+      GamepadNavigationManager.restoreFocusOwner();
+
+      expect(r.events, ['+app_screen']);
+
+      r.pop('app_screen');
+    });
+
+    test('falls back to the top layer when no owner was remembered', () {
+      final r = _Recorder();
+      r.push('app_screen');
+      r.push('my_systems_list');
+      GamepadNavigationManager.deactivateAll();
+      r.events.clear();
+
+      GamepadNavigationManager.restoreFocusOwner();
+
+      expect(r.events, ['+my_systems_list']);
+
+      r.pop('my_systems_list');
+      r.pop('app_screen');
+    });
+
+    test('a remembered owner is consumed, not reused by the next launch', () {
+      final r = _Recorder();
+      r.push('app_screen');
+      r.push('system_games_list');
+
+      GamepadNavigationManager.rememberFocusOwner('system_games_list');
+      GamepadNavigationManager.restoreFocusOwner();
+
+      // A later layer opens with nothing remembered for it. A stale owner
+      // would drag input back to the games list underneath.
+      r.push('game_settings_dialog');
+      r.events.clear();
+
+      GamepadNavigationManager.restoreFocusOwner();
+
+      expect(r.events, ['+game_settings_dialog']);
+
+      r.pop('game_settings_dialog');
+      r.pop('system_games_list');
+      r.pop('app_screen');
+    });
+
+    test('the modal launch dialog keeps input while a screen remounts', () {
+      // The dialog owns A/B (dismiss) for its whole lifetime; a background
+      // remount used to take that off it.
+      final r = _Recorder();
+      r.push('app_screen');
+      r.push('system_games_list');
+      r.push('game_launch_dialog', modal: true);
+      r.events.clear();
+
+      r.pop('my_systems_list'); // Not registered; mirrors a real remount.
+      r.push('my_systems_list');
+
+      expect(r.events, isEmpty);
+
+      r.pop('game_launch_dialog');
+      r.pop('my_systems_list');
+      r.pop('system_games_list');
+      r.pop('app_screen');
+    });
+  });
 }

--- a/test/windows_process_detection_test.dart
+++ b/test/windows_process_detection_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/game/game_launch_service.dart';
+
+/// Pins the parsing of `tasklist` output that decides whether a launched
+/// emulator is still alive on Windows.
+///
+/// The desktop session poll asks this question every two seconds; a false "not
+/// running" ends the session while the game is still on screen, which closes
+/// the launch dialog and reactivates gamepad navigation behind the emulator.
+/// The reported symptom was NeoStation navigating and launching further games
+/// under a running DuckStation.
+void main() {
+  group('csvListsProcess', () {
+    test('matches an image name too long for the default table column', () {
+      // The exact failure: tasklist's table format caps the image-name column
+      // at 25 characters, so `duckstation-qt-x64-ReleaseLTCG.exe` printed as
+      // `duckstation-qt-x64-Releas` and never matched. CSV quotes it in full.
+      const output =
+          '"duckstation-qt-x64-ReleaseLTCG.exe","4692","Console","1","301,984 K"';
+
+      expect(
+        GameLaunchService.csvListsProcess(
+          output,
+          'duckstation-qt-x64-ReleaseLTCG.exe',
+        ),
+        isTrue,
+        reason: 'a running emulator must never be reported as exited',
+      );
+    });
+
+    test('matches a short image name', () {
+      const output = '"retroarch.exe","1234","Console","1","120,000 K"';
+
+      expect(
+        GameLaunchService.csvListsProcess(output, 'retroarch.exe'),
+        isTrue,
+      );
+    });
+
+    test('ignores case, as Windows does', () {
+      const output = '"RetroArch.exe","1234","Console","1","120,000 K"';
+
+      expect(
+        GameLaunchService.csvListsProcess(output, 'retroarch.exe'),
+        isTrue,
+      );
+    });
+
+    test('reports nothing running when the filter selected nothing', () {
+      const output =
+          'INFO: No tasks are running which match the specified criteria.';
+
+      expect(
+        GameLaunchService.csvListsProcess(output, 'duckstation.exe'),
+        isFalse,
+      );
+    });
+
+    test('reports nothing running for empty output', () {
+      expect(GameLaunchService.csvListsProcess('', 'duckstation.exe'), isFalse);
+    });
+
+    test('does not match a different process', () {
+      const output = '"retroarch.exe","1234","Console","1","120,000 K"';
+
+      expect(
+        GameLaunchService.csvListsProcess(output, 'duckstation.exe'),
+        isFalse,
+      );
+    });
+
+    test('does not match the name appearing in a later column', () {
+      // Defensive: only the image-name field decides. A name that turns up
+      // anywhere else in the row is not this process running.
+      const output = '"other.exe","1234","duckstation.exe","1","120,000 K"';
+
+      expect(
+        GameLaunchService.csvListsProcess(output, 'duckstation.exe'),
+        isFalse,
+      );
+    });
+
+    test('does not match on a shared prefix', () {
+      const output =
+          '"duckstation-qt-x64-ReleaseLTCG.exe","4692","Console","1","301,984 K"';
+
+      expect(
+        GameLaunchService.csvListsProcess(output, 'duckstation.exe'),
+        isFalse,
+      );
+    });
+
+    test('finds the process among several rows', () {
+      const output =
+          '"retroarch.exe","1234","Console","1","120,000 K"\r\n'
+          '"duckstation-qt-x64-ReleaseLTCG.exe","4692","Console","1","301,984 K"\r\n';
+
+      expect(
+        GameLaunchService.csvListsProcess(
+          output,
+          'duckstation-qt-x64-ReleaseLTCG.exe',
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

A user on Discord reported that launching a PS1 game with standalone DuckStation left NeoStation
live in the background: "whenever you move the dpad or press buttons on controller, NeoStation is
still working and launching games/settings in the background. This basically makes it unusable."

The root cause is one line of `tasklist` parsing. Fixing it exposed three further defects on the same
path, each fixed in its own commit so they can be reverted independently.

**1. `tasklist` truncation ends the session two seconds after launch** (`e76f3825`)

`tasklist`'s default table format caps the image-name column at 25 characters and truncates anything
longer, so reading the full name back out of it never worked. DuckStation ships as
`duckstation-qt-x64-ReleaseLTCG.exe` (34 characters) and prints as `duckstation-qt-x64-Releas` — the
filter matched and the row came back, but the substring test against the full name did not.

`GameLaunchManager`'s two-second poll therefore declared the session over almost immediately, which
closed the launch dialog and reactivated the gamepad navigation layer underneath it while the game
was still on screen. Because the Windows gamepad backend delivers events regardless of window focus,
every D-pad press then navigated NeoStation behind the emulator and every A press launched another
game. `retroarch.exe` and every other short executable name fit the column, which is why only
standalone emulators surfaced it.

Now reads `/FO CSV`, which quotes the name in full, and compares only the first field.

**2. Nothing else stopped input reaching a background window** (`9e065d1c`)

Desktop gamepad input does not follow window focus the way keyboard input does. The only thing
keeping the hidden UI quiet during a game was the launch flow deactivating its navigation layers,
so *any* bug that ends a session early turns straight into ghost navigation. Input is now gated on
real window focus via `window_manager`, as a backstop rather than a fix for a specific bug.

The gate fails open: it starts enabled and every uncertain path leaves it enabled, so a platform
that never reports focus behaves exactly as before. The dangerous direction is a missed focus event
stranding the app as blurred, so input arriving while blurred re-asks the window manager (at most
once a second) and corrects itself — a missed event costs one press rather than the session. Android
is untouched; it blocks the pad natively while an emulator is in the foreground.

**3. Returning from a game woke the wrong screen** (`701c802e`)

Launching frees memory for the emulator, and a background screen that remounts during that window
re-pushes its own navigation layer, landing on top of the stack. Waking "the top layer" on return
then woke whatever had drifted up there, leaving the visible screen deactivated — the controller
appeared completely dead while the music resumed as normal. Observed with the systems carousel
re-registering behind the launch dialog:

```
Pushing layer: game_launch_dialog
Popping layer: my_systems_list
Pushing layer: my_systems_list      <- now above the dialog
...
Reactivating top layer: my_systems_list     <- games list left buried and inert
```

Each launcher now names the layer that owned input when the launch began, and gets that one back.
The launch dialog is also pushed as a modal layer, so a background remount cannot take the
controller off it mid-launch — it owns A and B for dismissal and was losing them for the rest of the
session.

**4. The launch dialog could stick on "Closing game" forever** (`fdbc85b5`)

On desktop the process-exit callback is dispatched from the middle of `endGameSession()` and drives
the dialog's close synchronously, which calls straight back into `endGameSession()`. The nested call
found `_isGameLaunched` still set — it is cleared at the bottom — so it re-ran the whole teardown,
recording playtime and the RomM session twice, then read `_currentGame!` after its first await, by
which point the outer call had nulled it.

Nothing surfaced: an unhandled async error does not reach `FlutterError.onError`, so the throw was
swallowed, `completeClose()` never ran, and the dialog sat on "Closing game" with the game already
gone. The only way out was dismissing it by hand. The teardown is now re-entrancy-guarded and reads
its state once up front, and the dialog completes its close in a `finally` so nothing can strand it
again.

Defects 3 and 4 are pre-existing, but the ordering that reaches them only became live once the
session stopped ending two seconds after launch.

## Steps to Reproduce

**Preconditions:** Windows, standalone DuckStation set as the PS1 default, emulator installed at a
path whose executable name is longer than 25 characters (the stock
`duckstation-qt-x64-ReleaseLTCG.exe` qualifies), controller connected.

1. Launch a PS1 game and wait for it to boot.
2. Press D-pad directions and A while the game is running.
3. Quit DuckStation.

Before: the selection moved and further games launched while the game was on screen; on return the
controller did nothing at all, though the UI music had resumed. `app.log` shows `Close triggered —
entering syncing phase` arriving immediately after `Game started — monitoring active`.

## Steps to Verify

**Preconditions:** as above.

1. Launch a PS1 game with standalone DuckStation and let it boot.
2. Press D-pad directions and A several times while the game runs. NeoStation must not move or
   launch anything — `app.log` shows `[WindowFocus] Window blurred — gamepad input suppressed`.
3. Quit DuckStation. The launch dialog closes by itself within about a second, and `app.log` shows
   `Close complete.` — that line was absent from every run before this branch.
4. The games list responds to the D-pad immediately, and B backs out to the systems view.
5. Launch a second game from the same screen and quit again, to exercise the restored layer order.

`app.log` should show `Close triggered — entering syncing phase` only *after* `Process exited with
code: 0`, never seconds after launch.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [x] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Verified end to end on Windows 11 against a real standalone DuckStation launch, including the
repeat-launch case, with `app.log` confirming each fix. Android is unaffected by construction (the
focus gate never initializes there and the native gamepad block is unchanged). Linux and macOS share
the desktop code paths but were not runtime-tested.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1593)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

New tests: `test/windows_process_detection_test.dart` (9 cases pinning the `tasklist` CSV parsing,
including the exact DuckStation row), `test/desktop_window_focus_test.dart` (6 cases pinning
fail-open and recovery), and 6 added to `test/gamepad_navigation_manager_test.dart` for the launch
focus owner.

<details>
<summary><b>Extra checks</b></summary>

**Navigation** — no new screens, but navigation behaviour changed:
- [x] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()` — unchanged; the launch dialog now pushes its existing layer as `modal`
- [x] B cancels / goes back, including out of a focused text field — unchanged

No user-facing strings, database, Android path, or `assets/systems/` changes.

</details>

---

AI-assisted: written with Claude Code; commits carry `AI-Assisted: Claude:Opus-5` trailers.
