### PR TITLE
fix(emulator): stop the default-emulator scan reporting healthy databases

### DIFF
--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -4124,6 +4124,45 @@ class SqliteService {
     DatabaseExecutorAdapter db,
   ) => instance._fixEmulatorDefaults(db);
 
+  /// Systems holding more than one *distinct* user-selected default emulator,
+  /// mapped to the emulator ids competing for them.
+  ///
+  /// The `DISTINCT` is the whole point. `user_emulator_config`'s primary key is
+  /// `emulator_unique_id` alone, so the same emulator can never appear twice —
+  /// but `app_emulators` is keyed on `(os_id, unique_identifier)` and therefore
+  /// holds one row per operating system the emulator is defined for. Joining
+  /// them fans a single user choice out to one row per OS, and counting those
+  /// rows reported a perfectly healthy database as broken: DuckStation is
+  /// defined for Android, Windows, Linux and macOS, so one PS1 default logged
+  /// as "system=ps1 has 4 user defaults (ps1.com.github.stenzek.duckstation
+  /// ×4)". The repeated id was the tell — a real violation names *different*
+  /// emulators.
+  ///
+  /// Counting distinct emulator ids still catches the real thing, which is two
+  /// different emulators both flagged as the user's pick for one system.
+  @visibleForTesting
+  static Future<Map<String, List<String>>> findDuplicateUserDefaults(
+    DatabaseExecutorAdapter db,
+  ) async {
+    final rows = await db.rawQuery('''
+      SELECT e.system_id AS sid,
+             GROUP_CONCAT(DISTINCT uc.emulator_unique_id) AS uids
+      FROM user_emulator_config uc
+      JOIN app_emulators e ON e.unique_identifier = uc.emulator_unique_id
+      WHERE uc.is_user_default = 1
+      GROUP BY e.system_id
+      HAVING COUNT(DISTINCT uc.emulator_unique_id) > 1
+    ''');
+
+    return {
+      for (final row in rows)
+        row['sid'].toString(): (row['uids']?.toString() ?? '')
+            .split(',')
+            .where((id) => id.isNotEmpty)
+            .toList(),
+    };
+  }
+
   /// Logs any system whose default-emulator state is self-contradictory.
   ///
   /// The invariant is "at most one `is_user_default` per system, and no app
@@ -4138,21 +4177,12 @@ class SqliteService {
       // NB: messages here deliberately avoid a word ending in "y" immediately
       // before a colon — `y` is a redacted query parameter, so "ANOMALY: system
       // ds" gets scrubbed to "ANOMALY: <redacted> ds" by the log redactor.
-      final dupes = await db.rawQuery('''
-        SELECT e.system_id AS sid,
-               COUNT(*) AS n,
-               GROUP_CONCAT(uc.emulator_unique_id) AS uids
-        FROM user_emulator_config uc
-        JOIN app_emulators e ON e.unique_identifier = uc.emulator_unique_id
-        WHERE uc.is_user_default = 1
-        GROUP BY e.system_id
-        HAVING COUNT(*) > 1
-      ''');
+      final dupes = await findDuplicateUserDefaults(db);
 
-      for (final row in dupes) {
+      for (final entry in dupes.entries) {
         _log.w(
-          '[EmuSel] anomaly - system=${row['sid']} has ${row['n']} user '
-          'defaults (${row['uids']})',
+          '[EmuSel] anomaly - system=${entry.key} has ${entry.value.length} '
+          'user defaults (${entry.value.join(', ')})',
         );
       }
 

--- a/test/emulator_default_anomaly_scan_test.dart
+++ b/test/emulator_default_anomaly_scan_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+import 'package:neostation/data/datasources/sqlite_service.dart';
+
+/// Pins the startup scan that reports a system with more than one user-selected
+/// default emulator.
+///
+/// The scan used to count *joined rows*. `app_emulators` is keyed on
+/// `(os_id, unique_identifier)`, so a single user choice fans out to one row per
+/// operating system the emulator is defined for, and a healthy database was
+/// reported as broken — "system=ps1 has 4 user defaults" for one DuckStation
+/// pick defined on four platforms.
+void main() {
+  late sqlite.Database db;
+  late DatabaseAdapter adapter;
+
+  setUp(() {
+    db = sqlite.sqlite3.openInMemory();
+    adapter = DatabaseAdapter(db);
+    db.execute('''
+      CREATE TABLE app_emulators (
+        unique_identifier TEXT NOT NULL,
+        os_id INTEGER NOT NULL,
+        system_id TEXT NOT NULL,
+        PRIMARY KEY (os_id, unique_identifier)
+      )
+    ''');
+    db.execute('''
+      CREATE TABLE user_emulator_config (
+        emulator_unique_id TEXT NOT NULL,
+        emulator_path TEXT NOT NULL,
+        is_user_default INTEGER DEFAULT NULL,
+        PRIMARY KEY (emulator_unique_id)
+      )
+    ''');
+  });
+
+  tearDown(() => db.close());
+
+  /// Registers [uniqueId] for [systemId] on each of [osIds], the way the
+  /// systems JSON does for every platform an emulator declares.
+  void defineEmulator(String uniqueId, String systemId, List<int> osIds) {
+    for (final osId in osIds) {
+      db.execute(
+        'INSERT INTO app_emulators (unique_identifier, os_id, system_id) '
+        'VALUES (?, ?, ?)',
+        [uniqueId, osId, systemId],
+      );
+    }
+  }
+
+  void chooseAsDefault(String uniqueId) {
+    db.execute(
+      'INSERT INTO user_emulator_config '
+      '(emulator_unique_id, emulator_path, is_user_default) VALUES (?, ?, 1)',
+      [uniqueId, ''],
+    );
+  }
+
+  group('findDuplicateUserDefaults', () {
+    test(
+      'one choice defined for several platforms is not an anomaly',
+      () async {
+        // The exact false positive: standalone DuckStation declares android,
+        // windows, linux and macos in assets/systems/ps1.json, so the join
+        // returned four rows for one deliberate choice.
+        defineEmulator('ps1.com.github.stenzek.duckstation', 'ps1', [
+          1,
+          2,
+          3,
+          4,
+        ]);
+        chooseAsDefault('ps1.com.github.stenzek.duckstation');
+
+        expect(
+          await SqliteService.findDuplicateUserDefaults(adapter),
+          isEmpty,
+          reason: 'a healthy single choice must never be reported as broken',
+        );
+      },
+    );
+
+    test('two different emulators for one system is an anomaly', () async {
+      // The real violation the scan exists to catch: whichever row the
+      // LIMIT 1 lookup happens to return wins, so the launch is a coin toss.
+      defineEmulator('ps1.com.github.stenzek.duckstation', 'ps1', [1, 2]);
+      defineEmulator('ps1.com.epsxe.ePSXe', 'ps1', [1, 2]);
+      chooseAsDefault('ps1.com.github.stenzek.duckstation');
+      chooseAsDefault('ps1.com.epsxe.ePSXe');
+
+      final anomalies = await SqliteService.findDuplicateUserDefaults(adapter);
+
+      expect(anomalies.keys, ['ps1']);
+      expect(
+        anomalies['ps1'],
+        containsAll([
+          'ps1.com.github.stenzek.duckstation',
+          'ps1.com.epsxe.ePSXe',
+        ]),
+      );
+    });
+
+    test('reports only the offending system', () async {
+      defineEmulator('ps1.duckstation', 'ps1', [1, 2, 3, 4]);
+      chooseAsDefault('ps1.duckstation');
+
+      defineEmulator('nds.melonds', 'nds', [1, 2]);
+      defineEmulator('nds.drastic', 'nds', [2]);
+      chooseAsDefault('nds.melonds');
+      chooseAsDefault('nds.drastic');
+
+      final anomalies = await SqliteService.findDuplicateUserDefaults(adapter);
+
+      expect(anomalies.keys, ['nds']);
+    });
+
+    test('a database with no user choices is silent', () async {
+      defineEmulator('ps1.duckstation', 'ps1', [1, 2, 3, 4]);
+
+      expect(await SqliteService.findDuplicateUserDefaults(adapter), isEmpty);
+    });
+
+    test('a cleared choice does not count', () async {
+      defineEmulator('ps1.duckstation', 'ps1', [1, 2]);
+      defineEmulator('ps1.epsxe', 'ps1', [1, 2]);
+      chooseAsDefault('ps1.duckstation');
+      db.execute(
+        'INSERT INTO user_emulator_config '
+        '(emulator_unique_id, emulator_path, is_user_default) VALUES (?, ?, 0)',
+        ['ps1.epsxe', ''],
+      );
+
+      expect(await SqliteService.findDuplicateUserDefaults(adapter), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
# Description

The startup default-emulator scan reports healthy databases as broken. It counts *joined rows*:

```sql
SELECT e.system_id, COUNT(*), GROUP_CONCAT(uc.emulator_unique_id)
FROM user_emulator_config uc
JOIN app_emulators e ON e.unique_identifier = uc.emulator_unique_id
WHERE uc.is_user_default = 1
GROUP BY e.system_id
HAVING COUNT(*) > 1
```

`user_emulator_config`'s primary key is `emulator_unique_id` alone, so the same emulator can never
appear twice — a duplicate row is not physically possible. But `app_emulators` is keyed on
`(os_id, unique_identifier)` and holds one row per operating system the emulator is defined for, so
the join fans a single user choice out to one row per platform.

Standalone DuckStation declares `android`, `windows`, `linux` and `macos` in
`assets/systems/ps1.json`, so one deliberate PS1 choice logs as:

```
[EmuSel] anomaly - system=ps1 has 4 user defaults (ps1.com.github.stenzek.duckstation ×4)
```

The repeated id is the tell — a real violation names *different* emulators. This fires for any
system whose chosen emulator is defined for more than one platform, so the warning is noise on a
healthy database and would bury a genuine one.

Counting distinct emulator ids still catches the real thing: two different emulators both flagged as
the user's pick for one system, where whichever row the `LIMIT 1` lookup happens to return wins the
launch.

The scan is log-only and the launch-path resolvers collapse the fan-out into sets and maps, so
nothing downstream ever misbehaved — this is a diagnostic that lied, not a launch bug.

The query is extracted into `findDuplicateUserDefaults` so the semantics can be pinned by tests. The
OS-scoped contradiction check alongside it is unchanged; it already scopes with `e2.os_id = e.os_id`
and is unaffected.

## Steps to Reproduce

**Preconditions:** any platform, any system whose user-selected default emulator is defined for more
than one OS in `assets/systems/` (PS1 with standalone DuckStation is the stock case).

1. Set standalone DuckStation as the default emulator for PS1.
2. Restart the app.
3. Look in `user-data/app.log` for `[EmuSel] anomaly`.

Before: `[EmuSel] anomaly - system=ps1 has 4 user defaults (ps1.com.github.stenzek.duckstation ×4)`
on every launch, with the same id repeated once per platform.

## Steps to Verify

**Preconditions:** as above.

1. Restart the app with a PS1 default set.
2. `app.log` shows `[EmuSel] default-emulator state consistent across all systems` and no anomaly
   line.
3. Change the PS1 default to a different emulator and restart — still consistent, because setting a
   default clears the previous one.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: log-only diagnostic with no behavioural effect; the query semantics
      are covered by unit tests against an in-memory database that reproduces the multi-OS
      `app_emulators` shape exactly, including the four-platform DuckStation row that caused the
      false positive.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1603)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

New test `test/emulator_default_anomaly_scan_test.dart` — 5 cases: a single choice defined for four
platforms is silent (the regression), two different emulators for one system is reported with both
ids, only the offending system is reported when a healthy one sits alongside it, an empty
`user_emulator_config` is silent, and a cleared (`is_user_default = 0`) row does not count.

<details>
<summary><b>Extra checks</b></summary>

**The database** — no schema change: this is a read-only diagnostic query, no new column, no
migration.

No user-facing strings, navigation, Android path, or `assets/systems/` changes.

</details>
