### PR TITLE
feat(games): put the ROM filename back on the details footer's clock line

### DIFF
--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -15,6 +15,7 @@ import '../../../../themes/corner_radii.dart';
 import '../../../../utils/game_utils.dart';
 import '../../../../widgets/monospaced_clock.dart';
 import '../../music/music_player.dart';
+import 'scrolling_status_line.dart';
 import 'package:neostation/utils/ra_coverage.dart';
 
 /// A sticky footer component for the game details card that provides actionable controls and status summaries.
@@ -93,10 +94,11 @@ class GameDetailsFooter extends StatelessWidget {
     // One row, always the same height, in reading order: what the game *is*
     // on the left, what you can *do* with it on the right.
     //
-    // The two text lines that used to sit above this row are mostly gone. The
+    // The two text lines that used to sit above this row are one line now. The
     // metadata strip (players, publisher, year, genre) reads better in the
     // game info tab, which already carried half of those facts, so the strip
-    // is not repeated on the artwork; the filename went with it.
+    // is not repeated on the artwork. The ROM filename that had the second of
+    // those lines to itself is back, sharing the play-time clock's line.
     //
     // The cloud-sync glyph rode at that strip's end, spent a while as a chip
     // in this row, and now lives on the game list's own selected row, at the
@@ -105,12 +107,12 @@ class GameDetailsFooter extends StatelessWidget {
     // look for a mark the row could carry itself, and it was taking a chip's
     // width off the achievements pill on every synced game.
     //
-    // What is left of those lines is the play-time clock, on its own above the
-    // row. It was on the row once and that is what starved the achievements
-    // pill down to seven pixels; a play-time reading is 96 to 112 units wide
-    // and the row's spare, on the handheld card, is about 46. The line costs
-    // the row nothing, which is the only place the clock fits without the pill
-    // paying for it.
+    // Neither of the survivors is on the row. The clock was there once and that
+    // is what starved the achievements pill down to seven pixels; a play-time
+    // reading is 96 to 112 units wide and the row's spare, on the handheld
+    // card, is about 46. The line above costs the row nothing, which is the
+    // only place the clock fits without the pill paying for it, and the
+    // filename rides the same line rather than reclaiming one of its own.
     //
     // Fixed height, both parts of it: the line is reserved whether or not the
     // game has a reading to put on it, so the footer does not resize with what
@@ -132,15 +134,32 @@ class GameDetailsFooter extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                // The line above the row: the ROM filename on the left, the
+                // play-time clock on the right.
+                //
+                // The clock had this line to itself and the filename was not
+                // rendered anywhere on the card. They pair well: the reading is
+                // a fixed, short glyph+digits block that wants the right edge,
+                // and the name is the one variable-width thing here, so giving
+                // it whatever the clock leaves costs the clock nothing and puts
+                // the name back without a third line.
                 SizedBox(
                   height: _clockLine.r,
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: hasPlayTime
-                        ? _InlinePlayTime(game: game)
-                        : const SizedBox.shrink(),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      // Takes the line's whole width when there is no reading
+                      // beside it, and scrolls when it is longer than what it
+                      // gets.
+                      Expanded(child: _InlineRomFileName(game: game)),
+                      if (hasPlayTime) ...[
+                        SizedBox(width: 10.r),
+                        _InlinePlayTime(game: game),
+                      ],
+                    ],
                   ),
                 ),
+                SizedBox(height: _clockRowGap.r),
                 SizedBox(
                   height: _bottomRowHeight,
                   // The whole row is touch-only. Every action on it has a
@@ -675,6 +694,20 @@ const double _controlSize = _bottomRow;
 /// achievements pill rendered seven pixels wide.
 const double _clockLine = 26;
 
+/// Air between the line above and the row of controls.
+///
+/// The line and the row used to butt straight together, which was survivable
+/// while the play-time clock sat at the left of the line, above the score chip.
+/// The clock is at the right margin now, and so is PLAY — the two are flush to
+/// within a couple of pixels — so the reading was sitting directly on the
+/// button's top edge with about 8 units between them, of which the shadow under
+/// the digits took three. It read as the digits hanging off the button rather
+/// than as a line above it.
+///
+/// Counted into [gameDetailsPanelBottomOffset] with the rest of the footer, so
+/// the panels above still stop clear of it.
+const double _clockRowGap = 6;
+
 /// Slack under the row, so the content does not sit on the card's edge.
 const double _bottomPadding = 11;
 
@@ -699,7 +732,7 @@ double get _pillIconSize => (_bottomRow - 10).r;
 ///
 /// Unscaled, like the panels' own offsets — the caller applies `.r`.
 double gameDetailsPanelBottomOffset() =>
-    _clockLine + _bottomRow + _bottomPadding + _panelGap;
+    _clockLine + _clockRowGap + _bottomRow + _bottomPadding + _panelGap;
 
 /// One square control on the footer's row: a glyph on the same pill the
 /// achievements indicator wears, so the row reads as a set.
@@ -910,6 +943,107 @@ class _InlineRating extends StatelessWidget {
 List<Shadow> get _onArtShadows => [
   Shadow(blurRadius: 1.r, color: Colors.black, offset: const Offset(2, 2)),
 ];
+
+/// How far [_onArtShadows] reaches past the glyphs it sits under: the 2px
+/// offset, plus the blur's own spread either side of that.
+///
+/// The filename needs it as slack in its marquee clip. Without it the name
+/// keeps its whole shadow while it fits and loses the bottom of it the moment
+/// it is long enough to scroll — see [ScrollingStatusLine.shadowRoom].
+double get _onArtShadowRoom => 6.r;
+
+/// The ROM filename, on the left of the play-time clock's line.
+///
+/// It is the one identity fact the list sidebar beside this card does not
+/// carry: the row there renders the *resolved display name*, and this is what
+/// that name was matched from. There is no game title on the card for the same
+/// reason in reverse — it would be a strict duplicate of the selected row.
+///
+/// Only populated for scraped games: [GameListService] sets
+/// `showRomFileNameSubtitle` exclusively on the scraped branch, because a
+/// filename under a name derived from that same filename says nothing. For an
+/// unscraped game, or a user running `preferFileName`, this renders nothing at
+/// all and the clock simply keeps its line — the line's height is reserved
+/// either way, so the footer does not resize as the cursor walks the list.
+///
+/// White with a drop shadow, matching the clock: this paints straight onto the
+/// game's fanart, which can be any colour under it.
+class _InlineRomFileName extends StatelessWidget {
+  final GameModel game;
+
+  const _InlineRomFileName({required this.game});
+
+  @override
+  Widget build(BuildContext context) {
+    final String label = game.showRomFileNameSubtitle ? game.romname : '';
+    if (label.isEmpty) return const SizedBox.shrink();
+
+    // The clock's own 15.r. They share a line, and two sizes on one line read
+    // as a heading with a caption after it rather than as two facts about the
+    // same game. The weight still separates them: w600 here against the
+    // reading's w700.
+    final TextStyle style = TextStyle(
+      color: Colors.white,
+      fontSize: 15.r,
+      fontWeight: FontWeight.w600,
+      height: 1.15,
+      shadows: _onArtShadows,
+    );
+
+    // No `RepaintBoundary` around this, deliberately. One looks free here —
+    // the footer rebuilds on every sync tick and every achievements poll, and
+    // a boundary would keep those off this line — but the marquee below moves
+    // this exact widget every 50ms, and a retained layer is *repositioned*
+    // rather than repainted. The damage the engine works out for that move is
+    // the layer's paint bounds, which for a `Text` is its line box and not the
+    // drop shadow hanging past it: the shadow's pixels are then neither
+    // cleared where they were nor drawn where they now belong, so the name
+    // scrolls out from under its own shadow and leaves it standing. It only
+    // shows up where a frame is a partial repaint, which is why it comes in
+    // from devices and not from a desktop build.
+    final Widget text = Text(
+      label,
+      maxLines: 1,
+      // No wrapping and no ellipsis: whichever branch below is taken, this
+      // text is laid out at its full width — either because it fits, or
+      // because the marquee is going to scroll past its end.
+      softWrap: false,
+      strutStyle: StrutStyle(
+        fontSize: 15.r,
+        height: 1.15,
+        forceStrutHeight: true,
+      ),
+      style: style,
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final TextPainter painter = TextPainter(
+          text: TextSpan(text: label, style: style),
+          maxLines: 1,
+          textDirection: Directionality.of(context),
+          textScaler: MediaQuery.textScalerOf(context),
+        )..layout();
+        final bool overflows = painter.width > constraints.maxWidth;
+        painter.dispose();
+
+        // Left in both branches: a name that fits sits at the margin, and one
+        // that does not starts there and travels. `ScrollingStatusLine` holds
+        // still until it genuinely overflows, but it is only given the line at
+        // all when the measurement above says it will move — a viewport and a
+        // 50ms timer are not worth arming for every short name.
+        if (!overflows) {
+          return Align(alignment: Alignment.centerLeft, child: text);
+        }
+        return ScrollingStatusLine(
+          resetKey: game.romname,
+          shadowRoom: _onArtShadowRoom,
+          children: [text],
+        );
+      },
+    );
+  }
+}
 
 /// Accumulated play time as a clock glyph and an HH:MM:SS reading, on its own
 /// line above the footer's row.

--- a/test/game_details_footer_rating_test.dart
+++ b/test/game_details_footer_rating_test.dart
@@ -19,11 +19,13 @@ import 'package:neostation/themes/chrome_surface.dart';
 ///
 /// It got there by losing two text lines. The metadata strip (players,
 /// publisher, year, genre) was painting scraped facts onto the game's fanart
-/// that the info tab is the place for, and the filename under it went with it;
-/// the cloud-sync glyph that rode at the end of that line spent a while as a
-/// chip in this row and now lives on the game list's own selected row, which is
-/// where the selection it reports on actually is. What is left is pinned here
-/// because each piece has been moved before:
+/// that the info tab is the place for; the cloud-sync glyph that rode at the
+/// end of that line spent a while as a chip in this row and now lives on the
+/// game list's own selected row, which is where the selection it reports on
+/// actually is. The ROM filename came back from that cull — it is the one
+/// identity fact the list row does not carry — but on the play-time clock's
+/// line rather than one of its own. What is left is pinned here because each
+/// piece has been moved before:
 ///
 ///  * The score has been in five places — a pill in this row, a segment of
 ///    the metadata marquee (where a long publisher could scroll it out of
@@ -58,6 +60,7 @@ GameModel _game({
   double rating = 18.0,
   int? playTime = 3671,
   bool isFavorite = false,
+  bool showRomFileNameSubtitle = true,
 }) => GameModel(
   romname: 'A Game (USA).chd',
   realname: 'A Game',
@@ -70,7 +73,7 @@ GameModel _game({
   rating: rating,
   playTime: playTime,
   isFavorite: isFavorite,
-  showRomFileNameSubtitle: true,
+  showRomFileNameSubtitle: showRomFileNameSubtitle,
 );
 
 void main() {
@@ -179,12 +182,49 @@ void main() {
   testWidgets('the scraped facts are not on the footer at all', (tester) async {
     await pumpFooter(tester);
 
-    // Publisher, year, genre and the ROM filename all belong to the info tab
-    // now; painting them on the artwork here was the duplicate.
+    // Publisher, year and genre belong to the info tab now; painting them on
+    // the artwork here was the duplicate. The filename is the exception: it is
+    // the one identity fact neither the info tab's strip nor the list row
+    // beside the card carries, so it is back on the clock's line.
     expect(find.text('Sony'), findsNothing);
     expect(find.text('1999'), findsNothing);
     expect(find.text('RPG'), findsNothing);
+    expect(find.text('A Game (USA).chd'), findsOneWidget);
+  });
+
+  testWidgets('the filename shares the clock line, name left and clock right', (
+    tester,
+  ) async {
+    // One line for both: the reading is a fixed, short block that wants the
+    // right edge and the name is the variable-width thing, so the name takes
+    // whatever the clock leaves rather than claiming a second line.
+    await pumpFooter(tester, game: _game(playTime: 3671), width: 640);
+
+    final name = tester.getRect(find.text('A Game (USA).chd'));
+    final clock = tester.getRect(find.byIcon(Symbols.schedule_rounded));
+
+    expect(name.right, lessThanOrEqualTo(clock.left), reason: 'name left');
+    expect(
+      name.center.dy,
+      moreOrLessEquals(clock.center.dy, epsilon: 2.0),
+      reason: 'one line, not stacked',
+    );
+    expect(
+      clock.bottom,
+      lessThanOrEqualTo(tester.getRect(find.byType(ExcludeFocus)).top),
+      reason: 'still above the controls row',
+    );
+  });
+
+  testWidgets('an unscraped game leaves the clock its line', (tester) async {
+    // `showRomFileNameSubtitle` is set only where the display name came from
+    // somewhere other than the filename; a filename under a name derived from
+    // that same filename says nothing, so there is nothing to render and the
+    // line is unchanged in height either way.
+    await pumpFooter(tester, game: _game(showRomFileNameSubtitle: false));
+
     expect(find.text('A Game (USA).chd'), findsNothing);
+    expect(find.byIcon(Symbols.schedule_rounded), findsOneWidget);
   });
 
   testWidgets('the score is a whole number, rounded up', (tester) async {
@@ -239,10 +279,15 @@ void main() {
     final clock = find.byIcon(Symbols.schedule_rounded);
     expect(clock, findsOneWidget);
 
+    // A gap, not just "not overlapping". The clock and PLAY are both at the
+    // right margin, so with the two lines butted together the reading sat on
+    // the button's top edge and read as hanging off it — and the shadow under
+    // the digits closed most of what little space there was.
     expect(
-      tester.getRect(clock).bottom,
-      lessThanOrEqualTo(tester.getRect(find.byType(ExcludeFocus)).top),
-      reason: 'above the row, not among the controls',
+      tester.getRect(find.byType(ExcludeFocus)).top -
+          tester.getRect(clock).bottom,
+      greaterThanOrEqualTo(4.0),
+      reason: 'above the row with air between, not sitting on PLAY',
     );
   });
 


### PR DESCRIPTION
# Description

The ROM filename is back on the game details card, sharing the play-time clock's line.

It came off the card when the metadata strip did: it had a line of its own under a strip of scraped facts (players, publisher, year, genre) that read better in the game info tab, so both went. But the filename is the one identity fact the list row beside the card does not carry. That row renders the *resolved display name*, and the filename is what that name was matched from, so losing it left nowhere on the card to see what file a game actually is.

It comes back on the clock's line rather than reclaiming one of its own. The two pair well: the reading is a fixed, short glyph+digits block that wants the right edge, and the name is the only variable-width thing on the line, so the name takes whatever the clock leaves and the clock pays nothing for it.

**Details**

* The name marquees when it is longer than the width it gets, on the same `ScrollingStatusLine` the filename used before, with `_onArtShadowRoom` restored as the clip's vertical slack so the drop shadow survives once it starts scrolling. A name that fits sits still at the left margin: no viewport and no 50ms timer armed for the short ones.
* Set at the clock's own `15.r`. Two sizes on one line read as a heading with a caption after it, so the weight separates them instead (w600 against the reading's w700).
* Moving the clock to the right margin needed air under it, which the line never had: it butted straight onto the controls row, which was survivable while the clock sat at the left above the score chip. PLAY is at that same right margin, and measured on the Thor the two are flush to within 2px, so the reading came to sit 8 units above the button's top edge, three of which the shadow under the digits took. It read as the digits hanging off the button. `_clockRowGap` opens that to a real gap and is counted into `gameDetailsPanelBottomOffset()` with the rest of the footer, so the panels above still stop clear of it.
* The line's height is otherwise unchanged and still reserved for every game, so the offset stays a constant and no panel moves as the cursor walks the list.
* Gated on `showRomFileNameSubtitle` exactly as before, so an unscraped game or a `preferFileName` user renders no name and the clock simply keeps the line. A filename under a name derived from that same filename says nothing.

## Steps to Verify

**Preconditions:** Android device, a system with scraped games (so `showRomFileNameSubtitle` is set), at least one game with a long filename and one with accumulated play time.

1. Enter a system so the game list and the details card are both on screen.
2. Select a scraped game with a short filename and some play time. The filename sits at the left of the line above the controls row, the clock reading at the right of that same line.
3. Check the space between that line and the PLAY button: there should be a visible gap, not the digits sitting on the button's top edge.
4. Select a game whose filename is wider than the space the clock leaves it. The name scrolls, wraps, and keeps its drop shadow intact while it moves. The clock beside it stays still.
5. Select an unscraped game. No filename renders and the clock keeps the line to itself. The card does not change height and no panel above it moves.

## Tested on

- [x] Android — device: AYN Thor (dev channel, release build)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

Verified on device across short and long filenames. The marquee's shadow was checked with a six-frame burst and pixel-diffs between consecutive frames: the diffs show discrete outlines of each glyph at its old and new position with no trail between them, no residual shadow pixels left standing, and no lag between the white glyph and its shadow. Shadow quality matches the static clock digits frame for frame, and letter and shadow are clipped together at the marquee boundary.

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**

No new strings. The only text rendered is `GameModel.romname`, which is data, not UI copy.

**The database**

Not touched. `showRomFileNameSubtitle` is an existing field set by `GameListService`.

**Navigation or a new screen**

- [x] Every interactive element is reachable by D-pad, not just touch/mouse

Nothing here is interactive: the line is two pieces of read-only text. The existing test asserting nothing on the footer's row can take the gamepad cursor still passes.

**Android**

- [x] Verified on a device, not only on desktop

No path parsing: `romname` is a stored display field, not a path being split.

</details>

## Screenshots / video

Three new widget tests cover the geometry in `test/game_details_footer_rating_test.dart`: the filename and clock share a line with the name to the left of the reading and their centres within 2px, an unscraped game leaves the clock its line, and the gap above the controls row is asserted as a real distance rather than the previous "does not overlap".
