### PR TITLE
perf(desktop): hand back decoded artwork on minimise and stop the shimmer scaling with refresh rate

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:neostation/services/config_service.dart';
 import 'package:neostation/services/logger_service.dart';
+import 'package:neostation/utils/image_cache_budget.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -132,55 +133,57 @@ class ToggleFullscreenAction extends Action<ToggleFullscreenIntent> {
   }
 }
 
-/// Configures the Flutter [ImageCache] based on platform and available RAM.
+/// Physical RAM in whole gigabytes, or null when the platform will not say.
 ///
-/// Android: reads total memory via [DeviceInfoPlugin] and applies tiered limits.
-/// Desktop (Windows/macOS/Linux): applies generous defaults.
-Future<void> _configureImageCache() async {
+/// device_info_plus reports memory on Android, Windows and macOS but not on
+/// Linux, which is why that one reads procfs directly.
+Future<int?> _physicalRamGb() async {
   try {
     if (Platform.isAndroid) {
       final info = await DeviceInfoPlugin().androidInfo;
       LoggerService.instance.i(
         'Android device detected: ${info.model}, RAM: ${info.physicalRamSize} MB',
       );
-      final ramGb = info.physicalRamSize ~/ 1024;
-      LoggerService.instance.i(
-        'Configuring image cache for Android device with $ramGb GB RAM',
-      );
-      int maxBytes;
-      int maxSize;
-
-      if (ramGb <= 2) {
-        maxBytes = 40 * 1024 * 1024;
-        maxSize = 300;
-      } else if (ramGb <= 4) {
-        maxBytes = 80 * 1024 * 1024;
-        maxSize = 600;
-      } else if (ramGb <= 8) {
-        maxBytes = 200 * 1024 * 1024;
-        maxSize = 1000;
-      } else {
-        maxBytes = 400 * 1024 * 1024;
-        maxSize = 1500;
-      }
-
-      LoggerService.instance.i(
-        'Setting image cache limits: maxSize=$maxSize, maxBytes=${maxBytes ~/ (1024 * 1024)} MB',
-      );
-
-      PaintingBinding.instance.imageCache.maximumSize = maxSize;
-      PaintingBinding.instance.imageCache.maximumSizeBytes = maxBytes;
-    } else if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
-      PaintingBinding.instance.imageCache.maximumSize = 2000;
-      PaintingBinding.instance.imageCache.maximumSizeBytes = 400 * 1024 * 1024;
-    } else {
-      PaintingBinding.instance.imageCache.maximumSize = 1000;
-      PaintingBinding.instance.imageCache.maximumSizeBytes = 100 * 1024 * 1024;
+      return info.physicalRamSize ~/ 1024;
     }
-  } catch (_) {
-    PaintingBinding.instance.imageCache.maximumSize = 1000;
-    PaintingBinding.instance.imageCache.maximumSizeBytes = 100 * 1024 * 1024;
+    if (Platform.isWindows) {
+      final info = await DeviceInfoPlugin().windowsInfo;
+      return info.systemMemoryInMegabytes ~/ 1024;
+    }
+    if (Platform.isMacOS) {
+      final info = await DeviceInfoPlugin().macOsInfo;
+      return info.memorySize ~/ (1024 * 1024 * 1024);
+    }
+    if (Platform.isLinux) {
+      final meminfo = File('/proc/meminfo');
+      if (!meminfo.existsSync()) return null;
+      for (final line in meminfo.readAsLinesSync()) {
+        if (!line.startsWith('MemTotal:')) continue;
+        final kb = int.tryParse(
+          RegExp(r'(\d+)').firstMatch(line)?.group(1) ?? '',
+        );
+        return kb == null ? null : kb ~/ (1024 * 1024);
+      }
+    }
+  } catch (e) {
+    LoggerService.instance.w('Could not read physical RAM: $e');
   }
+  return null;
+}
+
+/// Sizes the decoded-image cache for the machine this build is running on.
+Future<void> _configureImageCache() async {
+  final int? ramGb = await _physicalRamGb();
+  final budget = ImageCacheBudget.forRam(ramGb);
+
+  LoggerService.instance.i(
+    'Image cache: ${budget.maximumSizeMb} MB / ${budget.maximumSize} entries '
+    '(physical RAM: ${ramGb == null ? 'unknown' : '$ramGb GB'})',
+  );
+
+  PaintingBinding.instance.imageCache
+    ..maximumSize = budget.maximumSize
+    ..maximumSizeBytes = budget.maximumSizeBytes;
 }
 
 /// Global navigator key so overlay notifications can outlive the widget that
@@ -196,11 +199,13 @@ void main() async {
   runApp(const StartupLoadingApp());
   await WidgetsBinding.instance.endOfFrame;
 
-  await _configureImageCache();
-
   final log = LoggerService.instance;
   await log.init();
   log.i('Starting NeoStation...');
+
+  // After log.init(): this used to run before it, so the budget it picked was
+  // never visible in app.log.
+  await _configureImageCache();
 
   // Resolve the user-data location before anything reads it, so the cold-boot
   // wait happens once (behind the loading screen) rather than once per caller.

--- a/lib/utils/image_cache_budget.dart
+++ b/lib/utils/image_cache_budget.dart
@@ -1,0 +1,59 @@
+/// How much decoded image data the app is allowed to keep resident.
+///
+/// Flutter's [ImageCache] holds *decoded* bitmaps, so its budget is close to a
+/// floor on the process's memory once the user has browsed a library with
+/// artwork: the cache fills to its cap and, by design, never gives anything
+/// back on its own.
+///
+/// Desktop used to take the largest budget unconditionally while Android
+/// scaled its budget to the device. That is the wrong way round: a desktop
+/// build runs on everything from a 4 GB mini PC to a 64 GB tower, and the one
+/// that cannot spare 400 MB of box art is exactly the one that was being asked
+/// for it. Both now come from the same table.
+class ImageCacheBudget {
+  const ImageCacheBudget({
+    required this.maximumSize,
+    required this.maximumSizeBytes,
+  });
+
+  /// Entry-count cap, mapped onto [ImageCache.maximumSize].
+  final int maximumSize;
+
+  /// Byte cap, mapped onto [ImageCache.maximumSizeBytes]. This is the limit
+  /// that actually binds in practice; the count rarely gets there first.
+  final int maximumSizeBytes;
+
+  /// Megabytes of [maximumSizeBytes], for logging.
+  int get maximumSizeMb => maximumSizeBytes ~/ (1024 * 1024);
+
+  /// The budget for a machine with [ramGb] gigabytes of physical RAM.
+  ///
+  /// A null [ramGb] means the platform would not tell us. That takes the
+  /// smallest budget rather than the largest, because guessing high costs a
+  /// small machine hundreds of megabytes it does not have, while guessing low
+  /// costs a large machine nothing but some re-decoding on scrollback.
+  factory ImageCacheBudget.forRam(int? ramGb) {
+    if (ramGb == null || ramGb <= 2) {
+      return const ImageCacheBudget(
+        maximumSize: 300,
+        maximumSizeBytes: 40 * 1024 * 1024,
+      );
+    }
+    if (ramGb <= 4) {
+      return const ImageCacheBudget(
+        maximumSize: 600,
+        maximumSizeBytes: 80 * 1024 * 1024,
+      );
+    }
+    if (ramGb <= 8) {
+      return const ImageCacheBudget(
+        maximumSize: 1000,
+        maximumSizeBytes: 200 * 1024 * 1024,
+      );
+    }
+    return const ImageCacheBudget(
+      maximumSize: 1500,
+      maximumSizeBytes: 400 * 1024 * 1024,
+    );
+  }
+}

--- a/lib/widgets/app_lifecycle_handler.dart
+++ b/lib/widgets/app_lifecycle_handler.dart
@@ -12,6 +12,7 @@ import '../services/game_service.dart';
 import '../services/music_player_service.dart';
 import '../providers/sqlite_config_provider.dart';
 import 'package:provider/provider.dart';
+import 'package:window_manager/window_manager.dart';
 
 /// Widget that detects when the app returns to the foreground and reactivates the gamepad
 class AppLifecycleHandler extends StatefulWidget {
@@ -24,7 +25,7 @@ class AppLifecycleHandler extends StatefulWidget {
 }
 
 class _AppLifecycleHandlerState extends State<AppLifecycleHandler>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, WindowListener {
   String? _lastKnownPlan;
   AppLifecycleListener? _exitListener;
 
@@ -57,6 +58,13 @@ class _AppLifecycleHandlerState extends State<AppLifecycleHandler>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+
+    // Desktop minimising does not reach didChangeAppLifecycleState: measured on
+    // Windows, parking the window fires no lifecycle state at all. window_manager
+    // is the only signal for it, so the off-screen handling is hung off both.
+    if (_isDesktop) {
+      windowManager.addListener(this);
+    }
 
     // Register exit listener to clean up native resources (SoLoud audio threads)
     // so the process exits cleanly when the window is closed.
@@ -104,6 +112,9 @@ class _AppLifecycleHandlerState extends State<AppLifecycleHandler>
   void dispose() {
     _exitListener?.dispose();
     GameService.onScreenStateChanged = null;
+    if (_isDesktop) {
+      windowManager.removeListener(this);
+    }
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -148,6 +159,42 @@ class _AppLifecycleHandlerState extends State<AppLifecycleHandler>
       if (!mounted) return;
       Provider.of<NotificationService>(context, listen: false).suspend();
       MusicPlayerService().appPaused();
+      _releaseDecodedImages();
+    }
+  }
+
+  static bool get _isDesktop =>
+      Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+
+  /// Desktop's equivalent of going to the background.
+  ///
+  /// Only minimising counts. Losing focus to another window happens constantly
+  /// while alt-tabbing, and re-decoding the visible artwork every time would
+  /// cost more than it saves; minimising is the user actually parking the app.
+  @override
+  void onWindowMinimize() {
+    _releaseDecodedImages();
+  }
+
+  /// Hands the decoded-image cache back when the app leaves the screen.
+  ///
+  /// The cache fills to its whole budget as the user browses artwork and then
+  /// holds it: nothing evicts on idle, so a minimised NeoStation sits on
+  /// hundreds of megabytes of box art that nothing is drawing. Desktop makes
+  /// that the normal case, since the app is left running behind other windows
+  /// for hours at a time.
+  ///
+  /// [ImageCache.clear] drops the cached and pending entries but leaves the
+  /// live ones, so whatever is still on screen does not have to be decoded
+  /// again on the way back in. Scrollback re-decodes, which is the intended
+  /// trade and the same one [GameLaunchService] already makes when handing the
+  /// machine over to an emulator.
+  void _releaseDecodedImages() {
+    final imageCache = PaintingBinding.instance.imageCache;
+    final int freedMb = imageCache.currentSizeBytes ~/ (1024 * 1024);
+    imageCache.clear();
+    if (freedMb > 0) {
+      _log.i('Released $freedMb MB of decoded images while off screen');
     }
   }
 

--- a/lib/widgets/shimmering_logo.dart
+++ b/lib/widgets/shimmering_logo.dart
@@ -28,6 +28,16 @@ class _ShimmeringLogoState extends State<ShimmeringLogo>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
 
+  /// Sweep position the glint is actually drawn at, republished from
+  /// [_controller] at a capped rate. See [_publishSweep].
+  final ValueNotifier<double> _sweep = ValueNotifier<double>(0);
+
+  /// Sweep travel required before the glint is redrawn.
+  ///
+  /// The controller spans the whole sweep over two seconds, so this is about
+  /// one 60 Hz frame's worth of movement, or roughly 2% of the logo's width.
+  static const double _minSweepDelta = 0.0075;
+
   @override
   void initState() {
     super.initState();
@@ -35,12 +45,40 @@ class _ShimmeringLogoState extends State<ShimmeringLogo>
       vsync: this,
       duration: const Duration(milliseconds: 2000),
     );
+    _controller.addListener(_publishSweep);
     final progress = widget.progress;
     if (progress == null) {
       _controller.repeat();
     } else {
       _controller.value = progress.clamp(0.0, 1.0);
     }
+  }
+
+  /// Republishes the controller's position to [_sweep] once the glint has
+  /// moved far enough to be worth redrawing.
+  ///
+  /// Every repaint rebuilds a [ShaderMask], which forces an offscreen
+  /// `saveLayer`. Driving that straight off the controller means paying for it
+  /// once per vsync, so the same sweep cost four times as much on a 240 Hz
+  /// display as on a 60 Hz one while looking identical. It is shown during
+  /// startup and library loading, which is where the app can least afford it.
+  ///
+  /// The gate is distance travelled rather than elapsed wall-clock time. A
+  /// 60 Hz display already covers more than [_minSweepDelta] per frame and so
+  /// is unaffected, while a 240 Hz one folds four vsyncs into one repaint of
+  /// what is the same picture. Throttling on a [Stopwatch] instead would run
+  /// off a clock the animation knows nothing about, ignoring `timeDilation`
+  /// and never advancing at all under a test's fake clock.
+  ///
+  /// A controller that has stopped always publishes, so a settled position is
+  /// never left short of where it should be.
+  void _publishSweep() {
+    final double value = _controller.value;
+    if (_controller.isAnimating &&
+        (value - _sweep.value).abs() < _minSweepDelta) {
+      return;
+    }
+    _sweep.value = value;
   }
 
   @override
@@ -65,7 +103,9 @@ class _ShimmeringLogoState extends State<ShimmeringLogo>
 
   @override
   void dispose() {
+    _controller.removeListener(_publishSweep);
     _controller.dispose();
+    _sweep.dispose();
     super.dispose();
   }
 
@@ -75,9 +115,9 @@ class _ShimmeringLogoState extends State<ShimmeringLogo>
     final clear = glint.withValues(alpha: 0.0);
     final shine = glint.withValues(alpha: 0.55);
 
-    return AnimatedBuilder(
-      animation: _controller,
-      builder: (context, child) {
+    return ValueListenableBuilder<double>(
+      valueListenable: _sweep,
+      builder: (context, sweep, child) {
         return ShaderMask(
           shaderCallback: (bounds) {
             return LinearGradient(
@@ -86,7 +126,7 @@ class _ShimmeringLogoState extends State<ShimmeringLogo>
               end: const Alignment(1.0, 0.4),
               colors: [clear, clear, shine, clear, clear],
               stops: const [0.0, 0.38, 0.5, 0.62, 1.0],
-              transform: _SlidingGradientTransform(_controller.value),
+              transform: _SlidingGradientTransform(sweep),
             ).createShader(bounds);
           },
           // srcATop draws the glint over the logo but only where the logo has

--- a/test/image_cache_budget_test.dart
+++ b/test/image_cache_budget_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/image_cache_budget.dart';
+
+/// Desktop used to take the top budget unconditionally (400 MB / 2000 entries)
+/// while Android scaled its budget to the device, so a 4 GB mini PC was allowed
+/// ten times the decoded artwork of a 4 GB phone. Both come from one table now.
+void main() {
+  test('scales the budget with physical RAM', () {
+    expect(ImageCacheBudget.forRam(2).maximumSizeMb, 40);
+    expect(ImageCacheBudget.forRam(4).maximumSizeMb, 80);
+    expect(ImageCacheBudget.forRam(8).maximumSizeMb, 200);
+    expect(ImageCacheBudget.forRam(16).maximumSizeMb, 400);
+    expect(ImageCacheBudget.forRam(64).maximumSizeMb, 400);
+  });
+
+  test('never widens the budget as RAM shrinks', () {
+    int previous = 0;
+    for (final gb in <int>[1, 2, 3, 4, 6, 8, 12, 16, 32, 64, 128]) {
+      final budget = ImageCacheBudget.forRam(gb);
+      expect(
+        budget.maximumSizeBytes,
+        greaterThanOrEqualTo(previous),
+        reason: '$gb GB got a smaller budget than the tier below it',
+      );
+      expect(budget.maximumSize, greaterThan(0));
+      previous = budget.maximumSizeBytes;
+    }
+  });
+
+  test('an unreadable RAM figure takes the smallest budget, not the largest', () {
+    // Guessing high costs a small machine memory it does not have; guessing low
+    // costs a large one some re-decoding. Only one of those is a bug report.
+    expect(
+      ImageCacheBudget.forRam(null).maximumSizeBytes,
+      ImageCacheBudget.forRam(1).maximumSizeBytes,
+    );
+    expect(
+      ImageCacheBudget.forRam(null).maximumSizeBytes,
+      lessThan(ImageCacheBudget.forRam(64).maximumSizeBytes),
+    );
+  });
+
+  test('reports megabytes consistently with the byte cap', () {
+    for (final gb in <int?>[null, 2, 4, 8, 16]) {
+      final budget = ImageCacheBudget.forRam(gb);
+      expect(budget.maximumSizeMb * 1024 * 1024, budget.maximumSizeBytes);
+    }
+  });
+}

--- a/test/shimmering_logo_test.dart
+++ b/test/shimmering_logo_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/widgets/shimmering_logo.dart';
+
+/// The sweep repaints a [ShaderMask], which forces an offscreen `saveLayer`.
+/// Driven straight off the [AnimationController] that happened once per vsync,
+/// so the identical-looking sweep cost four times as much on a 240 Hz display
+/// as on a 60 Hz one — during startup and library loading, where the app can
+/// least afford it. Repaints are now gated on how far the glint has travelled,
+/// which is a clock the animation and the test both share.
+void main() {
+  Future<void> pumpLogo(WidgetTester tester, {double? progress}) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(child: ShimmeringLogo(width: 200, progress: progress)),
+        ),
+      ),
+    );
+  }
+
+  /// The current [ShaderMask] instance. A new one means the sweep repainted.
+  ShaderMask maskOf(WidgetTester tester) => tester.widget<ShaderMask>(
+    find.descendant(
+      of: find.byType(ShimmeringLogo),
+      matching: find.byType(ShaderMask),
+    ),
+  );
+
+  /// Repaints observed while pumping [ticks] frames [interval] apart.
+  Future<int> countRepaints(
+    WidgetTester tester, {
+    required Duration interval,
+    required int ticks,
+  }) async {
+    ShaderMask last = maskOf(tester);
+    int repaints = 0;
+    for (int i = 0; i < ticks; i++) {
+      await tester.pump(interval);
+      final ShaderMask now = maskOf(tester);
+      if (!identical(now, last)) {
+        repaints++;
+        last = now;
+      }
+    }
+    return repaints;
+  }
+
+  testWidgets('folds several vsyncs into one repaint at 240 Hz', (
+    tester,
+  ) async {
+    await pumpLogo(tester);
+
+    // 60 ticks of 4 ms is 240 ms of a 240 Hz display. Unthrottled that is 60
+    // repaints; gating on travel allows 240/2000 of the sweep at 0.0075 a
+    // time, so 16.
+    final int repaints = await countRepaints(
+      tester,
+      interval: const Duration(milliseconds: 4),
+      ticks: 60,
+    );
+
+    expect(repaints, lessThanOrEqualTo(20));
+    // Still visibly sweeping, not stalled.
+    expect(repaints, greaterThan(5));
+  });
+
+  testWidgets('repaints on every tick at 60 Hz', (tester) async {
+    await pumpLogo(tester);
+
+    // One 60 Hz frame already travels further than the gate, so nothing is
+    // dropped here.
+    final int repaints = await countRepaints(
+      tester,
+      interval: const Duration(milliseconds: 17),
+      ticks: 20,
+    );
+
+    expect(repaints, greaterThanOrEqualTo(18));
+  });
+
+  testWidgets('a progress-driven logo does not run a ticker at rest', (
+    tester,
+  ) async {
+    await pumpLogo(tester, progress: 0.5);
+    await tester.pumpAndSettle();
+
+    // With progress supplied the glint tracks the scan instead of sweeping, so
+    // there is nothing to animate once it has settled.
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('the ambient sweep keeps running', (tester) async {
+    await pumpLogo(tester);
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // No pumpAndSettle here: the ambient sweep is deliberately endless, and
+    // settling it would time out.
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+  });
+}


### PR DESCRIPTION
# Description

The two follow-ups left open by #459: the shimmering logo's cost on a high refresh display, and the memory floor the decoded-image cache leaves behind.

**Artwork is never handed back.** The image cache holds *decoded* bitmaps, so its budget is close to a floor on the process once a library with artwork has been browsed. It fills to the cap and, by design, nothing evicts on idle. Measured on Windows, scrolling ROMs put 396 MB in it against a 400 MB budget and it stayed there for as long as the app ran. It is now released when the app leaves the screen. Live images are kept, so what is still visible is not decoded again on the way back in; only scrollback pays, which is the same trade `GameLaunchService` already makes when handing the machine over to an emulator.

Desktop hangs this off `window_manager` rather than `didChangeAppLifecycleState`. Minimising a Flutter window on Windows fires **no** `AppLifecycleState` at all, which I confirmed by measurement: the first cut of this used the lifecycle hook and was completely inert, private bytes unchanged across a minimise and nothing logged. `WindowListener` is the signal desktop actually has, and `CenteredScrollController` already uses it for this kind of thing. Android keeps the lifecycle path. Only minimising counts, not losing focus, because alt-tabbing is constant and re-decoding the visible artwork every time would cost more than it saves.

**The budget itself now scales.** Desktop took the largest budget unconditionally (400 MB / 2000 entries) while Android scaled to the device, so a 4 GB mini PC was allowed ten times the decoded artwork of a 4 GB phone. Both now come from one table keyed on physical RAM: `device_info_plus` on Android, Windows and macOS, and procfs on Linux, which reports none. A figure the platform will not give takes the smallest budget rather than the largest, since guessing high costs a small machine memory it does not have while guessing low costs a large one some re-decoding. To be clear about what this half does not do: above 8 GB nothing changes, so it is not the part that helps the machines in the reports. The release on minimise is.

**The shimmer cost four times too much at 240 Hz.** The sweep repaints a `ShaderMask`, which forces an offscreen `saveLayer`. Driving that straight off the `AnimationController` meant paying for it once per vsync, so an identical-looking sweep cost four times as much on a 240 Hz display as on a 60 Hz one, during startup and library loading where the app can least afford it. Repaints are now gated on how far the glint has travelled. One 60 Hz frame already covers more than the threshold so those displays are unaffected; a 240 Hz one folds four vsyncs into a single repaint of the same picture.

The gate is distance rather than elapsed wall-clock time deliberately. A `Stopwatch` runs off a clock the animation knows nothing about: it ignores `timeDilation`, and it never advances at all under a widget test's fake clock, which makes the throttle untestable. That is not hypothetical, it is how the first version was written and the tests caught it.

Unlike the notification bell in #459, this one was never a runaway. Both loading states that use it are plain conditional branches, so the widget unmounts when loading ends and no ticker is left behind.

`_configureImageCache()` also moved to after `log.init()`. It ran before it, so the budget it chose was never visible in `app.log`.

### Measurements

Windows release build, 9,869 games, artwork browsed, 3440x1440 at 240 Hz:

| | Before | After |
|---|---|---|
| Private bytes, minimised | 1303 MB | **769 MB** |
| Private bytes, after restoring | 1359 MB | **759 MB** |
| Working set, minimised | 293 MB | 274 MB |
| Image cache reported on release | not released | 396 MB |

Detected RAM on the test machine logs as `Image cache: 400 MB / 1500 entries (physical RAM: 96 GB)`.

## Steps to Reproduce

**Preconditions:** a desktop build and a library with box art.

1. Launch and scroll through a system's games until the artwork has streamed past.
2. Sample the process: `(Get-Process neostation).PrivateMemorySize64`. It sits around 1.3 GB.
3. Minimise the window and leave it. Nothing is released; the figure does not move for as long as the app runs.

## Steps to Verify

**Preconditions:** a desktop build and a library with box art.

1. Launch. `app.log` now reports the chosen budget, e.g. `Image cache: 400 MB / 1500 entries (physical RAM: 96 GB)`. On a machine with 8 GB or less it should report a smaller one.
2. Scroll through a system's games so the artwork loads.
3. Minimise the window. `app.log` reports `Released N MB of decoded images while off screen`.
4. Sample private bytes: down by roughly the cache budget.
5. Restore the window. The screen redraws without a visible re-decode of what is on it, and private bytes stay down.
6. Alt-tab away and back instead of minimising. Nothing is released, by design.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [x] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Only measured on Windows. The Linux procfs RAM read and the macOS `memorySize` read are untested on their platforms, and Android's path is unchanged apart from coming through the shared table.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1585)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [ ] New assets have compatible licenses (no new assets)

New tests cover the budget table (tiering, monotonicity, the unreadable-RAM case) and the shimmer throttle (folding at 240 Hz, nothing dropped at 60 Hz, no ticker at rest in progress mode, ambient sweep still endless). The release itself has no unit test: asserting that `imageCache.clear()` clears the cache tests Flutter, not us, and its real verification is the measurement above.

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

None apply: no user-facing strings, no database or migration changes, no navigation or new screens, no Android path logic, no `assets/systems/` or emulator launching changes.

</details>

## Screenshots / video

No visual change. The shimmer sweeps identically; only how often it is redrawn changes.
