### PR TITLE
perf(scan): walk ROM folders off the UI isolate

### DIFF
--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -9,6 +9,7 @@ import 'package:neostation/services/android_service.dart';
 import 'package:neostation/services/saf_directory_service.dart';
 import 'package:neostation/services/logger_service.dart';
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:convert';
 import 'package:path/path.dart' as path;
 import 'package:flutter/foundation.dart';
@@ -248,7 +249,7 @@ class SqliteDatabaseService {
                 system.recursiveScan,
                 ignoreHiddenFiles: ignoreHiddenFiles,
               )
-            : await _scanStandardPath(
+            : await scanStandardPath(
                 target.dirPath,
                 validExtensionsSet,
                 system.recursiveScan,
@@ -1277,7 +1278,7 @@ class SqliteDatabaseService {
       try {
         final List<FileSystemEntity> children = await rootDir.list().toList();
         for (final child in children) {
-          if (await _shouldSkipStandardEntity(
+          if (_shouldSkipStandardEntity(
             child,
             ignoreHiddenFiles: ignoreHiddenFiles,
           )) {
@@ -1303,12 +1304,51 @@ class SqliteDatabaseService {
     }
   }
 
-  /// Recursively lists files within a standard filesystem path, filtering by extension.
-  static Future<List<RomEntry>> _scanStandardPath(
+  /// Recursively lists files within a standard filesystem path, filtering by
+  /// extension.
+  ///
+  /// The walk itself runs on a background isolate. It is pure filesystem work
+  /// — no plugin, no database — but every file costs two `await`s, and on the
+  /// root isolate those completions queue behind the frame pipeline: each file
+  /// then waits on a slice of a frame rather than on a syscall. Measured on a
+  /// 9,140-ROM library over 32 systems, the startup scan took ~17s on the root
+  /// isolate against ~0.3s for the identical walk with an idle event loop, and
+  /// the startup shimmer stuttered in step with it the whole way — the scan
+  /// and the animation were taking turns on one event loop.
+  ///
+  /// Android's SAF walk stays where it is: it reaches the DocumentsProvider
+  /// over a platform channel, which is only bound on the root isolate.
+  @visibleForTesting
+  static Future<List<RomEntry>> scanStandardPath(
     String pathStr,
     Set<String> validExtensions,
     bool recursive, {
     bool ignoreHiddenFiles = true,
+  }) async {
+    final result = await Isolate.run(
+      () => _walkStandardPath(
+        pathStr,
+        validExtensions,
+        recursive,
+        ignoreHiddenFiles: ignoreHiddenFiles,
+      ),
+    );
+    if (result.error != null) {
+      _log.e('Error scanning standard path $pathStr: ${result.error}');
+    }
+    return result.entries;
+  }
+
+  /// The body of [scanStandardPath], written to run on a bare isolate: it
+  /// touches nothing the root isolate owns, so it must not log or reach a
+  /// plugin. A failure comes back as [error] for the caller to log, along with
+  /// whatever the walk had already collected — the same partial result the
+  /// in-place `try` used to return.
+  static Future<({List<RomEntry> entries, String? error})> _walkStandardPath(
+    String pathStr,
+    Set<String> validExtensions,
+    bool recursive, {
+    required bool ignoreHiddenFiles,
   }) async {
     final entries = <RomEntry>[];
     try {
@@ -1316,7 +1356,7 @@ class SqliteDatabaseService {
         pathStr,
       ).list(recursive: recursive, followLinks: false).toList();
       for (final entity in entities) {
-        if (await _shouldSkipStandardEntity(
+        if (_shouldSkipStandardEntity(
           entity,
           ignoreHiddenFiles: ignoreHiddenFiles,
         )) {
@@ -1338,9 +1378,9 @@ class SqliteDatabaseService {
         }
       }
     } catch (e) {
-      _log.e('Error scanning standard path $pathStr: $e');
+      return (entries: entries, error: '$e');
     }
-    return entries;
+    return (entries: entries, error: null);
   }
 
   static bool _isDotEntryName(String name) {
@@ -1380,10 +1420,12 @@ class SqliteDatabaseService {
     return false;
   }
 
-  static Future<bool> _shouldSkipStandardEntity(
+  /// Sync on purpose: this only inspects the name it was handed, and as an
+  /// `async` function it cost the walk an extra event-loop turn per entry.
+  static bool _shouldSkipStandardEntity(
     FileSystemEntity entity, {
     required bool ignoreHiddenFiles,
-  }) async {
+  }) {
     if (!ignoreHiddenFiles) return false;
 
     final name = path.basename(entity.path);

--- a/test/rom_scan_standard_walk_test.dart
+++ b/test/rom_scan_standard_walk_test.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_database_service.dart';
+
+/// The desktop ROM walk runs on a background isolate, so every one of these
+/// cases crosses an isolate boundary and comes back. That is the point of the
+/// suite as much as the filtering is: the walk closure has to stay sendable
+/// and its [RomEntry] results have to survive the hop. A capture of anything
+/// the root isolate owns — a logger, a plugin, a database handle — fails here
+/// rather than in a startup scan on a user's machine.
+void main() {
+  late Directory root;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('rom_scan_walk_');
+    Future<void> write(String relative, int bytes) async {
+      final file = File('${root.path}/$relative');
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(List<int>.filled(bytes, 0));
+    }
+
+    await write('Sonic.md', 12);
+    await write('Streets of Rage.MD', 34);
+    await write('notes.txt', 5);
+    await write('.hidden.md', 7);
+    await write('Disc 1/Phantasy Star.md', 56);
+  });
+
+  tearDown(() async {
+    if (root.existsSync()) await root.delete(recursive: true);
+  });
+
+  Future<List<RomEntry>> walk({
+    bool recursive = true,
+    Set<String> extensions = const {'md'},
+    bool ignoreHiddenFiles = true,
+  }) async {
+    final entries = await SqliteDatabaseService.scanStandardPath(
+      root.path,
+      extensions,
+      recursive,
+      ignoreHiddenFiles: ignoreHiddenFiles,
+    );
+    entries.sort((a, b) => a.filename.compareTo(b.filename));
+    return entries;
+  }
+
+  group('scanStandardPath', () {
+    test('returns matching files with their sizes', () async {
+      final entries = await walk(recursive: false);
+      expect(entries.map((e) => e.filename), [
+        'Sonic.md',
+        'Streets of Rage.MD',
+      ]);
+      // The size survives the isolate hop, and the extension match is
+      // case-insensitive.
+      expect(entries.map((e) => e.size), [12, 34]);
+      expect(entries.first.path, '${root.path}/Sonic.md');
+    });
+
+    test('skips extensions the system does not claim', () async {
+      final entries = await walk();
+      expect(entries.map((e) => e.filename), isNot(contains('notes.txt')));
+    });
+
+    test('an empty extension set takes everything', () async {
+      final entries = await walk(recursive: false, extensions: const {});
+      expect(entries.map((e) => e.filename), contains('notes.txt'));
+    });
+
+    test('recursion reaches subfolders, and off it does not', () async {
+      expect(
+        (await walk()).map((e) => e.filename),
+        contains('Phantasy Star.md'),
+      );
+      expect(
+        (await walk(recursive: false)).map((e) => e.filename),
+        isNot(contains('Phantasy Star.md')),
+      );
+    });
+
+    test('hidden files are skipped unless the system asks for them', () async {
+      expect(
+        (await walk()).map((e) => e.filename),
+        isNot(contains('.hidden.md')),
+      );
+      expect(
+        (await walk(ignoreHiddenFiles: false)).map((e) => e.filename),
+        contains('.hidden.md'),
+      );
+    });
+
+    test('a missing directory yields nothing rather than throwing', () async {
+      final entries = await SqliteDatabaseService.scanStandardPath(
+        '${root.path}/does-not-exist',
+        const {'md'},
+        true,
+      );
+      expect(entries, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
# Description

The desktop ROM walk ran on the root isolate, where it competed with the frame pipeline for the one event loop. It costs two `await`s per file, and on the root isolate those completions queue behind frames: each ROM then waits on a slice of a frame rather than on a syscall.

The startup splash made the coupling visible. The shimmering logo stuttered in step with the scan the whole way through, because the scan and the animation were taking turns on the same event loop.

Measured on a 9,140-ROM library across 32 systems (CachyOS desktop, 3440x1440, ROMs on an NTFS volume):

| | Startup scan |
| --- | --- |
| before | **16.97s** |
| after | **1.25s** |

For scale, the identical walk in a bare Dart VM does the 1,394-file NES folder in 17ms, against 1,800ms in-app. The walk itself was never the cost; the event loop it sat on was.

### Changes

* `scanStandardPath` runs its body through `Isolate.run`. The body takes nothing the root isolate owns, so it cannot log: a failure comes back as a string for the caller to log, along with whatever the walk had already collected, which is the same partial result the in-place `try` returned.
* `_shouldSkipStandardEntity` is now sync. It only inspects the name it is handed, and as an `async` function it cost the walk an extra event-loop turn per entry.

Android's SAF walk deliberately stays on the root isolate: it reaches the DocumentsProvider over a platform channel, which is only bound there. So this is a desktop and Android-non-SAF change; the Thor's SAF path is untouched.

## Steps to Verify

**Preconditions:** a desktop build with a large library on a real filesystem path (mine: 9,140 ROMs, 32 systems), and `scanOnStartup` enabled.

1. Launch the app and watch the splash.
2. The shimmer sweeps smoothly instead of stuttering, and the scan is over in about a second rather than a quarter of a minute.
3. Check the log: the interval from `scanSystems starting` to `ScanResult[All Systems]` is the scan's wall time.
4. Confirm nothing changed about what was found: the `walked ... -> N entries` and `ScanResult[...] added/removed/total` lines should be identical to a build from `main`.

I did step 4 by diffing those 69 log lines across the two builds: same folders walked, same entry counts, same added/removed/total for every system.

## Tested on

- [x] Linux - device: CachyOS desktop, 3440x1440, ROMs on NTFS
- [ ] Android - device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested - why:

Android is not runtime-verified because the code path it changes is the non-SAF one; the Thor's ROM folders go through the SAF walk, which this PR leaves on the root isolate.

## Checklist

- [x] `dart format .` - no diff
- [x] `flutter analyze` - clean (no errors *or* warnings)
- [x] `flutter test` - all passing
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

New `test/rom_scan_standard_walk_test.dart` pins the walk's filtering (extensions, case, recursion, hidden files, sizes, a missing directory) with every case crossing the isolate boundary. That is as much the point as the filtering: it fails if the walk closure ever captures something the root isolate owns, rather than that surfacing as a broken scan on a user's machine.

<details>
<summary><b>Extra checks</b></summary>

**Android**

- [x] Path logic handles SAF `content://` URIs - unchanged: the SAF walk is deliberately left on the root isolate
- [ ] Verified on a device, not only on desktop - N/A, see above

</details>
