### PR TITLE
fix: add RetroArch core for Jaguar CD

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.23"
+  "latest_version": "0.3.24"
 }

--- a/assets/systems/jagcd.json
+++ b/assets/systems/jagcd.json
@@ -51,6 +51,56 @@
           "args": "\"{file.path}\""
         }
       }
+    },
+    {
+      "name": "RetroArch64 Virtual Jaguar",
+      "default_core": true,
+      "unique_id": "jagcd.ra64.virtualjaguar",
+      "description": "Supported extensions: cue, cdi.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"virtualjaguar\""
+        }
+      }
+    },
+    {
+      "name": "RetroArch32 Virtual Jaguar",
+      "default_core": true,
+      "unique_id": "jagcd.ra32.virtualjaguar",
+      "description": "Supported extensions: cue, cdi.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"virtualjaguar\""
+        }
+      }
+    },
+    {
+      "name": "RetroArch Virtual Jaguar",
+      "default_core": true,
+      "unique_id": "jagcd.ra.virtualjaguar",
+      "description": "Supported extensions: cue, cdi.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"virtualjaguar\""
+        },
+        "windows": {
+          "executable": "retroarch.exe",
+          "args": "-L virtualjaguar_libretro.dll \"{file.path}\""
+        },
+        "linux": {
+          "executable": "retroarch",
+          "flatpak": "org.libretro.RetroArch",
+          "emudeck_launcher": "retroarch.sh",
+          "args": "-L virtualjaguar_libretro.so \"{file.path}\""
+        },
+        "macos": {
+          "executable": "RetroArch.App",
+          "args": "-L virtualjaguar_libretro.dylib \"{file.path}\""
+        }
+      }
     }
   ],
   "neosync": {


### PR DESCRIPTION
# Description

Adds the Virtual Jaguar RetroArch core to Atari Jaguar CD, matching the existing Atari Jaguar configuration. This makes the core selectable on Android (64-bit, 32-bit, and standard RetroArch) and desktop RetroArch. The bundled systems manifest is bumped so existing installs receive the update.

Closes #483 

## Steps to Verify

**Preconditions:**

1. Have a Jaguar CD game in `.cue` or `.cdi` format and RetroArch with the Virtual Jaguar core installed.

1. Open Atari Jaguar CD in NeoStation.
2. Select a game and open its emulator/core selection.
3. Confirm that Virtual Jaguar is selectable for the installed RetroArch variant.
4. Launch the game and confirm RetroArch opens it with Virtual Jaguar.

## Tested on

- [ ] Android — device:
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [x] Not runtime-tested — configuration-only change; hardware/core unavailable locally

## Checklist

- [x] `dart format .` — no diff (no Dart files changed)
- [ ] `flutter analyze` — clean (no errors *or* warnings)
- [ ] `flutter test` — all passing (1,694 passing; 13 pre-existing failures)
- [ ] Tests added or updated (not needed for declarative systems configuration)
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses

<details>
<summary><b>Extra checks — emulator definitions</b></summary>

- [x] Fixed in JSON (`launch_arguments`, `keep_saf_uri`) rather than `EmulatorLauncher.kt` where possible
- [x] `assets/manifest.json` version bumped so this reaches existing installs OTA

</details>