### PR TITLE
fix(systems): resolve system settings against the focused card

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -763,8 +763,6 @@ mixin AppLocale {
   static const String appCount = 'app_count';
   static const String errorSystemNotFound = 'error_system_not_found';
   static const String errorLaunchingGame = 'error_launching_game';
-  static const String settingsNotAvailableRecent =
-      'settings_not_available_recent';
   static const String allSystems = 'all_systems';
   static const String noSystemsFound = 'no_systems_found';
   static const String setupLibrary = 'setup_library';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -813,8 +813,6 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.errorSystemNotFound:
       'Fehler: System für dieses Spiel nicht gefunden.',
   AppLocale.errorLaunchingGame: 'Fehler beim Starten des Spiels: {error}',
-  AppLocale.settingsNotAvailableRecent:
-      'Einstellungen für zuletzt gespielte Spiele hier nicht verfügbar.',
   AppLocale.allSystems: 'Alle Systeme',
   AppLocale.noSystemsFound: 'Keine Systeme gefunden',
   AppLocale.setupLibrary: 'Bibliothek einrichten',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -785,8 +785,6 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.appCount: '{count} App',
   AppLocale.errorSystemNotFound: 'Error: System not found for this game.',
   AppLocale.errorLaunchingGame: 'Error launching game: {error}',
-  AppLocale.settingsNotAvailableRecent:
-      'Settings not available for Recent Games here.',
   AppLocale.allSystems: 'All Systems',
   AppLocale.noSystemsFound: 'No systems found',
   AppLocale.setupLibrary: 'Setup Your Library',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -810,8 +810,6 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.errorSystemNotFound:
       'Error: Sistema no encontrado para este juego.',
   AppLocale.errorLaunchingGame: 'Error al iniciar el juego: {error}',
-  AppLocale.settingsNotAvailableRecent:
-      'Ajustes no disponibles para Juegos Recientes aquí.',
   AppLocale.allSystems: 'Todos los Sistemas',
   AppLocale.noSystemsFound: 'No se encontraron sistemas',
   AppLocale.setupLibrary: 'Configura tu Biblioteca',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -819,8 +819,6 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.appCount: '{count} app',
   AppLocale.errorSystemNotFound: 'Erreur : Système non trouvé pour ce jeu.',
   AppLocale.errorLaunchingGame: 'Erreur lors du lancement du jeu : {error}',
-  AppLocale.settingsNotAvailableRecent:
-      'Paramètres non disponibles pour les jeux récents ici.',
   AppLocale.allSystems: 'Tous les Systèmes',
   AppLocale.noSystemsFound: 'Aucun système trouvé',
   AppLocale.setupLibrary: 'Configurez votre Bibliothèque',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -789,8 +789,6 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.errorSystemNotFound:
       'Kesalahan: Sistem tidak ditemukan untuk game ini.',
   AppLocale.errorLaunchingGame: 'Kesalahan saat menjalankan game: {error}',
-  AppLocale.settingsNotAvailableRecent:
-      'Pengaturan tidak tersedia untuk game baru di sini.',
   AppLocale.allSystems: 'Semua Sistem',
   AppLocale.noSystemsFound: 'Tidak ada sistem ditemukan',
   AppLocale.setupLibrary: 'Siapkan Pustaka',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -808,8 +808,6 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.errorSystemNotFound:
       'Errore : Sistema non trovato per questo gioco.',
   AppLocale.errorLaunchingGame: 'Errore durante l’avvio del gioco : {error}',
-  AppLocale.settingsNotAvailableRecent:
-      'Impostazioni non disponibili per i giochi recenti qui.',
   AppLocale.allSystems: 'Tutti i Sistemi',
   AppLocale.noSystemsFound: 'Nessun sistema trovato',
   AppLocale.setupLibrary: 'Configura la tua Libreria',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -718,7 +718,6 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.appCount: '{count}個のアプリ',
   AppLocale.errorSystemNotFound: 'エラー: このゲームのシステムが見つかりません。',
   AppLocale.errorLaunchingGame: 'ゲームの起動中にエラーが発生しました: {error}',
-  AppLocale.settingsNotAvailableRecent: 'ここでは最近プレイしたゲームの設定は利用できません。',
   AppLocale.allSystems: 'すべてのシステム',
   AppLocale.noSystemsFound: 'システムが見つかりません',
   AppLocale.setupLibrary: 'ライブラリをセットアップ',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -724,7 +724,6 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.appCount: '{count} 앱',
   AppLocale.errorSystemNotFound: '오류: 이 게임에 대한 시스템을 찾을 수 없습니다.',
   AppLocale.errorLaunchingGame: '게임 실행 중 오류 발생: {error}',
-  AppLocale.settingsNotAvailableRecent: '최근 게임 카드에서는 설정을 사용할 수 없습니다.',
   AppLocale.allSystems: '모든 시스템',
   AppLocale.noSystemsFound: '시스템을 찾을 수 없습니다',
   AppLocale.setupLibrary: '라이브러리 설정',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -798,8 +798,6 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.appCount: '{count} app',
   AppLocale.errorSystemNotFound: 'Erro: Sistema não encontrado para este jogo.',
   AppLocale.errorLaunchingGame: 'Erro ao iniciar jogo: {error}',
-  AppLocale.settingsNotAvailableRecent:
-      'Configurações não disponíveis para jogos recentes aqui.',
   AppLocale.allSystems: 'Todos os Sistemas',
   AppLocale.noSystemsFound: 'Nenhum sistema encontrado',
   AppLocale.setupLibrary: 'Configure sua Biblioteca',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -796,8 +796,6 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.appCount: 'Приложение: {count}',
   AppLocale.errorSystemNotFound: 'Ошибка: Система для этой игры не найдена.',
   AppLocale.errorLaunchingGame: 'Ошибка запуска игры: {error}',
-  AppLocale.settingsNotAvailableRecent:
-      'Настройки недоступны для недавних игр.',
   AppLocale.allSystems: 'Все системы',
   AppLocale.noSystemsFound: 'Системы не найдены',
   AppLocale.setupLibrary: 'Настройка библиотеки',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -702,7 +702,6 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.appCount: '{count} 个应用',
   AppLocale.errorSystemNotFound: '错误：未发现该游戏的系统。',
   AppLocale.errorLaunchingGame: '启动游戏出错：{error}',
-  AppLocale.settingsNotAvailableRecent: '此处不可用最近游玩设置。',
   AppLocale.allSystems: '所有系统',
   AppLocale.noSystemsFound: '未发现系统',
   AppLocale.setupLibrary: '设置您的库',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -702,7 +702,6 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.appCount: '{count} 個應用程式',
   AppLocale.errorSystemNotFound: '錯誤：未發現該遊戲的系統。',
   AppLocale.errorLaunchingGame: '啟動遊戲發生錯誤：{error}',
-  AppLocale.settingsNotAvailableRecent: '此處無法使用最近遊玩設定。',
   AppLocale.allSystems: '所有系統',
   AppLocale.noSystemsFound: '未發現系統',
   AppLocale.setupLibrary: '設定您的收藏庫',

--- a/lib/models/my_systems.dart
+++ b/lib/models/my_systems.dart
@@ -265,6 +265,17 @@ class SystemInfo {
       ? customBackgroundPath!
       : 'assets/images/logos/$_resolvedPrimaryFolderName.webp';
 
+  /// The system whose settings this card configures.
+  ///
+  /// Normally its own [folderName]. A recent-activity card carries a game
+  /// rather than a system, but that game still belongs to one, so it resolves
+  /// through the game's `systemFolderName` — the same hop the card makes to
+  /// launch it. Both entry points to the settings dialog (the Y context menu
+  /// and START) read this, so neither can drift back into refusing a card the
+  /// other one accepts.
+  String? get settingsFolderName =>
+      (isGame ? gameModel?.systemFolderName : null) ?? folderName;
+
   /// Internal helper to determine the directory name used for asset resolution.
   String get _resolvedPrimaryFolderName =>
       (primaryFolderName != null && primaryFolderName!.isNotEmpty)

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -289,7 +289,10 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
       onNavigateRight: _navigateNext,
       onSelectItem: _selectCurrentSystem,
       onSettings: _openSystemSettingsFromCarousel,
-      onFavorite: widget.onYPressed,
+      // Resolved on every press: the host rebuilds this callback around the
+      // currently selected card, so holding the closure captured here would
+      // pin Y to the card selected when this state was created.
+      onFavorite: () => widget.onYPressed?.call(),
       onBack: widget.onBackPressed,
       onXButton:
           widget.onXPressed ??
@@ -570,6 +573,13 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
   }
 
   /// Opens configuration dialogs for the focused carousel item.
+  ///
+  /// A recent-activity card used to be turned away here on the grounds that it
+  /// carries a game rather than a system. The grid's START and both layouts' Y
+  /// menu resolve one through [SystemInfo.settingsFolderName] instead, so this
+  /// did the same job three different ways and refused what its siblings
+  /// allowed. It now shares their resolution, and reports an unresolvable card
+  /// the way the grid does rather than doing nothing.
   void _openSystemSettingsFromCarousel() async {
     final allSystems = _getSystemsList();
 
@@ -582,30 +592,30 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
     }
 
     final selectedSystemInfo = allSystems[_currentIndex];
-
-    // Block configuration for individual game cards (Recent Activity).
-    if (selectedSystemInfo.isGame) {
-      AppNotification.showNotification(
-        context,
-        AppLocale.settingsNotAvailableRecent.getString(context),
-        type: NotificationType.info,
-      );
-      return;
-    }
+    final folderName = selectedSystemInfo.settingsFolderName;
 
     final configProvider = Provider.of<SqliteConfigProvider>(
       context,
       listen: false,
     );
 
-    final selectedSystem = selectedSystemInfo.folderName == 'all'
+    final selectedSystem = folderName == 'all'
         ? _createAllGamesSystem(configProvider.detectedSystems)
         : configProvider.detectedSystems.cast<SystemModel?>().firstWhere(
-            (system) => system?.folderName == selectedSystemInfo.folderName,
+            (system) => system?.folderName == folderName,
             orElse: () => null,
           );
 
-    if (selectedSystem == null) return;
+    if (selectedSystem == null) {
+      if (mounted) {
+        AppNotification.showNotification(
+          context,
+          AppLocale.systemSettingsNotAvailable.getString(context),
+          type: NotificationType.info,
+        );
+      }
+      return;
+    }
 
     if (mounted) {
       await showDialog(

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -347,10 +347,10 @@ class MySystems extends StatelessWidget {
   /// Opens the emulator configuration dialog for a specific system.
   ///
   /// A recent-game card carries a game rather than a system, so it resolves
-  /// through the game's own `systemFolderName` — the same hop
-  /// [_navigateToSystem] makes to launch it. Without that the card's folder
-  /// name matches nothing in `detectedSystems`, the lookup throws, and the
-  /// catch below turns a real action into a "not available" notice.
+  /// through [SystemInfo.settingsFolderName] — the same hop [_navigateToSystem]
+  /// makes to launch it. Without that the card's folder name matches nothing in
+  /// `detectedSystems`, the lookup throws, and the catch below turns a real
+  /// action into a "not available" notice.
   void _openSystemSettings(
     BuildContext context,
     SystemInfo system,
@@ -360,9 +360,7 @@ class MySystems extends StatelessWidget {
     MySystems.isNavigating = true;
 
     try {
-      final String? folderName =
-          (system.isGame ? system.gameModel?.systemFolderName : null) ??
-          system.folderName;
+      final String? folderName = system.settingsFolderName;
 
       final selectedSystem = folderName == 'all'
           ? _createAllGamesSystem(context, configProvider.detectedSystems)

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid/gamepad_grid_nav.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid/gamepad_grid_nav.dart
@@ -38,9 +38,15 @@ extension _GamepadGridNav on _SystemCardGridViewState {
       },
       onSelectItem: () => widget.onEnterPressed?.call(),
       onSettings: () => widget.onEscapePressed?.call(),
-      // Y is unbound on the systems screen (the host passes nothing), so a null
-      // callback keeps the button silent exactly as before.
-      onFavorite: widget.onYPressed,
+      // Read through `widget` on every press, exactly as A and START above do.
+      // The host rebuilds this callback each frame around the *currently*
+      // selected card, so binding the closure itself here would pin Y to
+      // whichever card was selected when this state was created — Y opened the
+      // context menu for that first card no matter where the cursor had moved
+      // (the long-press route never had the bug: the card reads `widget` when
+      // it is built). A null `onYPressed` still does nothing, and Y counts as
+      // handled either way, so nothing else changes.
+      onFavorite: () => widget.onYPressed?.call(),
       // Likewise B: the systems screen is a root tab with nothing to pop, and a
       // null onBack also leaves the keyboard's Backspace unhandled, as it was.
       onBack: widget.onBackPressed,

--- a/test/system_settings_target_test.dart
+++ b/test/system_settings_target_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/game_model.dart';
+import 'package:neostation/models/my_systems.dart';
+
+/// Which system a systems-screen card opens the settings dialog for.
+///
+/// Both entry points — the Y context menu and START — used to answer this
+/// themselves, and drifted: the grid resolved a recent-activity card through
+/// the game on it, while the carousel's START refused the same card as having
+/// no system to configure. [SystemInfo.settingsFolderName] is the one answer
+/// they now share.
+void main() {
+  GameModel game({String? systemFolderName}) => GameModel(
+    romname: 'Game.z64',
+    realname: 'Game',
+    name: 'Game',
+    year: '1996',
+    developer: '',
+    publisher: '',
+    genre: '',
+    players: '1',
+    rating: 0,
+    systemFolderName: systemFolderName,
+  );
+
+  test('a system card configures itself', () {
+    expect(SystemInfo(folderName: 'snes').settingsFolderName, 'snes');
+  });
+
+  test('an aggregate card keeps its own virtual folder', () {
+    expect(SystemInfo(folderName: 'all').settingsFolderName, 'all');
+  });
+
+  test('a recent-activity card configures the system its game belongs to', () {
+    // The bug this getter exists for: the card's own folder name is the game's
+    // rom name, which matches no detected system.
+    final card = SystemInfo(
+      folderName: 'Game.z64',
+      isGame: true,
+      gameModel: game(systemFolderName: 'n64'),
+    );
+
+    expect(card.settingsFolderName, 'n64');
+  });
+
+  test('a game card with no system falls back to its own folder', () {
+    final card = SystemInfo(
+      folderName: 'Game.z64',
+      isGame: true,
+      gameModel: game(),
+    );
+
+    // Nothing resolves this, and the callers report it as unavailable rather
+    // than opening a dialog for the wrong hardware.
+    expect(card.settingsFolderName, 'Game.z64');
+  });
+}

--- a/test/systems_view_reuse_test.dart
+++ b/test/systems_view_reuse_test.dart
@@ -381,6 +381,40 @@ void main() {
       await tester.pumpWidget(const SizedBox.shrink());
     });
 
+    testWidgets('Y fires the host\'s current callback, not the mounted one', (
+      tester,
+    ) async {
+      // The host rebuilds onYPressed around whichever card is selected, so the
+      // grid has to read it on every press. Holding the closure it mounted with
+      // pinned the systems screen's Y menu to the card selected when the grid
+      // appeared — index 0 being the recent-activity card, that opened the last
+      // played game's system every time, wherever the cursor actually was.
+      final opened = <String?>[];
+
+      Widget gridFor(int index) => host(
+        SystemCardGridView(
+          crossAxisCount: 3,
+          systems: systems,
+          selectedIndex: index,
+          navLayerId: 'rebound_y',
+          onYPressed: () => opened.add(systems[index].title),
+          cardOverrideBuilder: stubCards,
+        ),
+      );
+
+      await tester.pumpWidget(gridFor(0));
+      await settleInput(tester);
+      await press(tester, LogicalKeyboardKey.keyY);
+      expect(opened, ['snes']);
+
+      await tester.pumpWidget(gridFor(2));
+      await settleInput(tester);
+      await press(tester, LogicalKeyboardKey.keyY);
+      expect(opened, ['snes', 'md']);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
+
     testWidgets('the override builder replaces only the cards it claims', (
       tester,
     ) async {
@@ -447,6 +481,43 @@ void main() {
 
       expect(activated, [0]);
       expect(options, [0]);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+
+    testWidgets('Y fires the host\'s current callback, not the mounted one', (
+      tester,
+    ) async {
+      // Same contract as the grid's: the carousel re-reads onYPressed on every
+      // press, so the card the cursor is on is the one the menu opens for.
+      final opened = <String?>[];
+
+      Widget carouselFor(int index) => host(
+        MySystemsCarousel(
+          items: systems,
+          selectedIndex: index,
+          navLayerId: 'rebound_carousel_y',
+          onYPressed: () => opened.add(systems[index].title),
+          blockSystemBack: false,
+          enablePullToRescan: false,
+          enableDynamicBackground: false,
+          enableThemeAssets: false,
+          enableSecondaryDisplay: false,
+          enableTabBumpers: false,
+          cardOverrideBuilder: stubCards,
+        ),
+      );
+
+      await tester.pumpWidget(carouselFor(0));
+      await settleInput(tester);
+      await press(tester, LogicalKeyboardKey.keyY);
+      expect(opened, ['snes']);
+
+      await tester.pumpWidget(carouselFor(2));
+      await settleInput(tester);
+      await press(tester, LogicalKeyboardKey.keyY);
+      expect(opened, ['snes', 'md']);
 
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pump(const Duration(milliseconds: 400));


### PR DESCRIPTION
# Description

Two ways the systems screen opened the wrong system's settings dialog, or refused to open it at all.

**The Y context menu opened the wrong system.** The screen builds its Y callback around whichever card is selected, but both layouts bound it once, in `initState`, straight into `GamepadNavigation`, whose callbacks are `final`. `didUpdateWidget` never rebound it, so Y stayed pinned to the card that was selected when the view mounted: index 0, the recent-activity card. That card resolves to the system its game belongs to, so every press opened the settings of the last game played, wherever the cursor actually was.

A and START were already written as `() => widget.onEnterPressed?.call()`, and the long-press route reads `widget.onYPressed` when the card is built, which is why only the pad's Y button was wrong. Y is now read the same way. A null `onYPressed` still does nothing, and Y counts as handled either way.

I audited every other `GamepadNavigation` in the app for the same shape. The ones that pass `widget.<callback>` straight in (games grid/carousel, RomM ROM grid/list, NeoSync dialogs, notification bell) all receive method tearoffs from their hosts, whose identity is stable and which read the selection at call time. The collections browser, the other host of these same two widgets, does the same. The systems screen was the only host handing down a closure built around the selected item, so it was the only one exposed.

**START in carousel mode refused a recent game.** It turned a recent-activity card away as carrying a game rather than a system, while the grid's START and both layouts' Y menu resolved one through the game's `systemFolderName`. Three copies of the same decision, and this was the copy that had drifted. `SystemInfo.settingsFolderName` is now the single answer all of them read, so they cannot drift apart again, and a card that resolves to nothing is reported rather than silently ignored. `settingsNotAvailableRecent` had no other call site, so it and its 12 translations go with it.

## Steps to Verify

**Preconditions:** an Android handheld with a gamepad, a library with several systems, and at least one game played recently, so the Recent Activity card is present at the front of the systems screen. Note which system that recent game belongs to.

Wrong system on Y (grid and carousel both):

1. Open the systems screen and let it settle on the first card.
2. D-pad to any other system, several cards along.
3. Press Y, then choose `Settings`.
4. Before: the dialog is for the recent game's system, not the focused one. After: it is the focused system.
5. Press B, switch layout (X, or Y then `View mode`), and repeat 2 to 4.

A long press on a card was always correct, so it is the useful control: before this change Y and long press on the same card disagreed, and now they match.

Recent card on START, carousel mode:

1. Switch the systems screen to carousel.
2. Put the cursor on the Recent Activity card.
3. Press START.
4. Before: a "Settings not available for Recent Games here" notice. After: the settings dialog for the system that game belongs to, which is what grid START and both layouts' Y menu already did.

## Tested on

- [x] Android — device: AYN Thor (dev channel, DB v156, 9140 games)
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing (1962)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

Both defects are covered by tests that fail without the fix:

- `test/systems_view_reuse_test.dart` gains one case per layout: mount at index 0, press Y, rebuild at index 2, press Y. On the unfixed code both report `['snes', 'snes']` instead of `['snes', 'md']`, which is the bug exactly.
- `test/system_settings_target_test.dart` covers `settingsFolderName`: a plain system card, an aggregate (`all`) card, a recent card resolving to its game's system, and a game card with no `systemFolderName` falling back to its own folder.

<details>
<summary><b>Extra checks</b></summary>

**User-facing text**
- [x] No new keys. One key removed, `settingsNotAvailableRecent`, along with its value in all 12 `app_locale_<lang>.dart` files, as the only call site is gone.
- [x] No hardcoded UI strings: the replacement notice uses the existing `AppLocale.systemSettingsNotAvailable`

**Navigation**
- [x] Every interactive element is reachable by D-pad, not just touch/mouse
- [x] No new routes or layers; the layer push and pop in these two views are untouched
- [x] B cancels / goes back, including out of a focused text field

**Android**
- [x] No path logic touched
- [x] Verified on a device, not only on desktop

</details>

## Screenshots / video

Not a visual change: the same dialog, opened for a different system.
