### PR TITLE
Update launch arguments to use file.path for the Xenra emulator

### DIFF
--- a/assets/systems/xbox360.json
+++ b/assets/systems/xbox360.json
@@ -82,7 +82,7 @@
       "description": "Supported extensions: iso.",
       "platforms": {
         "android": {
-          "launch_arguments": "-n Ali.Xanite.green/Ali.Xanite.LauncherActivity -d \"{file.uri}\""
+          "launch_arguments": "-n Ali.Xanite.green/Ali.Xanite.LauncherActivity -d \"{file.path}\""
         }
       }
     },


### PR DESCRIPTION
For some reason after the neostation update an error showed under file.uri saying to insert disc so changing the launch argument to file.path fixed the issue

This has only effected the Xbox 360 version of this emulator and there hasn't been a new update from the emulator so I think it is because of the latest neostation update.

