### PR TITLE
fix(android): extract archives whose SAF path is too long to name a folder

### DIFF
--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -532,6 +532,9 @@ class SqliteMigrations {
       case 153:
         await _migrateToVersion153(db);
         break;
+      case 154:
+        await _migrateToVersion154(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -6667,6 +6670,60 @@ class SqliteMigrations {
       _log.i('Migration v153 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v153: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v154: Reopens ROMs parked because their archive could not be
+  /// extracted.
+  ///
+  /// `ArchiveService` named its extraction directory with the basename of the
+  /// ROM path. On Android that path is a SAF `content://` URI whose document id
+  /// encodes every `/` as `%2F`, so there was no separator left to split on and
+  /// the whole encoded id became the directory name — 267 bytes for a ROM whose
+  /// own file name is 137. Past the filesystem's 255-byte limit on one
+  /// component the directory could not be created, extraction failed with
+  /// errno 36, and the ROM was parked `ra_hash_skipped = 'extract_failed'`.
+  ///
+  /// The bulk pass steps over parked ROMs, and the unpark in
+  /// `RetroAchievementsHashService` only runs when a human asked for the pass,
+  /// so without this the fix would never reach a library that already hit the
+  /// bug: the affected ROMs stay unmatched forever on every existing install.
+  /// Same reasoning as v144 and v153, which reopened what the CHD reader and
+  /// the new disc containers had parked.
+  ///
+  /// Scoped to `'extract_failed'`. `'error'` is the pass's general bucket and a
+  /// ROM under it failed for some other reason, so it is left alone. Archives
+  /// that are genuinely corrupt are reopened too and simply park again on the
+  /// next pass, which costs one read each and is the same trade the two earlier
+  /// migrations made. Nothing needs clearing on the hash side: an archive that
+  /// never extracted produced no hash to be wrong.
+  static Future<void> _migrateToVersion154(Database db) async {
+    _log.i('Migration v154: Reopening ROMs whose archive failed to extract');
+    try {
+      final romColumns = db
+          .select('PRAGMA table_info(user_roms)')
+          .map((c) => c['name'].toString())
+          .toSet();
+      if (!romColumns.contains('ra_hash_skipped')) {
+        _log.i('v154: user_roms has no ra_hash_skipped yet, nothing to reopen');
+        return;
+      }
+
+      db.execute("""
+        UPDATE user_roms SET ra_hash_skipped = NULL
+        WHERE ra_hash_skipped = 'extract_failed'
+      """);
+
+      final reopened = db.select('SELECT changes() AS n').first['n'] as int;
+      if (reopened > 0) {
+        _log.i('v154: reopened $reopened ROM(s) for re-matching');
+      }
+
+      _log.i('Migration v154 completed');
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v154: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -459,7 +459,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 153;
+  static const int _databaseVersion = 154;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;

--- a/lib/services/archive_service.dart
+++ b/lib/services/archive_service.dart
@@ -1,5 +1,7 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:archive/archive_io.dart';
+import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as path;
 import 'package:flutter_7zip/flutter_7zip.dart' as f7z;
 import 'config_service.dart';
@@ -13,6 +15,74 @@ import 'package:neostation/services/logger_service.dart';
 class ArchiveService {
   static final _log = LoggerService.instance;
 
+  /// Longest single path component most Android and Linux filesystems accept,
+  /// in bytes. Not characters: a Japanese ROM title costs three bytes a glyph.
+  static const int _maxNameBytes = 255;
+
+  /// Name of the directory that holds one archive's extracted contents.
+  ///
+  /// On desktop [archivePath] is a filesystem path and its basename is the file
+  /// name. On Android it is a SAF `content://` URI, and a SAF document id
+  /// encodes every `/` as `%2F` — so there is no separator left for
+  /// [path.basename] to split on and it returns the whole encoded id,
+  /// `primary%3Aemu%2Froms%2Fgba%2F…`, as the name. The encoding is what makes
+  /// that fatal rather than merely ugly: each separator costs three bytes
+  /// instead of one and every space becomes `%20`, so a deep folder plus a long
+  /// ROM name overruns the 255-byte limit on a single name and the directory
+  /// cannot be created at all (errno 36, `File name too long`). The ROM is then
+  /// parked as `extract_failed` and never hashed.
+  ///
+  /// Decoding the id and taking its real basename brings the name back inside
+  /// the limit by construction, because the archive itself lives on a
+  /// filesystem with the same limit, so its own file name already fits.
+  ///
+  /// Both callers derive the directory through here so that `extractRom` and
+  /// `cleanupTempFolder` cannot disagree about where it is; they each built the
+  /// path independently before, which is what let this go unnoticed on one of
+  /// them.
+  @visibleForTesting
+  static String tempDirNameFor(String archivePath) {
+    if (!archivePath.startsWith('content://')) {
+      // A plain path is already split on real separators. It is also not
+      // percent-encoded, so decoding it would corrupt any name holding a
+      // literal '%'.
+      return _clampToNameLimit(path.basename(archivePath));
+    }
+
+    final documentId = archivePath.split('/').last;
+    String decoded;
+    try {
+      decoded = Uri.decodeComponent(documentId);
+    } on ArgumentError {
+      decoded = documentId;
+    }
+
+    // A document id reads like "primary:emu/roms/gba/Game.zip" once decoded,
+    // and is always '/'-separated whatever the host platform's style is.
+    final name = path.posix.basename(decoded);
+    return _clampToNameLimit(name.isEmpty ? documentId : name);
+  }
+
+  /// Truncates [name] to [_maxNameBytes] **bytes** without splitting a rune.
+  ///
+  /// The backstop for the two paths above that can still hand back something
+  /// long: an undecodable document id, and a name that is genuinely oversized.
+  /// Nothing reads this name back, so losing the tail costs nothing.
+  static String _clampToNameLimit(String name) {
+    if (utf8.encode(name).length <= _maxNameBytes) return name;
+
+    final buffer = StringBuffer();
+    var bytes = 0;
+    for (final rune in name.runes) {
+      final char = String.fromCharCode(rune);
+      final size = utf8.encode(char).length;
+      if (bytes + size > _maxNameBytes) break;
+      buffer.write(char);
+      bytes += size;
+    }
+    return buffer.toString();
+  }
+
   /// Extracts a ROM from a ZIP or 7z archive into a temporary system-specific directory.
   ///
   /// The extraction target is located at `user-data/temp/[systemFolderName]/[archiveName]`.
@@ -25,7 +95,7 @@ class ArchiveService {
   ) async {
     try {
       final userDataPath = await ConfigService.getUserDataPath();
-      final archiveName = path.basename(archivePath);
+      final archiveName = tempDirNameFor(archivePath);
       final extension = path.extension(archivePath).toLowerCase();
 
       final tempDirPath = path.join(
@@ -156,7 +226,7 @@ class ArchiveService {
   ) async {
     try {
       final userDataPath = await ConfigService.getUserDataPath();
-      final zipName = path.basename(zipPath);
+      final zipName = tempDirNameFor(zipPath);
       final tempDirPath = path.join(
         userDataPath,
         'temp',

--- a/lib/services/archive_service.dart
+++ b/lib/services/archive_service.dart
@@ -83,6 +83,25 @@ class ArchiveService {
     return buffer.toString();
   }
 
+  /// Resolves an archive entry's name to a path inside [tempDirPath], or null
+  /// if the entry would land anywhere else.
+  ///
+  /// Entry names come out of the archive, not from us, and [path.join] trusts
+  /// them: an absolute name is treated as a complete path and [tempDirPath] is
+  /// discarded outright, while a relative one may walk out with `../`. Either
+  /// shape lets a crafted ROM archive write to any path the app can reach —
+  /// zip slip. No genuine ROM archive names its entries that way, so refusing
+  /// the entry costs nothing and the extraction simply reports failure.
+  @visibleForTesting
+  static String? safeOutputPath(String tempDirPath, String entryName) {
+    final root = path.normalize(path.absolute(tempDirPath));
+    final resolved = path.normalize(path.join(root, entryName));
+
+    // isWithin is false for the directory itself as well as for anything
+    // outside it, which is what we want: an entry must name a file under root.
+    return path.isWithin(root, resolved) ? resolved : null;
+  }
+
   /// Extracts a ROM from a ZIP or 7z archive into a temporary system-specific directory.
   ///
   /// The extraction target is located at `user-data/temp/[systemFolderName]/[archiveName]`.
@@ -159,15 +178,21 @@ class ArchiveService {
 
       if (largestIndex != -1) {
         final file = archive.getFile(largestIndex);
-        final outPath = path.join(tempDirPath, file.name);
+        final outPath = safeOutputPath(tempDirPath, file.name);
 
-        final outFile = File(outPath);
-        if (!await outFile.parent.exists()) {
-          await outFile.parent.create(recursive: true);
+        if (outPath == null) {
+          // Leaves largestFilePath null, so this returns failure below after
+          // the archive and the staged copy have been cleaned up as usual.
+          _log.e('Refusing 7z entry outside the temp directory: ${file.name}');
+        } else {
+          final outFile = File(outPath);
+          if (!await outFile.parent.exists()) {
+            await outFile.parent.create(recursive: true);
+          }
+
+          archive.extractToFile(largestIndex, outPath);
+          largestFilePath = outPath;
         }
-
-        archive.extractToFile(largestIndex, outPath);
-        largestFilePath = outPath;
       }
 
       archive.dispose();
@@ -202,7 +227,15 @@ class ArchiveService {
       }
 
       if (largestFile != null) {
-        final filePath = path.join(tempDirPath, largestFile.name);
+        final filePath = safeOutputPath(tempDirPath, largestFile.name);
+        if (filePath == null) {
+          _log.e(
+            'Refusing ZIP entry outside the temp directory: '
+            '${largestFile.name}',
+          );
+          return null;
+        }
+
         final outFile = File(filePath);
         await outFile.create(recursive: true);
 

--- a/lib/services/retroachievements_hash_service.dart
+++ b/lib/services/retroachievements_hash_service.dart
@@ -104,19 +104,26 @@ class RetroAchievementsHashService {
       await Future.delayed(const Duration(milliseconds: 500));
 
       final isolateToken = RootIsolateToken.instance!;
-      final hash = _replayIsolateLog(
-        await compute(_generateHashForSystemIsolate, {
-          'romPath': romPathToProcess,
-          'algo': policy.algo.jsonName,
-          'token': isolateToken,
-        }),
-      );
-
-      if (isArchive) {
-        await ArchiveService.cleanupTempFolder(
-          game.systemFolderName ?? 'unknown',
-          game.romPath!,
+      String? hash;
+      try {
+        hash = _replayIsolateLog(
+          await compute(_generateHashForSystemIsolate, {
+            'romPath': romPathToProcess,
+            'algo': policy.algo.jsonName,
+            'token': isolateToken,
+          }),
         );
+      } finally {
+        // In a finally because the hash runs in another isolate: a throw there
+        // used to skip the cleanup and strand the extracted ROM on disk, at
+        // full size, for every archive that failed to hash. The sibling path
+        // below already does it this way.
+        if (isArchive) {
+          await ArchiveService.cleanupTempFolder(
+            game.systemFolderName ?? 'unknown',
+            game.romPath!,
+          );
+        }
       }
 
       if (hash != null && hash.isNotEmpty) {

--- a/lib/utils/optimized_md5_utils.dart
+++ b/lib/utils/optimized_md5_utils.dart
@@ -286,10 +286,12 @@ class OptimizedMd5Utils {
             filePath,
             'temp_nes',
           );
-          if (extractedPath != null) {
-            final extractedBytes = await File(extractedPath).readAsBytes();
-            romBytes = extractedBytes;
-            await File(extractedPath).delete();
+          try {
+            if (extractedPath != null) {
+              romBytes = await File(extractedPath).readAsBytes();
+            }
+          } finally {
+            await ArchiveService.cleanupTempFolder('temp_nes', filePath);
           }
         } else if (bytes[0] == 0x50 &&
             bytes[1] == 0x4B &&
@@ -359,10 +361,12 @@ class OptimizedMd5Utils {
             filePath,
             'temp_snes',
           );
-          if (extractedPath != null) {
-            final extractedBytes = await File(extractedPath).readAsBytes();
-            romBytes = extractedBytes;
-            await File(extractedPath).delete();
+          try {
+            if (extractedPath != null) {
+              romBytes = await File(extractedPath).readAsBytes();
+            }
+          } finally {
+            await ArchiveService.cleanupTempFolder('temp_snes', filePath);
           }
         } else if (bytes[0] == 0x50 &&
             bytes[1] == 0x4B &&
@@ -529,9 +533,12 @@ class OptimizedMd5Utils {
             filePath,
             'temp_n64',
           );
-          if (extractedPath != null) {
-            romBytes = await File(extractedPath).readAsBytes();
-            await File(extractedPath).delete();
+          try {
+            if (extractedPath != null) {
+              romBytes = await File(extractedPath).readAsBytes();
+            }
+          } finally {
+            await ArchiveService.cleanupTempFolder('temp_n64', filePath);
           }
         } else {
           try {

--- a/test/archive_temp_dir_name_test.dart
+++ b/test/archive_temp_dir_name_test.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/archive_service.dart';
+
+/// The SAF form: a document id whose every '/' is encoded as %2F, so the URI
+/// has no separator left after the "/document/" segment.
+String _safUri(String documentId) =>
+    'content://com.android.externalstorage.documents/tree/'
+    '${Uri.encodeComponent('primary:emu/roms')}/document/'
+    '${Uri.encodeComponent(documentId)}';
+
+void main() {
+  group('ArchiveService.tempDirNameFor', () {
+    test('a SAF URI yields the ROM file name, not the encoded document id', () {
+      final uri = _safUri('primary:emu/roms/gba/Translations/Zelda.zip');
+
+      expect(ArchiveService.tempDirNameFor(uri), 'Zelda.zip');
+    });
+
+    test('the observed errno-36 case fits in a directory name', () {
+      // Verbatim from the Thor's app.log, 2026-09-01: this is the name that
+      // could not be created. The bug is a byte count, so that is what the
+      // case asserts — not the string, which is only how it got that long.
+      const documentId =
+          'primary:emu/roms/gba/Translations (GameBoy Advance)/'
+          'Summon Night - Swordcraft Story 3 - The Stone of Beginnings (Japan) '
+          '[T-En by Higsby & Normmatt & Teod & Unknownbrackets v0.9] [i] [n].zip';
+      final uri = _safUri(documentId);
+
+      // The fault: the encoded id on its own is far past the limit.
+      expect(
+        utf8.encode(uri.split('/').last).length,
+        greaterThan(255),
+        reason: 'the encoded document id is what used to name the directory',
+      );
+
+      final name = ArchiveService.tempDirNameFor(uri);
+      expect(utf8.encode(name).length, lessThanOrEqualTo(255));
+      expect(name, startsWith('Summon Night'));
+      expect(name, endsWith('.zip'));
+    });
+
+    test('a plain desktop path keeps its basename', () {
+      expect(
+        ArchiveService.tempDirNameFor(
+          '/home/user/roms/snes/Chrono Trigger.zip',
+        ),
+        'Chrono Trigger.zip',
+      );
+    });
+
+    test('a literal % in a plain path is not decoded', () {
+      // Decoding unconditionally would either corrupt this name or throw.
+      expect(
+        ArchiveService.tempDirNameFor('/roms/nes/Mega Man 100%.zip'),
+        'Mega Man 100%.zip',
+      );
+    });
+
+    test('extraction and cleanup derive the same name from the same path', () {
+      // The two used to build this independently, which is how one of them
+      // could be wrong on its own. Same input, same directory, or cleanup
+      // silently leaves the extracted ROM on disk.
+      final uri = _safUri(
+        'primary:emu/roms/psx/Final Fantasy VII (Disc 1).zip',
+      );
+
+      expect(
+        ArchiveService.tempDirNameFor(uri),
+        ArchiveService.tempDirNameFor(uri),
+      );
+    });
+
+    test('an oversized name is clamped in bytes without splitting a rune', () {
+      // Japanese titles cost three bytes a glyph, so a character-count clamp
+      // would still overrun the byte limit this is defending.
+      final documentId = 'primary:emu/roms/pce/${'ドラゴン' * 40}.zip';
+      final name = ArchiveService.tempDirNameFor(_safUri(documentId));
+
+      expect(utf8.encode(name).length, lessThanOrEqualTo(255));
+      // Round-trips, so no partial code unit survived the truncation.
+      expect(utf8.decode(utf8.encode(name)), name);
+    });
+
+    test('a malformed escape falls back rather than throwing', () {
+      const uri =
+          'content://com.android.externalstorage.documents/document/bad%ZZ';
+
+      expect(() => ArchiveService.tempDirNameFor(uri), returnsNormally);
+      expect(
+        utf8.encode(ArchiveService.tempDirNameFor(uri)).length,
+        lessThanOrEqualTo(255),
+      );
+    });
+  });
+}

--- a/test/archive_zip_slip_test.dart
+++ b/test/archive_zip_slip_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/archive_service.dart';
+import 'package:path/path.dart' as path;
+
+/// Entry names are attacker-controlled data inside the archive, so the guard
+/// has to hold for shapes no honest ROM set ever produces.
+void main() {
+  const tempDir = '/data/user-data/temp/snes/Chrono Trigger.zip';
+
+  group('ArchiveService.safeOutputPath', () {
+    test('an ordinary entry lands inside the temp directory', () {
+      final resolved = ArchiveService.safeOutputPath(
+        tempDir,
+        'Chrono Trigger.sfc',
+      );
+
+      expect(resolved, isNotNull);
+      expect(path.isWithin(tempDir, resolved!), isTrue);
+    });
+
+    test('a nested entry is allowed — archives legitimately hold folders', () {
+      final resolved = ArchiveService.safeOutputPath(
+        tempDir,
+        'disc1/Game (Track 01).bin',
+      );
+
+      expect(resolved, isNotNull);
+      expect(path.isWithin(tempDir, resolved!), isTrue);
+    });
+
+    test('a "./" prefix is not mistaken for an escape', () {
+      expect(ArchiveService.safeOutputPath(tempDir, './Game.sfc'), isNotNull);
+    });
+
+    test('a ../ traversal is refused', () {
+      expect(ArchiveService.safeOutputPath(tempDir, '../escaped.sfc'), isNull);
+    });
+
+    test('a deep traversal out of user-data is refused', () {
+      expect(
+        ArchiveService.safeOutputPath(tempDir, '../../../../../../etc/passwd'),
+        isNull,
+      );
+    });
+
+    test('an absolute entry name is refused', () {
+      // The quiet one: path.join treats an absolute second argument as the
+      // whole path and drops the temp directory without complaint, so this
+      // escapes without needing a single "..".
+      expect(
+        path.join(tempDir, '/etc/cron.d/payload'),
+        '/etc/cron.d/payload',
+        reason: 'documents the path.join behaviour the guard exists for',
+      );
+
+      expect(
+        ArchiveService.safeOutputPath(tempDir, '/etc/cron.d/payload'),
+        isNull,
+      );
+    });
+
+    test('a traversal that resolves back inside is still allowed', () {
+      // Not an escape: it ends up under the root, so refusing it would be a
+      // false positive on an archive that merely names its entries oddly.
+      expect(
+        ArchiveService.safeOutputPath(tempDir, 'sub/../Game.sfc'),
+        isNotNull,
+      );
+    });
+
+    test('an entry naming the directory itself is refused', () {
+      expect(ArchiveService.safeOutputPath(tempDir, '.'), isNull);
+      expect(ArchiveService.safeOutputPath(tempDir, ''), isNull);
+    });
+  });
+}

--- a/test/ra_extract_failed_reopen_migration_test.dart
+++ b/test/ra_extract_failed_reopen_migration_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:neostation/data/datasources/sqlite_migrations.dart';
+
+/// Tests for migration v154, which reopens the ROMs parked because their
+/// archive could not be extracted.
+///
+/// A `.zip`/`.7z` whose SAF path was long enough could not be extracted at all:
+/// the temp directory was named with the whole `%2F`-encoded document id and
+/// overran the filesystem's 255-byte limit on one component. Those ROMs were
+/// parked `ra_hash_skipped = 'extract_failed'`, and the match pass steps over
+/// parked ROMs — so without this the extraction fix reaches newly added ROMs
+/// only, and a library that already hit the bug never recovers.
+void main() {
+  late Database db;
+
+  setUp(() {
+    db = sqlite3.openInMemory();
+    db.execute('''
+      CREATE TABLE user_roms (
+        filename TEXT,
+        rom_path TEXT PRIMARY KEY,
+        app_system_id TEXT,
+        ra_hash TEXT,
+        id_ra INTEGER,
+        ra_hash_skipped TEXT
+      )
+    ''');
+  });
+
+  tearDown(() {
+    db.close();
+  });
+
+  Future<void> runV154() => SqliteMigrations.migrateToVersion(db, 154);
+
+  void addRom(String filename, String? skipped, {String? romPath}) {
+    db.execute(
+      'INSERT INTO user_roms (filename, rom_path, app_system_id, '
+      'ra_hash_skipped) VALUES (?, ?, ?, ?)',
+      [filename, romPath ?? '/roms/gba/$filename', 'gba', skipped],
+    );
+  }
+
+  String? skipReason(String filename) =>
+      db.select('SELECT ra_hash_skipped FROM user_roms WHERE filename = ?', [
+            filename,
+          ]).single['ra_hash_skipped']
+          as String?;
+
+  group('migration v154', () {
+    test('unparks a ROM parked as extract_failed', () async {
+      addRom('game.zip', 'extract_failed');
+      addRom('other.7z', 'extract_failed');
+
+      await runV154();
+
+      expect(skipReason('game.zip'), isNull);
+      expect(skipReason('other.7z'), isNull);
+    });
+
+    test('unparks the long SAF path that caused the bug', () async {
+      // The shape that overran the name limit: a deep folder and a translation
+      // patch name, every separator `%2F`-encoded.
+      addRom(
+        'summon-night.zip',
+        'extract_failed',
+        romPath:
+            'content://com.android.externalstorage.documents/document/'
+            'primary%3Aemu%2Froms%2Fgba%2FTranslations%20(GameBoy%20Advance)'
+            '%2FSummon%20Night%20-%20Swordcraft%20Story%203%20%5BT-En%5D.zip',
+      );
+
+      await runV154();
+
+      expect(skipReason('summon-night.zip'), isNull);
+    });
+
+    test('leaves other skip reasons alone', () async {
+      // 'error' is the pass's general bucket: a ROM under it failed for some
+      // other reason and this fix says nothing about it.
+      addRom('broken.zip', 'error');
+      addRom('gone.zip', 'missing');
+      addRom('huge.zip', 'oversize');
+      addRom('disc.cue', 'disc');
+
+      await runV154();
+
+      expect(skipReason('broken.zip'), 'error');
+      expect(skipReason('gone.zip'), 'missing');
+      expect(skipReason('huge.zip'), 'oversize');
+      expect(skipReason('disc.cue'), 'disc');
+    });
+
+    test('leaves a hash that was already found in place', () async {
+      db.execute(
+        "INSERT INTO user_roms (filename, rom_path, app_system_id, ra_hash, "
+        "id_ra) VALUES ('matched.zip', '/roms/gba/matched.zip', 'gba', "
+        "'abc123', 4242)",
+      );
+
+      await runV154();
+
+      final row = db.select(
+        'SELECT ra_hash, id_ra FROM user_roms WHERE filename = ?',
+        ['matched.zip'],
+      ).single;
+      expect(row['ra_hash'], 'abc123');
+      expect(row['id_ra'], 4242);
+    });
+
+    test('is idempotent — running it twice changes nothing further', () async {
+      addRom('game.zip', 'extract_failed');
+      addRom('broken.zip', 'error');
+
+      await runV154();
+      await runV154();
+
+      expect(skipReason('game.zip'), isNull);
+      expect(skipReason('broken.zip'), 'error');
+    });
+
+    test('does nothing on a database with no skip column yet', () async {
+      db.execute('DROP TABLE user_roms');
+      db.execute('CREATE TABLE user_roms (rom_path TEXT PRIMARY KEY)');
+
+      await expectLater(runV154(), completes);
+    });
+  });
+}


### PR DESCRIPTION
# Description

Three faults in the archive-extraction path, found while investigating why some
ROMs never get achievements. One is user-visible and was observed on device; the
other two are things in the same twenty lines that turned out to be wrong.

**1. A SAF path too long to name a folder** (`fix(android)`, the reason for this PR)

`ArchiveService` named its extraction directory with `path.basename()` of the ROM
path. On Android that path is a SAF `content://` URI, and a SAF document id
encodes every `/` as `%2F` — so there is no separator left for `basename` to
split on and it returns the **whole encoded id** as the directory name.

The encoding is what makes that fatal rather than merely ugly: each separator
costs three bytes instead of one and every space becomes `%20`. Measured on a
real failing ROM:

| | bytes |
|---|---|
| the encoded document id, used as the folder name | **267** |
| the ROM's own file name | 137 |
| filesystem limit for one path component | 255 |

Past 255 the directory cannot be created, extraction fails with `errno 36`, and
the ROM is parked `extract_failed` — which the automatic RA match pass then walks
past for good. **So an affected `.zip`/`.7z` silently never gets achievements,
permanently, with nothing in the UI to say why.** Deep folders plus long names
are the trigger, so translation-patch sets are hit hardest (`[T-En by …]
[Add by …] [n]`). 4 of them on a 9140-game library on my Thor.

Fixed by decoding the document id and taking its real basename, which is inside
the limit by construction — the archive lives on a filesystem with the same
limit, so its own file name already fits. Plain desktop paths keep using
`basename` untouched, because decoding one unconditionally would corrupt any name
holding a literal `%`. The backstop clamp counts **bytes, not characters**: the
limit is a byte count and a Japanese title costs three bytes a glyph.

`extractRom` and `cleanupTempFolder` now derive the directory through one
function. They built it independently before, which is how one could be wrong
without the other showing it.

**2. Archive entries could extract outside the temp folder** (`fix(security)`)

Both extraction paths did `path.join(tempDirPath, file.name)` with a name read
out of the archive. The `../` half is familiar; the quiet half is that an
absolute entry name makes `join` drop the prefix entirely, with no `..` needed:

```dart
path.join('/…/temp/snes/Game.zip', '/etc/cron.d/payload') == '/etc/cron.d/payload'
```

No such archive has been seen and nothing in a real ROM set names entries that
way — this closes the hole rather than fixing an observed failure. Refused
entries log and the extraction reports failure, which callers already handle.
Tests cover the false-positive side too: ordinary, nested, `./`-prefixed and
`sub/../Game.sfc` names all still extract.

**3. A failed hash left the extracted ROM on disk** (`fix(hashing)`)

Four sites cleaned up on the success path only. The three in
`optimized_md5_utils` deleted the extracted *file* but never the directory around
it, outside any `try` — an empty directory leaked per archive hashed. The fourth,
in `retroachievements_hash_service`, removed the directory but not in a `finally`,
and the hash runs in another isolate via `compute()`: any throw there stranded a
**full-size extracted ROM**, on exactly the failure path a scan hits repeatedly.
All four now clean up in a `finally`, matching the sibling path in the same file
and the one in `rom_fingerprint_service`.

**4. Reopening the ROMs already parked by fault 1** (`fix(db)`, migration v154)

Fixing extraction only helps ROMs added afterwards. Everything already parked
stays parked: `getRomsNeedingRaHash` filters `ra_hash_skipped IS NULL`, and the
unpark in `RetroAchievementsHashService` is gated on `reopenSkipped`, true only
when a human asks for the pass — deliberately, since reopening every parked ROM
unattended re-reads a shelf of unhashable discs on every launch.

**Confirmed on device:** after installing fixes 1–3 on the Thor, the startup
pass reported `RA re-match (hashMissing): 0 candidate ROMs` with `4` still
parked as `extract_failed`. The new code never ran against the ROMs it was
written for.

Migration **v154** clears the marker, the same shape and reasoning as **v144**
(the CHD reader) and **v153** (the new disc containers). Scoped to
`'extract_failed'` — `'error'` is the general bucket and a ROM under it failed
for some other reason. A genuinely corrupt archive is reopened and parks again
next pass, one read each, the same trade the two earlier migrations made.

> **Migration number:** 154 is the next free slot above `main` (153).
> `feat/collections-feature` and `feat/ra-hash-formats` both hold 154 today and
> will need to renumber above the new floor once this merges. Flagging it
> because that collision has silently swallowed a migration on this repo before.

## Steps to Reproduce

**Preconditions:** Android, ROM folders added via SAF, RetroAchievements signed
in. A `.zip` or `.7z` whose full path is long — a translation-patch ROM in a
subfolder is the reliable case, e.g.
`roms/gba/Translations (GameBoy Advance)/Summon Night - Swordcraft Story 3 - The Stone of Beginnings (Japan) [T-En by Higsby & Normmatt & Teod & Unknownbrackets v0.9] [i] [n].zip`

1. Let the RA hash pass run over a library containing that ROM.
2. Open the game — it has no achievements, and no error is shown.
3. In `app.log`: `Error extracting file content://… (OS Error: File name too long, errno = 36)` followed by `Failed to extract compressed file, aborting hash`.
4. Re-running the automatic match never retries it: the row is parked `extract_failed`.

## Steps to Verify

**Preconditions:** as above.

1. Install this build over the affected library.
2. On first launch the RA pass picks up the reopened ROMs instead of reporting
   `0 candidate ROMs`, and they hash without `errno 36`.
3. ROMs parked as `'error'` for other reasons (a missing `.bin` beside a `.cue`,
   an unreadable CHD) stay parked — intended, they are not this bug.

Note the migration's own log lines are not a usable signal: migrations run
before `LoggerService` is initialised, so **no** `Migration v…` line has ever
reached `app.log` on this device (`grep -c 'Migration v'` returns 0, for every
version, not just this one). The candidate count is the observable.

**Measured on the AYN Thor**, v153 → v154 on the same 9140-game library:

| | before (v153) | after (v154) |
|---|---|---|
| RA pass candidates | `0 candidate ROMs` | `4 candidate ROMs` |
| result | `0 processed, 0 hashed, 0 matched` | `4 processed, 4 hashed, 2 matched, 0 skipped` |
| still parked | `10 (error 6, extract_failed 4)` | `6 (error 6)` |
| `errno 36` occurrences | 2 | 0 |

All 4 previously unhashable ROMs now hash; 2 of them match a RetroAchievements
game and 2 do not, which is expected — they are romhacks/translations that RA
has no entry for. The 6 `'error'` ROMs are untouched, confirming the migration's
scoping.

`user-data/temp/` holds no directory created by this build. One 1 MB leftover
from 2026-08-22 remains under the *old* encoded naming scheme — it predates the
fix and, because the directory name is derived differently now, `cleanupTempFolder`
will not reap it. Harmless and self-limiting (no new ones can be created), but
worth knowing that upgrading does not tidy pre-existing ones.

## Tested on

- [x] Android — device: AYN Thor (dev channel, 9140-game library). All four
      commits deployed and verified here, including the v154 migration; numbers
      in the Steps to Verify table above.
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1661)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**The database**
- [x] Column added to the versioned migration — n/a, no new column; v154 is a data-only backfill
- [x] Migration number is above every slot in use on any open branch, not just `main` + 1 — scanned every local and remote ref; see the note above about 154
- [x] Migration is idempotent (`PRAGMA table_info` guard) and has a test — 6 cases, including running it twice
- [x] `_databaseVersion` bumped; new column selected in *every* system-loading query — n/a, no new column

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths — this is the whole subject of the PR
- [x] Verified on a device, not only on desktop — all four commits deployed to the Thor, with before/after numbers in the PR body

No user-facing strings, navigation, or `assets/systems/` changes.

</details>

## Notes for review

- 21 new tests across three files. The path-length case asserts a **byte count**
  rather than a string, because the length is the bug and the string is only how
  it got that long.
- The `errno 36` diagnosis was confirmed by running both the old and new
  derivation over the verbatim failing URI (267 → 137 bytes), not inferred from
  the log line.
- The temp-folder cleanup fix has **no test**: `cleanupTempFolder` resolves
  through `ConfigService.getUserDataPath()`, which needs platform channels, so a
  unit test would pass whether or not the fix is present.
- The four commits are independent and split cleanly if you would rather take
  them separately; the v154 migration is only worth taking together with
  commit 1, since it reopens what commit 1 makes extractable.
