### PR TITLE
feat(retroachievements): show games beaten

### DIFF
--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -1264,6 +1264,7 @@ mixin AppLocale {
   static const String raAotwOpenLocalGame = 'ra_aotw_open_local_game';
   static const String raAotwDownloadFromRomm = 'ra_aotw_download_from_romm';
   static const String raGamesPlayed = 'ra_games_played';
+  static const String raGamesBeaten = 'ra_games_beaten';
   static const String raAchievementProgress = 'ra_achievement_progress';
   static const String raRecent30Days = 'ra_recent_30_days';
 

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -1216,6 +1216,7 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.raAotwOpenLocalGame: 'Lokales Spiel öffnen',
   AppLocale.raAotwDownloadFromRomm: 'Von RomM herunterladen',
   AppLocale.raGamesPlayed: '{count} Spiele gespielt',
+  AppLocale.raGamesBeaten: '{count} Spiele abgeschlossen',
   AppLocale.raAchievementProgress: '{earned}/{total} Erfolge',
   AppLocale.raRecent30Days: '30 Tage',
 

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -1168,6 +1168,7 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.raAotwOpenLocalGame: 'Open local game',
   AppLocale.raAotwDownloadFromRomm: 'Download from RomM',
   AppLocale.raGamesPlayed: '{count} games played',
+  AppLocale.raGamesBeaten: '{count} games beaten',
   AppLocale.raAchievementProgress: '{earned}/{total} achievements',
   AppLocale.raRecent30Days: '30 days',
 

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -1210,6 +1210,7 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.raAotwOpenLocalGame: 'Abrir juego local',
   AppLocale.raAotwDownloadFromRomm: 'Descargar desde RomM',
   AppLocale.raGamesPlayed: '{count} juegos jugados',
+  AppLocale.raGamesBeaten: '{count} juegos completados',
   AppLocale.raAchievementProgress: '{earned}/{total} logros',
   AppLocale.raRecent30Days: '30 días',
 

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -1220,6 +1220,7 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.raAotwOpenLocalGame: 'Ouvrir le jeu local',
   AppLocale.raAotwDownloadFromRomm: 'Télécharger depuis RomM',
   AppLocale.raGamesPlayed: '{count} jeux joués',
+  AppLocale.raGamesBeaten: '{count} jeux terminés',
   AppLocale.raAchievementProgress: '{earned}/{total} succès',
   AppLocale.raRecent30Days: '30 jours',
 

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -1182,6 +1182,7 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.raAotwOpenLocalGame: 'Buka game lokal',
   AppLocale.raAotwDownloadFromRomm: 'Unduh dari RomM',
   AppLocale.raGamesPlayed: '{count} game dimainkan',
+  AppLocale.raGamesBeaten: '{count} game ditamatkan',
   AppLocale.raAchievementProgress: '{earned}/{total} pencapaian',
   AppLocale.raRecent30Days: '30 hari',
 

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -1209,6 +1209,7 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.raAotwOpenLocalGame: 'Apri gioco locale',
   AppLocale.raAotwDownloadFromRomm: 'Scarica da RomM',
   AppLocale.raGamesPlayed: '{count} giochi giocati',
+  AppLocale.raGamesBeaten: '{count} giochi completati',
   AppLocale.raAchievementProgress: '{earned}/{total} obiettivi',
   AppLocale.raRecent30Days: '30 giorni',
 

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -1070,6 +1070,7 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.raAotwOpenLocalGame: 'ローカルゲームを開く',
   AppLocale.raAotwDownloadFromRomm: 'RomMからダウンロード',
   AppLocale.raGamesPlayed: '{count}本プレイ',
+  AppLocale.raGamesBeaten: '{count}本クリア',
   AppLocale.raAchievementProgress: '実績 {earned}/{total}',
   AppLocale.raRecent30Days: '30日間',
 

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -1057,6 +1057,7 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.raAotwOpenLocalGame: '로컬 게임 열기',
   AppLocale.raAotwDownloadFromRomm: 'RomM에서 다운로드',
   AppLocale.raGamesPlayed: '{count}개 게임 플레이',
+  AppLocale.raGamesBeaten: '{count}개 게임 클리어',
   AppLocale.raAchievementProgress: '업적 {earned}/{total}',
   AppLocale.raRecent30Days: '30일',
 

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -1193,6 +1193,7 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.raAotwOpenLocalGame: 'Abrir jogo local',
   AppLocale.raAotwDownloadFromRomm: 'Baixar do RomM',
   AppLocale.raGamesPlayed: '{count} jogos jogados',
+  AppLocale.raGamesBeaten: '{count} jogos concluídos',
   AppLocale.raAchievementProgress: '{earned}/{total} conquistas',
   AppLocale.raRecent30Days: '30 dias',
 

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -1179,6 +1179,7 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.raAotwOpenLocalGame: 'Открыть локальную игру',
   AppLocale.raAotwDownloadFromRomm: 'Скачать из RomM',
   AppLocale.raGamesPlayed: 'Сыграно игр: {count}',
+  AppLocale.raGamesBeaten: 'Пройдено игр: {count}',
   AppLocale.raAchievementProgress: 'Достижения: {earned}/{total}',
   AppLocale.raRecent30Days: '30 дней',
 

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -1046,6 +1046,7 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.raAotwOpenLocalGame: '打开本地游戏',
   AppLocale.raAotwDownloadFromRomm: '从 RomM 下载',
   AppLocale.raGamesPlayed: '已玩 {count} 款游戏',
+  AppLocale.raGamesBeaten: '已通关 {count} 款游戏',
   AppLocale.raAchievementProgress: '成就 {earned}/{total}',
   AppLocale.raRecent30Days: '30 天',
 

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -1047,6 +1047,7 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.raAotwOpenLocalGame: '開啟本機遊戲',
   AppLocale.raAotwDownloadFromRomm: '從 RomM 下載',
   AppLocale.raGamesPlayed: '已玩 {count} 款遊戲',
+  AppLocale.raGamesBeaten: '已破關 {count} 款遊戲',
   AppLocale.raAchievementProgress: '成就 {earned}/{total}',
   AppLocale.raRecent30Days: '30 天',
 

--- a/lib/screens/retro_achievements_screen/ra_dashboard.dart
+++ b/lib/screens/retro_achievements_screen/ra_dashboard.dart
@@ -335,6 +335,9 @@ class RADashboardHubState extends State<RADashboardHub> {
     final highlightLabel = showCompletions
         ? AppLocale.raCompletionsLabel.getString(context)
         : AppLocale.raMasteriesLabel.getString(context);
+    final beatenGames = showCompletions
+        ? (raProvider.userAwards?.beatenCasualAwardsCount ?? 0)
+        : (raProvider.userAwards?.beatenHardcoreAwardsCount ?? 0);
 
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 14.r, vertical: 12.r),
@@ -409,6 +412,14 @@ class RADashboardHubState extends State<RADashboardHub> {
                           .getString(context)
                           .replaceFirst('{count}', '$trackedGames'),
                       color: theme.colorScheme.primary,
+                    ),
+                    _buildPill(
+                      context,
+                      icon: Symbols.flag_rounded,
+                      label: AppLocale.raGamesBeaten
+                          .getString(context)
+                          .replaceFirst('{count}', '$beatenGames'),
+                      color: theme.colorScheme.secondary,
                     ),
                     _buildPill(
                       context,

--- a/test/ra_dashboard_week_card_test.dart
+++ b/test/ra_dashboard_week_card_test.dart
@@ -10,6 +10,7 @@ import 'package:neostation/models/database_game_model.dart';
 import 'package:neostation/models/retro_achievements_dashboard_models.dart';
 import 'package:neostation/models/retro_achievements_gotw.dart';
 import 'package:neostation/models/retro_achievements_user.dart';
+import 'package:neostation/models/retro_achievements_user_awards.dart';
 import 'package:neostation/providers/retro_achievements_provider.dart';
 import 'package:neostation/providers/romm_provider.dart';
 import 'package:neostation/screens/retro_achievements_screen/ra_dashboard.dart';
@@ -19,11 +20,15 @@ class _DashboardProvider extends RetroAchievementsProvider {
     this._owned, {
     this.personalProgress = const AotwPersonalProgress.unknown(),
     this.showAotw = true,
+    this.casual = false,
+    this.awards,
   });
 
   final OwnedWeekGameResolution? _owned;
   final AotwPersonalProgress personalProgress;
   final bool showAotw;
+  final bool casual;
+  final RetroAchievementsUserAwards? awards;
 
   @override
   RetroAchievementsUser? get user => RetroAchievementsUser(
@@ -35,8 +40,8 @@ class _DashboardProvider extends RetroAchievementsProvider {
     lastGameId: 0,
     contribCount: 0,
     contribYield: 0,
-    totalPoints: 0,
-    totalCasualPoints: 0,
+    totalPoints: casual ? 0 : 1,
+    totalCasualPoints: casual ? 1 : 0,
     totalTruePoints: 0,
     permissions: 0,
     untracked: 0,
@@ -44,6 +49,9 @@ class _DashboardProvider extends RetroAchievementsProvider {
     userWallActive: false,
     motto: '',
   );
+
+  @override
+  RetroAchievementsUserAwards? get userAwards => awards;
 
   @override
   RetroAchievementsGOTW? get gotw => showAotw
@@ -215,5 +223,79 @@ void main() {
     await tester.pump();
 
     expect(find.text('No current Achievement of the Week'), findsOneWidget);
+  });
+
+  testWidgets('shows the mode-appropriate games beaten pill', (tester) async {
+    final awards = RetroAchievementsUserAwards(
+      totalAwardsCount: 0,
+      hiddenAwardsCount: 0,
+      masteryAwardsCount: 0,
+      completionAwardsCount: 0,
+      beatenHardcoreAwardsCount: 7,
+      beatenCasualAwardsCount: 11,
+      eventAwardsCount: 0,
+      siteAwardsCount: 0,
+      visibleUserAwards: [],
+    );
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<RetroAchievementsProvider>.value(
+            value: _DashboardProvider(null, awards: awards),
+          ),
+          ChangeNotifierProvider(create: (_) => RommProvider()),
+        ],
+        child: ScreenUtilInit(
+          designSize: const Size(1280, 720),
+          builder: (context, _) => MaterialApp(
+            localizationsDelegates:
+                FlutterLocalization.instance.localizationsDelegates,
+            supportedLocales: FlutterLocalization.instance.supportedLocales,
+            home: Scaffold(
+              body: RADashboardHub(
+                logoutSelected: false,
+                weekCardSelected: false,
+                onDisconnectRequested: () {},
+                onOwnedWeekGameSelected: (_) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('7 games beaten'), findsOneWidget);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<RetroAchievementsProvider>.value(
+            value: _DashboardProvider(null, casual: true, awards: awards),
+          ),
+          ChangeNotifierProvider(create: (_) => RommProvider()),
+        ],
+        child: ScreenUtilInit(
+          designSize: const Size(1280, 720),
+          builder: (context, _) => MaterialApp(
+            localizationsDelegates:
+                FlutterLocalization.instance.localizationsDelegates,
+            supportedLocales: FlutterLocalization.instance.supportedLocales,
+            home: Scaffold(
+              body: RADashboardHub(
+                logoutSelected: false,
+                weekCardSelected: false,
+                onDisconnectRequested: () {},
+                onOwnedWeekGameSelected: (_) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('11 games beaten'), findsOneWidget);
   });
 }


### PR DESCRIPTION
# Description

Adds a localized Games Beaten summary pill to the RetroAchievements dashboard header. It selects the user’s hardcore or casual beaten-game total to match their primary play mode.

AI-assisted implementation.

Closes #

## Steps to Verify

**Preconditions:**

1. Connect a RetroAchievements account with at least one beaten game.

1. Open the RetroAchievements dashboard.
2. Confirm the new flag pill displays the Games Beaten total in the profile summary.
3. Confirm the displayed count matches the account’s active mode (hardcore or casual).

## Tested on

- [x] Android — device: Retroid Pocket Nova
- [ ] Linux — device:
- [ ] Windows
- [ ] macOS
- [ ] Not runtime-tested — why:

## Checklist

- [x] `flutter analyze` — clean (no errors *or* warnings)
- [ ] `flutter test` — all passing (full suite has unrelated existing failures; targeted dashboard test passes)
- [x] Tests added or updated
- [x] No secrets, credentials, or personal data in the diff (including tests and fixtures)
- [x] New assets have compatible licenses (no new assets)

<details>
<summary><b>Extra checks — expand if this PR touches strings, the database, navigation, Android paths, or emulator launching</b></summary>

**User-facing text**
- [x] New keys in `lib/l10n/app_locale.dart` and a value in **all 12** `app_locale_<lang>.dart` files
- [x] No hardcoded UI strings — everything goes through `AppLocale`

**Android**
- [x] Verified on a device, not only on desktop

</details>

## Screenshots / video

Tested on-device; no screenshot attached.