### PR TITLE
feat(n64): add Gopher64 desktop emulator

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.23"
+  "latest_version": "0.3.24"
 }

--- a/assets/systems/n64.json
+++ b/assets/systems/n64.json
@@ -41,6 +41,27 @@
   },
   "emulators": [
     {
+      "name": "Standalone Gopher64",
+      "unique_id": "n64.gopher64",
+      "description": "Supported extensions: bin, n64, ndd, u1, v64, z64.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "windows": {
+          "executable": "gopher64-windows-x86_64.exe",
+          "args": "\"{file.path}\""
+        },
+        "linux": {
+          "executable": "gopher64-linux-x86_64",
+          "flatpak": "io.github.gopher64.gopher64",
+          "args": "\"{file.path}\""
+        },
+        "macos": {
+          "executable": "Gopher64.app",
+          "args": "\"{file.path}\""
+        }
+      }
+    },
+    {
       "name": "Standalone Mupen64Plus FZ",
       "unique_id": "n64.org.mupen64plusae.v3.fzurita",
       "description": "Supported extensions: bin, n64, ndd, u1, v64, z64.",

--- a/test/systems_linux_hints_test.dart
+++ b/test/systems_linux_hints_test.dart
@@ -57,6 +57,7 @@ void main() {
     'org.azahar_emu.Azahar',
     'net.kuribo64.melonDS',
     'info.cemu.Cemu',
+    'io.github.gopher64.gopher64',
     'io.github.stella_emu.Stella',
   };
 


### PR DESCRIPTION
## Description

Adds Gopher64 as a standalone Nintendo 64 emulator on Windows, Linux, and macOS. The Android release is intentionally excluded.

The Linux entry supports the official Flatpak ID; Windows and macOS match the official release executable and app-bundle names. The systems manifest is bumped to `0.3.24` so existing installs receive the update.

Closes #

## Steps to Verify

**Preconditions:**

1. Install Gopher64 on the applicable desktop platform.
2. Add an N64 ROM.

1. Select Gopher64 for Nintendo 64 in NeoStation.
2. Launch the ROM.
3. Confirm Gopher64 starts with the selected ROM.

## Tested on

- [ ] Android — intentionally unsupported
- [ ] Linux — not runtime-tested
- [ ] Windows — not runtime-tested
- [ ] macOS — not runtime-tested
- [x] Not runtime-tested — definition uses the official release artifact names; JSON validation and emulator anomaly scan passed.

## Checklist

- [x] `flutter analyze` — clean
- [ ] `flutter test` — the full suite reports 12 existing failures on this macOS environment, including the macOS seed-authority platform-map assumption
- [x] Tests added or updated — existing emulator-definition scan covers the JSON shape
- [x] No secrets, credentials, or personal data in the diff
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks</b></summary>

**`assets/systems/` or emulator launching**
- [x] Fixed in JSON rather than `EmulatorLauncher.kt`
- [x] `assets/manifest.json` version bumped for OTA delivery
</details>