### PR TITLE
feat(notifications): drive the popup with the gamepad and keep running tasks on Clear all

### DIFF
--- a/lib/screens/neo_sync_screen/login_screen/custom_save_folders_view.dart
+++ b/lib/screens/neo_sync_screen/login_screen/custom_save_folders_view.dart
@@ -211,6 +211,7 @@ class _CustomSaveFoldersViewState extends State<CustomSaveFoldersView> {
         type: custom.NotificationType.info,
         notificationId: notificationId,
         progress: 0,
+        ongoing: true,
       );
 
       try {
@@ -224,6 +225,7 @@ class _CustomSaveFoldersViewState extends State<CustomSaveFoldersView> {
             type: custom.NotificationType.info,
             notificationId: notificationId,
             progress: provider.syncProgress,
+            ongoing: true,
           );
         }
 

--- a/lib/screens/scraper_screen/scraper_contents/scraping_content.dart
+++ b/lib/screens/scraper_screen/scraper_contents/scraping_content.dart
@@ -83,6 +83,7 @@ class ScrapingContentState extends State<ScrapingContent> {
         message: localeScrapingInProgress,
         type: GlobalNotificationType.info,
         progress: 0,
+        ongoing: true,
       );
 
       // Paso 1: Sincronizar system IDs

--- a/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
@@ -336,6 +336,7 @@ class DirectoriesSettingsContentState
       message: localeEsdeImporting,
       type: GlobalNotificationType.info,
       progress: 0,
+      ongoing: true,
     );
 
     EsdeImportResult? result;
@@ -357,6 +358,7 @@ class DirectoriesSettingsContentState
                 : '$localeEsdeImporting: $label',
             type: GlobalNotificationType.info,
             progress: p,
+            ongoing: true,
           );
         },
       );

--- a/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
@@ -161,6 +161,7 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
         message: localeScanning,
         type: GlobalNotificationType.info,
         progress: 0,
+        ongoing: true,
       );
 
       final result = await RomFolderOrganizerService.organizeRomFolders(
@@ -174,6 +175,7 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
             message: localeScanning,
             type: GlobalNotificationType.info,
             progress: completed / total,
+            ongoing: true,
           );
         },
       );
@@ -330,6 +332,7 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
         message: localeScanning,
         type: GlobalNotificationType.info,
         progress: 0,
+        ongoing: true,
       );
 
       final result = await MetadataCleanupService.clean(
@@ -343,6 +346,7 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
             ),
             type: GlobalNotificationType.info,
             progress: progress,
+            ongoing: true,
           );
         },
       );

--- a/lib/services/global_notification_service.dart
+++ b/lib/services/global_notification_service.dart
@@ -14,6 +14,16 @@ class GlobalNotificationData {
   final GlobalNotificationType type;
   final double? progress;
 
+  /// True while the notification tracks work that is still running.
+  ///
+  /// "Clear all" leaves these listed: clearing the bell is a request to tidy
+  /// away messages, not to abandon a scrape, an import or a hashing pass that
+  /// is still going. Dropping one would also silence it for good, because
+  /// [GlobalNotificationService.update] is a no-op once the id is gone, so the
+  /// progress bar (and the inline bar Tools renders from it) would never come
+  /// back and the completion message would never arrive.
+  final bool ongoing;
+
   const GlobalNotificationData({
     required this.id,
     required this.message,
@@ -22,6 +32,7 @@ class GlobalNotificationData {
     this.icon,
     required this.type,
     this.progress,
+    this.ongoing = false,
   });
 }
 
@@ -33,6 +44,9 @@ class GlobalNotificationData {
 ///
 /// Notifications never auto-dismiss: they stay listed until the user dismisses
 /// them, either individually or with the "Clear all" action in the dropdown.
+/// "Clear all" skips notifications marked [GlobalNotificationData.ongoing] so
+/// running work keeps reporting; the per-notification close button still
+/// removes any single one, including an ongoing one.
 class GlobalNotificationService {
   static final GlobalNotificationService _instance =
       GlobalNotificationService._internal();
@@ -53,6 +67,7 @@ class GlobalNotificationService {
     IconData? icon,
     GlobalNotificationType type = GlobalNotificationType.info,
     double? progress,
+    bool ongoing = false,
   }) {
     final current = notifier.value;
     final existingIndex = current.indexWhere((n) => n.id == id);
@@ -64,6 +79,7 @@ class GlobalNotificationService {
       icon: icon,
       type: type,
       progress: progress,
+      ongoing: ongoing,
     );
 
     if (existingIndex == -1) {
@@ -77,6 +93,11 @@ class GlobalNotificationService {
   }
 
   /// Updates an active notification only if its [id] exists.
+  ///
+  /// [ongoing] deliberately defaults to false rather than carrying the current
+  /// value over: the last update of a run is the completion message, and those
+  /// call sites are the ones that would forget to clear the flag. Progress
+  /// updates opt back in, next to the [progress] value they already pass.
   void update({
     required String id,
     required String message,
@@ -85,6 +106,7 @@ class GlobalNotificationService {
     IconData? icon,
     GlobalNotificationType? type,
     double? progress,
+    bool ongoing = false,
   }) {
     final current = notifier.value;
     final index = current.indexWhere((n) => n.id == id);
@@ -102,16 +124,21 @@ class GlobalNotificationService {
         icon: icon ?? existing.icon,
         type: type ?? existing.type,
         progress: progress ?? existing.progress,
+        ongoing: ongoing,
       ),
       ...current.sublist(index + 1),
     ];
   }
 
-  /// Removes the notification with the given [id], or clears all notifications
-  /// when no [id] is provided.
+  /// Removes the notification with the given [id], or clears every notification
+  /// that is not tracking running work when no [id] is provided.
+  ///
+  /// The blanket form is what "Clear all" calls, and it keeps
+  /// [GlobalNotificationData.ongoing] entries: see that field for why removing
+  /// one silences the task for the rest of the run.
   void dismiss([String? id]) {
     if (id == null) {
-      notifier.value = [];
+      notifier.value = notifier.value.where((n) => n.ongoing).toList();
       return;
     }
 

--- a/lib/services/ra_library_match_runner.dart
+++ b/lib/services/ra_library_match_runner.dart
@@ -140,6 +140,9 @@ class RaLibraryMatchRunner {
     );
     publish();
 
+    // Every caller of this is a pass that is still running, so the
+    // notification is marked ongoing and "Clear all" leaves it alone. The
+    // terminal message goes through `_finish`, which clears the flag.
     void showOrUpdate({
       required String message,
       required GlobalNotificationType type,
@@ -151,6 +154,7 @@ class RaLibraryMatchRunner {
           message: message,
           type: type,
           progress: progress,
+          ongoing: true,
         );
       } else {
         notificationShown = true;
@@ -160,6 +164,7 @@ class RaLibraryMatchRunner {
           message: message,
           type: type,
           progress: progress,
+          ongoing: true,
         );
       }
     }

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -72,8 +72,9 @@ class GamepadNavigation {
   final VoidCallback? onLeftBumper;
   final VoidCallback? onRightBumper;
 
-  /// Select (View) chord combos. The Select button is a pure modifier — on its
-  /// own it does nothing. While it is held (or within a short window of a pulse),
+  /// Select (View) chord combos. On its own Select fires [onSelectButton], or
+  /// [globalSelectTap] when the layer defines none.
+  /// While it is held (or within a short window of a pulse),
   /// a face-button press fires the matching modifier callback instead of its
   /// normal action, and suppresses that normal action.
   final VoidCallback? onSelectModifierA;
@@ -255,6 +256,16 @@ class GamepadNavigation {
   /// Only the active navigation layer drives this.
   static final ValueNotifier<bool> selectHeldNotifier = ValueNotifier(false);
 
+  /// App-wide fallback for a plain Select (View) tap.
+  ///
+  /// The header notification bell registers itself here so Select opens the
+  /// notifications popup from anywhere the header is on screen, without every
+  /// screen having to wire up a callback it does not own. It only runs when the
+  /// active layer has no [onSelectButton] of its own: a screen that already
+  /// gives Select a meaning (muting the preview video, picking a save) keeps
+  /// it, and never fires two actions from one press.
+  static VoidCallback? globalSelectTap;
+
   /// Tap-vs-chord decisions for Select. See [SelectTap] for the rules.
   final SelectTap _selectTap = SelectTap();
 
@@ -296,7 +307,12 @@ class GamepadNavigation {
     _selectTapTimer = Timer(SelectTap.chordWindow, () {
       _selectTapTimer = null;
       if (!_selectTap.tapStillValid) return;
-      onSelectButton?.call();
+      final owned = onSelectButton;
+      if (owned != null) {
+        owned();
+        return;
+      }
+      globalSelectTap?.call();
     });
   }
 
@@ -816,9 +832,10 @@ class GamepadNavigation {
       if (!allowedWhileTyping.contains(event.inputType)) return;
     }
 
-    // Select (View) is a PURE chord modifier: on its own it does nothing. Track
-    // its state — before the press/release gate below — so a face button pressed
-    // alongside it fires a combo. Some controllers only reliably report one edge
+    // Select (View) is first and foremost a chord modifier. Track its state —
+    // before the press/release gate below — so a face button pressed alongside
+    // it fires a combo; a tap that fires no chord falls through to the tap
+    // action on release (see [_onSelectUp]). Some controllers only reliably report one edge
     // of this button, so the timestamp is stamped on BOTH press and release.
     if (event.inputType == GamepadInputType.buttonSelect) {
       final now = DateTime.now();

--- a/lib/widgets/custom_notification.dart
+++ b/lib/widgets/custom_notification.dart
@@ -51,6 +51,7 @@ class AppNotification {
     NotificationType type = NotificationType.info,
     String? notificationId,
     double? progress,
+    bool ongoing = false,
   }) {
     final id = notificationId ?? _generateId();
     GlobalNotificationService().show(
@@ -61,6 +62,7 @@ class AppNotification {
       icon: icon,
       type: _mapType(type),
       progress: progress,
+      ongoing: ongoing,
     );
   }
 
@@ -84,8 +86,8 @@ class AppNotification {
     );
   }
 
-  /// Dismisses the notification with [notificationId], or all notifications if
-  /// no id is provided.
+  /// Dismisses the notification with [notificationId], or every notification
+  /// that is not tracking running work if no id is provided.
   static void dismiss([String? notificationId]) {
     GlobalNotificationService().dismiss(notificationId);
   }

--- a/lib/widgets/notification_bell.dart
+++ b/lib/widgets/notification_bell.dart
@@ -3,9 +3,12 @@ import 'package:flutter_localization/flutter_localization.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/services/gamepad/gamepad_navigation_manager.dart';
 import 'package:neostation/services/global_notification_service.dart';
+import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/themes/app_themes.dart';
 import 'package:neostation/themes/corner_radii.dart';
+import 'package:neostation/utils/gamepad_nav.dart';
 
 /// Notification bell icon that opens a dropdown with all active global
 /// notifications, including their progress.
@@ -15,6 +18,10 @@ import 'package:neostation/themes/corner_radii.dart';
 /// The dropdown is rendered through an [OverlayEntry] (not `showMenu`) so the
 /// notification list can rebuild live without `showMenu`'s `IntrinsicWidth`
 /// choking on the shrink-wrapping list viewport.
+///
+/// Gamepad: Select (View) opens and closes the dropdown from anywhere the
+/// header is on screen, the D-pad walks the entries, A acts on the highlighted
+/// one and B closes. See [_NotificationsDropdownMenuState].
 class NotificationBell extends StatefulWidget {
   const NotificationBell({super.key});
 
@@ -62,6 +69,24 @@ class _NotificationBellState extends State<NotificationBell>
     // Tween begin (1.0 = fully opaque) sits at controller value 0.
     _pulseController.value = 0;
     _notifications.addListener(_syncPulse);
+
+    // The bell is the only surface for notifications and it has no place in
+    // any screen's own navigation order, so Select reaches it instead. The
+    // hook is app-wide but yields to a screen that gives Select its own
+    // meaning; see [GamepadNavigation.globalSelectTap].
+    GamepadNavigation.globalSelectTap = _handleSelectTap;
+  }
+
+  /// Opens the dropdown on a Select tap, or closes it if it is already open.
+  ///
+  /// Ignored while another route covers the header. The bell stays mounted
+  /// underneath a pushed game screen or an open dialog, so without this a
+  /// Select tap there would drop a popup anchored to an off-screen bell on top
+  /// of a surface that has no notification affordance at all.
+  void _handleSelectTap() {
+    if (!mounted) return;
+    if (ModalRoute.of(context)?.isCurrent != true) return;
+    _toggleDropdown(context);
   }
 
   /// Pulses briefly when a notification arrives, then parks the controller at
@@ -97,6 +122,11 @@ class _NotificationBellState extends State<NotificationBell>
 
   @override
   void dispose() {
+    // Only clear the hook if it is still ours: a rebuilt header registers the
+    // replacement bell before the old one is disposed.
+    if (GamepadNavigation.globalSelectTap == _handleSelectTap) {
+      GamepadNavigation.globalSelectTap = null;
+    }
     _notifications.removeListener(_syncPulse);
     _closeDropdown();
     _pulseController.dispose();
@@ -182,7 +212,7 @@ class _NotificationBellState extends State<NotificationBell>
             Positioned(
               top: offset.dy + size.height + _dropdownGap,
               right: _dropdownRightInset,
-              child: const _NotificationsDropdownMenu(),
+              child: _NotificationsDropdownMenu(onClose: _closeDropdown),
             ),
           ],
         );
@@ -197,14 +227,177 @@ class _NotificationBellState extends State<NotificationBell>
   }
 }
 
-class _NotificationsDropdownMenu extends StatelessWidget {
-  const _NotificationsDropdownMenu();
+/// One D-pad stop inside the dropdown.
+///
+/// "Clear all" is an entry of its own rather than a header button, because a
+/// header button is unreachable with a controller and clearing the bell would
+/// then be mouse-only.
+class _DropdownEntry {
+  /// Notification this entry acts on, or null for the "Clear all" entry.
+  final String? notificationId;
+
+  const _DropdownEntry.clearAll() : notificationId = null;
+  const _DropdownEntry.notification(String id) : notificationId = id;
+
+  bool get isClearAll => notificationId == null;
+}
+
+class _NotificationsDropdownMenu extends StatefulWidget {
+  /// Closes the dropdown. B and a Select tap both route here, as does acting
+  /// on the last remaining entry.
+  final VoidCallback onClose;
+
+  const _NotificationsDropdownMenu({required this.onClose});
+
+  @override
+  State<_NotificationsDropdownMenu> createState() =>
+      _NotificationsDropdownMenuState();
+}
+
+class _NotificationsDropdownMenuState
+    extends State<_NotificationsDropdownMenu> {
+  /// Modal, so a widget mounting behind the dropdown (the systems grid when a
+  /// startup scan finishes, say) is slotted underneath instead of stealing the
+  /// controller while the popup is on screen.
+  static const String _navLayerId = 'notification_dropdown';
+
+  late final GamepadNavigation _gamepadNav;
+  final ScrollController _scrollController = ScrollController();
+
+  /// Row keys by notification id, so the highlighted row can be scrolled into
+  /// view without guessing at row heights — messages run to six lines, so no
+  /// fixed-height arithmetic would be right.
+  final Map<String, GlobalKey> _rowKeys = {};
+
+  int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _gamepadNav = GamepadNavigation(
+      onNavigateUp: () => _move(-1),
+      onNavigateDown: () => _move(1),
+      onSelectItem: _activateSelected,
+      onBack: widget.onClose,
+      // Select toggles: the button that opened the popup closes it again.
+      onSelectButton: widget.onClose,
+      // A handful of entries that wrap; a held direction would just spin.
+      allowRepeat: false,
+    );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _gamepadNav.initialize();
+      GamepadNavigationManager.pushLayer(
+        _navLayerId,
+        onActivate: () => _gamepadNav.activate(),
+        onDeactivate: () => _gamepadNav.deactivate(),
+        modal: true,
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    GamepadNavigationManager.popLayer(_navLayerId);
+    _gamepadNav.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  /// The current D-pad stops, in the order they are drawn.
+  List<_DropdownEntry> _entriesFor(List<GlobalNotificationData> notifications) {
+    return [
+      if (notifications.any((n) => !n.ongoing)) const _DropdownEntry.clearAll(),
+      for (final n in notifications) _DropdownEntry.notification(n.id),
+    ];
+  }
+
+  /// Keeps the highlight on a real entry after the list changed underneath it —
+  /// a task finishing removes the "Clear all" entry's reason to exist, and a
+  /// dismissal shortens the list.
+  int _clampedIndex(int count) {
+    if (count == 0) return 0;
+    return _selectedIndex.clamp(0, count - 1);
+  }
+
+  void _move(int delta) {
+    final entries = _entriesFor(GlobalNotificationService().notifier.value);
+    if (entries.isEmpty) return;
+    final from = _clampedIndex(entries.length);
+    setState(() {
+      _selectedIndex = (from + delta + entries.length) % entries.length;
+    });
+    SfxService().playNavSound();
+    _scrollSelectedIntoView();
+  }
+
+  void _scrollSelectedIntoView() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final entries = _entriesFor(GlobalNotificationService().notifier.value);
+      if (entries.isEmpty) return;
+      final entry = entries[_clampedIndex(entries.length)];
+      if (entry.isClearAll) {
+        // Outside the scroll view; showing the top of the list reads as
+        // "the header is what you are on".
+        if (_scrollController.hasClients) {
+          _scrollController.animateTo(
+            0,
+            duration: const Duration(milliseconds: 160),
+            curve: Curves.easeOut,
+          );
+        }
+        return;
+      }
+      final rowContext = _rowKeys[entry.notificationId]?.currentContext;
+      if (rowContext == null) return;
+      Scrollable.ensureVisible(
+        rowContext,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 160),
+        curve: Curves.easeOut,
+      );
+    });
+  }
+
+  /// A on the highlighted entry: the same action its on-screen control offers.
+  void _activateSelected() {
+    final service = GlobalNotificationService();
+    final entries = _entriesFor(service.notifier.value);
+    if (entries.isEmpty) return;
+
+    final entry = entries[_clampedIndex(entries.length)];
+    SfxService().playEnterSound();
+    if (entry.isClearAll) {
+      service.dismiss();
+    } else {
+      service.dismiss(entry.notificationId);
+    }
+
+    // Nothing left to look at, so don't leave an empty panel on screen.
+    if (service.notifier.value.isEmpty) {
+      widget.onClose();
+      return;
+    }
+    setState(() {
+      _selectedIndex = _clampedIndex(
+        _entriesFor(service.notifier.value).length,
+      );
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<List<GlobalNotificationData>>(
       valueListenable: GlobalNotificationService().notifier,
       builder: (context, notifications, _) {
+        final entries = _entriesFor(notifications);
+        final selected = _clampedIndex(entries.length);
+        final clearAllSelected =
+            entries.isNotEmpty && entries[selected].isClearAll;
+        final selectedNotificationId = entries.isEmpty || clearAllSelected
+            ? null
+            : entries[selected].notificationId;
         return Material(
           color: Theme.of(context).colorScheme.surface,
           elevation: 6,
@@ -246,15 +439,38 @@ class _NotificationsDropdownMenu extends StatelessWidget {
                           fontWeight: FontWeight.bold,
                         ),
                       ),
-                      if (notifications.isNotEmpty)
+                      // Hidden when every listed notification is still
+                      // tracking running work: "Clear all" leaves those alone
+                      // (a scrape or an import must not lose its progress bar
+                      // because the bell was tidied), so offering it there is
+                      // a button that visibly does nothing.
+                      if (notifications.any((n) => !n.ongoing))
                         GestureDetector(
-                          onTap: () => GlobalNotificationService().dismiss(),
-                          child: Text(
-                            AppLocale.clearAll.getString(context),
-                            style: TextStyle(
-                              color: Theme.of(context).colorScheme.primary,
-                              fontSize: 10.r,
-                              fontWeight: FontWeight.w600,
+                          onTap: () {
+                            setState(() => _selectedIndex = 0);
+                            _activateSelected();
+                          },
+                          child: Container(
+                            padding: EdgeInsets.symmetric(
+                              horizontal: 6.r,
+                              vertical: 2.r,
+                            ),
+                            decoration: BoxDecoration(
+                              color: clearAllSelected
+                                  ? Theme.of(context).colorScheme.primary
+                                        .withValues(alpha: 0.15)
+                                  : Colors.transparent,
+                              borderRadius: CornerRadii.of(
+                                context,
+                              ).radiusInternal,
+                            ),
+                            child: Text(
+                              AppLocale.clearAll.getString(context),
+                              style: TextStyle(
+                                color: Theme.of(context).colorScheme.primary,
+                                fontSize: 10.r,
+                                fontWeight: FontWeight.w600,
+                              ),
                             ),
                           ),
                         ),
@@ -279,6 +495,7 @@ class _NotificationsDropdownMenu extends StatelessWidget {
                 else
                   Flexible(
                     child: ListView.separated(
+                      controller: _scrollController,
                       shrinkWrap: true,
                       padding: EdgeInsets.zero,
                       itemCount: notifications.length,
@@ -289,8 +506,18 @@ class _NotificationsDropdownMenu extends StatelessWidget {
                         ).colorScheme.outline.withValues(alpha: 0.2),
                       ),
                       itemBuilder: (context, index) {
+                        final data = notifications[index];
                         return _NotificationDropdownItem(
-                          data: notifications[index],
+                          key: _rowKeys.putIfAbsent(data.id, GlobalKey.new),
+                          data: data,
+                          selected: data.id == selectedNotificationId,
+                          onFocus: () {
+                            setState(() {
+                              _selectedIndex = entries.indexWhere(
+                                (e) => e.notificationId == data.id,
+                              );
+                            });
+                          },
                         );
                       },
                     ),
@@ -307,7 +534,19 @@ class _NotificationsDropdownMenu extends StatelessWidget {
 class _NotificationDropdownItem extends StatelessWidget {
   final GlobalNotificationData data;
 
-  const _NotificationDropdownItem({required this.data});
+  /// Whether the D-pad highlight is on this row.
+  final bool selected;
+
+  /// Moves the highlight here, so a pointer and the D-pad agree on where the
+  /// cursor is instead of leaving a stale highlight elsewhere in the list.
+  final VoidCallback onFocus;
+
+  const _NotificationDropdownItem({
+    super.key,
+    required this.data,
+    required this.selected,
+    required this.onFocus,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -326,70 +565,77 @@ class _NotificationDropdownItem extends StatelessWidget {
         icon = Symbols.info_rounded;
     }
 
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 10.r),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(icon, color: iconColor, size: 16.r),
-          SizedBox(width: 8.r),
-          Expanded(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (data.title != null)
-                  Text(
-                    data.title!,
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.onSurface,
-                      fontSize: 11.r,
-                      fontWeight: FontWeight.bold,
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onFocus,
+      child: Container(
+        color: selected
+            ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.15)
+            : Colors.transparent,
+        padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 10.r),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, color: iconColor, size: 16.r),
+            SizedBox(width: 8.r),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (data.title != null)
+                    Text(
+                      data.title!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onSurface,
+                        fontSize: 11.r,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    maxLines: 1,
+                  Text(
+                    data.message,
+                    style: TextStyle(
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.8),
+                      fontSize: 10.r,
+                    ),
+                    // Enough room for a message that names a path and then says
+                    // what to do about it. At three lines the ROM-folder warnings
+                    // were cut off mid-advice ("…came from a temporary deskt"),
+                    // leaving the one actionable half of the message unread.
+                    // Short notifications are unaffected: this is a maximum.
+                    maxLines: 6,
                     overflow: TextOverflow.ellipsis,
                   ),
-                Text(
-                  data.message,
-                  style: TextStyle(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.onSurface.withValues(alpha: 0.8),
-                    fontSize: 10.r,
-                  ),
-                  // Enough room for a message that names a path and then says
-                  // what to do about it. At three lines the ROM-folder warnings
-                  // were cut off mid-advice ("…came from a temporary deskt"),
-                  // leaving the one actionable half of the message unread.
-                  // Short notifications are unaffected: this is a maximum.
-                  maxLines: 6,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                if (data.progress != null) ...[
-                  SizedBox(height: 6.r),
-                  LinearProgressIndicator(
-                    value: data.progress,
-                    minHeight: 3.r,
-                    color: iconColor,
-                    backgroundColor: iconColor.withValues(alpha: 0.2),
-                    borderRadius: BorderRadius.circular(2.r),
-                  ),
+                  if (data.progress != null) ...[
+                    SizedBox(height: 6.r),
+                    LinearProgressIndicator(
+                      value: data.progress,
+                      minHeight: 3.r,
+                      color: iconColor,
+                      backgroundColor: iconColor.withValues(alpha: 0.2),
+                      borderRadius: BorderRadius.circular(2.r),
+                    ),
+                  ],
                 ],
-              ],
+              ),
             ),
-          ),
-          SizedBox(width: 8.r),
-          GestureDetector(
-            onTap: () => GlobalNotificationService().dismiss(data.id),
-            child: Icon(
-              Symbols.close_rounded,
-              color: Theme.of(
-                context,
-              ).colorScheme.onSurface.withValues(alpha: 0.5),
-              size: 14.r,
+            SizedBox(width: 8.r),
+            GestureDetector(
+              onTap: () => GlobalNotificationService().dismiss(data.id),
+              child: Icon(
+                Symbols.close_rounded,
+                color: Theme.of(
+                  context,
+                ).colorScheme.onSurface.withValues(alpha: 0.5),
+                size: 14.r,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/scraping_notification_listener.dart
+++ b/lib/widgets/scraping_notification_listener.dart
@@ -60,6 +60,7 @@ class _ScrapingNotificationListenerState
           : AppLocale.scrapingInProgress.getString(context),
       type: GlobalNotificationType.info,
       progress: total > 0 ? processed / total : null,
+      ongoing: true,
     );
   }
 

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -1494,6 +1494,7 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
       message: localeEsdeImporting,
       type: GlobalNotificationType.info,
       progress: 0,
+      ongoing: true,
     );
 
     EsdeImportResult? result;
@@ -1515,6 +1516,7 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
                 : '$localeEsdeImporting: $label',
             type: GlobalNotificationType.info,
             progress: p,
+            ongoing: true,
           );
         },
       );

--- a/test/notification_bell_gamepad_test.dart
+++ b/test/notification_bell_gamepad_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/services/gamepad/gamepad_navigation_manager.dart';
+import 'package:neostation/services/global_notification_service.dart';
+import 'package:neostation/themes/corner_radii.dart';
+import 'package:neostation/utils/gamepad_nav.dart';
+import 'package:neostation/widgets/notification_bell.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The bell is the only surface for notifications and sits in no screen's own
+/// navigation order, so a controller could never reach it: Select opens it from
+/// anywhere the header is on screen, and the popup then owns input until B (or
+/// another Select tap) closes it.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await FlutterLocalization.instance.ensureInitialized();
+    FlutterLocalization.instance.init(
+      mapLocales: [MapLocale('en', AppLocale.en)],
+      initLanguageCode: 'en',
+    );
+  });
+
+  tearDown(() {
+    GlobalNotificationService().notifier.value = [];
+    GamepadNavigation.globalSelectTap = null;
+  });
+
+  Future<void> pumpBell(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(size: Size(1920, 1080)),
+        child: ScreenUtilInit(
+          designSize: const Size(1920, 1080),
+          builder: (context, child) => MaterialApp(
+            localizationsDelegates:
+                FlutterLocalization.instance.localizationsDelegates,
+            supportedLocales: FlutterLocalization.instance.supportedLocales,
+            theme: ThemeData(
+              extensions: <ThemeExtension<dynamic>>[CornerRadii.m()],
+            ),
+            home: const Scaffold(body: Center(child: NotificationBell())),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  bool isOpen() =>
+      find.text('Clear all').evaluate().isNotEmpty ||
+      find.text('No active notifications').evaluate().isNotEmpty;
+
+  testWidgets('a mounted bell claims the app-wide Select tap', (tester) async {
+    await pumpBell(tester);
+    expect(GamepadNavigation.globalSelectTap, isNotNull);
+  });
+
+  testWidgets('the Select tap opens the popup, and a second one closes it', (
+    tester,
+  ) async {
+    GlobalNotificationService().show(id: 'done', message: 'Import complete');
+    await pumpBell(tester);
+    expect(isOpen(), isFalse);
+
+    GamepadNavigation.globalSelectTap!();
+    await tester.pump();
+    expect(isOpen(), isTrue);
+
+    // On the device the second tap reaches the popup's own layer, which binds
+    // Select to close; the bell's hook toggles for the same reason, so either
+    // route ends with the popup shut.
+    GamepadNavigation.globalSelectTap!();
+    await tester.pump();
+    expect(isOpen(), isFalse);
+  });
+
+  testWidgets('an empty bell still opens, so Select always answers', (
+    tester,
+  ) async {
+    await pumpBell(tester);
+
+    GamepadNavigation.globalSelectTap!();
+    await tester.pump();
+
+    expect(find.text('No active notifications'), findsOneWidget);
+  });
+
+  testWidgets('the open popup takes input from the screen underneath it', (
+    tester,
+  ) async {
+    final events = <String>[];
+    GamepadNavigationManager.pushLayer(
+      'test_app_screen',
+      onActivate: () => events.add('+app'),
+      onDeactivate: () => events.add('-app'),
+    );
+    addTearDown(() => GamepadNavigationManager.popLayer('test_app_screen'));
+
+    GlobalNotificationService().show(id: 'done', message: 'Import complete');
+    await pumpBell(tester);
+    events.clear();
+
+    GamepadNavigation.globalSelectTap!();
+    // The layer is pushed in a post-frame callback, like every other screen's.
+    await tester.pump();
+    await tester.pump();
+    expect(events, ['-app'], reason: 'the popup must own the controller');
+
+    GamepadNavigation.globalSelectTap!();
+    await tester.pump();
+    await tester.pump();
+    expect(events, ['-app', '+app'], reason: 'closing hands input back');
+  });
+
+  testWidgets('the bell releases the Select tap when it leaves the tree', (
+    tester,
+  ) async {
+    await pumpBell(tester);
+    expect(GamepadNavigation.globalSelectTap, isNotNull);
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    expect(GamepadNavigation.globalSelectTap, isNull);
+  });
+}

--- a/test/notification_clear_all_test.dart
+++ b/test/notification_clear_all_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/global_notification_service.dart';
+
+/// "Clear all" tidies away messages; it must never take a running task's
+/// notification with it. Losing one is not cosmetic: [update] is a no-op once
+/// the id is gone, so the progress bar never comes back and the completion
+/// message never arrives — the task reads as cancelled.
+void main() {
+  final service = GlobalNotificationService();
+
+  setUp(() => service.notifier.value = []);
+  tearDown(() => service.notifier.value = []);
+
+  List<String> ids() => service.notifier.value.map((n) => n.id).toList();
+
+  test('clear all removes finished notifications', () {
+    service.show(id: 'done', message: 'Import complete');
+    service.dismiss();
+    expect(ids(), isEmpty);
+  });
+
+  test('clear all keeps a notification that tracks running work', () {
+    service.show(
+      id: 'scrape',
+      message: 'Scraping',
+      progress: 0.4,
+      ongoing: true,
+    );
+    service.show(id: 'done', message: 'Import complete');
+
+    service.dismiss();
+
+    expect(ids(), ['scrape']);
+    expect(service.notifier.value.single.progress, 0.4);
+  });
+
+  test('a kept notification keeps reporting progress and completion', () {
+    service.show(
+      id: 'scrape',
+      message: 'Scraping',
+      progress: 0.4,
+      ongoing: true,
+    );
+    service.dismiss();
+
+    service.update(
+      id: 'scrape',
+      message: 'Scraping',
+      progress: 0.8,
+      ongoing: true,
+    );
+    expect(service.notifier.value.single.progress, 0.8);
+
+    service.update(
+      id: 'scrape',
+      message: 'Scraping complete',
+      type: GlobalNotificationType.success,
+    );
+    final finished = service.notifier.value.single;
+    expect(finished.message, 'Scraping complete');
+    expect(finished.ongoing, isFalse);
+
+    // Finished, so the next "Clear all" takes it.
+    service.dismiss();
+    expect(ids(), isEmpty);
+  });
+
+  test('an update marks the notification finished unless it opts back in', () {
+    service.show(
+      id: 'scrape',
+      message: 'Scraping',
+      progress: 0.4,
+      ongoing: true,
+    );
+    service.update(
+      id: 'scrape',
+      message: 'Failed',
+      type: GlobalNotificationType.error,
+    );
+    expect(service.notifier.value.single.ongoing, isFalse);
+  });
+
+  test('the per-notification close button still removes an ongoing one', () {
+    service.show(
+      id: 'scrape',
+      message: 'Scraping',
+      progress: 0.4,
+      ongoing: true,
+    );
+    service.dismiss('scrape');
+    expect(ids(), isEmpty);
+  });
+}


### PR DESCRIPTION
# Description

Two related fixes to the header notification popup.

**"Clear all" no longer silences a running task.** It emptied the whole list, running tasks included. Nothing was actually cancelled, but the effect was indistinguishable from it: `update()` is a no-op once the id is gone, so a cleared in-flight notification never came back. Its progress bar was lost, the inline bar that Settings > Tools renders from the same list went blank, and the completion message never arrived. `GlobalNotificationData` now carries an `ongoing` flag and the blanket `dismiss()` keeps those entries. The per-notification close button still removes any single notification, including an ongoing one, so there is always an escape hatch.

On `update()` the flag defaults to `false` rather than carrying the previous value over, deliberately: the last update of a run is the completion message, and those are the call sites that would forget to clear it. Progress updates opt back in, next to the `progress` value they already pass, so forgetting the flag degrades to the old behaviour instead of stranding a notification nobody can clear.

**The popup is now gamepad-navigable.** The bell sits in the header and in no screen's own navigation order, so a controller could never reach it. Select (View) opens it from anywhere the header is on screen, the D-pad walks the entries, A acts on the highlighted one, and B (or another Select tap) closes it.

`GamepadNavigation` gains a `globalSelectTap` hook that fires only when the active layer has no `onSelectButton` of its own, so a screen that already gives Select a meaning keeps it: muting the preview video on the games grid and carousel, picking a save in NeoSync. One press never fires two actions. The bell also ignores the hook while another route covers the header, so a Select tap on a pushed game screen or an open dialog cannot drop a popup anchored to an off-screen bell.

The popup pushes a modal `GamepadNavigationManager` layer while open and pops it in `dispose()`, so a widget that mounts behind it (the systems grid when a startup scan finishes) is slotted underneath instead of taking the controller back.

"Clear all" became an entry in the D-pad order rather than a header-row button, which a controller cannot reach. It is also hidden when every listed notification is still tracking running work, since clearing leaves those alone and the button would visibly do nothing.

Closes #

## Steps to Reproduce

**Preconditions:** a library large enough that a Tools job takes a while (a few thousand ROMs).

1. Open Settings > Tools and start "Clean orphaned metadata".
2. While it runs, open the notification bell in the header. A progress notification is listed.
3. Press "Clear all".
4. Before: the progress notification disappears, the inline progress bar on the Tools row goes blank, and no completion message ever arrives, so the job looks cancelled. After: the running notification stays, keeps advancing, and reports its result.

## Steps to Verify

**Preconditions:** a gamepad connected, on any tab that shows the header.

1. Press Select (View). The notifications popup opens.
2. Press D-pad down and up. The highlight walks "Clear all" and the notification rows and wraps at the ends. The screen behind the popup must not move.
3. Press A on a notification row. That one notification is removed.
4. Press A on "Clear all". Finished notifications go, a running one (with a progress bar) stays.
5. Press B. The popup closes and the D-pad drives the screen underneath again.
6. Press Select on the games grid or carousel. It still mutes the preview video rather than opening the popup.

## Tested on

- [ ] Android - device: AYN Thor (built and installed, gamepad behaviour NOT yet driven end to end on the device)
- [ ] Linux - device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested - why: the change is built and installed on an AYN Thor, but the controller flow has not been verified on hardware yet. Worth a pass before merge, particularly step 2 (the popup highlight must move without the carousel behind it also moving).

## Checklist

- [x] `dart format .` - no diff
- [x] `flutter analyze` - clean (no errors *or* warnings)
- [x] `flutter test` - all passing (1624)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks - expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files - no new strings, the popup reuses `clearAll` and `noActiveNotifications`
- [x] No hardcoded UI strings - everything goes through `AppLocale`

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse - this is the point of the change; "Clear all" and each row are now D-pad stops
- [x] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()` - the popup pushes `notification_dropdown` (modal) in a post-frame callback and pops it in `dispose()`
- [x] B cancels / goes back, including out of a focused text field

</details>

## Notes for review

Two things worth a second opinion:

- **The `globalSelectTap` fallback.** Select is bound per screen today and free on most of them, so the hook only fires when the active layer defines nothing for it. The alternative was wiring `onSelectButton` into every screen that shows the header, which is more code and easy to miss one. Happy to change tack.
- **No D-pad widget test.** Driving arrows from a widget test would have to beat the navigator's directional throttle, which is wall-clock (`DateTime.now()`) and so cannot be advanced by `tester.pump`. The tests cover the Select hook, toggling, and that opening the popup takes input from the layer underneath and hands it back on close.
