### PR TITLE
fix(m3u): handle SAF move failures safely

### DIFF
--- a/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/neogamelab/neostation/MainActivity.kt
@@ -1609,18 +1609,20 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
         result: MethodChannel.Result
     ) {
         Thread {
+            var created: Uri? = null
             try {
                 val sourceUri = Uri.parse(sourceUriString)
                 val targetUri = safDocumentUri(targetUriString)
-                val created = android.provider.DocumentsContract.createDocument(
+                val createdFile = android.provider.DocumentsContract.createDocument(
                     contentResolver,
                     targetUri,
                     "application/octet-stream",
                     name
                 ) ?: throw java.io.IOException("Could not create target file")
+                created = createdFile
 
                 contentResolver.openInputStream(sourceUri)?.use { input ->
-                    contentResolver.openOutputStream(created, "w")?.use { output ->
+                    contentResolver.openOutputStream(createdFile, "w")?.use { output ->
                         input.copyTo(output)
                     } ?: throw java.io.IOException("Could not open target file")
                 } ?: throw java.io.IOException("Could not open source file")
@@ -1628,8 +1630,19 @@ class MainActivity: MultiDisplayFlutterActivity(), GamepadsCompatibleActivity {
                 if (!android.provider.DocumentsContract.deleteDocument(contentResolver, sourceUri)) {
                     throw java.io.IOException("Could not remove source file")
                 }
+                created = null
                 runOnUiThread { result.success(true) }
             } catch (e: Exception) {
+                // A move is copy-then-delete for SAF. Remove only the file we
+                // created if either step fails, so a retry cannot leave duplicates.
+                created?.let { destinationUri ->
+                    runCatching {
+                        android.provider.DocumentsContract.deleteDocument(
+                            contentResolver,
+                            destinationUri
+                        )
+                    }
+                }
                 runOnUiThread { result.error("MOVE_FILE_FAILED", e.message, null) }
             }
         }.start()

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -246,6 +246,8 @@ mixin AppLocale {
   static const String organizeMultiDiscNoSetsFound =
       'organize_multi_disc_no_sets_found';
   static const String organizeMultiDiscFailed = 'organize_multi_disc_failed';
+  static const String organizeMultiDiscPartialFailure =
+      'organize_multi_disc_partial_failure';
   static const String organizeMultiDiscWarning = 'organize_multi_disc_warning';
 
   static const String cleanOrphanedMetadata = 'clean_orphaned_metadata';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -257,6 +257,8 @@ const Map<String, dynamic> appLocaleDe = {
       'Keine Multi-Disc-Sets zum Organisieren gefunden{skipped}.',
   AppLocale.organizeMultiDiscFailed:
       'Multi-Disc-Spiele konnten nicht organisiert werden: {error}',
+  AppLocale.organizeMultiDiscPartialFailure:
+      '{failed} Set(s) konnten nicht organisiert werden. {result}',
   AppLocale.organizeMultiDiscWarning:
       'Dadurch werden passende ROM-Dateien in neue Spielordner verschoben und .m3u-Wiedergabelisten auf dem Speicher erstellt. Dies kann nicht automatisch rückgängig gemacht werden.',
   AppLocale.cleanOrphanedMetadata: 'Verwaiste Metadaten bereinigen',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -248,6 +248,8 @@ const Map<String, dynamic> appLocaleEn = {
       'No multi-disc sets found to organize{skipped}.',
   AppLocale.organizeMultiDiscFailed:
       'Failed to organize multi-disc games: {error}',
+  AppLocale.organizeMultiDiscPartialFailure:
+      '{failed} set(s) could not be organized. {result}',
   AppLocale.organizeMultiDiscWarning:
       'This moves matching ROM files into new game folders and creates .m3u playlists on your storage. This cannot be undone automatically.',
   AppLocale.cleanOrphanedMetadata: 'Clean Orphaned Metadata',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -259,6 +259,8 @@ const Map<String, dynamic> appLocaleEs = {
       'No se encontraron conjuntos multidisco para organizar{skipped}.',
   AppLocale.organizeMultiDiscFailed:
       'No se pudieron organizar los juegos multidisco: {error}',
+  AppLocale.organizeMultiDiscPartialFailure:
+      'No se pudieron organizar {failed} conjunto(s). {result}',
   AppLocale.organizeMultiDiscWarning:
       'Esto moverá los archivos ROM coincidentes a nuevas carpetas de juegos y creará listas .m3u en tu almacenamiento. No se puede deshacer automáticamente.',
   AppLocale.cleanOrphanedMetadata: 'Limpiar metadata huérfana',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -263,6 +263,8 @@ const Map<String, dynamic> appLocaleFr = {
       'Aucun lot multi-disques à organiser{skipped}.',
   AppLocale.organizeMultiDiscFailed:
       'Échec de l’organisation des jeux multi-disques : {error}',
+  AppLocale.organizeMultiDiscPartialFailure:
+      '{failed} ensemble(s) n’ont pas pu être organisés. {result}',
   AppLocale.organizeMultiDiscWarning:
       'Cette opération déplacera les ROM correspondantes dans de nouveaux dossiers de jeux et créera des listes .m3u sur votre stockage. Elle ne peut pas être annulée automatiquement.',
   AppLocale.cleanOrphanedMetadata: 'Nettoyer les métadonnées orphelines',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -246,6 +246,8 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.organizeMultiDiscNoSetsFound:
       'Tidak ada set multi-disk yang ditemukan untuk diatur{skipped}.',
   AppLocale.organizeMultiDiscFailed: 'Gagal mengatur game multi-disk: {error}',
+  AppLocale.organizeMultiDiscPartialFailure:
+      '{failed} set tidak dapat diatur. {result}',
   AppLocale.organizeMultiDiscWarning:
       'Ini akan memindahkan file ROM yang cocok ke folder game baru dan membuat playlist .m3u di penyimpanan Anda. Tindakan ini tidak dapat dibatalkan secara otomatis.',
   AppLocale.cleanOrphanedMetadata: 'Bersihkan Metadata Yatim',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -256,6 +256,8 @@ const Map<String, dynamic> appLocaleIt = {
       'Nessun set multi-disco da organizzare{skipped}.',
   AppLocale.organizeMultiDiscFailed:
       'Impossibile organizzare i giochi multi-disco: {error}',
+  AppLocale.organizeMultiDiscPartialFailure:
+      'Impossibile organizzare {failed} set. {result}',
   AppLocale.organizeMultiDiscWarning:
       'Questa operazione sposterà i file ROM corrispondenti in nuove cartelle di gioco e creerà playlist .m3u sul dispositivo di archiviazione. Non può essere annullata automaticamente.',
   AppLocale.cleanOrphanedMetadata: 'Pulisci metadati orfani',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -213,6 +213,7 @@ const Map<String, dynamic> appLocaleJa = {
       '完了: {groups} セットを整理、{files} ファイルを移動、{playlists} プレイリストを作成{skipped}。',
   AppLocale.organizeMultiDiscNoSetsFound: '整理するマルチディスクセットは見つかりませんでした{skipped}。',
   AppLocale.organizeMultiDiscFailed: 'マルチディスクゲームの整理に失敗しました: {error}',
+  AppLocale.organizeMultiDiscPartialFailure: '{failed} セットを整理できませんでした。{result}',
   AppLocale.organizeMultiDiscWarning:
       '一致するROMファイルを新しいゲームフォルダへ移動し、ストレージに.m3uプレイリストを作成します。この操作を自動的に元に戻すことはできません。',
   AppLocale.cleanOrphanedMetadata: '孤立したメタデータを削除',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -212,6 +212,8 @@ const Map<String, dynamic> appLocaleKo = {
       '완료: {groups}개 세트 정리, {files}개 파일 이동, {playlists}개 재생목록 생성{skipped}.',
   AppLocale.organizeMultiDiscNoSetsFound: '정리할 멀티 디스크 세트를 찾지 못했습니다{skipped}.',
   AppLocale.organizeMultiDiscFailed: '멀티 디스크 게임 정리 실패: {error}',
+  AppLocale.organizeMultiDiscPartialFailure:
+      '{failed}개 세트를 정리하지 못했습니다. {result}',
   AppLocale.organizeMultiDiscWarning:
       '일치하는 ROM 파일을 새 게임 폴더로 옮기고 저장소에 .m3u 재생목록을 만듭니다. 이 작업은 자동으로 되돌릴 수 없습니다.',
   AppLocale.cleanOrphanedMetadata: '고아 메타데이터 정리',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -255,6 +255,8 @@ const Map<String, dynamic> appLocalePt = {
       'Nenhum conjunto multi-disco encontrado para organizar{skipped}.',
   AppLocale.organizeMultiDiscFailed:
       'Falha ao organizar jogos multi-disco: {error}',
+  AppLocale.organizeMultiDiscPartialFailure:
+      'Não foi possível organizar {failed} conjunto(s). {result}',
   AppLocale.organizeMultiDiscWarning:
       'Isto moverá os ficheiros ROM correspondentes para novas pastas de jogos e criará listas .m3u no armazenamento. Não pode ser desfeito automaticamente.',
   AppLocale.cleanOrphanedMetadata: 'Limpar Metadados Órfãos',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -253,6 +253,8 @@ const Map<String, dynamic> appLocaleRu = {
       'Многодисковые наборы для организации не найдены{skipped}.',
   AppLocale.organizeMultiDiscFailed:
       'Не удалось организовать многодисковые игры: {error}',
+  AppLocale.organizeMultiDiscPartialFailure:
+      'Не удалось организовать наборов: {failed}. {result}',
   AppLocale.organizeMultiDiscWarning:
       'Подходящие ROM-файлы будут перемещены в новые папки игр, а на накопителе будут созданы плейлисты .m3u. Это нельзя отменить автоматически.',
   AppLocale.cleanOrphanedMetadata: 'Очистить потерянные метаданные',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -208,6 +208,7 @@ const Map<String, dynamic> appLocaleZh = {
       '完成：已整理 {groups} 组，移动 {files} 个文件，创建 {playlists} 个播放列表{skipped}。',
   AppLocale.organizeMultiDiscNoSetsFound: '未找到可整理的多碟组合{skipped}。',
   AppLocale.organizeMultiDiscFailed: '整理多碟游戏失败：{error}',
+  AppLocale.organizeMultiDiscPartialFailure: '有 {failed} 组无法整理。{result}',
   AppLocale.organizeMultiDiscWarning:
       '这将把匹配的 ROM 文件移动到新的游戏文件夹，并在存储设备上创建 .m3u 播放列表。此操作无法自动撤销。',
   AppLocale.cleanOrphanedMetadata: '清理孤立元数据',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -208,6 +208,7 @@ const Map<String, dynamic> appLocaleZhHant = {
       '完成：已整理 {groups} 組、移動 {files} 個檔案、建立 {playlists} 個播放清單{skipped}。',
   AppLocale.organizeMultiDiscNoSetsFound: '找不到可整理的多片組合{skipped}。',
   AppLocale.organizeMultiDiscFailed: '整理多片遊戲失敗：{error}',
+  AppLocale.organizeMultiDiscPartialFailure: '有 {failed} 組無法整理。{result}',
   AppLocale.organizeMultiDiscWarning:
       '這將把相符的 ROM 檔案移至新的遊戲資料夾，並在儲存空間中建立 .m3u 播放清單。此操作無法自動復原。',
   AppLocale.cleanOrphanedMetadata: '清理孤立中介資料',

--- a/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
@@ -114,6 +114,8 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
     final localeSkippedSuffix = AppLocale.organizeMultiDiscSkippedSuffix
         .getString(context);
     final localeFailed = AppLocale.organizeMultiDiscFailed.getString(context);
+    final localePartialFailure = AppLocale.organizeMultiDiscPartialFailure
+        .getString(context);
     final localeConfirm = AppLocale.confirm.getString(context);
 
     if (_currentRomFolders.isEmpty) {
@@ -207,9 +209,16 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
                   )
                   .replaceFirst('{skipped}', skippedNote)
             : localeNoSetsFound.replaceFirst('{skipped}', skippedNote);
-        completionType = result.hasChanges
-            ? NotificationType.success
-            : NotificationType.info;
+        if (result.hasFailures) {
+          completionMessage = localePartialFailure
+              .replaceFirst('{failed}', result.groupsFailed.toString())
+              .replaceFirst('{result}', completionMessage);
+          completionType = NotificationType.error;
+        } else {
+          completionType = result.hasChanges
+              ? NotificationType.success
+              : NotificationType.info;
+        }
       }
     } catch (e, stackTrace) {
       _log.e('Failed to organize multi-disc games: $e', stackTrace: stackTrace);

--- a/lib/services/rom_folder_organizer_service.dart
+++ b/lib/services/rom_folder_organizer_service.dart
@@ -13,6 +13,7 @@ class RomFolderOrganizerResult {
   final int filesMoved;
   final int playlistsCreated;
   final int rootsSkipped;
+  final int groupsFailed;
 
   const RomFolderOrganizerResult({
     required this.groupsOrganized,
@@ -20,10 +21,13 @@ class RomFolderOrganizerResult {
     required this.filesMoved,
     required this.playlistsCreated,
     required this.rootsSkipped,
+    required this.groupsFailed,
   });
 
   bool get hasChanges =>
       groupsOrganized > 0 || foldersCreated > 0 || filesMoved > 0;
+
+  bool get hasFailures => groupsFailed > 0;
 }
 
 class _MutableResult {
@@ -32,6 +36,7 @@ class _MutableResult {
   int filesMoved = 0;
   int playlistsCreated = 0;
   int rootsSkipped = 0;
+  int groupsFailed = 0;
 
   RomFolderOrganizerResult freeze() {
     return RomFolderOrganizerResult(
@@ -40,6 +45,7 @@ class _MutableResult {
       filesMoved: filesMoved,
       playlistsCreated: playlistsCreated,
       rootsSkipped: rootsSkipped,
+      groupsFailed: groupsFailed,
     );
   }
 }
@@ -464,7 +470,11 @@ class RomFolderOrganizerService {
           directoryUri,
           folderBaseName,
         );
-        if (targetUri == null) continue;
+        if (targetUri == null) {
+          _log.e('[M3U] Could not create SAF folder for $folderBaseName.');
+          result.groupsFailed++;
+          continue;
+        }
         result.foldersCreated++;
       }
 
@@ -473,40 +483,55 @@ class RomFolderOrganizerService {
       final playlistLines = <String>[];
       final sourceDiscPaths = <String>[];
       final sourceDiscFilenames = <String>[];
+      var groupFailed = false;
       for (final disc in sortedDiscFiles) {
         final filename = entries
             .firstWhere(
               (entry) => entry['uri'].toString() == disc.file.path,
             )['name']
             .toString();
-        if (await SafDirectoryService.moveFile(
+        final moved = await SafDirectoryService.moveFile(
           disc.file.path,
           targetUri,
           filename,
-        )) {
-          result.filesMoved++;
+        );
+        if (!moved) {
+          _log.e(
+            '[M3U] Stopped organizing $folderBaseName because $filename could not be moved.',
+          );
+          result.groupsFailed++;
+          groupFailed = true;
+          break;
         }
+        result.filesMoved++;
         sourceDiscPaths.add(disc.file.path);
         sourceDiscFilenames.add(filename);
         playlistLines.add(filename);
       }
+      if (groupFailed) continue;
 
       final playlistName = '$folderBaseName.m3u';
-      if (playlist != null &&
-          await SafDirectoryService.moveFile(
-            playlist['uri'].toString(),
-            targetUri,
-            playlistName,
-          )) {
+      if (playlist != null) {
+        final moved = await SafDirectoryService.moveFile(
+          playlist['uri'].toString(),
+          targetUri,
+          playlistName,
+        );
+        if (!moved) {
+          _log.e(
+            '[M3U] Stopped organizing $folderBaseName because its existing playlist could not be moved.',
+          );
+          result.groupsFailed++;
+          continue;
+        }
         result.filesMoved++;
-      } else if (playlist == null) {
-        result.playlistsCreated++;
       }
       if (await SafDirectoryService.writeTextFile(
         targetUri,
         playlistName,
         '${playlistLines.join('\n')}\n',
       )) {
+        if (playlist == null) result.playlistsCreated++;
         final metadataTransfer =
             await ScraperRepository.transferMetadataToPlaylist(
               sourceRomPaths: sourceDiscPaths,
@@ -526,6 +551,9 @@ class RomFolderOrganizerService {
           }
         }
         result.groupsOrganized++;
+      } else {
+        _log.e('[M3U] Could not write playlist $playlistName.');
+        result.groupsFailed++;
       }
     }
   }


### PR DESCRIPTION
# Description

Prevents the multi-disc organizer from creating incomplete playlists when an Android Storage Access Framework (SAF) move fails.

- Stops the affected game immediately; no M3U, metadata, or media migration is produced for a partial group.
- Rolls back the newly created destination file when copying succeeds but deleting the source fails, preventing duplicate discs on retry.
- Reports the number of failed groups through a localized completion notification.

AI-assisted: Codex (GPT-5)

## Steps to Verify

**Preconditions:**

1. An Android device with a SAF-configured ROM directory containing a multi-disc game.
2. A storage provider or permission state that makes deletion of a source disc fail after the destination document has been created.

1. Open **Settings → Tools → Organize Multi-Disc Games**.
2. Run the organizer.
3. Verify that the affected game has no created or updated M3U playlist and its metadata is not migrated.
4. Verify that the source disc remains and the newly created destination copy is removed when rollback is permitted.
5. Verify that the completion notification reports the partial failure instead of remaining ongoing.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: no Android device with the reported SAF provider was available.

## Checklist

- [ ] `dart format .` — no diff
- [ ] `flutter analyze` — clean (no errors *or* warnings)
- [ ] `flutter test` — all passing
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [x] No hardcoded UI strings — everything goes through `AppLocale`

**The database**
- [ ] Column added to the versioned migration in `sqlite_migrations.dart` **and** the `CREATE TABLE` in `sqlite_service.dart`
- [ ] Migration number is above every slot in use on any open branch, not just `main` + 1
- [ ] Migration is idempotent (`PRAGMA table_info` guard) and has a test
- [ ] `_databaseVersion` bumped; new column selected in *every* system-loading query

**Navigation or a new screen**
- [ ] Every interactive element is reachable by D-pad, not just touch/mouse
- [ ] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()`
- [ ] B cancels / goes back, including out of a focused text field

**Android**
- [x] Path logic handles SAF `content://` URIs (`%2F`-encoded), not just desktop paths
- [ ] Verified on a device, not only on desktop

**`assets/systems/` or emulator launching**
- [ ] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible
- [ ] `assets/manifest.json` version bumped if this should reach existing installs OTA

</details>
