### PR TITLE
feat(xcloud): add Xbox Game Pass cloud/remote-play launch support

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.23"
+  "latest_version": "0.3.24"
 }

--- a/assets/systems/xcloud.json
+++ b/assets/systems/xcloud.json
@@ -1,0 +1,63 @@
+{
+  "system": {
+    "id": "xcloud",
+    "multidisc": false,
+    "name": "XBox Game Pass",
+    "neosync": {
+      "sync": false,
+      "sync_folder": null
+    },
+    "short_name": "XCloud",
+    "details": {
+      "manufacturer": "Microsoft",
+      "release_date": "2017-06-01",
+      "description": "Microsoft's Cloud Gaming Platform",
+      "type": "virtual"
+    },
+    "ids": {
+      "screenscraper": null,
+      "retroachievements": null
+    },
+    "folders": [
+      "xcloud"
+    ],
+    "colors": [
+      "#91C300",
+      "#FFFFFF"
+    ],
+    "extensions": [
+      "xcloud"
+    ]
+  },
+"emulators": [
+    {
+      "name": "Standalone Better XCloud - Cloud Gaming",
+      "unique_id": "com.redphx.betterxc",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: xcloud.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.redphx.betterxc/com.redphx.betterxc.activity.MainActivity -a android.intent.action.VIEW -d bxc://play/{tags.localgameid} --activity-clear-task --activity-clear-top"
+        }
+      }
+    },
+    {
+      "name": "Standalone Better XCloud - Remote Play",
+      "unique_id": "com.redphx.betterxc.remoteplay",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: xcloud.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.redphx.betterxc/com.redphx.betterxc.activity.MainActivity -a android.intent.action.VIEW -d bxc://remote-play/{tags.localgameid} --activity-clear-task --activity-clear-top"
+        }
+      }
+    }
+  ],
+  "neosync": {
+    "sync": false,
+    "android_sync_folder": [],
+    "windows_sync_folder": [],
+    "linux_sync_folder": [],
+    "macos_sync_folder": []
+  }
+}

--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -600,6 +600,7 @@ class SqliteDatabaseService {
           '.amazon',
           '.pcgame',
           '.customgame',
+          '.xcloud',
         };
         if (titleId == null &&
             windowsIdExts.any(entry.filename.toLowerCase().endsWith)) {


### PR DESCRIPTION
# Description

Adds the `xcloud` virtual system (Xbox Game Pass / Xbox Cloud Gaming), launched
via the Better XCloud Android app, with two emulator entries — Cloud Gaming and
Remote Play — differing only in the `bxc://` URI scheme they launch.

Also fixes `{tags.localgameid}` resolution for this system: the placeholder
substitution in `launcher_service.dart` already supported it, but it only ever
fires once `game.titleId` is populated, which requires the scanner to actually
read a `.xcloud` file's own content as a title id. `sqlite_database_service.dart`'s
`windowsIdExts` set (the extensions whose content becomes `title_id`, following
the same pattern already used for `.steam`/`.epic`/`.gog`/etc.) was missing
`.xcloud`, so the placeholder was never substituted and the literal string
`{tags.localgameid}` was passed straight into the launch intent.

`assets/manifest.json` is bumped so this reaches existing installs without
requiring a full app release.

## Steps to Verify

**Preconditions:** Better XCloud (`com.redphx.betterxc`) installed on an
Android device/emulator, and NeoStation configured with a ROM folder
containing an `xcloud` subfolder.

1. Add a game entry: `Game Name.xcloud` (empty file — its content is the
   game's cloud id, e.g. an Xbox product id/GUID).
2. Scan the `xcloud` system in NeoStation.
3. Launch the game via **Standalone Better XCloud - Cloud Gaming** — confirm
   Better XCloud opens directly to `bxc://play/<id>` (not a literal
   `{tags.localgameid}` in its address bar/logs).
4. Repeat via **Standalone Better XCloud - Remote Play** — confirm it opens
   `bxc://remote-play/<id>`.

## Tested on

- [x] Android — device: sideloaded debug/release build, verified both emulator
      launch variants resolve the game id correctly.
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `dart format .` — no diff
- [x] `flutter analyze` — clean (no errors *or* warnings)
- [x] `flutter test` — all passing
- [ ] Tests added or updated — no new automated test; this is a JSON config +
      one-line extension-set addition, verified via manual device testing (see
      Steps to Verify)
- [x] No secrets, credentials, or personal data in the diff (including tests
      and fixtures)
- [x] New assets have compatible licenses — no new binary assets, JSON config
      only

<details>
<summary>Extra checks — assets/systems/ / emulator launching</summary>

- [x] Fixed in JSON (`launch_arguments`) rather than `EmulatorLauncher.kt` —
      no Kotlin changes
- [x] `assets/manifest.json` version bumped so this reaches existing installs
      OTA

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)