### PR TITLE
fix(esde): honour a relocated ES-DE MediaDirectory

### DIFF
--- a/lib/providers/file_provider.dart
+++ b/lib/providers/file_provider.dart
@@ -5,6 +5,7 @@ import 'package:neostation/repositories/system_repository.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:neostation/services/config_service.dart';
+import 'package:neostation/services/esde_import_service.dart';
 import 'package:neostation/services/logger_service.dart';
 
 /// Provider responsible for abstracting filesystem access across Android and Desktop platforms.
@@ -46,8 +47,16 @@ class FileProvider extends ChangeNotifier {
   /// import is not configured. Used for read-time fallback artwork resolution.
   String? _esdeRoot;
 
-  /// NeoStation system folder name -> ES-DE `downloaded_media` subfolder name,
-  /// captured during ES-DE import.
+  /// Absolute path to the folder ES-DE writes downloaded artwork into, or null
+  /// when ES-DE is not configured. Usually `<_esdeRoot>/downloaded_media`, but
+  /// ES-DE lets the user move it (see [EsdeImportService.resolveMediaRoot]), so
+  /// it is re-resolved from `es_settings.xml` on every load rather than
+  /// persisted: a user who moves the folder in ES-DE keeps their art without
+  /// having to re-run the import.
+  String? _esdeMediaRoot;
+
+  /// NeoStation system folder name -> ES-DE media subfolder name, captured
+  /// during ES-DE import (a folder under [_esdeMediaRoot]).
   Map<String, String> _esdeSystemDirs = {};
 
   /// "systemFolder\u0000romBase" -> ES-DE media subfolder (the ROM's directory
@@ -446,6 +455,9 @@ class FileProvider extends ChangeNotifier {
       _esdeRoot = (rootRaw != null && rootRaw.trim().isNotEmpty)
           ? rootRaw.trim()
           : null;
+      _esdeMediaRoot = _esdeRoot == null
+          ? null
+          : EsdeImportService.resolveMediaRoot(_esdeRoot!);
 
       final map = <String, String>{};
       if (_esdeRoot != null) {
@@ -486,6 +498,7 @@ class FileProvider extends ChangeNotifier {
       _esdeMediaSubdirs = subdirs;
     } catch (e) {
       _esdeRoot = null;
+      _esdeMediaRoot = null;
       _esdeSystemDirs = {};
       _esdeMediaSubdirs = {};
     }
@@ -517,7 +530,8 @@ class FileProvider extends ChangeNotifier {
     String romName, [
     List<String>? extensions,
   ]) {
-    if (_esdeRoot == null) return const [];
+    final mediaRoot = _esdeMediaRoot;
+    if (mediaRoot == null) return const [];
     final esdeDir = _esdeSystemDirs[systemFolderName];
     if (esdeDir == null) return const [];
     final categories = _esdeMediaCategories[imageType];
@@ -538,8 +552,7 @@ class FileProvider extends ChangeNotifier {
         for (final extension in extList) {
           candidates.add(
             path.joinAll([
-              _esdeRoot!,
-              'downloaded_media',
+              mediaRoot,
               esdeDir,
               category,
               if (sub.isNotEmpty) sub,
@@ -576,6 +589,7 @@ class FileProvider extends ChangeNotifier {
     _mediaPath = null;
     _documentsPath = null;
     _esdeRoot = null;
+    _esdeMediaRoot = null;
     _esdeSystemDirs = {};
     _esdeMediaSubdirs = {};
     _isInitialized = false;

--- a/lib/services/esde_import_service.dart
+++ b/lib/services/esde_import_service.dart
@@ -71,14 +71,15 @@ class EsdeImportResult {
 /// NeoStation's `user_screenscraper_metadata` on a fill-gaps-only basis (never
 /// clobbering existing NeoStation-scraped values). Artwork is NOT copied: the
 /// ES-DE folder path plus a per-system `esde_media_dir` are persisted so
-/// [FileProvider] can resolve `downloaded_media/` files as read-time fallback
+/// [FileProvider] can resolve ES-DE's media files as read-time fallback
 /// (a later NeoStation scrape lands in NeoStation's own media folder and takes
-/// precedence automatically).
+/// precedence automatically). Which folder that media sits in is not assumed:
+/// see [resolveMediaRoot].
 class EsdeImportService {
   static final _log = LoggerService.instance;
 
   /// Runs the import against [esdeRoot] (the ES-DE application folder that
-  /// contains `gamelists/` and `downloaded_media/`).
+  /// contains `gamelists/`, `settings/`, and by default `downloaded_media/`).
   ///
   /// [onProgress] is invoked as `(fraction 0..1, currentSystemLabel)`.
   static Future<EsdeImportResult> import(
@@ -87,6 +88,7 @@ class EsdeImportService {
   }) async {
     var result = const EsdeImportResult();
     _mediaIndexCache.clear();
+    final mediaRoot = resolveMediaRoot(esdeRoot);
 
     final gamelistsDir = Directory(path.join(esdeRoot, 'gamelists'));
     if (!gamelistsDir.existsSync()) {
@@ -126,7 +128,7 @@ class EsdeImportService {
       // system with an unreadable gamelist.xml counts as skipped, not matched.
       final matchedBefore = result.systemsMatched;
       result = await _importSystem(
-        esdeRoot: esdeRoot,
+        mediaRoot: mediaRoot,
         esdeDirName: esdeDirName,
         appSystemId: appSystemId,
         gamelistFile: File(path.join(systemDir.path, 'gamelist.xml')),
@@ -144,12 +146,12 @@ class EsdeImportService {
       // imported (a corrupt/unparseable gamelist.xml is skipped, not matched);
       // otherwise we'd record an esde_media_dir with no matching metadata rows.
       if (result.systemsMatched > matchedBefore) {
-        await _recordEsdeMediaDir(esdeRoot, esdeDirName, appSystemId);
+        await _recordEsdeMediaDir(mediaRoot, esdeDirName, appSystemId);
         importedDirs.add(esdeDirName.toLowerCase());
       }
     }
 
-    await _linkMediaOnlySystems(esdeRoot, importedDirs);
+    await _linkMediaOnlySystems(mediaRoot, importedDirs);
 
     onProgress?.call(1.0, '');
     _log.i(
@@ -184,8 +186,109 @@ class EsdeImportService {
     return deleted;
   }
 
+  /// Default media folder name inside an ES-DE application folder.
+  static const String defaultMediaDirName = 'downloaded_media';
+
+  /// Absolute path to the folder ES-DE actually writes downloaded artwork
+  /// into for the application folder [esdeRoot].
+  ///
+  /// ES-DE lets the user move that folder anywhere; the choice lives in
+  /// `settings/es_settings.xml` as `<string name="MediaDirectory" value="…" />`
+  /// and, when set, REPLACES `<esdeRoot>/downloaded_media` outright (the value
+  /// is the media folder itself, not a parent holding one). Without reading it
+  /// an import of such an install finds no artwork at all — issue #456.
+  ///
+  /// ES-DE expands `~` and `%ESPATH%` inside the value, so we do too.
+  /// `%ESPATH%` is the ES-DE *binary's* directory, which we can't know from
+  /// the picked folder, so both the ES-DE folder and its parent are tried (the
+  /// usual portable layout puts `ES-DE.exe` next to the `ES-DE/` data folder).
+  ///
+  /// Falls back to `<esdeRoot>/downloaded_media` whenever the setting is
+  /// absent, blank, unreadable, or names a folder that isn't there — a stale
+  /// setting must not cost the user the media they do have.
+  static String resolveMediaRoot(String esdeRoot) {
+    final fallback = path.join(esdeRoot, defaultMediaDirName);
+    final settingsFile = File(
+      path.join(esdeRoot, 'settings', 'es_settings.xml'),
+    );
+    if (!settingsFile.existsSync()) return fallback;
+
+    String? raw;
+    try {
+      // Parsed as a fragment and decoded leniently for the same reasons
+      // gamelist.xml is: ES-DE's own parser is lenient, and one bad byte in an
+      // unrelated setting must not cost us the media directory.
+      final doc = XmlDocumentFragment.parse(
+        utf8.decode(settingsFile.readAsBytesSync(), allowMalformed: true),
+      );
+      for (final e in doc.findAllElements('string')) {
+        if (e.getAttribute('name') == 'MediaDirectory') {
+          raw = e.getAttribute('value');
+          break;
+        }
+      }
+    } catch (e) {
+      _log.w('ES-DE: failed to read ${settingsFile.path}: $e');
+      return fallback;
+    }
+
+    if (raw == null || raw.trim().isEmpty) return fallback;
+
+    for (final candidate in _expandEsdePath(raw.trim(), esdeRoot)) {
+      if (Directory(candidate).existsSync()) {
+        if (candidate != fallback) {
+          _log.i('ES-DE: using custom MediaDirectory "$candidate"');
+        }
+        return candidate;
+      }
+    }
+
+    _log.w(
+      'ES-DE: MediaDirectory "$raw" does not exist, '
+      'falling back to $fallback',
+    );
+    return fallback;
+  }
+
+  /// Expansions of an ES-DE settings path [raw], most-likely first. `~` uses
+  /// the user's home directory; `%ESPATH%` has no single answer from a picked
+  /// data folder, so it yields one candidate per plausible binary location.
+  static List<String> _expandEsdePath(String raw, String esdeRoot) {
+    var value = raw.replaceAll('\\', '/');
+
+    final home =
+        Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
+    if (home != null && home.isNotEmpty) {
+      if (value == '~') {
+        value = home;
+      } else if (value.startsWith('~/')) {
+        value = path.join(home, value.substring(2));
+      }
+    }
+
+    final esPaths = value.contains('%ESPATH%')
+        ? [path.dirname(esdeRoot), esdeRoot]
+        : const <String?>[null];
+
+    final candidates = <String>[];
+    for (final esPath in esPaths) {
+      var expanded = esPath == null
+          ? value
+          : value.replaceAll('%ESPATH%', esPath.replaceAll('\\', '/'));
+      // ES-DE tolerates a trailing separator; path.join would keep it and the
+      // resulting media paths would carry a doubled separator.
+      while (expanded.length > 1 && expanded.endsWith('/')) {
+        expanded = expanded.substring(0, expanded.length - 1);
+      }
+      if (expanded.isEmpty) continue;
+      final normalized = path.normalize(expanded);
+      if (!candidates.contains(normalized)) candidates.add(normalized);
+    }
+    return candidates;
+  }
+
   /// Wires up the artwork fallback for ES-DE systems that have a
-  /// `downloaded_media/<system>/` tree but no `gamelists/<system>/gamelist.xml`
+  /// `<mediaRoot>/<system>/` tree but no `gamelists/<system>/gamelist.xml`
   /// — a normal state in ES-DE (media survives a gamelist the user deleted, and
   /// some systems are scraped for art without ever being played).
   ///
@@ -194,13 +297,13 @@ class EsdeImportService {
   /// ROM NeoStation has scanned. Without this the whole system's art is
   /// invisible even though the files are right there.
   static Future<void> _linkMediaOnlySystems(
-    String esdeRoot,
+    String mediaRoot,
     Set<String> importedDirs,
   ) async {
-    final mediaRoot = Directory(path.join(esdeRoot, 'downloaded_media'));
-    if (!mediaRoot.existsSync()) return;
+    final mediaDir = Directory(mediaRoot);
+    if (!mediaDir.existsSync()) return;
 
-    for (final dir in mediaRoot.listSync().whereType<Directory>()) {
+    for (final dir in mediaDir.listSync().whereType<Directory>()) {
       final esdeDirName = path.basename(dir.path);
       if (importedDirs.contains(esdeDirName.toLowerCase())) continue;
 
@@ -210,7 +313,7 @@ class EsdeImportService {
       if (system == null) continue;
 
       await _recordEsdeMediaDir(
-        esdeRoot,
+        mediaRoot,
         esdeDirName,
         system['app_system_id']!,
       );
@@ -222,7 +325,7 @@ class EsdeImportService {
   }
 
   static Future<EsdeImportResult> _importSystem({
-    required String esdeRoot,
+    required String mediaRoot,
     required String esdeDirName,
     required String appSystemId,
     required File gamelistFile,
@@ -283,7 +386,7 @@ class EsdeImportService {
     // transaction (and fsync) per game.
     final batch = db.batch();
 
-    final games = _selectGames(doc, esdeRoot, esdeDirName);
+    final games = _selectGames(doc, mediaRoot, esdeDirName);
     for (var g = 0; g < games.length; g++) {
       if (g % 100 == 0) onGameProgress?.call(g / games.length);
       final game = games[g];
@@ -401,19 +504,17 @@ class EsdeImportService {
     return result;
   }
 
-  /// Persists which ES-DE `downloaded_media` subfolder backs a NeoStation
-  /// system so read-time fallback can resolve artwork. Prefers a folder that
-  /// actually contains a `downloaded_media/<dir>` tree; otherwise only sets it
-  /// when not already populated.
+  /// Persists which ES-DE media subfolder backs a NeoStation system so
+  /// read-time fallback can resolve artwork. Prefers a folder that actually
+  /// contains a `<mediaRoot>/<dir>` tree; otherwise only sets it when not
+  /// already populated.
   static Future<void> _recordEsdeMediaDir(
-    String esdeRoot,
+    String mediaRoot,
     String esdeDirName,
     String appSystemId,
   ) async {
     final db = await SqliteService.getDatabase();
-    final hasMedia = Directory(
-      path.join(esdeRoot, 'downloaded_media', esdeDirName),
-    ).existsSync();
+    final hasMedia = Directory(path.join(mediaRoot, esdeDirName)).existsSync();
 
     final existing = await db.query(
       'user_system_settings',
@@ -503,7 +604,7 @@ class EsdeImportService {
   /// the artwork fallback resolves correctly; otherwise keep the first seen.
   static List<XmlElement> _selectGames(
     XmlNode doc,
-    String esdeRoot,
+    String mediaRoot,
     String esdeDirName,
   ) {
     final chosen = <String, XmlElement>{};
@@ -524,19 +625,19 @@ class EsdeImportService {
         (_text(existing, 'path') ?? '').replaceAll('\\', '/'),
       );
       final newSubdir = _mediaSubdir(normalized);
-      if (!_esdeMediaExists(esdeRoot, esdeDirName, filename, existingSubdir) &&
-          _esdeMediaExists(esdeRoot, esdeDirName, filename, newSubdir)) {
+      if (!_esdeMediaExists(mediaRoot, esdeDirName, filename, existingSubdir) &&
+          _esdeMediaExists(mediaRoot, esdeDirName, filename, newSubdir)) {
         chosen[key] = game;
       }
     }
     return chosen.values.toList();
   }
 
-  /// Whether any `downloaded_media/<system>/<category>/<subdir>/` folder holds a
+  /// Whether any `<mediaRoot>/<system>/<category>/<subdir>/` folder holds a
   /// file whose name (sans extension) matches [filename]'s base — i.e. ES-DE
   /// scraped artwork for this ROM under [subdir].
   static bool _esdeMediaExists(
-    String esdeRoot,
+    String mediaRoot,
     String esdeDirName,
     String filename,
     String subdir,
@@ -550,13 +651,7 @@ class EsdeImportService {
       'marquees',
       'fanart',
     ]) {
-      final dir = path.join(
-        esdeRoot,
-        'downloaded_media',
-        esdeDirName,
-        category,
-        subdir,
-      );
+      final dir = path.join(mediaRoot, esdeDirName, category, subdir);
       if (_mediaIndex(dir).contains(base)) return true;
     }
     return false;
@@ -624,7 +719,7 @@ class EsdeImportService {
   @visibleForTesting
   static List<XmlElement> selectGamesForTest(
     XmlNode doc,
-    String esdeRoot,
+    String mediaRoot,
     String esdeDirName,
-  ) => _selectGames(doc, esdeRoot, esdeDirName);
+  ) => _selectGames(doc, mediaRoot, esdeDirName);
 }

--- a/test/esde_import_service_test.dart
+++ b/test/esde_import_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:neostation/repositories/scraper_repository.dart';
 import 'package:neostation/services/esde_import_service.dart';
+import 'package:path/path.dart' as p;
 import 'package:xml/xml.dart';
 
 import 'database_test_helper.dart';
@@ -123,6 +124,97 @@ void main() {
     });
   });
 
+  group('resolveMediaRoot', () {
+    late Directory root;
+
+    setUp(() {
+      root = Directory.systemTemp.createTempSync('esde_settings_');
+    });
+
+    tearDown(() => root.deleteSync(recursive: true));
+
+    void writeSettings(String body) {
+      Directory('${root.path}/settings').createSync(recursive: true);
+      File('${root.path}/settings/es_settings.xml').writeAsStringSync(body);
+    }
+
+    test('defaults to downloaded_media when there is no settings file', () {
+      expect(
+        EsdeImportService.resolveMediaRoot(root.path),
+        p.join(root.path, 'downloaded_media'),
+      );
+    });
+
+    test('defaults when MediaDirectory is absent or blank', () {
+      writeSettings(
+        '<?xml version="1.0"?>\n<string name="ROMDirectory" value="/roms" />',
+      );
+      expect(
+        EsdeImportService.resolveMediaRoot(root.path),
+        p.join(root.path, 'downloaded_media'),
+      );
+
+      writeSettings('<string name="MediaDirectory" value="" />');
+      expect(
+        EsdeImportService.resolveMediaRoot(root.path),
+        p.join(root.path, 'downloaded_media'),
+      );
+    });
+
+    test('uses a custom MediaDirectory that exists', () {
+      final custom = Directory('${root.path}/elsewhere/media')
+        ..createSync(recursive: true);
+      writeSettings('<string name="MediaDirectory" value="${custom.path}" />');
+      expect(
+        EsdeImportService.resolveMediaRoot(root.path),
+        p.normalize(custom.path),
+      );
+    });
+
+    test('ignores a trailing separator on the value', () {
+      final custom = Directory('${root.path}/elsewhere/media')
+        ..createSync(recursive: true);
+      writeSettings('<string name="MediaDirectory" value="${custom.path}/" />');
+      expect(
+        EsdeImportService.resolveMediaRoot(root.path),
+        p.normalize(custom.path),
+      );
+    });
+
+    test('expands %ESPATH% against the ES-DE folder and its parent', () {
+      // Portable layout: the binary sits next to the data folder, so
+      // %ESPATH% is the PARENT of the folder the user picked.
+      final custom = Directory('${root.parent.path}/media_espath')
+        ..createSync(recursive: true);
+      addTearDown(() => custom.deleteSync(recursive: true));
+      writeSettings(
+        '<string name="MediaDirectory" value="%ESPATH%/media_espath" />',
+      );
+      expect(
+        EsdeImportService.resolveMediaRoot(root.path),
+        p.normalize(custom.path),
+      );
+    });
+
+    test('falls back to downloaded_media when the custom folder is gone', () {
+      writeSettings(
+        '<string name="MediaDirectory" value="${root.path}/not_there" />',
+      );
+      expect(
+        EsdeImportService.resolveMediaRoot(root.path),
+        p.join(root.path, 'downloaded_media'),
+      );
+    });
+
+    test('survives a malformed settings file', () {
+      writeSettings('<string name="MediaDirectory" value="/x" ');
+      expect(
+        EsdeImportService.resolveMediaRoot(root.path),
+        p.join(root.path, 'downloaded_media'),
+      );
+    });
+  });
+
   group('EsdeImportService DB behavior', () {
     final dbHelper = DatabaseTestHelper();
     late dynamic db;
@@ -232,6 +324,51 @@ void main() {
         expect(result.gamesImported, 1);
       },
     );
+
+    test('import reads media from a relocated ES-DE MediaDirectory', () async {
+      // A second system whose art exists but that has no gamelist.xml, so the
+      // only thing that can wire it up is the media walk (issue #456).
+      await db.execute(
+        "INSERT INTO app_systems (id, real_name, folder_name, screenscraper_id) VALUES ('megadrive', 'Mega Drive', 'megadrive', 1)",
+      );
+      await db.execute(
+        "INSERT INTO user_roms (filename, rom_path, app_system_id) VALUES ('sonic.smc', '/roms/snes/sonic.smc', 'snes')",
+      );
+
+      final tempRoot = Directory.systemTemp.createTempSync('esde_test_');
+      addTearDown(() => tempRoot.deleteSync(recursive: true));
+
+      // The media lives OUTSIDE the ES-DE folder, exactly as it does once the
+      // user moves it: `<tempRoot>/downloaded_media` never exists.
+      final mediaDir = Directory.systemTemp.createTempSync('esde_media_');
+      addTearDown(() => mediaDir.deleteSync(recursive: true));
+      Directory(
+        '${mediaDir.path}/megadrive/covers',
+      ).createSync(recursive: true);
+      File(
+        '${mediaDir.path}/megadrive/covers/sonic.png',
+      ).writeAsStringSync('x');
+
+      Directory('${tempRoot.path}/settings').createSync(recursive: true);
+      File('${tempRoot.path}/settings/es_settings.xml').writeAsStringSync(
+        '<?xml version="1.0"?>\n'
+        '<string name="MediaDirectory" value="${mediaDir.path}" />\n',
+      );
+
+      final systemDir = Directory('${tempRoot.path}/gamelists/snes')
+        ..createSync(recursive: true);
+      File('${systemDir.path}/gamelist.xml').writeAsStringSync(
+        '<gameList><game><path>./sonic.smc</path><name>Sonic</name></game></gameList>',
+      );
+
+      await EsdeImportService.import(tempRoot.path);
+
+      final rows = await db.rawQuery(
+        "SELECT esde_media_dir FROM user_system_settings WHERE app_system_id = 'megadrive'",
+      );
+      expect(rows.length, 1);
+      expect(rows.first['esde_media_dir'], 'megadrive');
+    });
 
     test('import does not skip games ES-DE marks hidden', () async {
       await db.execute(

--- a/test/file_provider_test.dart
+++ b/test/file_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:neostation/providers/file_provider.dart';
 
@@ -96,6 +98,29 @@ void main() {
         ]);
       },
     );
+
+    test('follows a relocated ES-DE MediaDirectory', () async {
+      // ES-DE lets the user move the media folder; the choice lives in
+      // es_settings.xml and replaces `downloaded_media` outright (issue #456).
+      final esdeRoot = Directory.systemTemp.createTempSync('esde_root_');
+      addTearDown(() => esdeRoot.deleteSync(recursive: true));
+      final mediaDir = Directory.systemTemp.createTempSync('esde_media_');
+      addTearDown(() => mediaDir.deleteSync(recursive: true));
+
+      Directory('${esdeRoot.path}/settings').createSync(recursive: true);
+      File('${esdeRoot.path}/settings/es_settings.xml').writeAsStringSync(
+        '<string name="MediaDirectory" value="${mediaDir.path}" />',
+      );
+
+      await db.update('user_config', {'esde_folder_path': esdeRoot.path});
+      await provider.refreshEsde();
+
+      expect(provider.getEsdeMediaCandidates('snes', 'fanarts', 'sonic.smc'), [
+        '${mediaDir.path}/snes/fanart/sonic.png',
+        '${mediaDir.path}/snes/fanart/sonic.jpg',
+        '${mediaDir.path}/snes/fanart/sonic.webp',
+      ]);
+    });
 
     test('returns nothing for a system with no recorded ES-DE media dir', () {
       expect(


### PR DESCRIPTION
# Description

ES-DE lets the user move its media folder anywhere and records the choice in `settings/es_settings.xml` as `<string name="MediaDirectory" value="…" />`. NeoStation hardcoded `<esdeRoot>/downloaded_media` in both the import walk and the read-time artwork fallback, so on such an install every media path pointed at a folder that no longer exists: the import found no art, and game lists showed placeholders. The only workaround was a `downloaded_media` symlink.

Adds `EsdeImportService.resolveMediaRoot()`, which reads `MediaDirectory` and mirrors what ES-DE itself does with the value:

- When set it **replaces** `downloaded_media` outright (the value names the media folder, not a parent holding one).
- `~` expands to the user's home directory.
- `%ESPATH%` is the ES-DE *binary's* directory, which can't be derived from the picked data folder, so both the ES-DE folder and its parent are tried. That covers the portable layout in the issue (`ES-DE.exe` next to the `ES-DE/` data folder).
- Absent, blank, unreadable, or naming a folder that isn't there all fall back to `<esdeRoot>/downloaded_media` — a stale setting must never cost the user the media they do have.

The settings file is parsed as a fragment with lenient UTF-8, exactly as `gamelist.xml` already is, so ES-DE's own lenient output and a stray bad byte in an unrelated setting can't lose the media directory.

The import resolves the root once and threads it through as `mediaRoot`. `FileProvider` re-resolves it on every config load rather than persisting it, so a user who moves the folder in ES-DE keeps their art without re-running the import.

Closes #456

## Steps to Verify

**Preconditions:** an ES-DE install NeoStation has already imported, and a system whose art exists in ES-DE but *not* in NeoStation's own `media/<system>/box2d` (so every cover on screen comes from the ES-DE fallback). Vectrex was used below: 23 ROMs, 23 ES-DE covers, empty NeoStation media folder.

1. With `MediaDirectory` unset, open that system's game list. Art shows.
2. Point `MediaDirectory` at an empty folder, e.g. `<string name="MediaDirectory" value="/storage/emulated/0/emu/esde-media-test" />`. Restart NeoStation, reopen the list. **All ES-DE art is gone** — before this change it was unaffected, because the setting was ignored.
3. Copy that system's media folder into the relocated root. Restart, reopen the list. **Art returns**, now resolved from the new path.
4. Create a system folder that exists *only* in the relocated root (`atarilynx/covers/…` was used — the real `downloaded_media` has no such folder). Run Settings → Directories → Import ES-DE data. The import logs `ES-DE: using custom MediaDirectory "…"` and `linked art-only system "atarilynx" … to lynx`, and `user_system_settings.esde_media_dir` for that system becomes `atarilynx`.

Step 4 is the discriminating one. On a build without this change the import does the opposite: it links the art-only systems from the old default location and never sees `atarilynx`.

## Tested on

- [x] Android — device: AYN Thor (dev channel, release build), against a real 12 GB ES-DE install with 9,140 scanned games
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1670)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

**Tests added (10):**

- `resolveMediaRoot`: no settings file, absent value, blank value, a custom directory that exists, a trailing separator on the value, `%ESPATH%` expansion, a custom directory that is gone, and a malformed settings file.
- `esde_import_service_test.dart` — an import whose media lives entirely outside the ES-DE folder wires up an art-only system. Fails without this change.
- `file_provider_test.dart` — read-time candidates follow the relocated root.

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths — the ES-DE root is already a resolved filesystem path by the time it reaches this code (`UserDataLocationService.resolveAndroidUserDataPath` / `safUriToRealPath` in the folder picker), and the new code only joins onto it. Verified on-device against a SAF-picked ES-DE folder.
- [x] Verified on a device, not only on desktop

No new user-facing strings, no schema change, no navigation change, no `assets/systems/` change.
