### PR TITLE
fix(setup-wizard): keep the art pack when the wizard moves the user data

### DIFF
--- a/lib/providers/neo_assets_provider.dart
+++ b/lib/providers/neo_assets_provider.dart
@@ -50,6 +50,17 @@ class NeoAssetsProvider extends ChangeNotifier {
     await loadThemes();
   }
 
+  /// Re-runs [init] against the *current* user-data location.
+  ///
+  /// The setup wizard's first step can move the user data after this provider
+  /// has already initialised, which leaves the cache directory and the active
+  /// theme resolved against the folder the app started in. Calling this once
+  /// the database has been reopened at the new path re-derives both.
+  Future<void> reinitialize() async {
+    _initialized = false;
+    await init();
+  }
+
   /// Fetches the list of available themes from the remote server.
   Future<void> loadThemes() async {
     _loading = true;
@@ -82,8 +93,10 @@ class NeoAssetsProvider extends ChangeNotifier {
   /// Downloads all required assets for the specified theme and applies it.
   ///
   /// Calculates a download plan to identify missing or outdated assets and
-  /// performs a batch download with real-time progress updates.
-  Future<void> downloadAndApplyTheme(
+  /// performs a batch download with real-time progress updates. Returns whether
+  /// the pack was actually applied, so a caller that reports success (the setup
+  /// wizard) doesn't claim a pack the user has no art for.
+  Future<bool> downloadAndApplyTheme(
     String themeFolder,
     List<String> systemFolderNames, {
     bool forceRedownload = false,
@@ -105,6 +118,21 @@ class NeoAssetsProvider extends ChangeNotifier {
           'Skipping forced redownload of "$themeFolder": '
           'theme metadata unreachable, keeping the cached art',
         );
+      }
+
+      // Nothing the pack declares matched anything installed — which on a first
+      // apply means the theme metadata never arrived (a dropped request leaves
+      // `systems` unknown, and an unknown list covers nothing). Marking the
+      // pack active here is how a theme comes to read as applied with not one
+      // background on disk: no later launch re-plans it, so the art never
+      // appears until the user re-picks the pack by hand.
+      if (plan.systemsToDownload.isEmpty) {
+        _log.w(
+          'Not applying theme "$themeFolder": the download plan covers no '
+          'systems (metadata unreachable, or the pack covers none of the '
+          '${systemFolderNames.length} installed systems)',
+        );
+        return false;
       }
 
       final clearFirst = forced || plan.forceRedownload;
@@ -149,8 +177,10 @@ class NeoAssetsProvider extends ChangeNotifier {
 
       _activeThemeFolder = themeFolder;
       await ConfigRepository.updateActiveTheme(themeFolder);
+      return true;
     } catch (e) {
       _log.e('Error downloading theme: $e');
+      return false;
     } finally {
       _downloading = false;
       _downloadProgress = 0.0;

--- a/lib/services/neo_assets_service.dart
+++ b/lib/services/neo_assets_service.dart
@@ -237,6 +237,19 @@ class NeoAssetsService {
   /// 404-versus-transient-failure split without a network.
   static http.Client _client = http.Client();
 
+  /// Forgets the resolved theme-cache directory so the next call re-derives it
+  /// from the current user-data path.
+  ///
+  /// [_cacheDir] memoises the path on first use, which is at app start — before
+  /// the setup wizard's first step can move the user-data location. Without
+  /// this, a wizard that relocates the user data downloads the art pack into
+  /// the *old* folder while the database records the pack at the new one: the
+  /// art shows for the rest of that session and is gone on the next launch,
+  /// with the pack still selected in System Art.
+  static void resetCacheDir() {
+    _cachedThemeDir = null;
+  }
+
   /// Points the service at a stub client and a scratch cache directory.
   @visibleForTesting
   static void debugConfigure({http.Client? client, String? cacheDir}) {

--- a/lib/services/retro_achievements_cache.dart
+++ b/lib/services/retro_achievements_cache.dart
@@ -46,6 +46,14 @@ class RetroAchievementsCache {
     return _cachedDir!;
   }
 
+  /// Forgets the resolved cache directory so the next call re-derives it from
+  /// the current user-data path. Call after the user-data location changes —
+  /// the path is memoised on first use and would otherwise keep writing to the
+  /// previous location for the rest of the session.
+  static void resetCacheDir() {
+    _cachedDir = null;
+  }
+
   /// Points the cache at [directory] and forgets which keys were replayed.
   /// Tests use this to exercise the store without a platform user-data path.
   @visibleForTesting

--- a/lib/services/screenscraper/media_resolver.dart
+++ b/lib/services/screenscraper/media_resolver.dart
@@ -32,6 +32,14 @@ class ScreenscraperMediaResolver {
     return _cachedMediaDirectory!;
   }
 
+  /// Forgets the resolved media directory so the next call re-derives it from
+  /// the current user-data path. Call after the user-data location changes —
+  /// the path is memoised on first use and would otherwise keep writing
+  /// scraped media into the previous location for the rest of the session.
+  static void resetMediaDirectory() {
+    _cachedMediaDirectory = null;
+  }
+
   /// Maps API media type names to NeoStation folder names.
   static String mapMediaTypeToFolder(String mediaType) {
     switch (mediaType) {

--- a/lib/services/user_data_location_service.dart
+++ b/lib/services/user_data_location_service.dart
@@ -4,6 +4,9 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:neostation/services/config_service.dart';
 import 'package:neostation/services/logger_service.dart';
+import 'package:neostation/services/neo_assets_service.dart';
+import 'package:neostation/services/retro_achievements_cache.dart';
+import 'package:neostation/services/screenscraper/media_resolver.dart';
 
 class UserDataLocationService {
   static const String customPathKey = 'custom_user_data_path';
@@ -21,12 +24,29 @@ class UserDataLocationService {
     // A new location invalidates any "storage unavailable" verdict cached for
     // the previous one, which would otherwise fail fast for the whole session.
     ConfigService.resetStorageAvailability();
+    _resetPathDerivedCaches();
   }
 
   static Future<void> clearCustomPath() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(customPathKey);
     ConfigService.resetStorageAvailability();
+    _resetPathDerivedCaches();
+  }
+
+  /// Drops every directory that was derived from the *previous* user-data path.
+  ///
+  /// These services each memoise their folder on first use, which happens at
+  /// app start — before the setup wizard's first step can move the user data.
+  /// Leaving them pinned means the rest of the session keeps writing to the old
+  /// location while the database lives at the new one, so the work is silently
+  /// stranded: the art pack downloaded during the wizard is gone on the next
+  /// launch even though System Art still shows it as applied. The settings-side
+  /// move gets away with it only because it forces a restart afterwards.
+  static void _resetPathDerivedCaches() {
+    NeoAssetsService.resetCacheDir();
+    RetroAchievementsCache.resetCacheDir();
+    ScreenscraperMediaResolver.resetMediaDirectory();
   }
 
   /// Counts top-level entries in [dirPath].

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -806,6 +806,14 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
       );
       await configProvider.reinitialize();
 
+      // The database is now open at the new path, but this provider resolved
+      // its cache directory and active theme against the old one at launch.
+      // Without this the art pack downloaded on the final step lands in the
+      // folder the app started in, and is gone on the next launch even though
+      // System Art still shows the pack as applied.
+      if (!mounted) return;
+      await context.read<NeoAssetsProvider>().reinitialize();
+
       if (mounted) setState(() => _selectedUserDataPath = selected);
     } catch (e) {
       _log.e('User data location selection failed in wizard: $e');
@@ -1597,13 +1605,27 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
         .toList();
 
     setState(() => _isDownloadingArt = true);
+    bool applied = false;
     try {
-      await neoAssets.downloadAndApplyTheme(recommended.folder, systemFolders);
+      applied = await neoAssets.downloadAndApplyTheme(
+        recommended.folder,
+        systemFolders,
+      );
     } catch (e) {
       _log.e('Wizard art pack download failed: $e');
     }
     if (!mounted) return;
     setState(() => _isDownloadingArt = false);
+
+    // A failed download leaves the step exactly as it was — the button reads
+    // "Download Art Pack" again, so the user can retry or skip past it. Ending
+    // setup here instead would drop them into an app whose art never arrived
+    // with nothing said about it.
+    if (!applied) {
+      _log.w('Art pack was not applied; staying on the wizard art-pack step');
+      return;
+    }
+
     // Downloading the pack is the final action — finish setup directly instead
     // of making the user press Finish on a redundant "installed" screen.
     await _finishSetup();

--- a/test/neo_assets_apply_guard_test.dart
+++ b/test/neo_assets_apply_guard_test.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:neostation/providers/neo_assets_provider.dart';
+import 'package:neostation/services/neo_assets_service.dart';
+
+/// A theme may only be recorded as applied once there is art to show for it.
+///
+/// The plan is built from the pack's declared `systems` list, so a dropped
+/// metadata request covers nothing — and nothing is downloaded. Marking the
+/// pack active anyway is how a theme comes to read as applied with not one
+/// background on disk: no later launch re-plans it, so the user sees the pack
+/// selected in System Art with plain backgrounds everywhere, and only re-picking
+/// it by hand fixes that.
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('neo_assets_apply_test');
+  });
+
+  tearDown(() {
+    NeoAssetsService.debugReset();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  void useClient(Future<http.Response> Function(http.Request) handler) {
+    NeoAssetsService.debugConfigure(
+      client: MockClient(handler),
+      cacheDir: tempDir.path,
+    );
+  }
+
+  test('an unreachable theme manifest does not apply the pack', () async {
+    useClient((_) async => http.Response('upstream is down', 503));
+
+    final provider = NeoAssetsProvider();
+    final applied = await provider.downloadAndApplyTheme('NeoStation', const [
+      'gb',
+      'snes',
+    ]);
+
+    expect(applied, isFalse);
+    expect(provider.hasActiveTheme, isFalse);
+    expect(provider.activeThemeFolder, isEmpty);
+  });
+
+  test(
+    'a pack covering none of the installed systems does not apply',
+    () async {
+      useClient((request) async {
+        if (request.url.path.endsWith('theme.json')) {
+          return http.Response(
+            jsonEncode({
+              'version': '1.0.0',
+              'systems': ['dreamcast'],
+            }),
+            200,
+          );
+        }
+        return http.Response('not found', 404);
+      });
+
+      final provider = NeoAssetsProvider();
+      final applied = await provider.downloadAndApplyTheme('NeoStation', const [
+        'gb',
+        'snes',
+      ]);
+
+      expect(applied, isFalse);
+      expect(provider.hasActiveTheme, isFalse);
+    },
+  );
+}

--- a/test/user_data_relocation_cache_test.dart
+++ b/test/user_data_relocation_cache_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/config_service.dart';
+import 'package:neostation/services/neo_assets_service.dart';
+import 'package:neostation/services/user_data_location_service.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Regression test for art packs installed during the setup wizard vanishing on
+/// the next launch.
+///
+/// Directories derived from the user-data path are memoised on first use, which
+/// happens at app start — before the wizard's first step can move the user data.
+/// The wizard changes the location without restarting, so a pinned directory
+/// keeps the rest of that session writing to the folder the app started in: the
+/// art pack downloads into the old location while the database records it at the
+/// new one, and the next launch finds a pack marked applied with no art at all.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmp;
+  late Directory first;
+  late Directory second;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('neostation_relocation_');
+    first = Directory(p.join(tmp.path, 'first'))..createSync(recursive: true);
+    second = Directory(p.join(tmp.path, 'second'))..createSync(recursive: true);
+    SharedPreferences.setMockInitialValues({});
+    ConfigService.resetStorageAvailability();
+    NeoAssetsService.resetCacheDir();
+  });
+
+  tearDown(() {
+    NeoAssetsService.resetCacheDir();
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  test('the theme cache follows a user-data location change', () async {
+    await UserDataLocationService.setCustomPath(first.path);
+
+    // Resolve once, the way app start does: this is what used to pin the
+    // directory for the whole session.
+    await NeoAssetsService.ensureCacheDirInitialized();
+    expect(
+      await NeoAssetsService.backgroundCachePath('NeoStation', 'gb'),
+      p.join(first.path, 'themes', 'NeoStation', 'backgrounds', 'gb.webp'),
+    );
+
+    await UserDataLocationService.setCustomPath(second.path);
+
+    expect(
+      await NeoAssetsService.backgroundCachePath('NeoStation', 'gb'),
+      p.join(second.path, 'themes', 'NeoStation', 'backgrounds', 'gb.webp'),
+      reason:
+          'art downloaded after the wizard moved the user data must land in '
+          'the new location, not the one the app started in',
+    );
+  });
+
+  test('the sync resolver follows a user-data location change too', () async {
+    await UserDataLocationService.setCustomPath(first.path);
+    await NeoAssetsService.ensureCacheDirInitialized();
+
+    await UserDataLocationService.setCustomPath(second.path);
+    await NeoAssetsService.ensureCacheDirInitialized();
+
+    // The systems grid reads backgrounds synchronously; it must agree with the
+    // async path the downloader wrote to, or the art is there and unreadable.
+    final resolved = NeoAssetsService.backgroundCachePathSync(
+      'NeoStation',
+      'gb',
+    );
+    expect(resolved, startsWith(second.path));
+  });
+
+  test('clearing the custom path re-derives the theme cache as well', () async {
+    await UserDataLocationService.setCustomPath(first.path);
+    await NeoAssetsService.ensureCacheDirInitialized();
+
+    await UserDataLocationService.clearCustomPath();
+
+    expect(
+      NeoAssetsService.backgroundCachePathSync('NeoStation', 'gb'),
+      isNull,
+      reason: 'the pinned directory must be dropped, not kept',
+    );
+  });
+}


### PR DESCRIPTION
# Description

Picking the NeoStation art pack on the setup wizard's last step did not stick. The art showed for the rest of that session and was gone on the next launch, with the pack still shown as selected in System Art; only re-picking it (None, then NeoStation again) brought it back. It happens when the user changes the user-data location on the wizard's **first** step — the default-location path was never affected.

Directories derived from the user-data path are memoised on first use, which happens at app start, before the wizard's first step can move the user data. `NeoAssetsProvider` is registered eagerly (`lazy: false`), so `NeoAssetsService._cachedThemeDir` is pinned to the folder the app launched in. The wizard's location change calls `setCustomPath()` and reopens the **database** at the new path, but leaves that memo alone: the download writes ~95 backgrounds into the old folder while the database records the pack at the new one, so the next launch resolves an empty `themes/` directory. The settings-side move only escapes this because it forces a restart afterwards (`RestartRequiredDialog`).

Changes:

- **Reset every path-derived cache** in `UserDataLocationService.setCustomPath()` / `clearCustomPath()`, so both callers are covered. The theme cache was the reported symptom, but `RetroAchievementsCache._cachedDir` and `ScreenscraperMediaResolver._cachedMediaDirectory` are pinned the same way and were stranded the same way — scraped media and the RA offline cache also went to the old folder for the rest of a relocating session.
- **Re-run `NeoAssetsProvider.init()` from the wizard** once the database has been reopened, so the active theme is read from the new location's database rather than the one the app started against.
- **Stop recording a pack as applied when the download plan covers no systems.** Unreachable theme metadata leaves the pack's declared `systems` list unknown, which covers nothing and downloads nothing — and marking it active anyway is a second route to a pack that reads as applied with no art on disk, since nothing re-plans it on a later launch. `downloadAndApplyTheme` now reports whether it applied, and a failed wizard download leaves the step in place so the user can retry or skip instead of finishing setup silently.

Known limitation, deliberately out of scope: installs that already hit this keep a pack marked active with its art stranded in the old folder, and still need one manual re-pick. A startup self-heal (active theme with no backgrounds on disk ⇒ re-apply) would fix those too, at the cost of a conditional download on launch — happy to add it if wanted.

`app.log` still lands in the old folder for the remainder of a relocating session. That is a live open sink rather than a memoised path, so re-pointing it mid-session is riskier than it is worth; it follows the new location from the next launch.

## Steps to Reproduce

**Preconditions:** a fresh install (no user data), any Android device, network available.

1. Launch the app so the setup wizard appears.
2. On step 1 (User data location), tap **Select User Data Folder** and pick a folder outside the app-private default — e.g. `/storage/emulated/0/Documents` (Android refuses `Download`). Accept the SAF grant and the "Folder Not Empty" warning.
3. Continue through the wizard: skip the accessibility permission, select a ROM folder, let the scan finish, skip the ES-DE import.
4. On the last step tap **Download Art Pack** and let it finish. The wizard closes; the systems grid shows artwork.
5. Force-stop and relaunch the app.

Before this PR, step 5 shows every system tile as a flat colour block, while Settings → System Art still shows NeoStation selected with a green check. On disk, the backgrounds are in `/sdcard/Android/data/<pkg>/files/user-data/themes/NeoStation/backgrounds` while the live database is at `/sdcard/Documents/data.sqlite` and `Documents/themes/` holds only `manifest.json`.

## Steps to Verify

**Preconditions:** same as above — fresh install, Android device, network available.

1. Run steps 1–5 above on this branch.
2. The systems grid shows artwork **after** the restart, not just before it.
3. Confirm on disk: `ls /sdcard/Documents/themes/NeoStation/backgrounds | wc -l` → 95, and `ls /sdcard/Android/data/<pkg>/files/user-data/themes/NeoStation/backgrounds | wc -l` → 0.
4. Regression check with the default location: run the wizard again without changing the user-data folder; the art pack still applies as before.

## Tested on

- [x] Android — device: AYN Thor (featuretest channel, release build)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Both directions were exercised on-device: the failure reproduced first (flat tiles after restart, art stranded in the old folder), then the same run on the fixed build kept its artwork across the restart with the 95 files in the new location. The default-location wizard path was run separately and is unchanged.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1629)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

New tests:

- `test/user_data_relocation_cache_test.dart` — the theme cache follows a location change, the sync resolver agrees with the async path, and clearing the custom path drops the memo. Confirmed non-vacuous: all three fail with the reset removed.
- `test/neo_assets_apply_guard_test.dart` — an unreachable theme manifest, and a pack covering none of the installed systems, both leave the theme unapplied.

<details>
<summary><b>Extra checks</b></summary>

**User-facing text**
- No new strings — the failed-download path reuses the existing art-pack step copy rather than adding a locale key.

**Android**
- [x] Verified on a device, not only on desktop
- No path parsing changed; the SAF-derived custom path is handled by the existing `safUriToRealPath`.

</details>
