### PR TITLE
feat(secondary): show a clock and battery on the Now Playing screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -844,6 +844,11 @@ Future<void> subDisplay() async {
   // even for a user on a light theme. Read it from the same config row.
   String? initThemeName;
 
+  // Same story for the Now Playing corner clock: the shared state carries the
+  // 12/24-hour preference, but only once the main engine has pushed it, so seed
+  // it here to avoid opening on the wrong format.
+  bool initUse12HourClock = false;
+
   // Same screen-power guard as the main engine, keyed off this engine's own
   // notifier: the two engines share no memory, so GameService's is not live
   // here. Set before the config read below, which can throw — falling back to
@@ -857,6 +862,10 @@ Future<void> subDisplay() async {
       initLang = rawConfig['app_language'].toString();
     }
     initThemeName = rawConfig?['theme_name']?.toString();
+    initUse12HourClock =
+        (int.tryParse(rawConfig?['use_12_hour_clock']?.toString() ?? '0') ??
+            0) ==
+        1;
     // Same story for UI sounds: this engine has its own SfxService singleton,
     // so the main engine's setEnabled/setVolume never reach it. The main engine
     // also pushes these through the shared state, but that can land after the
@@ -890,7 +899,12 @@ Future<void> subDisplay() async {
     initLanguageCode: initLang.isNotEmpty ? initLang : 'en',
   );
 
-  runApp(SecondaryScreen(initialThemeName: initThemeName));
+  runApp(
+    SecondaryScreen(
+      initialThemeName: initThemeName,
+      initialUse12HourClock: initUse12HourClock,
+    ),
+  );
 }
 
 /// Provides MaterialLocalizations as a fallback for locales that Flutter's

--- a/lib/models/secondary_display_state.dart
+++ b/lib/models/secondary_display_state.dart
@@ -224,6 +224,14 @@ class SecondaryDisplayStateData {
   /// pushed by the main engine for the same cross-engine reason as [sfxEnabled].
   final double sfxVolume;
 
+  /// Whether clocks use the 12-hour (AM/PM) form. User setting, pushed by the
+  /// main engine so the Now Playing corner clock matches the primary header.
+  ///
+  /// Null means "not pushed yet": the secondary engine seeds its own value from
+  /// the config row at startup (see `subDisplay`), and a non-null default here
+  /// would let the first shared-state snapshot overwrite that seed with a guess.
+  final bool? use12HourClock;
+
   SecondaryDisplayStateData({
     required this.systemName,
     this.gameFanart,
@@ -293,6 +301,7 @@ class SecondaryDisplayStateData {
     // like the persisted setting rather than silently muting or blasting.
     this.sfxEnabled = true,
     this.sfxVolume = 0.75,
+    this.use12HourClock,
   });
 
   /// Returns a new instance with the specified properties updated.
@@ -373,6 +382,7 @@ class SecondaryDisplayStateData {
     bool? setupWizardActive,
     bool? sfxEnabled,
     double? sfxVolume,
+    bool? use12HourClock,
   }) {
     return SecondaryDisplayStateData(
       systemName: systemName ?? this.systemName,
@@ -454,6 +464,7 @@ class SecondaryDisplayStateData {
       setupWizardActive: setupWizardActive ?? this.setupWizardActive,
       sfxEnabled: sfxEnabled ?? this.sfxEnabled,
       sfxVolume: sfxVolume ?? this.sfxVolume,
+      use12HourClock: use12HourClock ?? this.use12HourClock,
     );
   }
 
@@ -537,6 +548,7 @@ class SecondaryDisplayStateData {
       setupWizardActive: json['setupWizardActive'] as bool? ?? false,
       sfxEnabled: json['sfxEnabled'] as bool? ?? true,
       sfxVolume: (json['sfxVolume'] as num?)?.toDouble() ?? 0.75,
+      use12HourClock: json['use12HourClock'] as bool?,
     );
   }
 
@@ -603,6 +615,7 @@ class SecondaryDisplayStateData {
       'setupWizardActive': setupWizardActive,
       'sfxEnabled': sfxEnabled,
       'sfxVolume': sfxVolume,
+      'use12HourClock': use12HourClock,
     };
   }
 }
@@ -719,6 +732,7 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
     bool? setupWizardActive,
     bool? sfxEnabled,
     double? sfxVolume,
+    bool? use12HourClock,
   }) async {
     if (!Platform.isAndroid) return;
 
@@ -804,6 +818,7 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
           setupWizardActive: setupWizardActive,
           sfxEnabled: sfxEnabled,
           sfxVolume: sfxVolume,
+          use12HourClock: use12HourClock,
         ),
       );
     } catch (e) {

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -296,6 +296,7 @@ class SqliteConfigProvider extends ChangeNotifier with WidgetsBindingObserver {
           fanartDimLevel: _config.fanartDimLevel,
           sfxEnabled: _config.sfxEnabled,
           sfxVolume: _config.sfxVolume,
+          use12HourClock: _config.use12HourClock,
         );
       }
 

--- a/lib/providers/sqlite_config_provider/mutators.dart
+++ b/lib/providers/sqlite_config_provider/mutators.dart
@@ -188,9 +188,13 @@ extension SqliteConfigMutators on SqliteConfigProvider {
   }
 
   /// Updates whether the header clock uses a 12-hour (AM/PM) format.
+  ///
+  /// Also pushed to the secondary display, whose Now Playing corner clock uses
+  /// the same preference and runs in an engine that can't see this provider.
   Future<void> updateUse12HourClock(bool value) async {
     _config = _config.copyWith(use12HourClock: value);
     await SqliteConfigService.saveConfig(_config);
+    _secondaryDisplayState?.updateState(use12HourClock: value);
     _notify();
   }
 

--- a/lib/providers/sqlite_config_provider/secondary_display.dart
+++ b/lib/providers/sqlite_config_provider/secondary_display.dart
@@ -100,6 +100,7 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
         dockSlotCount: _config.dockSlotCount,
         sfxEnabled: _config.sfxEnabled,
         sfxVolume: _config.sfxVolume,
+        use12HourClock: _config.use12HourClock,
         // If the main UI is already up (e.g. a display hot-connected after
         // launch), carry the ready latch so the dock slides in on connect;
         // during cold boot this is still false and the dock stays parked until
@@ -197,6 +198,8 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
               state.fanartDimLevel != _config.fanartDimLevel ||
               state.sfxEnabled != _config.sfxEnabled ||
               state.sfxVolume != _config.sfxVolume ||
+              (state.use12HourClock != null &&
+                  state.use12HourClock != _config.use12HourClock) ||
               (ScreenshotService.lastKnownAccess != null &&
                   state.screenshotAccessEnabled !=
                       ScreenshotService.lastKnownAccess))) {
@@ -227,6 +230,7 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
           fanartDimLevel: _config.fanartDimLevel,
           sfxEnabled: _config.sfxEnabled,
           sfxVolume: _config.sfxVolume,
+          use12HourClock: _config.use12HourClock,
           screenshotAccessEnabled: ScreenshotService.lastKnownAccess,
         );
       }

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -25,12 +25,21 @@ import 'widgets/app_dock.dart';
 import 'widgets/now_playing_panel.dart';
 
 class SecondaryScreen extends StatefulWidget {
-  const SecondaryScreen({super.key, this.initialThemeName});
+  const SecondaryScreen({
+    super.key,
+    this.initialThemeName,
+    this.initialUse12HourClock = false,
+  });
 
   /// Theme name read from the database by this engine's entrypoint, used until
   /// the main engine pushes its state. Without it the display would open on
   /// the platform-brightness fallback — black on a light theme.
   final String? initialThemeName;
+
+  /// 12/24-hour clock preference read from the database by this engine's
+  /// entrypoint, used for the Now Playing corner clock until the main engine
+  /// pushes its own value.
+  final bool initialUse12HourClock;
 
   @override
   State<SecondaryScreen> createState() => _SecondaryScreenState();
@@ -1414,6 +1423,8 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                       value: value,
                       sessionRunning: _sessionWatch.isRunning,
                       sessionTime: _formatSessionTime(),
+                      use12HourClock:
+                          value.use12HourClock ?? widget.initialUse12HourClock,
                       onRequestScreenshot: _requestScreenshot,
                     ),
             ),

--- a/lib/screens/secondary_screen/widgets/now_playing_panel.dart
+++ b/lib/screens/secondary_screen/widgets/now_playing_panel.dart
@@ -3,6 +3,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import '../../../models/secondary_display_state.dart';
 import '../now_playing_helpers.dart';
+import 'status_readout.dart';
 
 /// The Now Playing page shown on the secondary display: boxart + game/system
 /// title + play-time / session / last-played stats.
@@ -20,6 +21,7 @@ class NowPlayingPanel extends StatelessWidget {
     required this.value,
     required this.sessionRunning,
     required this.sessionTime,
+    required this.use12HourClock,
     required this.onRequestScreenshot,
   });
 
@@ -31,6 +33,10 @@ class NowPlayingPanel extends StatelessWidget {
   /// Pre-formatted elapsed session time (`HH:MM:SS`); only shown when
   /// [sessionRunning].
   final String sessionTime;
+
+  /// Whether the corner clock uses the 12-hour (AM/PM) form, mirroring the
+  /// user's header-clock preference.
+  final bool use12HourClock;
 
   /// Asks the main engine to capture a screenshot of the main screen.
   final VoidCallback onRequestScreenshot;
@@ -122,6 +128,19 @@ class NowPlayingPanel extends StatelessWidget {
                   ),
                 ),
               ],
+            ),
+          ),
+          // Clock + battery, pinned to the corner the panel's own content never
+          // reaches. The bottom screen is the only place these are readable
+          // while a game owns the top screen, and a single wake tap surfaces
+          // them alongside the play-time stats.
+          Positioned(
+            top: 22.r,
+            right: 26.r,
+            child: StatusReadout(
+              scheme: scheme,
+              themeName: value.themeName,
+              use12HourClock: use12HourClock,
             ),
           ),
         ],

--- a/lib/screens/secondary_screen/widgets/status_readout.dart
+++ b/lib/screens/secondary_screen/widgets/status_readout.dart
@@ -1,0 +1,203 @@
+import 'dart:async';
+
+import 'package:battery_plus/battery_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+import '../../../services/secondary_apps_service.dart';
+import '../../../themes/app_themes.dart';
+import '../../../utils/time_format.dart';
+
+/// Small clock + battery readout for the secondary display's Now Playing page.
+///
+/// The bottom screen is the only place these are visible while a game owns the
+/// top screen, so this mirrors the primary [Header] pill in miniature: the same
+/// [formatClockTime] formatter, the same battery icon ramp, the same
+/// charge-level colours from the active theme, and the same "no battery
+/// reported" opt-out (-1).
+///
+/// Owns its own minute ticker and battery subscription: the panel around it is
+/// a pure, input-driven subtree, and the host screen already re-renders it
+/// every second for the session clock, so keeping this state local avoids
+/// threading two more values through every push.
+class StatusReadout extends StatefulWidget {
+  const StatusReadout({
+    super.key,
+    required this.scheme,
+    required this.themeName,
+    required this.use12HourClock,
+  });
+
+  /// Colour scheme derived from the painted panel background (see
+  /// `panelScheme`), so the clock stays legible on light and dark themes.
+  final ColorScheme scheme;
+
+  /// Active theme name, pushed by the main engine. Resolves the battery
+  /// colours — the readout can't reach them through the tree the way the
+  /// primary header does, because this engine has no [ThemeProvider].
+  final String? themeName;
+
+  /// Whether the clock uses the 12-hour (AM/PM) form. Mirrors the user's
+  /// header-clock preference, pushed across from the main engine.
+  final bool use12HourClock;
+
+  @override
+  State<StatusReadout> createState() => _StatusReadoutState();
+}
+
+class _StatusReadoutState extends State<StatusReadout> {
+  final Battery _battery = Battery();
+
+  DateTime _now = DateTime.now();
+  Timer? _clockTimer;
+
+  /// Charge percentage, or -1 when this device reports no battery (desktops,
+  /// and any platform where the plugin isn't reachable from this engine).
+  int _batteryLevel = -1;
+  BatteryState? _batteryState;
+  StreamSubscription<BatteryState>? _batteryStateSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _readBatteryLevel();
+    _listenToBatteryState();
+    _startClockTimer();
+    SecondaryAppsService.deviceScreenOn.addListener(_onScreenPowerChanged);
+  }
+
+  @override
+  void dispose() {
+    SecondaryAppsService.deviceScreenOn.removeListener(_onScreenPowerChanged);
+    _clockTimer?.cancel();
+    _batteryStateSubscription?.cancel();
+    super.dispose();
+  }
+
+  /// Stops ticking while the lid is shut and refreshes the moment it opens.
+  ///
+  /// This panel stays mounted behind a closed lid, so without the stop the
+  /// readout would keep waking the CPU each minute for a screen nobody can see.
+  /// The refresh on the way back matters just as much: Android holds timers
+  /// while the device sleeps, so a clock left to its own schedule can show the
+  /// time the lid closed at for up to a minute after it opens.
+  void _onScreenPowerChanged() {
+    if (SecondaryAppsService.deviceScreenOn.value) {
+      _clockTimer?.cancel();
+      _tick();
+      _startClockTimer();
+    } else {
+      _clockTimer?.cancel();
+      _clockTimer = null;
+    }
+  }
+
+  /// Ticks on the minute boundary rather than every 60s from now, so the
+  /// displayed minute never lags the real one by up to a minute.
+  void _startClockTimer() {
+    final secondsUntilNextMinute = 60 - DateTime.now().second;
+    _clockTimer = Timer(Duration(seconds: secondsUntilNextMinute), () {
+      _tick();
+      _clockTimer = Timer.periodic(const Duration(minutes: 1), (_) => _tick());
+    });
+  }
+
+  void _tick() {
+    if (!mounted) return;
+    setState(() => _now = DateTime.now());
+    // Same cadence as the primary header: the level moves slowly enough that a
+    // minute is plenty, and the charge/discharge stream covers the rest.
+    _readBatteryLevel();
+  }
+
+  Future<void> _readBatteryLevel() async {
+    int level;
+    try {
+      level = await _battery.batteryLevel;
+    } catch (_) {
+      // No battery, or the plugin isn't registered in this engine — either way
+      // the block hides rather than showing a wrong number.
+      level = -1;
+    }
+    if (!mounted) return;
+    setState(() => _batteryLevel = level);
+  }
+
+  void _listenToBatteryState() {
+    try {
+      _batteryStateSubscription = _battery.onBatteryStateChanged.listen((
+        state,
+      ) {
+        if (mounted) setState(() => _batteryState = state);
+        // A plug/unplug moves the level fast, so don't wait for the next tick.
+        _readBatteryLevel();
+      }, onError: (_) {});
+    } catch (_) {
+      // Some platforms don't expose battery state; ignore silently.
+    }
+  }
+
+  bool get _isCharging =>
+      _batteryState == BatteryState.charging ||
+      _batteryState == BatteryState.full;
+
+  /// Battery glyph for the current charge, matching the primary header's ramp.
+  IconData get _batteryIcon {
+    if (_isCharging) return Symbols.battery_android_frame_bolt;
+    if (_batteryLevel >= 90) return Symbols.battery_full;
+    if (_batteryLevel >= 75) return Symbols.battery_android_frame_6;
+    if (_batteryLevel >= 60) return Symbols.battery_android_frame_5;
+    if (_batteryLevel >= 45) return Symbols.battery_android_frame_4;
+    if (_batteryLevel >= 30) return Symbols.battery_android_frame_3;
+    if (_batteryLevel >= 15) return Symbols.battery_android_frame_2;
+    return Symbols.battery_android_frame_1;
+  }
+
+  /// The primary header's charge-level colours, from the same theme: green
+  /// above 20%, amber down to 6%, red at 5% and below. Charging is carried by
+  /// the bolt glyph alone, exactly as it is up top.
+  Color get _batteryColor {
+    final colors = AppThemes.getCustomColorsByName(widget.themeName);
+    if (_batteryLevel > 20) return colors.batteryFull;
+    if (_batteryLevel > 5) return colors.batteryMedium;
+    return colors.batteryLow;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final muted = widget.scheme.onSurface.withValues(alpha: 0.55);
+    final batteryColor = _batteryColor;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Symbols.schedule_rounded, color: muted, size: 19.r),
+        SizedBox(width: 7.r),
+        Text(
+          formatClockTime(_now, use12Hour: widget.use12HourClock),
+          style: TextStyle(
+            color: widget.scheme.onSurface,
+            fontSize: 18.r,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.5.r,
+          ),
+        ),
+        if (_batteryLevel >= 0) ...[
+          SizedBox(width: 16.r),
+          Icon(_batteryIcon, color: batteryColor, size: 21.r),
+          SizedBox(width: 6.r),
+          Text(
+            '$_batteryLevel%',
+            style: TextStyle(
+              color: batteryColor,
+              fontSize: 18.r,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.5.r,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/themes/app_themes.dart
+++ b/lib/themes/app_themes.dart
@@ -63,55 +63,64 @@ class AppThemes {
   static dynamic get palenightCustomColors => palenight.PalenightCustomColors();
   static dynamic get horizonCustomColors => horizon.HorizonCustomColors();
 
+  /// Retrieves a theme's custom colors from its name.
+  ///
+  /// The same mapping [getCustomColors] uses, minus the [ThemeProvider] lookup
+  /// — the secondary display runs in an engine with no provider in its tree but
+  /// does know the theme name pushed by the main engine, and its battery
+  /// readout has to color itself exactly like the primary header's.
+  static dynamic getCustomColorsByName(String? themeName) {
+    var resolvedThemeName = themeName ?? 'system';
+
+    if (resolvedThemeName == 'system') {
+      final brightness =
+          WidgetsBinding.instance.platformDispatcher.platformBrightness;
+      resolvedThemeName = brightness == Brightness.dark ? 'dark' : 'light';
+    }
+
+    final custom = customThemes[resolvedThemeName];
+    if (custom != null) {
+      return custom.customColors;
+    }
+
+    switch (resolvedThemeName) {
+      case 'light':
+        return light.LightCustomColors();
+      case 'oled':
+        return oled.OledCustomColors();
+      case 'valentine':
+        return valentine.ValentineCustomColors();
+      case 'dracula':
+        return dracula.DraculaCustomColors();
+      case 'nord':
+        return nord.NordCustomColors();
+      case 'coffee':
+        return coffee.CoffeeCustomColors();
+      case 'tokyo_night':
+        return tokyo_night.TokyoNightCustomColors();
+      case 'retro':
+        return retro.RetroCustomColors();
+      case 'abyss':
+        return abyss.AbyssCustomColors();
+      case 'cyberpunk':
+        return cyberpunk.CyberpunkCustomColors();
+      case 'aqua':
+        return aqua.AquaCustomColors();
+      case 'palenight':
+        return palenight.PalenightCustomColors();
+      case 'horizon':
+        return horizon.HorizonCustomColors();
+      default:
+        return dark.DarkCustomColors();
+    }
+  }
+
   /// Retrieves header colors based on the current context's theme.
   static dynamic getCustomColors(BuildContext context) {
     // Prefer detection by theme name if a ThemeProvider is available (more reliable).
     try {
       final themeProvider = Provider.of<ThemeProvider>(context, listen: false);
-      final themeName = themeProvider.currentThemeName;
-      String resolvedThemeName = themeName;
-
-      if (themeName == 'system') {
-        final brightness =
-            WidgetsBinding.instance.platformDispatcher.platformBrightness;
-        resolvedThemeName = brightness == Brightness.dark ? 'dark' : 'light';
-      }
-
-      final custom = customThemes[resolvedThemeName];
-      if (custom != null) {
-        return custom.customColors;
-      }
-
-      switch (resolvedThemeName) {
-        case 'light':
-          return light.LightCustomColors();
-        case 'oled':
-          return oled.OledCustomColors();
-        case 'valentine':
-          return valentine.ValentineCustomColors();
-        case 'dracula':
-          return dracula.DraculaCustomColors();
-        case 'nord':
-          return nord.NordCustomColors();
-        case 'coffee':
-          return coffee.CoffeeCustomColors();
-        case 'tokyo_night':
-          return tokyo_night.TokyoNightCustomColors();
-        case 'retro':
-          return retro.RetroCustomColors();
-        case 'abyss':
-          return abyss.AbyssCustomColors();
-        case 'cyberpunk':
-          return cyberpunk.CyberpunkCustomColors();
-        case 'aqua':
-          return aqua.AquaCustomColors();
-        case 'palenight':
-          return palenight.PalenightCustomColors();
-        case 'horizon':
-          return horizon.HorizonCustomColors();
-        default:
-          return dark.DarkCustomColors();
-      }
+      return getCustomColorsByName(themeProvider.currentThemeName);
     } catch (_) {
       // Fallback to color comparison if provider is not available.
     }

--- a/test/secondary_display_state_test.dart
+++ b/test/secondary_display_state_test.dart
@@ -95,6 +95,9 @@ void main() {
       // are the only way the UI-sound setting crosses the engine boundary.
       sfxEnabled: false,
       sfxVolume: 0.25,
+      // Non-null and non-default: the secondary engine's corner clock reads
+      // this, and null would round-trip as "not pushed yet" either way.
+      use12HourClock: true,
     );
 
     test('round-trips every field through toJson/fromJson', () {
@@ -154,6 +157,10 @@ void main() {
       // setting rather than silently muting the bottom screen.
       expect(restored.sfxEnabled, isTrue);
       expect(restored.sfxVolume, 0.75);
+      // Null, not false: the secondary engine seeds the clock format from the
+      // config row itself, and a `false` here would look like a real push and
+      // overwrite that seed with 24-hour on every snapshot.
+      expect(restored.use12HourClock, isNull);
     });
 
     test('coerces numeric fields delivered as doubles', () {
@@ -282,6 +289,28 @@ void main() {
 
       expect(loud.sfxEnabled, isTrue);
       expect(loud.copyWith(sfxEnabled: false).sfxEnabled, isFalse);
+    });
+
+    test('a partial update that omits the clock format preserves it', () {
+      // Pushed once, from General settings; every later push from either
+      // engine has to carry it or the corner clock flips format mid-game.
+      final twelveHour = SecondaryDisplayStateData(
+        systemName: 'snes',
+        use12HourClock: true,
+      );
+
+      final next = twelveHour.copyWith(nowPlayingActive: true);
+
+      expect(next.use12HourClock, isTrue);
+    });
+
+    test('an unpushed clock format stays null through a partial update', () {
+      // Null is the secondary engine's cue to keep its own seeded value, so a
+      // merge must not settle it to a default.
+      final unpushed = SecondaryDisplayStateData(systemName: 'snes');
+
+      expect(unpushed.use12HourClock, isNull);
+      expect(unpushed.copyWith(nowPlayingActive: true).use12HourClock, isNull);
     });
   });
 }

--- a/test/status_readout_test.dart
+++ b/test/status_readout_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/screens/secondary_screen/widgets/status_readout.dart';
+import 'package:neostation/services/secondary_apps_service.dart';
+import 'package:neostation/themes/app_themes.dart';
+
+/// Covers the secondary display's corner clock + battery readout.
+///
+/// The bottom screen runs in its own Flutter engine, spawned by `sub_screen`
+/// rather than by the activity that registers the app's plugins — so the one
+/// thing this widget must never do is fail loudly when `battery_plus` isn't
+/// reachable. These pin that fallback (clock alone, no wrong number) alongside
+/// the two clock formats and the low-battery colouring.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('dev.fluttercommunity.plus/battery');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  var levelReads = 0;
+
+  setUp(() {
+    levelReads = 0;
+    SecondaryAppsService.deviceScreenOn.value = true;
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+    SecondaryAppsService.deviceScreenOn.value = true;
+  });
+
+  /// Answers `getBatteryLevel` with [level], or throws the way an unregistered
+  /// plugin does when [level] is null.
+  void mockBattery(int? level) {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method != 'getBatteryLevel') return null;
+      levelReads++;
+      if (level == null) {
+        throw MissingPluginException(
+          'No implementation found for getBatteryLevel',
+        );
+      }
+      return level;
+    });
+  }
+
+  Future<void> pumpReadout(
+    WidgetTester tester, {
+    required bool use12HourClock,
+    String? themeName = 'dark',
+  }) async {
+    await tester.pumpWidget(
+      ScreenUtilInit(
+        designSize: const Size(640, 480),
+        builder: (context, _) => MaterialApp(
+          home: Scaffold(
+            body: StatusReadout(
+              scheme: const ColorScheme.dark(),
+              themeName: themeName,
+              use12HourClock: use12HourClock,
+            ),
+          ),
+        ),
+      ),
+    );
+    // The level is read asynchronously in initState; settle so the first
+    // answer (or failure) has landed before asserting.
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shows the battery percentage the platform reports', (
+    tester,
+  ) async {
+    mockBattery(87);
+
+    await pumpReadout(tester, use12HourClock: false);
+
+    expect(find.text('87%'), findsOneWidget);
+  });
+
+  testWidgets('drops the battery block when the plugin is unreachable', (
+    tester,
+  ) async {
+    // What the secondary engine does if `battery_plus` never registered there:
+    // the clock still has to render, and no percentage may be invented.
+    mockBattery(null);
+
+    await pumpReadout(tester, use12HourClock: false);
+
+    expect(find.textContaining('%'), findsNothing);
+    expect(find.byType(Text), findsOneWidget);
+  });
+
+  testWidgets('renders the clock in the format the user picked', (
+    tester,
+  ) async {
+    mockBattery(50);
+
+    await pumpReadout(tester, use12HourClock: true);
+    final twelveHour = tester.widgetList<Text>(find.byType(Text)).first.data!;
+    expect(twelveHour, anyOf(contains('AM'), contains('PM')));
+
+    await pumpReadout(tester, use12HourClock: false);
+    final twentyFourHour = tester
+        .widgetList<Text>(find.byType(Text))
+        .first
+        .data!;
+    expect(twentyFourHour, isNot(anyOf(contains('AM'), contains('PM'))));
+  });
+
+  testWidgets('colours the battery by charge level, like the primary header', (
+    tester,
+  ) async {
+    // The same theme colours the header reads, resolved by name because this
+    // engine has no ThemeProvider: a user glancing down should not have to
+    // learn a second colour language for the same number.
+    final colors = AppThemes.getCustomColorsByName('dark');
+
+    Future<Color> colorAtLevel(int level) async {
+      mockBattery(level);
+      // Tear the old readout down first: the level is read in initState, so a
+      // re-pump of the same widget would keep showing the previous charge.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await pumpReadout(tester, use12HourClock: false);
+      final text = tester.widget<Text>(find.text('$level%'));
+      return text.style!.color!;
+    }
+
+    expect(await colorAtLevel(80), colors.batteryFull);
+    expect(await colorAtLevel(21), colors.batteryFull);
+    expect(await colorAtLevel(20), colors.batteryMedium);
+    expect(await colorAtLevel(6), colors.batteryMedium);
+    expect(await colorAtLevel(5), colors.batteryLow);
+    expect(await colorAtLevel(1), colors.batteryLow);
+  });
+
+  testWidgets('stops ticking behind a closed lid and catches up on wake', (
+    tester,
+  ) async {
+    mockBattery(64);
+
+    await pumpReadout(tester, use12HourClock: false);
+    expect(levelReads, 1);
+
+    // Lid shut: the panel stays mounted, but nothing should wake the CPU for a
+    // screen nobody can see.
+    SecondaryAppsService.deviceScreenOn.value = false;
+    await tester.pump(const Duration(minutes: 3));
+    expect(levelReads, 1);
+
+    // Lid open: refresh immediately rather than showing the time it closed at
+    // until the next minute boundary, then resume ticking.
+    SecondaryAppsService.deviceScreenOn.value = true;
+    await tester.pump();
+    expect(levelReads, 2);
+
+    await tester.pump(const Duration(minutes: 2));
+    expect(levelReads, greaterThan(2));
+  });
+}


### PR DESCRIPTION
# Description

While a single-screen game owns the top display, the bottom screen is the only place the time and charge can be read without interrupting play: the AYN button's long-press overlay covers the game to show them. The Now Playing page already wakes on a tap to show play time, so the same tap now answers "what time is it, how much battery is left" alongside it.

The readout sits in the corner the panel's content never reaches, and it dims and wakes with the panel rather than staying lit. It mirrors the primary header on purpose: the same clock formatter, the same battery icon ramp, and the same charge-level colours from the active theme (green above 20%, amber down to 6%, red at 5% and below, charging shown by the bolt glyph), so glancing down doesn't mean learning a second colour language for the same number. The achievements page is left alone, since its header row is already full.

Two cross-engine details this needed:

- **Battery colours.** They live in the theme's custom colours, which the header reaches through a `ThemeProvider` the secondary engine doesn't have. The name-based half of `AppThemes.getCustomColors` is now `getCustomColorsByName`, and the context version delegates to it, so both screens resolve the same values from the theme name the main engine already pushes. The header's own path, including its provider-less colour-comparison fallback, is unchanged.
- **The 12/24-hour preference** had no way across the engine boundary. It is now seeded from the config row in `subDisplay()` and pushed through the shared state, so toggling it in settings applies live. The state field is nullable on purpose: null means "not pushed yet", so the first snapshot can't clobber the engine's own seed with a guessed `false`.

Battery reads are guarded, so if the plugin were ever unreachable from the spawned engine the block hides rather than showing a wrong number. It is reachable in practice: `sub_screen` spawns the engine through `FlutterEngineGroup`, which registers plugins on the spawned engine, and `battery_plus` answers there (verified on the Thor).

Ticking stops behind a closed lid and refreshes the moment it opens, so it adds nothing to idle drain and can't show the time the lid closed at.

No new database column and no new locale strings: the readout is glyphs and digits, and it reuses the existing `use_12_hour_clock` setting.

**Known limitation:** an imported custom theme's name doesn't resolve in the secondary engine (`AppThemes.customThemes` is only populated by `ThemeProvider` in the main engine), so its battery colours fall back to the dark set. That is the same fallback `resolveTheme` already takes for the panel itself, so the readout stays consistent with what surrounds it.

## Steps to Verify

**Preconditions:** a dual-screen Android handheld (AYN Thor), any system with a launchable game.

1. Launch a single-screen game so the bottom screen shows Now Playing.
2. Wait for the panel to dim, then tap once to wake it: the clock and battery percentage are in the top-right, beside the play-time stats.
3. Compare the battery colour with the top screen's header pill — same colour for the same charge.
4. Plug the charger in: the glyph becomes the bolt, matching the header.
5. Settings → General → toggle "Use 12-Hour Clock": the corner clock switches format live, without relaunching.
6. Close the lid for a couple of minutes and reopen it: the clock reads the current time immediately, not the time the lid closed at.

## Tested on

- [x] Android — device: AYN Thor (dev channel, release build)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Verified on device: readout renders on the Now Playing page, battery colour matches the top screen, charging bolt appears, dark and light themes both legible, 12/24-hour toggle applies live, and the clock is accurate on lid reopen.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [x] No new keys needed — the readout is glyphs and digits, and AM/PM comes from the existing `formatClockTime` shared with the header
- [x] No hardcoded UI strings

**The database**
- [x] No schema change — reuses the existing `use_12_hour_clock` column, so no migration and no version collision with open branches

**Navigation or a new screen**
- [x] Not applicable — the bottom screen is touch-only by design (the gamepad is driving the game on the main screen), and this adds no interactive element

**Android**
- [x] No path logic
- [x] Verified on a device, not only on desktop

</details>

## Tests

- `test/status_readout_test.dart` — the reported percentage, the fallback when the battery plugin is unreachable (clock renders, no invented number), both clock formats, the charge-level colour mapping pinned against the theme's own colours at 80/21/20/6/5/1%, and the lid gating (no polling while shut, immediate refresh on wake).
- `test/secondary_display_state_test.dart` — the new field's JSON round-trip, its null default, and the copyWith merge contract (a partial push must not drop or settle it).
