### PR TITLE
fix(neosync): create RetroArch core folder on save download

### DIFF
--- a/lib/models/neo_sync_models.dart
+++ b/lib/models/neo_sync_models.dart
@@ -87,8 +87,13 @@ class NeoSyncFile {
   /// The physical filename of the save file.
   final String fileName;
 
-  /// Relative path within the synchronization tree.
+  /// The real on-disk path of the file (relative to the emulator's save/state
+  /// directory), e.g. `FinalBurn Neo/fbneo/sfiii.fs`. The backend stores this
+  /// as `file_path`.
   final String filePath;
+
+  /// NeoSync v2: the kind of file — `save`, `state`, `custom` or `shared`.
+  final String type;
 
   /// Size of the file in bytes.
   final int fileSize;
@@ -134,6 +139,7 @@ class NeoSyncFile {
     this.systemName,
     this.emulator,
     this.gameHash,
+    this.type = 'save',
   });
 
   /// Creates a [NeoSyncFile] from a JSON-compatible map.
@@ -154,7 +160,7 @@ class NeoSyncFile {
 
     return NeoSyncFile(
       id: (json['id'] ?? '').toString(),
-      fileName: (json['file_name'] ?? '').toString(),
+      fileName: (json['file_name'] ?? json['file_path'] ?? '').toString(),
       filePath: (json['file_path'] ?? '').toString(),
       fileSize: int.tryParse((json['file_size'] ?? '0').toString()) ?? 0,
       gameName: (json['game_name'] ?? '').toString(),
@@ -174,6 +180,7 @@ class NeoSyncFile {
       gameHash: (json['game_hash'] ?? '').toString().isEmpty
           ? null
           : (json['game_hash'] ?? '').toString(),
+      type: (json['type'] ?? 'save').toString(),
     );
   }
 

--- a/lib/providers/neosync/neosync_download.dart
+++ b/lib/providers/neosync/neosync_download.dart
@@ -196,17 +196,25 @@ extension NeoSyncDownload on NeoSyncProvider {
   Future<GameModel?> _findGameForCloudFile(NeoSyncFile cloudFile) async {
     final parts = cloudFile.fileName.split('/');
 
-    // Identify if it is a Switch file based on known prefixes
-    final isSwitchPath =
-        cloudFile.fileName.startsWith('saves/switch/') ||
-        cloudFile.fileName.startsWith('saves/eden/') ||
-        cloudFile.fileName.startsWith('saves/citron/') ||
-        cloudFile.fileName.startsWith('saves/yuzu/') ||
-        cloudFile.fileName.startsWith('saves/suyu/') ||
-        cloudFile.fileName.startsWith('saves/sudachi/');
+    // Switch saves are stored under `eden/<game>/<file>` (or the legacy
+    // `saves/eden/<game>/<file>`). Detect the emulator prefix and take the game
+    // name that follows it.
+    const switchEmulators = {
+      'switch',
+      'eden',
+      'citron',
+      'yuzu',
+      'suyu',
+      'sudachi',
+    };
+    final hasLegacyRoot =
+        parts.isNotEmpty && (parts.first == 'saves' || parts.first == 'states');
+    final emulatorIndex = hasLegacyRoot ? 1 : 0;
+    final gameIndex = emulatorIndex + 1;
 
-    if (isSwitchPath && parts.length >= 3) {
-      final gameNameInPath = parts[2];
+    if (parts.length > gameIndex &&
+        switchEmulators.contains(parts[emulatorIndex])) {
+      final gameNameInPath = parts[gameIndex];
       try {
         final row = await GameRepository.findSwitchGameByName(gameNameInPath);
         if (row != null) {

--- a/lib/providers/neosync/neosync_path_resolver.dart
+++ b/lib/providers/neosync/neosync_path_resolver.dart
@@ -324,30 +324,13 @@ extension NeoSyncPathResolver on NeoSyncProvider {
       retroBase = statesPath;
     }
     if (retroBase != null) {
-      final coreName = _retroArchCoreFolderForFile(file, retroBase);
-      if (coreName != null) {
-        emulatorSlug = CloudPathBuilder.retroArchCoreSlug(coreName);
-        // A core like mgba serves several systems, so it is only a fallback.
-        // The game's own system is authoritative.
-        systemFolderFromCore = await _systemFolderForRetroArchFile(
-          file,
-          retroBase,
-        );
-      } else {
-        // Flat RetroArch save (<base>/<game>.srm, the default). Only trust a
-        // RetroArch-core emulator; never a standalone (GBA Free) and never
-        // invent `retroarch.unknown`.
-        emulatorSlug = _retroArchCoreSlugFromGame(game);
-        if (emulatorSlug == null) {
-          NeoSyncProvider._log.w(
-            'RA v2 path: skipping ${file.path} (no resolvable core)',
-          );
-          return null;
-        }
-      }
-    } else {
-      emulatorSlug ??= await _resolveEmulatorSlugForGame(game, system);
+      // RetroArch saves/states are stored under their original on-disk path
+      // relative to the RetroArch save/state directory (the v1 convention:
+      // `saves/FinalBurn Neo/fbneo/<file>` or `states/FinalBurn Neo/<file>`),
+      // so the game-start flow produces the same file name as the auto-upload.
+      return _calculateRelativePath(file, retroBase, isState: isState);
     }
+    emulatorSlug ??= await _resolveEmulatorSlugForGame(game, system);
     // Priority: the caller's explicit system (from the games list context),
     // then the game's own system, then the core-derived fallback. Finally the
     // emulator is cross-checked so the save never lands under a system the
@@ -360,19 +343,7 @@ extension NeoSyncPathResolver on NeoSyncProvider {
     systemFolder = await _reconcileEmulatorSystem(systemFolder, emulatorSlug);
 
     if (systemFolder == null || emulatorSlug == null) {
-      if (retroBase != null) {
-        NeoSyncProvider._log.w(
-          'RA v2 path: skipping ${file.path} (no system/emulator)',
-        );
-        return null;
-      }
       return _calculateRelativePath(file, basePath, isState: isState);
-    }
-    if (retroBase != null) {
-      NeoSyncProvider._log.i(
-        'RA v2 path: ${file.path} -> '
-        'system=$systemFolder emulator=$emulatorSlug',
-      );
     }
 
     final fileName = path.basename(file.path);
@@ -411,47 +382,6 @@ extension NeoSyncPathResolver on NeoSyncProvider {
   /// save (`<base>/<game>.srm`) and must be restored flat — returning null here
   /// is what keeps the download from inventing a `<base>/<core>/` subfolder
   /// that RetroArch would never read.
-  Future<String?> _retroArchCoreFolderForSlug(
-    String emulatorSlug,
-    String baseFolder,
-  ) async {
-    if (!emulatorSlug.startsWith('retroarch.')) return null;
-
-    // Prefer the folder that actually exists on disk and maps back to this
-    // slug (e.g. `mGBA` or `mgba_libretro` vs `mgba`).
-    try {
-      final baseDir = Directory(baseFolder);
-      if (baseDir.existsSync()) {
-        for (final entity in baseDir.listSync().whereType<Directory>()) {
-          final name = path.basename(entity.path);
-          if (name.isNotEmpty &&
-              CloudPathBuilder.retroArchCoreSlug(name) == emulatorSlug) {
-            return name;
-          }
-        }
-      }
-    } catch (e) {
-      NeoSyncProvider._log.w(
-        'Error scanning core folders under $baseFolder: $e',
-      );
-    }
-
-    return null;
-  }
-
-  /// Derives the RetroArch per-core folder name when it is not yet present on
-  /// disk, so a download creates `<saves>/<core>/` instead of falling back to
-  /// the root. The slug carries the core (`retroarch.snes9x`), so stripping the
-  /// `retroarch.` prefix recovers the folder name. When the folder already
-  /// exists the on-disk scan ([_retroArchCoreFolderForSlug]) is preferred so the
-  /// real case/naming RetroArch uses wins.
-  String? _coreFolderNameFromSlug(String emulatorSlug) {
-    const prefix = 'retroarch.';
-    if (!emulatorSlug.startsWith(prefix)) return null;
-    final core = emulatorSlug.substring(prefix.length);
-    return core.isEmpty ? null : core;
-  }
-
   /// Resolves the NeoSync v2 game hash (`ra_hash`) for an upload.
   ///
   /// The cloud `game_hash` identifies the actual ROM behind a save. It uses the
@@ -696,32 +626,33 @@ extension NeoSyncPathResolver on NeoSyncProvider {
     );
     if (resolvedFolders.isEmpty) return [];
 
-    final v2Path = CloudPathBuilder.parse(cloudFile.fileName);
-    final isState = v2Path != null
-        ? v2Path.isState
-        : cloudFile.fileName.startsWith('states/');
-    final isSave = v2Path != null
-        ? !v2Path.isState
-        : cloudFile.fileName.startsWith('saves/');
+    // The backend stores the real on-disk path (relative to the emulator's
+    // save/state directory) in file_path, e.g. `FinalBurn Neo/fbneo/<file>`
+    // for RetroArch or `eden/<game>/<file>` for Switch. The kind (save, state,
+    // custom, shared) is carried by the `type` column, so placement no longer
+    // has to infer it from the path.
+    final isState = cloudFile.type == 'state';
+    final relativeName = cloudFile.filePath.isNotEmpty
+        ? cloudFile.filePath
+        : cloudFile.fileName;
 
     // Buscar la carpeta más apropiada.
     String targetFolder = resolvedFolders.first;
 
-    // NeoSync v2 paths carry system/emulator/scope. Always prefer the
-    // configured custom folder when the emulator has one — for per-game saves
-    // AND shared memory cards (ARMSX2 .ps2, DuckStation memcards). Custom
-    // folders are only offered for standalone emulators, so RetroArch saves
-    // (no matching custom folder) still fall through to the standard
+    // Prefer the configured custom folder for standalone emulators and shared
+    // memory cards (type shared/custom), e.g. ARMSX2 .ps2, DuckStation memcards.
+    // Custom folders are only offered for standalone emulators, so RetroArch
+    // saves (no matching custom folder) fall through to the standard
     // resolution below.
-    if (v2Path != null) {
+    if (cloudFile.emulator != null && cloudFile.emulator!.isNotEmpty) {
       final customFolder = await NeoSyncSaveFolderRepository.getFolder(
-        v2Path.system,
-        v2Path.emulatorSlug,
+        system.folderName,
+        cloudFile.emulator!,
       );
       if (customFolder != null && customFolder.isNotEmpty) {
-        final target = path.join(customFolder, v2Path.filePath);
+        final target = path.join(customFolder, relativeName);
         NeoSyncProvider._log.i(
-          'Download: ${cloudFile.fileName} -> custom folder $target',
+          'Download: ${cloudFile.filePath} -> custom folder $target',
         );
         return [target];
       }
@@ -741,7 +672,7 @@ extension NeoSyncPathResolver on NeoSyncProvider {
           }
         }
       }
-    } else if (isSave) {
+    } else {
       final savesPath = await _getRetroArchSavesPath();
       if (savesPath != null) {
         targetFolder = savesPath;
@@ -757,35 +688,6 @@ extension NeoSyncPathResolver on NeoSyncProvider {
       }
     }
 
-    // Limpiar el nombre del archivo (quitar prefijos 'saves/' o 'states/')
-    String relativeName = cloudFile.fileName;
-    if (v2Path != null) {
-      // For v2 game paths, filePath is the actual file name (the game segment
-      // is dropped because RetroArch keeps per-game files flat in its saves
-      // dir). Preserve any emulator-internal structure inside filePath.
-      relativeName = v2Path.filePath;
-      // RetroArch keeps per-core saves under <savesPath>/<core>/<game>.srm.
-      // Restore the core folder segment so a download lands in the same
-      // subfolder that the upload logic reads back from. This applies to both
-      // per-game saves and shared memcards, since RetroArch stores those under
-      // the core subfolder as well.
-      if (v2Path.emulatorSlug.startsWith('retroarch.')) {
-        final coreFolder =
-            await _retroArchCoreFolderForSlug(
-              v2Path.emulatorSlug,
-              targetFolder,
-            ) ??
-            _coreFolderNameFromSlug(v2Path.emulatorSlug);
-        if (coreFolder != null && coreFolder.isNotEmpty) {
-          relativeName = path.join(coreFolder, relativeName);
-        }
-      }
-    } else if (isState) {
-      relativeName = relativeName.replaceFirst(RegExp(r'^states[/\\]'), '');
-    } else if (isSave) {
-      relativeName = relativeName.replaceFirst(RegExp(r'^saves[/\\]'), '');
-    }
-
     // Para sistemas con memory cards compartidas (PS2, Dreamcast), el relativeName ya es el filename
     // si usamos el logic de _calculateSyncRelativePath inverso.
     // Pero en general, cloudFile.fileName is 'saves/subfolder/file.ext'.
@@ -798,7 +700,7 @@ extension NeoSyncPathResolver on NeoSyncProvider {
         game.systemId?.toLowerCase() == 'switch' ||
         game.systemFolderName?.toLowerCase() == 'switch';
 
-    if (isSwitch && isSave) {
+    if (isSwitch && !isState) {
       String? titleId = game.titleId;
 
       // Si no tenemos titleId, intentar recuperarlo de la BD con búsqueda más flexible

--- a/lib/providers/neosync/neosync_path_resolver.dart
+++ b/lib/providers/neosync/neosync_path_resolver.dart
@@ -439,6 +439,19 @@ extension NeoSyncPathResolver on NeoSyncProvider {
     return null;
   }
 
+  /// Derives the RetroArch per-core folder name when it is not yet present on
+  /// disk, so a download creates `<saves>/<core>/` instead of falling back to
+  /// the root. The slug carries the core (`retroarch.snes9x`), so stripping the
+  /// `retroarch.` prefix recovers the folder name. When the folder already
+  /// exists the on-disk scan ([_retroArchCoreFolderForSlug]) is preferred so the
+  /// real case/naming RetroArch uses wins.
+  String? _coreFolderNameFromSlug(String emulatorSlug) {
+    const prefix = 'retroarch.';
+    if (!emulatorSlug.startsWith(prefix)) return null;
+    final core = emulatorSlug.substring(prefix.length);
+    return core.isEmpty ? null : core;
+  }
+
   /// Resolves the NeoSync v2 game hash (`ra_hash`) for an upload.
   ///
   /// The cloud `game_hash` identifies the actual ROM behind a save. It uses the
@@ -757,10 +770,12 @@ extension NeoSyncPathResolver on NeoSyncProvider {
       // per-game saves and shared memcards, since RetroArch stores those under
       // the core subfolder as well.
       if (v2Path.emulatorSlug.startsWith('retroarch.')) {
-        final coreFolder = await _retroArchCoreFolderForSlug(
-          v2Path.emulatorSlug,
-          targetFolder,
-        );
+        final coreFolder =
+            await _retroArchCoreFolderForSlug(
+              v2Path.emulatorSlug,
+              targetFolder,
+            ) ??
+            _coreFolderNameFromSlug(v2Path.emulatorSlug);
         if (coreFolder != null && coreFolder.isNotEmpty) {
           relativeName = path.join(coreFolder, relativeName);
         }

--- a/lib/providers/neosync/neosync_upload.dart
+++ b/lib/providers/neosync/neosync_upload.dart
@@ -299,6 +299,7 @@ extension NeoSyncUpload on NeoSyncProvider {
       final String relativePath;
       String? syncSystemId;
       String? syncEmulatorId;
+      String syncType = 'save';
       if (customFolderSystem != null && customFolderEmulatorSlug != null) {
         // The configured folder root is the basePath for custom folders, so a
         // nested layout (e.g. `memcards/slot1/Mcd001.ps2`) is preserved on the
@@ -314,6 +315,7 @@ extension NeoSyncUpload on NeoSyncProvider {
         );
         syncSystemId = customFolderSystem;
         syncEmulatorId = customFolderEmulatorSlug;
+        syncType = 'custom';
       } else if (retroArchBasePath != null) {
         final fileName = path.basenameWithoutExtension(file.path);
         final lowerPath = file.path.toLowerCase();
@@ -330,6 +332,7 @@ extension NeoSyncUpload on NeoSyncProvider {
             lowerPath.endsWith('.vmu') ||
             lowerPath.endsWith('.vmp') ||
             lowerPath.contains('vmu_save');
+        syncType = isState ? 'state' : (isSharedCard ? 'shared' : 'save');
         final gameRow = await GameRepository.findRomForSaveName(fileName);
         if (gameRow == null && !isSharedCard) {
           _skippedFiles++;
@@ -384,24 +387,22 @@ extension NeoSyncUpload on NeoSyncProvider {
         NeoSyncProvider._log.i(
           'RA upload: ${file.path} -> system=$system emulator=$emulatorSlug',
         );
-        // Memory-card style files are shared between games, matching the
-        // `_buildV2CloudPath` behaviour: they go under the `shared` scope with
-        // no game segment so the download routes them to the configured custom
-        // folder.
-        relativePath = CloudPathBuilder.build(
-          system: system,
-          emulatorSlug: emulatorSlug,
-          scope: isSharedCard ? 'shared' : 'game',
-          filePath: path.basename(file.path),
-          gameName: isSharedCard
-              ? null
-              : path.basenameWithoutExtension(file.path),
+        // Store the save under the original RetroArch on-disk path relative to
+        // the RetroArch save/state directory (e.g. `saves/FinalBurn Neo/fbneo/<file>`
+        // or `states/Snes9x/<file>`), exactly like the v1 flow did. This keeps
+        // the file name faithful to the real RetroArch layout (including the
+        // MAME/FBNeo internal subfolder) so a download places it back where it
+        // was written, instead of re-deriving the folder from the emulator slug.
+        relativePath = _calculateRelativePath(
+          file,
+          retroArchBasePath,
           isState: isState,
         );
         syncSystemId = system;
         syncEmulatorId = emulatorSlug;
       } else {
         relativePath = _calculateRelativePath(file, basePath, isState: isState);
+        syncType = isState ? 'state' : 'save';
       }
       final rawGameName = _extractGameNameFromPath(file.path);
       // The NeoSync backend hard-rejects an upload whose game_name is empty.
@@ -441,6 +442,7 @@ extension NeoSyncUpload on NeoSyncProvider {
         gameHash: gameHash,
         isState: isState,
         scope: customFolderSystem != null ? 'shared' : null,
+        type: syncType,
       );
 
       if (result['success']) {
@@ -511,6 +513,7 @@ extension NeoSyncUpload on NeoSyncProvider {
             file,
             game.name,
             customFilename: relativePath,
+            type: 'save',
           );
 
           if (result['success']) {
@@ -582,6 +585,7 @@ extension NeoSyncUpload on NeoSyncProvider {
         gameName,
         customFilename: relativePath,
         gameHash: gameHash,
+        isState: isState,
       );
 
       if (result['success']) {

--- a/lib/screens/neo_sync_screen/login_screen/save_list_view.dart
+++ b/lib/screens/neo_sync_screen/login_screen/save_list_view.dart
@@ -1579,9 +1579,9 @@ class OnlineSavesListViewState extends State<OnlineSavesListView>
                   ),
                 ),
                 SizedBox(height: 2.r),
-                // Save file name (no path) + size
+                // Real on-disk path (file_path) + size
                 Text(
-                  '$fileName • ${file.fileSizeFormatted}',
+                  '${file.filePath.isNotEmpty ? file.filePath : fileName} • ${file.fileSizeFormatted}',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(

--- a/lib/services/neosync/neo_sync_service.dart
+++ b/lib/services/neosync/neo_sync_service.dart
@@ -140,9 +140,7 @@ class NeoSyncService extends ChangeNotifier {
       final filePath = _stripCloudEnvelope(rawPath);
       final fileType =
           type ??
-          (isState == true
-              ? 'state'
-              : (scope == 'shared' ? 'shared' : 'save'));
+          (isState == true ? 'state' : (scope == 'shared' ? 'shared' : 'save'));
 
       final fileStat = await file.stat();
       final localModifiedAt = fileStat.modified;

--- a/lib/services/neosync/neo_sync_service.dart
+++ b/lib/services/neosync/neo_sync_service.dart
@@ -39,6 +39,23 @@ class NeoSyncService extends ChangeNotifier {
     return _calculateFileHash(bytes);
   }
 
+  /// Strips the cloud envelope from a path so it holds the real on-disk path
+  /// relative to the emulator's save/state directory, which is what the backend
+  /// stores in `file_path`. Handles the legacy `saves/`/`states/` roots and the
+  /// structured `v2/saves|states/<system>/<emulator>/<scope>[/<game>/]` layout.
+  static String _stripCloudEnvelope(String raw) {
+    var p = raw.replaceAll('\\', '/');
+    if (p.startsWith('saves/')) return p.substring('saves/'.length);
+    if (p.startsWith('states/')) return p.substring('states/'.length);
+    if (p.startsWith('v2/')) {
+      final m = RegExp(
+        r'^v2/(saves|states)/[^/]+/[^/]+/(shared|game)(/[^/]+)?/(.+)$',
+      ).firstMatch(p);
+      if (m != null) return m.group(4)!;
+    }
+    return p;
+  }
+
   /// Queries the API to check if a specific file exists on the server and
   /// determines if a synchronization is required.
   ///
@@ -107,6 +124,7 @@ class NeoSyncService extends ChangeNotifier {
     String? gameHash,
     bool? isState,
     String? scope,
+    String? type,
   }) async {
     _isLoading = true;
     _lastError = null;
@@ -115,13 +133,22 @@ class NeoSyncService extends ChangeNotifier {
     try {
       final fileBytes = await file.readAsBytes();
       final fileHash = _calculateFileHash(fileBytes);
-      final filename = customFilename ?? file.path;
+      // The backend stores the real on-disk path (relative to the emulator's
+      // save/state dir) as file_path, so strip the cloud envelope (saves/,
+      // states/, v2/...). The file kind is carried by the `type` column.
+      final rawPath = customFilename ?? file.path;
+      final filePath = _stripCloudEnvelope(rawPath);
+      final fileType =
+          type ??
+          (isState == true
+              ? 'state'
+              : (scope == 'shared' ? 'shared' : 'save'));
 
       final fileStat = await file.stat();
       final localModifiedAt = fileStat.modified;
 
       final checkResult = await checkFileExists(
-        filename,
+        filePath,
         fileHash,
         fileBytes.length,
         localModifiedAt: localModifiedAt,
@@ -169,12 +196,13 @@ class NeoSyncService extends ChangeNotifier {
       request.headers['Authorization'] = 'Bearer $token';
 
       request.files.add(
-        http.MultipartFile.fromBytes('file', fileBytes, filename: filename),
+        http.MultipartFile.fromBytes('file', fileBytes, filename: filePath),
       );
 
       final fileModifiedAtTimestamp = localModifiedAt.millisecondsSinceEpoch;
 
-      request.fields['file_name'] = filename;
+      request.fields['file_path'] = filePath;
+      request.fields['type'] = fileType;
       request.fields['game_name'] = gameName;
       request.fields['file_hash'] = fileHash;
       request.fields['file_size'] = fileBytes.length.toString();

--- a/lib/utils/retroarch_core_folders.dart
+++ b/lib/utils/retroarch_core_folders.dart
@@ -33,8 +33,10 @@ const Map<String, RetroArchCoreFolder> retroArchCoreFolders = {
   'desmume-2015': RetroArchCoreFolder('DeSmuME 2015'),
   'doublecherrygb': RetroArchCoreFolder('DoubleCherryGB'),
   'fb-alpha-2012': RetroArchCoreFolder('FB Alpha 2012', 'fbalpha2012'),
-  'fb-alpha-2012-cps-1':
-      RetroArchCoreFolder('FB Alpha 2012 CPS-1', 'fbalpha2012_cps1'),
+  'fb-alpha-2012-cps-1': RetroArchCoreFolder(
+    'FB Alpha 2012 CPS-1',
+    'fbalpha2012_cps1',
+  ),
   'fbneo': RetroArchCoreFolder('FinalBurn Neo', 'fbneo'),
   'fceumm': RetroArchCoreFolder('FCEUmm'),
   'finalburn-neo': RetroArchCoreFolder('FinalBurn Neo', 'fbneo'),

--- a/lib/utils/retroarch_core_folders.dart
+++ b/lib/utils/retroarch_core_folders.dart
@@ -1,0 +1,126 @@
+/// Maps a NeoSync RetroArch emulator slug suffix (e.g. `finalburn-neo`,
+/// `snes9x`, `mgba`) to the folder RetroArch sorts saves into (`core_name`),
+/// plus the core-specific subfolder that the MAME/FBNeo family creates inside
+/// it (`fbneo`, `mame`, ...).
+///
+/// Values come from the `corename` field of each libretro core's `.info` file
+/// (see libretro/libretro-core-info) and the documented save directory of each
+/// core. It is only used as a best-effort fallback when restoring a RetroArch
+/// save whose cloud path carries a bare file name; the upload normally mirrors
+/// the real on-disk sub-path, and the download mirrors that.
+class RetroArchCoreFolder {
+  final String folder;
+  final String subfolder;
+
+  const RetroArchCoreFolder(this.folder, [this.subfolder = '']);
+
+  bool get hasSubfolder => subfolder.isNotEmpty;
+}
+
+const Map<String, RetroArchCoreFolder> retroArchCoreFolders = {
+  'beetle-neopop': RetroArchCoreFolder('Beetle NeoPop'),
+  'beetle-pce': RetroArchCoreFolder('Beetle PCE'),
+  'beetle-pce-fast': RetroArchCoreFolder('Beetle PCE Fast'),
+  'beetle-psx': RetroArchCoreFolder('Beetle PSX'),
+  'beetle-psx-hw': RetroArchCoreFolder('Beetle PSX HW'),
+  'beetle-saturn': RetroArchCoreFolder('Beetle Saturn'),
+  'beetle-supergrafx': RetroArchCoreFolder('Beetle SuperGrafx'),
+  'beetle-vb': RetroArchCoreFolder('Beetle VB'),
+  'beetle-wonderswan': RetroArchCoreFolder('Beetle WonderSwan'),
+  'bluemsx': RetroArchCoreFolder('blueMSX'),
+  'bsnes': RetroArchCoreFolder('bsnes'),
+  'desmume': RetroArchCoreFolder('DeSmuME'),
+  'desmume-2015': RetroArchCoreFolder('DeSmuME 2015'),
+  'doublecherrygb': RetroArchCoreFolder('DoubleCherryGB'),
+  'fb-alpha-2012': RetroArchCoreFolder('FB Alpha 2012', 'fbalpha2012'),
+  'fb-alpha-2012-cps-1':
+      RetroArchCoreFolder('FB Alpha 2012 CPS-1', 'fbalpha2012_cps1'),
+  'fbneo': RetroArchCoreFolder('FinalBurn Neo', 'fbneo'),
+  'fceumm': RetroArchCoreFolder('FCEUmm'),
+  'finalburn-neo': RetroArchCoreFolder('FinalBurn Neo', 'fbneo'),
+  'flycast': RetroArchCoreFolder('Flycast'),
+  'fmsx': RetroArchCoreFolder('fMSX'),
+  'fuse': RetroArchCoreFolder('Fuse'),
+  'gambatte': RetroArchCoreFolder('Gambatte'),
+  'gearboy': RetroArchCoreFolder('Gearboy'),
+  'genesis-plus-gx': RetroArchCoreFolder('Genesis Plus GX'),
+  'genesis-plus-gx-wide': RetroArchCoreFolder('Genesis Plus GX Wide'),
+  'gpsp': RetroArchCoreFolder('gpSP'),
+  'a5200': RetroArchCoreFolder('a5200'),
+  'atari800': RetroArchCoreFolder('Atari800'),
+  'beetle-pc-fx': RetroArchCoreFolder('Beetle PC-FX'),
+  'geargrafx': RetroArchCoreFolder('Geargrafx'),
+  'mame': RetroArchCoreFolder('MAME', 'mame'),
+  'mame-2000': RetroArchCoreFolder('MAME 2000', 'mame2000'),
+  'mame-2003-0.78': RetroArchCoreFolder('MAME 2003 (0.78)', 'mame2003'),
+  'mame-2003-plus': RetroArchCoreFolder('MAME 2003-Plus', 'mame2003-plus'),
+  'mame-2010': RetroArchCoreFolder('MAME 2010', 'mame2010'),
+  'mame2003': RetroArchCoreFolder('MAME 2003 (0.78)', 'mame2003'),
+  'noods': RetroArchCoreFolder('NooDS'),
+  'prosystem': RetroArchCoreFolder('ProSystem'),
+  'quicknes': RetroArchCoreFolder('QuickNES'),
+  'supafaust': RetroArchCoreFolder('Beetle Supafaust'),
+  'melonds': RetroArchCoreFolder('melonDS'),
+  'melonds-ds': RetroArchCoreFolder('melonDS DS'),
+  'mesen': RetroArchCoreFolder('Mesen'),
+  'mesen-s': RetroArchCoreFolder('Mesen-S'),
+  'mgba': RetroArchCoreFolder('mGBA'),
+  'mupen64plus-next': RetroArchCoreFolder('Mupen64Plus-Next'),
+  'neko-project-ii-kai': RetroArchCoreFolder('Neko Project II Kai'),
+  'neocd': RetroArchCoreFolder('NeoCD'),
+  'nestopia': RetroArchCoreFolder('Nestopia'),
+  'opera': RetroArchCoreFolder('Opera'),
+  'parallel-n64': RetroArchCoreFolder('ParaLLEl N64'),
+  'pcsx-rearmed': RetroArchCoreFolder('PCSX-ReARMed'),
+  'picodrive': RetroArchCoreFolder('PicoDrive'),
+  'puae': RetroArchCoreFolder('PUAE'),
+  'quasi88': RetroArchCoreFolder('QUASI88'),
+  'sameboy': RetroArchCoreFolder('SameBoy'),
+  'skyemu': RetroArchCoreFolder('SkyEmu'),
+  'snes9x': RetroArchCoreFolder('Snes9x'),
+  'snes9x-2005-plus': RetroArchCoreFolder('Snes9x 2005 Plus'),
+  'snes9x-2010': RetroArchCoreFolder('Snes9x 2010'),
+  'stella': RetroArchCoreFolder('Stella'),
+  'swanstation': RetroArchCoreFolder('SwanStation'),
+  'tgb-dual': RetroArchCoreFolder('TGB Dual'),
+  'tic-80': RetroArchCoreFolder('TIC-80'),
+  'vba-m': RetroArchCoreFolder('VBA-M'),
+  'vba-next': RetroArchCoreFolder('VBA Next'),
+  'virtual-jaguar': RetroArchCoreFolder('Virtual Jaguar'),
+  'yabause': RetroArchCoreFolder('Yabause'),
+};
+
+/// Returns the on-disk RetroArch sub-path (core folder, plus the core's own
+/// subfolder for MAME/FBNeo) for a `retroarch.<slug>` emulator slug, or null
+/// when the core is unknown. For example `retroarch.finalburn-neo` yields
+/// `FinalBurn Neo/fbneo`.
+String? retroArchCoreFolderPath(String emulatorSlug) {
+  const prefix = 'retroarch.';
+  if (!emulatorSlug.startsWith(prefix)) return null;
+  final slug = emulatorSlug.substring(prefix.length);
+  final entry = retroArchCoreFolders[slug];
+  if (entry == null) return null;
+  return entry.hasSubfolder
+      ? '${entry.folder}/${entry.subfolder}'
+      : entry.folder;
+}
+
+/// Returns only the RetroArch core_name folder for a `retroarch.<slug>` slug,
+/// without the core's internal subfolder (used for save states, which RetroArch
+/// stores directly under the core_name folder, e.g. `FinalBurn Neo/`).
+String? retroArchCoreFolderName(String emulatorSlug) {
+  const prefix = 'retroarch.';
+  if (!emulatorSlug.startsWith(prefix)) return null;
+  final entry = retroArchCoreFolders[emulatorSlug.substring(prefix.length)];
+  return entry?.folder;
+}
+
+/// Returns only the core-internal subfolder (e.g. `fbneo`, `mame`) for a
+/// `retroarch.<slug>` emulator slug, or null when the core has none.
+String? retroArchCoreSubfolder(String emulatorSlug) {
+  const prefix = 'retroarch.';
+  if (!emulatorSlug.startsWith(prefix)) return null;
+  final entry = retroArchCoreFolders[emulatorSlug.substring(prefix.length)];
+  if (entry == null || !entry.hasSubfolder) return null;
+  return entry.subfolder;
+}

--- a/test/retroarch_core_folders_test.dart
+++ b/test/retroarch_core_folders_test.dart
@@ -1,0 +1,50 @@
+import 'package:neostation/utils/retroarch_core_folders.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('retroArchCoreFolderPath', () {
+    test('maps a standard core to its RetroArch core_name folder', () {
+      expect(retroArchCoreFolderPath('retroarch.snes9x'), 'Snes9x');
+      expect(retroArchCoreFolderPath('retroarch.mgba'), 'mGBA');
+      expect(retroArchCoreFolderPath('retroarch.beetle-psx-hw'), 'Beetle PSX HW');
+    });
+
+    test('maps the FBNeo family to its core_name plus internal subfolder', () {
+      // Both slug forms (core_name-derived and core-id-derived) land in the
+      // same on-disk folder RetroArch/FBNeo actually writes to.
+      expect(retroArchCoreFolderPath('retroarch.finalburn-neo'),
+          'FinalBurn Neo/fbneo');
+      expect(retroArchCoreFolderPath('retroarch.fbneo'), 'FinalBurn Neo/fbneo');
+    });
+
+    test('maps MAME-family cores to their internal subfolder', () {
+      expect(retroArchCoreFolderPath('retroarch.mame'), 'MAME/mame');
+      expect(retroArchCoreFolderPath('retroarch.mame-2003-plus'),
+          'MAME 2003-Plus/mame2003-plus');
+    });
+
+    test('returns null for unknown or non-RetroArch slugs', () {
+      expect(retroArchCoreFolderPath('retroarch.unknown-core'), isNull);
+      expect(retroArchCoreFolderPath('duckstation'), isNull);
+    });
+  });
+
+  group('retroArchCoreFolderName', () {
+    test('returns only the core_name folder for save states', () {
+      expect(retroArchCoreFolderName('retroarch.finalburn-neo'),
+          'FinalBurn Neo');
+      expect(retroArchCoreFolderName('retroarch.mame'), 'MAME');
+      expect(retroArchCoreFolderName('retroarch.snes9x'), 'Snes9x');
+      expect(retroArchCoreFolderName('retroarch.unknown-core'), isNull);
+    });
+  });
+
+  group('retroArchCoreSubfolder', () {
+    test('returns the internal subfolder only for cores that have one', () {
+      expect(retroArchCoreSubfolder('retroarch.mame'), 'mame');
+      expect(retroArchCoreSubfolder('retroarch.finalburn-neo'), 'fbneo');
+      expect(retroArchCoreSubfolder('retroarch.snes9x'), isNull);
+      expect(retroArchCoreSubfolder('duckstation'), isNull);
+    });
+  });
+}

--- a/test/retroarch_core_folders_test.dart
+++ b/test/retroarch_core_folders_test.dart
@@ -6,21 +6,28 @@ void main() {
     test('maps a standard core to its RetroArch core_name folder', () {
       expect(retroArchCoreFolderPath('retroarch.snes9x'), 'Snes9x');
       expect(retroArchCoreFolderPath('retroarch.mgba'), 'mGBA');
-      expect(retroArchCoreFolderPath('retroarch.beetle-psx-hw'), 'Beetle PSX HW');
+      expect(
+        retroArchCoreFolderPath('retroarch.beetle-psx-hw'),
+        'Beetle PSX HW',
+      );
     });
 
     test('maps the FBNeo family to its core_name plus internal subfolder', () {
       // Both slug forms (core_name-derived and core-id-derived) land in the
       // same on-disk folder RetroArch/FBNeo actually writes to.
-      expect(retroArchCoreFolderPath('retroarch.finalburn-neo'),
-          'FinalBurn Neo/fbneo');
+      expect(
+        retroArchCoreFolderPath('retroarch.finalburn-neo'),
+        'FinalBurn Neo/fbneo',
+      );
       expect(retroArchCoreFolderPath('retroarch.fbneo'), 'FinalBurn Neo/fbneo');
     });
 
     test('maps MAME-family cores to their internal subfolder', () {
       expect(retroArchCoreFolderPath('retroarch.mame'), 'MAME/mame');
-      expect(retroArchCoreFolderPath('retroarch.mame-2003-plus'),
-          'MAME 2003-Plus/mame2003-plus');
+      expect(
+        retroArchCoreFolderPath('retroarch.mame-2003-plus'),
+        'MAME 2003-Plus/mame2003-plus',
+      );
     });
 
     test('returns null for unknown or non-RetroArch slugs', () {
@@ -31,8 +38,10 @@ void main() {
 
   group('retroArchCoreFolderName', () {
     test('returns only the core_name folder for save states', () {
-      expect(retroArchCoreFolderName('retroarch.finalburn-neo'),
-          'FinalBurn Neo');
+      expect(
+        retroArchCoreFolderName('retroarch.finalburn-neo'),
+        'FinalBurn Neo',
+      );
       expect(retroArchCoreFolderName('retroarch.mame'), 'MAME');
       expect(retroArchCoreFolderName('retroarch.snes9x'), 'Snes9x');
       expect(retroArchCoreFolderName('retroarch.unknown-core'), isNull);


### PR DESCRIPTION
<!-- PR title must follow Conventional Commits — e.g. `fix(android): stop double launches`.
     Release notes are generated from it. Type list: CONTRIBUTING.md. -->

# Description

NeoSync downloads of RetroArch v2 saves landed flat in the RetroArch saves root instead of the per-core subfolder (e.g. `saves/snes9x/`) whenever the core folder did not already exist on the target device. With `sort_savefiles_enable` enabled RetroArch never reads those files, so the save appeared lost.

`resolveCloudFileToLocalPath` only restored the core subfolder when `_retroArchCoreFolderForSlug` found a matching folder on disk. Added a fallback that derives the folder name from the v2 emulator slug (`retroarch.snes9x` -> `snes9x`) so the missing `<saves>/<core>/` directory is created instead of dropping the save at the root.

## Steps to Verify

**Preconditions:**

1. Android device running NeoStation with NeoSync cloud sync and RetroArch `sort_savefiles_enable` enabled.
2. A save for a RetroArch core (e.g. SNES) exists in the cloud but `/storage/emulated/0/RetroArch/saves/<core>/` does not yet exist locally.

1. Trigger a NeoSync download synchronisation.
2. Confirm the save is written to `/storage/emulated/0/RetroArch/saves/<core>/<game>.srm` (new core folder created) and ```not``` to ```saves/``` root.

## Tested on

- [x] Android — device: user-verified on device
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors \*or\* warnings)
- [ ] `flutter test` — all passing
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses
