### PR TITLE
feat(vita): add Vita3K Plus for Android

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.22"
+  "latest_version": "0.3.23"
 }

--- a/assets/systems/vita.json
+++ b/assets/systems/vita.json
@@ -65,6 +65,17 @@
       }
     },
 	{
+      "name": "Standalone Vita3K Plus",
+      "unique_id": "vita.vita3k.plus",
+      "description": "Supported extensions: psvita.",
+      "is_retroachievements_compatible": false,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n org.vita3k.emulator/org.vita3k.emulator.Emulator --esa AppStartParameters \"-r,{tags.vita_game_id}\""
+        }
+      }
+    },
+	{
       "name": "Standalone EmucoreV",
       "unique_id": "vita.emucorev",
       "description": "Supported extensions: dpt.",


### PR DESCRIPTION
## Description

Adds Vita3K Plus as a selectable standalone Android emulator for PS Vita. The definition launches org.vita3k.emulator.Emulator with the Vita title ID.

Vita3K Plus retains the standard Vita3K Android package ID, so Android cannot install both variants side-by-side.

## Steps to Verify

1. Install Vita3K Plus on an Android device.
2. Choose Standalone Vita3K Plus for a PS Vita game with a title ID.
3. Launch the game and confirm Vita3K Plus opens it.

## Tested on

- Not runtime-tested: configuration-only change; no Android device available.

## Checks

- flutter test test/emulator_seed_default_test.dart
- Systems manifest version bumped for OTA delivery
- Emulator launch configured in JSON