### PR TITLE
fix(desktop): keep the splash status text off the logo's scale

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -571,10 +571,12 @@ class _StartupScaffoldState extends State<_StartupScaffold> {
 
   @override
   Widget build(BuildContext context) {
-    // Same factor the shimmering splash uses, so the wordmark and the status
-    // block grow with the logo instead of being stranded at design size on a
-    // desktop window.
+    // Same factor the shimmering splash uses, so the logo and the spacing
+    // around it grow instead of being stranded at design size on a desktop
+    // window. The wordmark takes the damped text scale — grown by the full
+    // factor it reads as a banner rather than a caption under the glyph.
     final scale = SplashStatusLayout.scaleOf(context);
+    final textScale = SplashStatusLayout.textScaleOf(context);
     final children = widget.childrenBuilder(context, _colors);
     return MaterialApp(
       debugShowCheckedModeBanner: false,
@@ -612,7 +614,7 @@ class _StartupScaffoldState extends State<_StartupScaffold> {
                           'NeoStation',
                           style: TextStyle(
                             color: _colors.foreground,
-                            fontSize: 28 * scale,
+                            fontSize: 28 * textScale,
                             fontWeight: FontWeight.w600,
                             letterSpacing: 1.2,
                           ),
@@ -667,6 +669,7 @@ class _StartupLoadingAppState extends State<StartupLoadingApp> {
       animatedLogo: true,
       childrenBuilder: (context, colors) {
         final scale = SplashStatusLayout.scaleOf(context);
+        final textScale = SplashStatusLayout.textScaleOf(context);
         return [
           AnimatedOpacity(
             opacity: _showText ? 1.0 : 0.0,
@@ -681,7 +684,7 @@ class _StartupLoadingAppState extends State<StartupLoadingApp> {
                 // first frames if the font isn't warmed up yet.
                 style: GoogleFonts.anta(
                   color: colors.foreground.withValues(alpha: 0.6),
-                  fontSize: 17 * scale,
+                  fontSize: 17 * textScale,
                   letterSpacing: 0.3,
                 ),
               ),
@@ -732,6 +735,7 @@ class StartupStorageErrorApp extends StatelessWidget {
       onKeyEvent: _handleKey,
       childrenBuilder: (context, colors) {
         final scale = SplashStatusLayout.scaleOf(context);
+        final textScale = SplashStatusLayout.textScaleOf(context);
         return [
           ConstrainedBox(
             constraints: BoxConstraints(maxWidth: 520 * scale),
@@ -743,7 +747,7 @@ class StartupStorageErrorApp extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     color: colors.foreground.withValues(alpha: 0.8),
-                    fontSize: 16 * scale,
+                    fontSize: 16 * textScale,
                   ),
                 ),
                 if (storagePath != null && storagePath!.isNotEmpty) ...[
@@ -753,7 +757,7 @@ class StartupStorageErrorApp extends StatelessWidget {
                     textAlign: TextAlign.center,
                     style: TextStyle(
                       color: colors.foreground.withValues(alpha: 0.55),
-                      fontSize: 13 * scale,
+                      fontSize: 13 * textScale,
                     ),
                   ),
                 ],

--- a/lib/screens/systems_screen/system_content.dart
+++ b/lib/screens/systems_screen/system_content.dart
@@ -156,7 +156,7 @@ class _SystemContentState extends State<SystemContent> {
                       .replaceFirst('{total}', raProgress.total.toString())
                 : AppLocale.raMatchProgressBusy.getString(context),
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              fontSize: 17.r,
+              fontSize: 17 * SplashStatusLayout.textScaleOf(context),
               color: Theme.of(
                 context,
               ).colorScheme.onSurface.withValues(alpha: 0.6),
@@ -187,7 +187,7 @@ class _SystemContentState extends State<SystemContent> {
             // 17 to match the startup screen's status line — the theme's
             // bodySmall (12) reads too small at couch distance.
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              fontSize: 17.r,
+              fontSize: 17 * SplashStatusLayout.textScaleOf(context),
               color: Theme.of(
                 context,
               ).colorScheme.onSurface.withValues(alpha: 0.6),

--- a/lib/widgets/splash_status_layout.dart
+++ b/lib/widgets/splash_status_layout.dart
@@ -21,7 +21,9 @@ import 'shimmering_logo.dart';
 /// Every size here is expressed in the app's 640×480 design space and scaled by
 /// [scaleOf], so the splash keeps its proportions on a desktop window instead
 /// of stranding a fixed-size logo in the middle of a 1920×1080 screen while the
-/// rest of the app scales up around it.
+/// rest of the app scales up around it. The status text the callers hand in is
+/// the exception: it uses the damped [textScaleOf] instead, so a big window
+/// grows the logo without turning the status line into a headline.
 class SplashStatusLayout extends StatelessWidget {
   const SplashStatusLayout({super.key, required this.children, this.progress});
 
@@ -84,6 +86,28 @@ class SplashStatusLayout extends StatelessWidget {
         math.max(size.height, _splitScreenMinHeight) / _designSize.height;
     return math.max(1.0, math.min(scaleWidth, scaleHeight));
   }
+
+  /// How much bigger than the design space a panel has to be before the status
+  /// text grows at all.
+  ///
+  /// Handhelds sit just above the 640×480 design space — the Thor's 831×467
+  /// resolves to ~1.3 — and their status line was already the right size at a
+  /// flat 17px. Anything inside this headroom therefore renders text exactly
+  /// as it did before the splash became scale-aware; only a genuinely larger
+  /// panel, a desktop window or a TV, starts growing it.
+  static const double _textGrowthHeadroom = 1.4;
+
+  /// The factor the splash *text* is scaled by.
+  ///
+  /// Text does not want the logo's scale. The logo is a graphic and reads
+  /// right at a constant share of the screen, but a status line grown by the
+  /// full factor turns into a headline on a desktop window — the 17px line
+  /// under the logo landed at ~38px on 1080p. So the growth is both deferred
+  /// past [_textGrowthHeadroom] and damped by a square root: the line still
+  /// scales up on a big panel, where 17px is too small to read at couch
+  /// distance, but far more slowly than the glyph above it.
+  static double textScaleOf(BuildContext context) =>
+      math.sqrt(math.max(1.0, scaleOf(context) / _textGrowthHeadroom));
 
   @override
   Widget build(BuildContext context) {

--- a/test/splash_status_layout_test.dart
+++ b/test/splash_status_layout_test.dart
@@ -130,6 +130,57 @@ void main() {
       expect(logo.height, lessThanOrEqualTo(1080 * 0.40));
     });
 
+    testWidgets('the status text scale is damped against the logo scale', (
+      tester,
+    ) async {
+      // The logo wants the full ScreenUtil factor; the status line under it
+      // does not. Scaled in step, the 17px line landed near 38px on a 1080p
+      // window and read as a headline rather than a caption.
+      Future<({double scale, double textScale})> factorsAt(Size size) async {
+        tester.view.physicalSize = size;
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+        late double scale;
+        late double textScale;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                scale = SplashStatusLayout.scaleOf(context);
+                textScale = SplashStatusLayout.textScaleOf(context);
+                return const SizedBox();
+              },
+            ),
+          ),
+        );
+        return (scale: scale, textScale: textScale);
+      }
+
+      // Every handheld — up to and including the Thor, which is half again
+      // the design space — renders the status line at exactly the flat size it
+      // always did. Only the logo above it grows on those panels.
+      for (final size in const [
+        Size(320, 240),
+        Size(480, 320),
+        Size(640, 480),
+        Size(831, 467), // Thor
+      ]) {
+        final f = await factorsAt(size);
+        expect(
+          f.textScale,
+          moreOrLessEquals(1.0, epsilon: 0.001),
+          reason: '$size must keep the status text at its design size',
+        );
+      }
+
+      // A desktop window still grows the text — a 17px line is too small at
+      // couch distance on a big panel — but by much less than the logo.
+      final desktop = await factorsAt(const Size(1920, 1080));
+      expect(desktop.textScale, greaterThan(1.0));
+      expect(desktop.textScale, lessThan(desktop.scale));
+      expect(17 * desktop.textScale, lessThan(24));
+    });
+
     testWidgets('panels below the design size never grow', (tester) async {
       // The scale is floored at 1, so the handhelds that were already laying
       // out correctly render exactly as they did before.


### PR DESCRIPTION
# Description

#463 scaled the splash logo with the window, and scaled the status block under it by the same factor so a 630px logo would not sit over 17px text. That was too much for the text: on a 1080p window the status line landed at ~38px and read as a headline rather than a caption, and on the Thor a 22px line was already bigger than it wanted to be.

Text now takes its own factor, `SplashStatusLayout.textScaleOf`:

* Growth is **deferred** until the panel is 1.4x the 640x480 design space. Handhelds sit just above the design size (the Thor's 831x467 resolves to ~1.3), and their status line was already right at a flat 17. Every panel inside that headroom renders text exactly as it did before the splash became scale-aware.
* Past that it grows by a **square root**, so a big panel still gets a line that reads at couch distance without competing with the glyph.

Sizes on the panels the app ships on (17px at design size):

| Panel | Before #463 | After #463 | This PR |
| --- | --- | --- | --- |
| Thor (831x467) | 17.0 | 22.1 | **17.0** |
| Steam Deck (1280x800) | 17.0 | 28.3 | **18.5** |
| 1080p window | 17.0 | 38.2 | **21.6** |
| 3440x1440 | 17.0 | 51.0 | **24.9** |

The logo, the spacing around it and the scan progress bar keep the full `scaleOf` factor, so nothing about #463's logo sizing changes. Applied to the startup loading line, the storage-error screen's body and path, the wordmark on the error screen's centred column, and the scan splash's status line.

## Steps to Verify

**Preconditions:** a display meaningfully larger than 640x480 (a desktop window, or the Thor for the no-change case).

1. Launch the app and watch the splash while the startup scan runs.
2. The status line under the logo is a caption, not a headline: roughly a fifth of the logo's height on a desktop window.
3. On a handheld at or below ~1.4x the design size (the Thor included), the line is the same 17px it was before #463.
4. The logo itself is unchanged from #463 on every panel.

## Tested on

- [x] Android - device: AYN Thor (dev channel, status line back to 17px)
- [x] Linux - device: CachyOS desktop, 3440x1440
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested - why:

## Checklist

- [x] `dart format .` - no diff
- [x] `flutter analyze` - clean (no errors *or* warnings)
- [x] `flutter test` - all passing
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

`test/splash_status_layout_test.dart` gains a case asserting the text factor is exactly 1 on every handheld through the Thor, and strictly between 1 and the logo's factor on a 1080p window.

## Screenshots / video

Not captured. The change is a font size on a splash that is up for about a second; the table above is the measurable form of it.
