### PR TITLE
fix(desktop): scale the splash logo and folder mosaic with the window

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -533,7 +533,12 @@ class _StartupScaffold extends StatefulWidget {
   });
 
   /// Builds the status area, given the resolved startup palette.
-  final List<Widget> Function(StartupThemeColors colors) childrenBuilder;
+  ///
+  /// Handed the context so callers can size their text with
+  /// [SplashStatusLayout.scaleOf] — these screens run before `ScreenUtilInit`,
+  /// so `.r` is not available to them.
+  final List<Widget> Function(BuildContext context, StartupThemeColors colors)
+  childrenBuilder;
 
   /// Show the shimmering logo instead of the static one. Used by the loading
   /// screen, where the shine doubles as the activity indicator; the error
@@ -566,7 +571,11 @@ class _StartupScaffoldState extends State<_StartupScaffold> {
 
   @override
   Widget build(BuildContext context) {
-    final children = widget.childrenBuilder(_colors);
+    // Same factor the shimmering splash uses, so the wordmark and the status
+    // block grow with the logo instead of being stranded at design size on a
+    // desktop window.
+    final scale = SplashStatusLayout.scaleOf(context);
+    final children = widget.childrenBuilder(context, _colors);
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: _colors.themeData,
@@ -589,26 +598,26 @@ class _StartupScaffoldState extends State<_StartupScaffold> {
               ? SplashStatusLayout(children: children)
               : Center(
                   child: Padding(
-                    padding: const EdgeInsets.all(32),
+                    padding: EdgeInsets.all(32 * scale),
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         Image.asset(
                           'assets/images/logo_transparent.png',
-                          width: 112,
-                          height: 112,
+                          width: 112 * scale,
+                          height: 112 * scale,
                         ),
-                        const SizedBox(height: 24),
+                        SizedBox(height: 24 * scale),
                         Text(
                           'NeoStation',
                           style: TextStyle(
                             color: _colors.foreground,
-                            fontSize: 28,
+                            fontSize: 28 * scale,
                             fontWeight: FontWeight.w600,
                             letterSpacing: 1.2,
                           ),
                         ),
-                        const SizedBox(height: 24),
+                        SizedBox(height: 24 * scale),
                         ...children,
                       ],
                     ),
@@ -656,27 +665,30 @@ class _StartupLoadingAppState extends State<StartupLoadingApp> {
   Widget build(BuildContext context) {
     return _StartupScaffold(
       animatedLogo: true,
-      childrenBuilder: (colors) => [
-        AnimatedOpacity(
-          opacity: _showText ? 1.0 : 0.0,
-          duration: const Duration(milliseconds: 400),
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 440),
-            child: Text(
-              _startupString(AppLocale.startupLoading),
-              textAlign: TextAlign.center,
-              // Same voice as the splash's status line: the app font (Anta),
-              // small and dimmed. GoogleFonts falls back gracefully for the
-              // first frames if the font isn't warmed up yet.
-              style: GoogleFonts.anta(
-                color: colors.foreground.withValues(alpha: 0.6),
-                fontSize: 17,
-                letterSpacing: 0.3,
+      childrenBuilder: (context, colors) {
+        final scale = SplashStatusLayout.scaleOf(context);
+        return [
+          AnimatedOpacity(
+            opacity: _showText ? 1.0 : 0.0,
+            duration: const Duration(milliseconds: 400),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: 440 * scale),
+              child: Text(
+                _startupString(AppLocale.startupLoading),
+                textAlign: TextAlign.center,
+                // Same voice as the splash's status line: the app font (Anta),
+                // small and dimmed. GoogleFonts falls back gracefully for the
+                // first frames if the font isn't warmed up yet.
+                style: GoogleFonts.anta(
+                  color: colors.foreground.withValues(alpha: 0.6),
+                  fontSize: 17 * scale,
+                  letterSpacing: 0.3,
+                ),
               ),
             ),
           ),
-        ),
-      ],
+        ];
+      },
     );
   }
 }
@@ -718,52 +730,57 @@ class StartupStorageErrorApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return _StartupScaffold(
       onKeyEvent: _handleKey,
-      childrenBuilder: (colors) => [
-        ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 520),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                _startupString(AppLocale.startupStorageUnavailable),
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: colors.foreground.withValues(alpha: 0.8),
-                  fontSize: 16,
-                ),
-              ),
-              if (storagePath != null && storagePath!.isNotEmpty) ...[
-                const SizedBox(height: 12),
+      childrenBuilder: (context, colors) {
+        final scale = SplashStatusLayout.scaleOf(context);
+        return [
+          ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: 520 * scale),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
                 Text(
-                  storagePath!,
+                  _startupString(AppLocale.startupStorageUnavailable),
                   textAlign: TextAlign.center,
                   style: TextStyle(
-                    color: colors.foreground.withValues(alpha: 0.55),
-                    fontSize: 13,
+                    color: colors.foreground.withValues(alpha: 0.8),
+                    fontSize: 16 * scale,
                   ),
                 ),
-              ],
-              const SizedBox(height: 24),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ElevatedButton(
-                    onPressed: onRetry,
-                    child: Text(_startupString(AppLocale.startupStorageRetry)),
-                  ),
-                  const SizedBox(width: 16),
-                  TextButton(
-                    onPressed: onUseDefault,
-                    child: Text(
-                      _startupString(AppLocale.startupStorageUseDefault),
+                if (storagePath != null && storagePath!.isNotEmpty) ...[
+                  SizedBox(height: 12 * scale),
+                  Text(
+                    storagePath!,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: colors.foreground.withValues(alpha: 0.55),
+                      fontSize: 13 * scale,
                     ),
                   ),
                 ],
-              ),
-            ],
+                SizedBox(height: 24 * scale),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ElevatedButton(
+                      onPressed: onRetry,
+                      child: Text(
+                        _startupString(AppLocale.startupStorageRetry),
+                      ),
+                    ),
+                    SizedBox(width: 16 * scale),
+                    TextButton(
+                      onPressed: onUseDefault,
+                      child: Text(
+                        _startupString(AppLocale.startupStorageUseDefault),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
-        ),
-      ],
+        ];
+      },
     );
   }
 }

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1534,11 +1534,21 @@ class _SystemGamesListState extends State<SystemGamesList> {
       builder: (context, constraints) {
         // Scale the preview to the panel: fill most of the width but leave room
         // for the name/count and keep it within the panel height.
+        //
+        // The cap is in design space (`.r`), never below its original 460: a
+        // fixed cap left the mosaic at roughly half its relative size on a
+        // desktop window, where every other element in the panel scales up
+        // around it, and the floor keeps the panels that already laid out
+        // correctly exactly as they were. The lower bound stays a raw 200 —
+        // that is a size the mosaic may overflow a cramped panel to reach, so
+        // scaling it up would push the mosaic off the bottom of a short screen
+        // rather than enlarge it.
         final maxByWidth = constraints.maxWidth * 0.82;
         final maxByHeight = constraints.maxHeight.isFinite
             ? constraints.maxHeight * 0.68
             : maxByWidth;
-        final side = min(maxByWidth, maxByHeight).clamp(200.0, 460.0);
+        final maxSide = max(460.0, 460.r);
+        final side = min(maxByWidth, maxByHeight).clamp(200.0, maxSide);
 
         return Center(
           child: Column(

--- a/lib/screens/systems_screen/system_content.dart
+++ b/lib/screens/systems_screen/system_content.dart
@@ -1,6 +1,7 @@
 import '../../services/ra_library_match_runner.dart';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:provider/provider.dart';
@@ -132,21 +133,21 @@ class _SystemContentState extends State<SystemContent> {
         // and one calm line is the whole point.
         if (raProgress != null) ...[
           SizedBox(
-            width: 220,
+            width: 220.r,
             child: ClipRRect(
-              borderRadius: BorderRadius.circular(2),
+              borderRadius: BorderRadius.circular(2.r),
               child: LinearProgressIndicator(
                 value: raProgress.total != null && raProgress.total! > 0
                     ? (raProgress.done ?? 0) / raProgress.total!
                     : null,
-                minHeight: 3,
+                minHeight: 3.r,
                 backgroundColor: Theme.of(
                   context,
                 ).colorScheme.onSurface.withValues(alpha: 0.12),
               ),
             ),
           ),
-          const SizedBox(height: 16),
+          SizedBox(height: 16.r),
           Text(
             raProgress.done != null && raProgress.total != null
                 ? AppLocale.raMatchProgressCounted
@@ -155,7 +156,7 @@ class _SystemContentState extends State<SystemContent> {
                       .replaceFirst('{total}', raProgress.total.toString())
                 : AppLocale.raMatchProgressBusy.getString(context),
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              fontSize: 17,
+              fontSize: 17.r,
               color: Theme.of(
                 context,
               ).colorScheme.onSurface.withValues(alpha: 0.6),
@@ -166,19 +167,19 @@ class _SystemContentState extends State<SystemContent> {
           ),
         ] else if (configProvider.isScanning) ...[
           SizedBox(
-            width: 220,
+            width: 220.r,
             child: ClipRRect(
-              borderRadius: BorderRadius.circular(2),
+              borderRadius: BorderRadius.circular(2.r),
               child: LinearProgressIndicator(
                 value: configProvider.scanProgress,
-                minHeight: 3,
+                minHeight: 3.r,
                 backgroundColor: Theme.of(
                   context,
                 ).colorScheme.onSurface.withValues(alpha: 0.12),
               ),
             ),
           ),
-          const SizedBox(height: 16),
+          SizedBox(height: 16.r),
           Text(
             configProvider.scanStatus.isNotEmpty
                 ? configProvider.scanStatus
@@ -186,7 +187,7 @@ class _SystemContentState extends State<SystemContent> {
             // 17 to match the startup screen's status line — the theme's
             // bodySmall (12) reads too small at couch distance.
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              fontSize: 17,
+              fontSize: 17.r,
               color: Theme.of(
                 context,
               ).colorScheme.onSurface.withValues(alpha: 0.6),

--- a/lib/widgets/permission_check_wrapper.dart
+++ b/lib/widgets/permission_check_wrapper.dart
@@ -4,7 +4,7 @@ import 'package:neostation/services/logger_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../providers/sqlite_config_provider.dart';
 import 'setup_wizard.dart';
-import 'shimmering_logo.dart';
+import 'splash_status_layout.dart';
 
 /// Widget that checks the initial configuration and shows the wizard if necessary
 class PermissionCheckWrapper extends StatefulWidget {
@@ -125,7 +125,10 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
     if (_isChecking) {
       // Show loading while checking — same shimmering logo as the rest of the
       // startup chain, so this gate doesn't read as a separate plain screen.
-      return const Scaffold(body: Center(child: ShimmeringLogo()));
+      // Laid out by SplashStatusLayout (with no status block) rather than a
+      // bare centred logo: that keeps the glyph at the same size and centre as
+      // the screens on either side of this gate, so it doesn't jump.
+      return const Scaffold(body: SplashStatusLayout(children: []));
     }
 
     if (_needsSetup) {

--- a/lib/widgets/splash_status_layout.dart
+++ b/lib/widgets/splash_status_layout.dart
@@ -17,6 +17,11 @@ import 'shimmering_logo.dart';
 /// progress bar ended up printed across the glyph. For the same reason the
 /// logo is scaled down once it would take more than [_maxLogoHeightFraction]
 /// of the screen, which is what guarantees room for the status block below it.
+///
+/// Every size here is expressed in the app's 640×480 design space and scaled by
+/// [scaleOf], so the splash keeps its proportions on a desktop window instead
+/// of stranding a fixed-size logo in the middle of a 1920×1080 screen while the
+/// rest of the app scales up around it.
 class SplashStatusLayout extends StatelessWidget {
   const SplashStatusLayout({super.key, required this.children, this.progress});
 
@@ -26,10 +31,10 @@ class SplashStatusLayout extends StatelessWidget {
   /// Forwarded to [ShimmeringLogo]. Null keeps the ambient sweep.
   final double? progress;
 
-  /// Rendered logo width on a screen with room for it. Matches what the
-  /// startup and scan splashes used before the layout was made responsive,
-  /// so nothing moves on the devices that were already laying out correctly.
-  static const double _maxLogoWidth = 280;
+  /// Rendered logo width in design space. Matches what the startup and scan
+  /// splashes used before the layout was made responsive, so on a screen the
+  /// size of the design space nothing moves.
+  static const double _logoWidth = 280;
 
   /// Aspect ratio of `assets/images/logo_transparent.png` (772×510).
   static const double _logoAspect = 772 / 510;
@@ -40,7 +45,7 @@ class SplashStatusLayout extends StatelessWidget {
 
   /// Share of the screen height the logo may take before it is scaled down.
   /// Chosen so the Thor's ~467dp-tall screen still renders the logo at its
-  /// full [_maxLogoWidth] — only panels shorter than that scale it back.
+  /// full [_logoWidth] — only panels shorter than that scale it back.
   static const double _maxLogoHeightFraction = 0.40;
 
   /// Clear space between the logo's bottom edge and the status block.
@@ -54,8 +59,39 @@ class SplashStatusLayout extends StatelessWidget {
   static const double _horizontalPadding = 32;
   static const double _maxStatusWidth = 480;
 
+  /// The app's `ScreenUtil` design size (see `ScreenUtilInit` in `main.dart`).
+  static const Size _designSize = Size(640, 480);
+
+  /// Minimum screen height ScreenUtil's `splitScreenMode` assumes.
+  static const double _splitScreenMinHeight = 700;
+
+  /// The factor `.r` resolves to at this screen size, computed without
+  /// ScreenUtil.
+  ///
+  /// The startup screens (`_StartupScaffold` in `main.dart`) are mounted by
+  /// `runApp` *before* `ScreenUtilInit`, so `.r` there throws a late-init
+  /// error. Mirroring the formula keeps the pre-init splash, the scan splash
+  /// and the app itself at one scale, so the logo neither jumps nor changes
+  /// size across the handoff.
+  ///
+  /// Floored at 1 so no device renders the splash smaller than it did before
+  /// the splash became scale-aware; screens too short for the result are
+  /// handled by [_maxLogoHeightFraction], not by shrinking the whole scale.
+  static double scaleOf(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final scaleWidth = size.width / _designSize.width;
+    final scaleHeight =
+        math.max(size.height, _splitScreenMinHeight) / _designSize.height;
+    return math.max(1.0, math.min(scaleWidth, scaleHeight));
+  }
+
   @override
   Widget build(BuildContext context) {
+    final scale = scaleOf(context);
+    final maxLogoWidth = _logoWidth * scale;
+    final gap = _gap * scale;
+    final bottomInset = _bottomInset * scale;
+
     return LayoutBuilder(
       builder: (context, constraints) {
         // Fall back to the design size when handed an unbounded axis; the
@@ -63,13 +99,13 @@ class SplashStatusLayout extends StatelessWidget {
         // would otherwise produce a NaN offset.
         final width = constraints.maxWidth.isFinite
             ? constraints.maxWidth
-            : _maxLogoWidth / _maxLogoWidthFraction;
+            : maxLogoWidth / _maxLogoWidthFraction;
         final height = constraints.maxHeight.isFinite
             ? constraints.maxHeight
-            : _maxLogoWidth / _logoAspect / _maxLogoHeightFraction;
+            : maxLogoWidth / _logoAspect / _maxLogoHeightFraction;
 
         final logoWidth = math.min(
-          _maxLogoWidth,
+          maxLogoWidth,
           math.min(
             width * _maxLogoWidthFraction,
             height * _maxLogoHeightFraction * _logoAspect,
@@ -77,9 +113,11 @@ class SplashStatusLayout extends StatelessWidget {
         );
         final logoHeight = logoWidth / _logoAspect;
 
+        final maxStatusWidth = _maxStatusWidth * scale;
+        final statusPadding = _horizontalPadding * scale;
         final statusWidth = math.max(
           0.0,
-          math.min(_maxStatusWidth, width) - _horizontalPadding * 2,
+          math.min(maxStatusWidth, width) - statusPadding * 2,
         );
 
         return Stack(
@@ -88,10 +126,10 @@ class SplashStatusLayout extends StatelessWidget {
               child: ShimmeringLogo(width: logoWidth, progress: progress),
             ),
             Positioned(
-              top: height / 2 + logoHeight / 2 + _gap,
+              top: height / 2 + logoHeight / 2 + gap,
               left: 0,
               right: 0,
-              bottom: _bottomInset,
+              bottom: bottomInset,
               // The status text is laid out at its natural size and only
               // scaled down when the panel is too short to hold it — a long
               // status that wraps to three lines shrinks to fit rather than

--- a/test/splash_status_layout_test.dart
+++ b/test/splash_status_layout_test.dart
@@ -96,11 +96,55 @@ void main() {
       }
     });
 
-    testWidgets('a tall panel renders the logo at its full width', (
+    testWidgets('the design size renders the logo at its full width', (
       tester,
     ) async {
-      await pumpAt(tester, const Size(831, 467), const [Text('x')]);
+      // 640x480 is the app's ScreenUtil design space, so the scale is 1 there
+      // and the logo lands on the 280 the splash has always used.
+      await pumpAt(tester, const Size(640, 480), const [Text('x')]);
       expect(tester.getRect(find.byType(ShimmeringLogo)).width, 280);
+    });
+
+    testWidgets('a short panel is capped by its height, not the width', (
+      tester,
+    ) async {
+      // The Thor is 467dp tall, so the height fraction sets the size — landing
+      // within a few pixels of the 280 it rendered at before the splash
+      // started scaling with the screen.
+      await pumpAt(tester, const Size(831, 467), const [Text('x')]);
+      expect(
+        tester.getRect(find.byType(ShimmeringLogo)).width,
+        moreOrLessEquals(280, epsilon: 4),
+      );
+    });
+
+    testWidgets('the logo scales up with a desktop window', (tester) async {
+      // A fixed 280px logo is stranded in the middle of a 1920x1080 window
+      // while the rest of the app scales up around it (everything else sizes
+      // off ScreenUtil's 640x480 design space). The splash follows the same
+      // scale, still inside the width and height caps.
+      await pumpAt(tester, const Size(1920, 1080), const [Text('x')]);
+      final logo = tester.getRect(find.byType(ShimmeringLogo));
+      expect(logo.width, greaterThan(560));
+      expect(logo.width, lessThanOrEqualTo(1920 * 0.55));
+      expect(logo.height, lessThanOrEqualTo(1080 * 0.40));
+    });
+
+    testWidgets('panels below the design size never grow', (tester) async {
+      // The scale is floored at 1, so the handhelds that were already laying
+      // out correctly render exactly as they did before.
+      for (final size in const [
+        Size(320, 240),
+        Size(480, 320),
+        Size(480, 272),
+        Size(575, 431),
+      ]) {
+        await pumpAt(tester, size, const [Text('x')]);
+        expect(
+          tester.getRect(find.byType(ShimmeringLogo)).width,
+          lessThanOrEqualTo(280),
+        );
+      }
     });
   });
 }


### PR DESCRIPTION
# Description

The splash logo and the game list's subfolder preview mosaic were sized in raw
logical pixels while everything around them sizes off ScreenUtil's 640x480
design space. On a desktop window that gap is wide: this was reported on a
3440x1440 panel, where `.r` resolves to 3.0, so a fixed 280px logo covered 8% of
the screen width and the mosaic sat pinned at its 460px cap.

Both now scale with the window:

- `SplashStatusLayout` gains `scaleOf()`, which reproduces ScreenUtil's `.r`
  factor from `MediaQuery`. It cannot just use `.r`: the startup screens are
  mounted by `runApp` before `ScreenUtilInit`, so `.r` throws a late-init error
  there. The factor is floored at 1, so no panel that already laid out correctly
  shrinks.
- The status blocks scale in step, otherwise a 840px logo would sit over 17px
  text. `main.dart`'s startup and storage-error screens go through `scaleOf`
  (their `childrenBuilder` now takes the context), while the scan splash uses
  `.r` directly since it is inside `ScreenUtilInit`.
- `PermissionCheckWrapper` was rendering a bare `ShimmeringLogo()` at the
  default 280, so the logo visibly jumped in size passing through that gate. It
  now uses `SplashStatusLayout` with no status block, which is the same geometry
  as the screens on either side of it.
- The mosaic's fixed 460 cap becomes `max(460, 460.r)`. The 200 lower bound
  stays raw on purpose: that is a size the mosaic is allowed to overflow a
  cramped panel to reach, so scaling it up would push it off the bottom of a
  short screen rather than enlarge it.

Measured effect, logo width:

| panel | before | after |
|---|---|---|
| at or below 640x480 design size | unchanged | unchanged |
| Thor (831x467) | 280 | 283 (height cap binds) |
| Steam Deck (1280x800) | 280 | 467 |
| 1280x720 window | 280 | 420 |
| 3440x1440 fullscreen | 280 | 840 |

Handhelds are deliberately untouched: the scale floor of 1 means every panel at
or below the design size renders exactly as it did before.

## Steps to Verify

**Preconditions:** Windows, Linux or macOS desktop, ideally a display larger
than 1280x720 (the effect grows with the window). A system with ROM subfolders
and the per-system "Show Subfolders" setting enabled, with box art scraped for
some of the games inside those folders.

1. Launch the app and watch the startup splash. The shimmering logo scales with
   the window instead of sitting small in the middle of it, and the loading text
   underneath scales with it.
2. Let the ROM scan run (or clear the cached systems to force one). The scan
   splash keeps the logo the same size and in the same place, so nothing jumps
   between the two screens.
3. Open a system that has subfolders, in list view.
4. Highlight a folder row. The preview mosaic in the right-hand panel fills the
   panel rather than stopping at a fixed 460px square.
5. Resize the window (or toggle fullscreen with Alt+Enter) and repeat 3 and 4.
   Both track the new size.
6. On a handheld (Thor, Steam Deck, or any panel at or below 640x480), confirm
   nothing has changed size.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [x] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Built and run on Windows at both 3440x1440 fullscreen and 1280x720 windowed.
The app logs the resolved factor at startup (`[display:main] ... .r=3.000`),
which is what the numbers in the table above are taken from. Not runtime-tested
on Android: the change is desktop-facing, and the widget tests cover the
handheld geometries (Thor, Steam Deck, Konkr, Retroid Nova) to prove they do not
move.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1614)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [ ] New assets have compatible licenses (no new assets)

`test/splash_status_layout_test.dart` gains coverage for the new behaviour: the
design size renders at exactly 280, a short panel is capped by its height rather
than its width, a desktop window scales up while staying inside both fraction
caps, and panels below the design size never grow. The existing assertion that
the Thor renders at exactly 280 was replaced, since its height cap now sets the
size at 283.

None of the conditional extra checks apply: this adds no user-facing strings, no
database columns, no navigation or new screens, no Android path logic and no
emulator launching changes.

## Screenshots / video

Not attached. The effect is a size change rather than a layout change, so the
measured widths in the table above describe it more precisely than a screenshot
would; the logged `.r` value makes it reproducible on any panel.
