### PR TITLE
fix(vita): use Vita3K Plus package ID

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.23"
+  "latest_version": "0.3.24"
 }

--- a/assets/systems/vita.json
+++ b/assets/systems/vita.json
@@ -71,7 +71,7 @@
       "is_retroachievements_compatible": false,
       "platforms": {
         "android": {
-          "launch_arguments": "-n org.vita3k.emulator/org.vita3k.emulator.Emulator --esa AppStartParameters \"-r,{tags.vita_game_id}\""
+          "launch_arguments": "-n org.vita3kplus.emulator/org.vita3k.emulator.Emulator --esa AppStartParameters \"-r,{tags.vita_game_id}\""
         }
       }
     },


### PR DESCRIPTION
## Description

Corrects the Android package in the Vita3K Plus system definition from `org.vita3k.emulator` to `org.vita3kplus.emulator`, allowing NeoStation to detect and launch the installed Plus variant. Bumps the systems manifest to `0.3.24` so existing installs receive the update.

Closes #

## Steps to Verify

**Preconditions:**

1. Install Vita3K Plus (`org.vita3kplus.emulator`) on an Android device.
2. Refresh NeoStation systems definitions.

1. Open the PS Vita emulator menu.
2. Confirm **Standalone Vita3K Plus** is listed as installed.
3. Launch a PS Vita game and confirm Vita3K Plus opens.

## Tested on

- [ ] Android — not runtime-tested; ADB device access was unavailable
- [x] JSON validation (`jq empty`)
- [x] `flutter analyze` — clean
- [x] Focused emulator-default tests

## Checklist

- [x] `flutter analyze` — clean
- [x] Tests added or updated — not needed; this corrects a declarative package identifier
- [x] No secrets, credentials, or personal data in the diff
- [x] Fixed in JSON rather than `EmulatorLauncher.kt`
- [x] `assets/manifest.json` version bumped for OTA delivery