### PR TITLE
fix(games): release the carousel's input layer before the route pops

### DIFF
--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -658,7 +658,19 @@ class _SystemGamesListState extends State<SystemGamesList> {
     // Immediate resource termination.
     _stopVideoAndCleanup();
 
-    // Release current input layers.
+    // Release current input layers — all three of them.
+    //
+    // Only the view actually in use has a layer on the stack; popping the other
+    // two is a no-op that logs "not found in stack". Missing one is not: the
+    // route stays mounted for the length of the pop transition, so whichever
+    // layer is left behind is still the *top* one and goes on swallowing input
+    // on behalf of a screen that is being torn down. `games_carousel` was the
+    // one missing, and it is popped from the carousel's `dispose()` — which
+    // runs at the *end* of the pop. So backing out of a system in carousel view
+    // left the D-pad dead for the whole transition: the press played its nav
+    // sound and moved the dying carousel's own index, while the systems screen
+    // underneath never saw it.
+    GamepadNavigationManager.popLayer('games_carousel');
     GamepadNavigationManager.popLayer('games_grid');
     GamepadNavigationManager.popLayer('system_games_list');
 


### PR DESCRIPTION
# Description

Backing out of a system in **carousel view** left the D-pad dead for the length
of the transition. The press played its nav sound and moved nothing.

`_goBack` releases the games screen's input layers before popping the route, but
it only released two of the three. `games_carousel` is popped from the
carousel's own `dispose()`, which runs at the *end* of the pop, so for the whole
transition the dying carousel was still the top registered layer and went on
taking input on behalf of a screen being torn down. It handled the press, played
the sound and moved its own index. The systems screen underneath never saw it.

Grid and list views were unaffected, which is what made this look like a
transition problem rather than a teardown one: `games_grid` and
`system_games_list` were both already in that list.

Popping a layer the current view never pushed is a no-op that logs `not found in
stack`. The `games_grid` line already does exactly that on every carousel exit,
so the asymmetry was the bug, not the extra call.

## Steps to Reproduce

**Preconditions:** the games view set to carousel mode, on a system with enough
games to move between.

1. Open the system.
2. Press B to back out, and immediately press D-pad right.
3. The nav sound plays. The systems selection does not move.

## Steps to Verify

**Preconditions:** as above. Verified on an AYN Thor, carousel view, a 660-game
system.

1. Open the system, press B, immediately press D-pad right.
2. The systems selection moves.
3. Repeat in grid view and in list view. Both behave as they did before, since
   their layers were already released.

## Tested on

- [x] Android — device: AYN Thor
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

No test: the fault is in route teardown ordering, between `_goBack` and the
carousel's `dispose()`. Reproducing it needs a real pushed route mid-pop with a
live `GamepadNavigationManager` stack, which the existing manager tests do not
stand up. The device repro above is the check.

<details>
<summary><b>Extra checks — navigation</b></summary>

**Navigation or a new screen**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse
- [x] Full-screen routes push a `GamepadNavigationManager` layer in `initialize()` and pop it in `dispose()`
- [x] B cancels / goes back, including out of a focused text field

This PR is the other half of that second point: the layer is still popped in
`dispose()`, and `_goBack` now releases it up front as well, so the window
between the two stops swallowing input.

</details>
