### PR TITLE
build(android): ship per-ABI APKs instead of one universal build

### DIFF
--- a/build-utils/build-android.ps1
+++ b/build-utils/build-android.ps1
@@ -7,7 +7,7 @@ param(
 
 Write-Host "Building Flutter Android APK..." -ForegroundColor Green
 
-# Verificar que estamos en el directorio correcto
+# Verify we are in the correct directory
 $projectRoot = Split-Path -Parent $PSScriptRoot
 
 # Build release APK
@@ -33,14 +33,14 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-# Obtener versión del pubspec.yaml
+# Get version from pubspec.yaml
 $version = (Select-String -Path "$projectRoot\pubspec.yaml" -Pattern "^version:\s*(.+)" | ForEach-Object { $_.Matches.Groups[1].Value }).Trim()
 
-# Crear directorio de salida
+# Create output directory
 Write-Host "Creating output directory..." -ForegroundColor Cyan
 New-Item -ItemType Directory -Path "$projectRoot\release" -Force | Out-Null
 
-# Copiar y renombrar APKs
+# Copy and rename the APKs
 Write-Host "Copying APKs to release..." -ForegroundColor Cyan
 # Both must publish: UpdateService picks the one matching the ABI the running
 # app was installed for.

--- a/build-utils/build-android.ps1
+++ b/build-utils/build-android.ps1
@@ -21,7 +21,12 @@ if (Test-Path "$projectRoot\$EnvFile") {
     Write-Host "Env file not found: $EnvFile" -ForegroundColor Yellow
 }
 
-flutter build apk --release $envArg
+# One APK instead of a universal one: every device NeoStation targets is arm64,
+# but plain `flutter build apk` packs armeabi-v7a and x86_64 in as well. Both
+# flags are needed: --target-platform only drops the engine and AOT libs, while
+# --split-per-abi sets abiFilters, which is what drops the plugin natives
+# Gradle packages for every ABI.
+flutter build apk --release --split-per-abi --target-platform android-arm64 $envArg
 
 if ($LASTEXITCODE -ne 0) {
     Write-Host "Error during build" -ForegroundColor Red
@@ -37,7 +42,9 @@ New-Item -ItemType Directory -Path "$projectRoot\release" -Force | Out-Null
 
 # Copiar y renombrar APK
 Write-Host "Copying APK to release..." -ForegroundColor Cyan
-$sourceApk = "$projectRoot\build\app\outputs\flutter-apk\app-release.apk"
+# --split-per-abi renames the output to carry the ABI.
+$apkDir = "$projectRoot\build\app\outputs\flutter-apk"
+$sourceApk = "$apkDir\app-arm64-v8a-release.apk"
 $destApk = "$projectRoot\release\neostation-android-arm64-v8a-$version.apk"
 
 if (Test-Path $sourceApk) {
@@ -48,6 +55,11 @@ if (Test-Path $sourceApk) {
     Write-Host "Resultado en: release\" -ForegroundColor Cyan
     Get-ChildItem -Path "$projectRoot\release" -Filter "*.apk" | Format-Table Name, @{Name="Size (MB)";Expression={[math]::Round($_.Length/1MB, 2)}}, LastWriteTime
 } else {
-    Write-Host "No se encontró el APK en: $sourceApk" -ForegroundColor Red
+    Write-Host "No arm64-v8a release APK found in: $apkDir" -ForegroundColor Red
+    if (Test-Path $apkDir) {
+        Get-ChildItem -Path $apkDir | Select-Object -ExpandProperty Name
+    } else {
+        Write-Host "  (directory does not exist)"
+    }
     exit 1
 }

--- a/build-utils/build-android.ps1
+++ b/build-utils/build-android.ps1
@@ -21,12 +21,12 @@ if (Test-Path "$projectRoot\$EnvFile") {
     Write-Host "Env file not found: $EnvFile" -ForegroundColor Yellow
 }
 
-# One APK instead of a universal one: every device NeoStation targets is arm64,
-# but plain `flutter build apk` packs armeabi-v7a and x86_64 in as well. Both
-# flags are needed: --target-platform only drops the engine and AOT libs, while
-# --split-per-abi sets abiFilters, which is what drops the plugin natives
-# Gradle packages for every ABI.
-flutter build apk --release --split-per-abi --target-platform android-arm64 $envArg
+# One APK per ABI instead of a universal one: no target device is x86_64, and
+# armeabi-v7a is kept for 32-bit Android TV boxes. Both flags are needed:
+# --target-platform only drops the engine and AOT libs, while --split-per-abi
+# sets abiFilters, which is what drops the plugin natives Gradle packages for
+# every ABI.
+flutter build apk --release --split-per-abi --target-platform android-arm64,android-arm $envArg
 
 if ($LASTEXITCODE -ne 0) {
     Write-Host "Error during build" -ForegroundColor Red
@@ -40,22 +40,26 @@ $version = (Select-String -Path "$projectRoot\pubspec.yaml" -Pattern "^version:\
 Write-Host "Creating output directory..." -ForegroundColor Cyan
 New-Item -ItemType Directory -Path "$projectRoot\release" -Force | Out-Null
 
-# Copiar y renombrar APK
-Write-Host "Copying APK to release..." -ForegroundColor Cyan
-# --split-per-abi renames the output to carry the ABI.
+# Copiar y renombrar APKs
+Write-Host "Copying APKs to release..." -ForegroundColor Cyan
+# Both must publish: UpdateService picks the one matching the ABI the running
+# app was installed for.
 $apkDir = "$projectRoot\build\app\outputs\flutter-apk"
-$sourceApk = "$apkDir\app-arm64-v8a-release.apk"
-$destApk = "$projectRoot\release\neostation-android-arm64-v8a-$version.apk"
+$missing = $false
 
-if (Test-Path $sourceApk) {
-    Copy-Item -Path $sourceApk -Destination $destApk -Force
-    
-    Write-Host ""
-    Write-Host "Build completado!" -ForegroundColor Green
-    Write-Host "Resultado en: release\" -ForegroundColor Cyan
-    Get-ChildItem -Path "$projectRoot\release" -Filter "*.apk" | Format-Table Name, @{Name="Size (MB)";Expression={[math]::Round($_.Length/1MB, 2)}}, LastWriteTime
-} else {
-    Write-Host "No arm64-v8a release APK found in: $apkDir" -ForegroundColor Red
+foreach ($abi in @("arm64-v8a", "armeabi-v7a")) {
+    $sourceApk = "$apkDir\app-$abi-release.apk"
+    $destApk = "$projectRoot\release\neostation-android-$abi-$version.apk"
+
+    if (Test-Path $sourceApk) {
+        Copy-Item -Path $sourceApk -Destination $destApk -Force
+    } else {
+        Write-Host "No $abi release APK found in: $apkDir" -ForegroundColor Red
+        $missing = $true
+    }
+}
+
+if ($missing) {
     if (Test-Path $apkDir) {
         Get-ChildItem -Path $apkDir | Select-Object -ExpandProperty Name
     } else {
@@ -63,3 +67,8 @@ if (Test-Path $sourceApk) {
     }
     exit 1
 }
+
+Write-Host ""
+Write-Host "Build completado!" -ForegroundColor Green
+Write-Host "Resultado en: release\" -ForegroundColor Cyan
+Get-ChildItem -Path "$projectRoot\release" -Filter "*.apk" | Format-Table Name, @{Name="Size (MB)";Expression={[math]::Round($_.Length/1MB, 2)}}, LastWriteTime

--- a/build-utils/build-android.ps1
+++ b/build-utils/build-android.ps1
@@ -26,6 +26,11 @@ if (Test-Path "$projectRoot\$EnvFile") {
 # --target-platform only drops the engine and AOT libs, while --split-per-abi
 # sets abiFilters, which is what drops the plugin natives Gradle packages for
 # every ABI.
+#
+# Removing --split-per-abi later is not free: Flutter rewrites versionCode to
+# abi*1000+build (127 ships as 1127/2127), so a universal build after this one
+# must jump the pubspec build number above the highest shipped code, or Android
+# refuses the install as a downgrade.
 flutter build apk --release --split-per-abi --target-platform android-arm64,android-arm $envArg
 
 if ($LASTEXITCODE -ne 0) {

--- a/build-utils/build-android.sh
+++ b/build-utils/build-android.sh
@@ -70,6 +70,7 @@ if [ -f "$SOURCE_APK" ]; then
     echo "Result in: release/"
     ls -lh "$DEST_APK"
 else
-    echo "APK not found at: $SOURCE_APK"
+    echo "No arm64-v8a release APK found in: $APK_DIR"
+    ls -1 "$APK_DIR" 2>/dev/null || echo "  (directory does not exist)"
     exit 1
 fi

--- a/build-utils/build-android.sh
+++ b/build-utils/build-android.sh
@@ -45,12 +45,13 @@ else
   echo "Warning: Keystore environment variables not set. Release build may use debug signing."
 fi
 
-# One APK instead of a universal one: every device NeoStation targets is arm64,
-# but plain `flutter build apk` packs armeabi-v7a and x86_64 in as well. Both
-# flags are needed: --target-platform only drops the engine and AOT libs, while
-# --split-per-abi sets abiFilters, which is what drops the plugin natives
-# Gradle packages for every ABI.
-flutter build apk --release --split-per-abi --target-platform android-arm64 $ENV_ARG
+# One APK per ABI instead of a universal one: no target device is x86_64, and
+# armeabi-v7a is kept for 32-bit Android TV boxes. Both flags are needed:
+# --target-platform only drops the engine and AOT libs, while --split-per-abi
+# sets abiFilters, which is what drops the plugin natives Gradle packages for
+# every ABI.
+flutter build apk --release --split-per-abi \
+    --target-platform android-arm64,android-arm $ENV_ARG
 
 # Get version from pubspec.yaml
 VERSION=$(grep 'version:' pubspec.yaml | head -1 | awk '{print $2}' | tr -d '\r')
@@ -58,19 +59,29 @@ VERSION=$(grep 'version:' pubspec.yaml | head -1 | awk '{print $2}' | tr -d '\r'
 # Create output directory
 mkdir -p "$PROJECT_ROOT/release"
 
-# Copy and rename APK. --split-per-abi renames the output to carry the ABI.
+# Copy and rename the APKs. Both must publish: UpdateService picks the one
+# matching the ABI the running app was installed for.
 APK_DIR="$PROJECT_ROOT/build/app/outputs/flutter-apk"
-SOURCE_APK="$APK_DIR/app-arm64-v8a-release.apk"
-DEST_APK="$PROJECT_ROOT/release/neostation-android-arm64-v8a-$VERSION.apk"
+MISSING=0
 
-if [ -f "$SOURCE_APK" ]; then
-    cp "$SOURCE_APK" "$DEST_APK"
-    echo ""
-    echo "Build completed!"
-    echo "Result in: release/"
-    ls -lh "$DEST_APK"
-else
-    echo "No arm64-v8a release APK found in: $APK_DIR"
+for ABI in arm64-v8a armeabi-v7a; do
+    SOURCE_APK="$APK_DIR/app-$ABI-release.apk"
+    DEST_APK="$PROJECT_ROOT/release/neostation-android-$ABI-$VERSION.apk"
+
+    if [ -f "$SOURCE_APK" ]; then
+        cp "$SOURCE_APK" "$DEST_APK"
+    else
+        echo "No $ABI release APK found in: $APK_DIR"
+        MISSING=1
+    fi
+done
+
+if [ "$MISSING" -ne 0 ]; then
     ls -1 "$APK_DIR" 2>/dev/null || echo "  (directory does not exist)"
     exit 1
 fi
+
+echo ""
+echo "Build completed!"
+echo "Result in: release/"
+ls -lh "$PROJECT_ROOT/release/neostation-android-"*"-$VERSION.apk"

--- a/build-utils/build-android.sh
+++ b/build-utils/build-android.sh
@@ -50,6 +50,11 @@ fi
 # --target-platform only drops the engine and AOT libs, while --split-per-abi
 # sets abiFilters, which is what drops the plugin natives Gradle packages for
 # every ABI.
+#
+# Removing --split-per-abi later is not free: Flutter rewrites versionCode to
+# abi*1000+build (127 ships as 1127/2127), so a universal build after this one
+# must jump the pubspec build number above the highest shipped code, or Android
+# refuses the install as a downgrade.
 flutter build apk --release --split-per-abi \
     --target-platform android-arm64,android-arm $ENV_ARG
 

--- a/build-utils/build-android.sh
+++ b/build-utils/build-android.sh
@@ -45,7 +45,12 @@ else
   echo "Warning: Keystore environment variables not set. Release build may use debug signing."
 fi
 
-flutter build apk --release $ENV_ARG
+# One APK instead of a universal one: every device NeoStation targets is arm64,
+# but plain `flutter build apk` packs armeabi-v7a and x86_64 in as well. Both
+# flags are needed: --target-platform only drops the engine and AOT libs, while
+# --split-per-abi sets abiFilters, which is what drops the plugin natives
+# Gradle packages for every ABI.
+flutter build apk --release --split-per-abi --target-platform android-arm64 $ENV_ARG
 
 # Get version from pubspec.yaml
 VERSION=$(grep 'version:' pubspec.yaml | head -1 | awk '{print $2}' | tr -d '\r')
@@ -53,8 +58,9 @@ VERSION=$(grep 'version:' pubspec.yaml | head -1 | awk '{print $2}' | tr -d '\r'
 # Create output directory
 mkdir -p "$PROJECT_ROOT/release"
 
-# Copy and rename APK
-SOURCE_APK="$PROJECT_ROOT/build/app/outputs/flutter-apk/app-release.apk"
+# Copy and rename APK. --split-per-abi renames the output to carry the ABI.
+APK_DIR="$PROJECT_ROOT/build/app/outputs/flutter-apk"
+SOURCE_APK="$APK_DIR/app-arm64-v8a-release.apk"
 DEST_APK="$PROJECT_ROOT/release/neostation-android-arm64-v8a-$VERSION.apk"
 
 if [ -f "$SOURCE_APK" ]; then

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -1,3 +1,4 @@
+import 'dart:ffi' show Abi;
 import 'dart:io';
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
@@ -127,7 +128,12 @@ class UpdateService {
     String platformPattern;
 
     if (Platform.isAndroid) {
-      platformPattern = '-android-arm64-v8a-';
+      // Match the ABI this build was compiled for, not the ones the device
+      // supports: the installer rejects an update whose native libs differ
+      // from the installed package.
+      platformPattern = Abi.current() == Abi.androidArm
+          ? '-android-armeabi-v7a-'
+          : '-android-arm64-v8a-';
     } else if (Platform.isWindows) {
       platformPattern = '-windows-x64-';
     } else if (Platform.isLinux) {


### PR DESCRIPTION
# Description

`flutter build apk --release` had no ABI constraint, so the release asset named
"neostation-android-arm64-v8a" was really a universal APK. Native libs were
117.4 MB of the 123.1 MB 0.9.2 release: x86_64 43.2 MB, arm64-v8a 40.3 MB,
armeabi-v7a 33.8 MB. Nothing NeoStation targets runs x86_64.

Build one APK per ABI and publish both:

| | before | after |
|---|---|---|
| arm64-v8a | 123.1 MB (universal) | 51.4 MB |
| armeabi-v7a | 123.1 MB (universal) | 44.8 MB |

Both flags are needed. `--target-platform` alone only drops the engine and AOT
libs, leaving the plugin natives (ffmpeg, mdk, sqlite3, soloud, ass) that Gradle
packages from AARs for every ABI; that build still came out at 79.8 MB.
`--split-per-abi` is what sets abiFilters.

armeabi-v7a is kept rather than dropped with x86_64: Miguel reports Android TV
users on a 32-bit userland who currently have nothing they can install.

`UpdateService` needed a matching fix. It hardcoded `-android-arm64-v8a-`, which
was unambiguous with one Android asset per release but would hand every 32-bit
user an arm64 APK the installer refuses. It now selects on `Abi.current()`, the
ABI the running build was compiled for, not the ABIs the device reports: an
install has to stay on the ABI it was installed with. Users still on a
pre-0.9.3 universal APK land correctly too, since a 32-bit-only device running
one resolves to `Abi.androidArm`.

The Windows `build-android.ps1` is brought in line with the same two flags, and
both scripts now fail the build if either APK is missing rather than exiting on
arm64 alone. No workflow change: the release job globs `release/*`.

## Note for review: versionCode changes permanently

`--split-per-abi` makes Flutter's Gradle plugin override versionCode with
`abi*1000+build` (`FlutterPlugin.kt:673`; ABI map arm32 -> 1, arm64 -> 2).
Verified with `aapt2` on the built APKs:

| APK | versionCode |
|---|---|
| universal (today) | `127` |
| armeabi-v7a | `1127` |
| arm64-v8a | `2127` |

Upgrades are unaffected: both are far above any installed universal APK, and
each ABI's codes stay monotonic. The updater is unaffected too, since it
compares the versionName.

The catch is for us, not for users: a later release built *without* the flag
drops back to the raw build number, below every installed split APK, and
Android refuses it as a downgrade. The updater would still offer it, download
it, and fail at the installer with no clear cause. Recoverable by jumping the
pubspec build number above the highest shipped code (e.g. `0.13.0+2200`), so
it is a constraint rather than a dead end. There is a comment in both build
scripts where someone would remove the flag.

If you would rather not carry that constraint, the alternative is setting
`force-version-code-ignoring-abi=true`, which keeps versionCode equal to the
build number for both APKs. It would mean both assets share a versionCode,
which is fine for GitHub releases but not for Play multi-APK.

## Steps to Verify

**Preconditions:** a checkout of this branch, Android build toolchain.

1. Run `./build-utils/build-android.sh`.
2. `release/` holds both `neostation-android-arm64-v8a-<version>.apk` and
   `neostation-android-armeabi-v7a-<version>.apk`.
3. `unzip -l` each: `lib/` contains exactly one ABI directory, and the two
   APKs carry the same set of 19 native libs, so no plugin AAR is missing a
   32-bit slice.
4. Install the arm64 APK, open the in-app updater, confirm it offers the
   arm64-v8a asset and not the armeabi-v7a one.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — why: verified by build only so far. Both APKs were
  produced and their `lib/` contents diffed; neither has been installed, and
  the updater's asset choice has not been exercised on a device. No 32-bit
  device available to test the armeabi-v7a APK.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses
